### PR TITLE
fix(ci): grant all permissions required by reusable docker workflow

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -30,6 +30,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
+      security-events: write
     with:
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): grant all permissions required by reusable docker workflow`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Grant the full set of permissions that the `lgtm-ci` reusable Docker workflow needs:

- `attestations: write` — used by `actions/attest-build-provenance` in the build job
- `security-events: write` — used by `github/codeql-action/upload-sarif` in the scan job (Trivy SARIF upload)

When a caller specifies `permissions` on a job that calls a reusable workflow, those permissions become the **maximum** the callee's jobs can request. The reusable workflow has two jobs (`build` and `scan`) that collectively need five permission scopes — the caller was only granting three, causing `startup_failure` before any jobs could be created.

Also keeps the SHA pin from #51.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (CI-only change, no code tests applicable)
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (`cargo test && cargo clippy`)

## Related Issues

Related #49, #50, #51

## Details

**Root cause:** The `startup_failure` was caused by a permissions mismatch between the caller and the reusable workflow. GitHub validates that all permissions requested by the callee's jobs are within the caller's grants *before* creating any jobs. Missing `security-events: write` (needed by the `scan` job) and `attestations: write` (needed by the `build` job) caused the pre-flight check to fail silently.

**Also fixed along the way:**
- Org-level Actions allowlist updated to include `docker/setup-qemu-action@*`, `actions/attest-build-provenance@*`, `aquasecurity/trivy-action@*` (needed by reusable workflow steps)
- Reusable workflow pinned to SHA instead of nested `@v0` tag (#51)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configurations to enhance security and attestation capabilities in the Docker build and publish workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->