### PR TITLE
fix(ci): remove unsupported attestations permission from docker workflow

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -30,7 +30,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-      attestations: write
     with:
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume


### PR DESCRIPTION
## Summary
- Remove `attestations: write` from the caller's job-level permissions in `docker-build-publish.yml`
- This permission scope caused `startup_failure` (zero jobs created) when calling the `lgtm-ci` reusable Docker workflow
- The reusable workflow already declares `attestations: write` internally where it's actually needed

## Context
After merging #49, the `Build - Docker Image & Registry` workflow failed with `startup_failure` on every run (including re-runs), while all other workflows succeeded. The `attestations` permission scope is not recognized in the caller→reusable workflow permission inheritance context.

Closes the CI failure from [run 21961642288](https://github.com/lgtm-hq/Rustume/actions/runs/21961642288).

## Test plan
- [x] `lintro chk` — all 26 tools pass, zero issues
- [x] `cargo test` — all 156 tests pass
- [ ] Verify the Docker workflow succeeds after merge (trigger via `workflow_dispatch`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure maintenance to CI/CD workflows. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->