### PR TITLE
chore: update repository references for org migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,29 +1,29 @@
 # CODEOWNERS - Rustume
 # Default owners for everything in the repo
-* @TurboCoder13
+* @lgtm-hq/maintainers
 
 # Core crates
-/crates/ @TurboCoder13
+/crates/ @lgtm-hq/maintainers
 
 # CI/CD and workflows
-/.github/workflows/ @TurboCoder13
-/.github/actions/ @TurboCoder13
-/scripts/ci/ @TurboCoder13
+/.github/workflows/ @lgtm-hq/maintainers
+/.github/actions/ @lgtm-hq/maintainers
+/scripts/ci/ @lgtm-hq/maintainers
 
 # Documentation
-/docs/ @TurboCoder13
-/README.md @TurboCoder13
+/docs/ @lgtm-hq/maintainers
+/README.md @lgtm-hq/maintainers
 
 # Configuration
-/Cargo.toml @TurboCoder13
-/.lintro-config.yaml @TurboCoder13
+/Cargo.toml @lgtm-hq/maintainers
+/.lintro-config.yaml @lgtm-hq/maintainers
 
 # Tests
-/tests/ @TurboCoder13
+/tests/ @lgtm-hq/maintainers
 
 # Bindings
-/bindings/ @TurboCoder13
+/bindings/ @lgtm-hq/maintainers
 
 # Docker
-/docker/ @TurboCoder13
-/Dockerfile @TurboCoder13
+/docker/ @lgtm-hq/maintainers
+/Dockerfile @lgtm-hq/maintainers

--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -1,6 +1,6 @@
 ---
 # Lintro Configuration for Rustume
-# https://github.com/TurboCoder13/py-lintro
+# https://github.com/lgtm-hq/py-lintro
 #
 # Lintro is the master configuration source for all tools.
 # Native tool configs are used when available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ guidelines and information for contributors.
 
 ```bash
 # Clone the repository
-git clone https://github.com/TurboCoder13/Rustume.git
+git clone https://github.com/lgtm-hq/Rustume.git
 cd Rustume
 
 # Build all crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*", "bindings/*"]
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/TurboCoder13/Rustume"
+repository = "https://github.com/lgtm-hq/Rustume"
 
 [workspace.dependencies]
 # Serialization

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -54,7 +54,7 @@ const DEFAULT_PORT: u16 = 3000;
         version = "0.1.0",
         description = "REST API for resume parsing, rendering, and validation.\n\n## Features\n\n- **Parse**: Import resumes from JSON Resume, LinkedIn exports, or Reactive Resume v3\n- **Render**: Generate PDF or PNG previews of resumes\n- **Validate**: Check resume data against the schema\n- **Templates**: List available resume templates with theme colors",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
-        contact(name = "Rustume", url = "https://github.com/TurboCoder13/Rustume")
+        contact(name = "Rustume", url = "https://github.com/lgtm-hq/Rustume")
     ),
     servers(
         (url = "/", description = "Local server")


### PR DESCRIPTION
## Summary
- Update all GitHub repository URLs from `TurboCoder13/Rustume` to `lgtm-hq/Rustume`
- Update CODEOWNERS to reference `@lgtm-hq/maintainers` team
- Update py-lintro reference to `lgtm-hq/py-lintro`

## Files Changed
| File | Change |
|------|--------|
| `CONTRIBUTING.md` | Clone URL |
| `Cargo.toml` | Repository URL |
| `crates/server/src/main.rs` | API contact URL |
| `.github/CODEOWNERS` | Use `@lgtm-hq/maintainers` team |
| `.lintro-config.yaml` | py-lintro URL |

## Pre-merge checklist
- [ ] Create `maintainers` team at https://github.com/orgs/lgtm-hq/teams
- [ ] Add @TurboCoder13 to the maintainers team

## Test plan
- [x] Lint check passed
- [x] All 170 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository references across project configuration files
  * Updated code ownership assignments for project maintenance
  * Updated API documentation metadata with new repository information
  
These changes reflect administrative updates to project metadata and do not affect user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->