### PR TITLE
feat(web): complete section editor parity for all types

### DIFF
--- a/apps/web/src/components/builder/SectionEditor.tsx
+++ b/apps/web/src/components/builder/SectionEditor.tsx
@@ -2,7 +2,20 @@ import { For, Show, createSignal, type JSX } from "solid-js";
 import { Button, Input, RichTextEditor } from "../ui";
 import { resumeStore, type SectionKey } from "../../stores/resume";
 import { generateId, createEmptyUrl } from "../../wasm/types";
-import type { Experience, Education, Skill, Project } from "../../wasm/types";
+import type {
+  Experience,
+  Education,
+  Skill,
+  Project,
+  Profile,
+  Award,
+  Certification,
+  Publication,
+  Language,
+  Interest,
+  Volunteer,
+  Reference,
+} from "../../wasm/types";
 
 // Singularize section titles for better UX
 const SINGULAR_MAP: Record<string, string> = {
@@ -516,6 +529,484 @@ export function ProjectsEditor() {
             <Input
               label="Link Label"
               placeholder="View Project"
+              value={item.url.label}
+              onInput={(v) => update({ url: { ...item.url, label: v } })}
+            />
+            <Input
+              label="Link URL"
+              type="url"
+              placeholder="https://..."
+              value={item.url.href}
+              onInput={(v) => update({ url: { ...item.url, href: v } })}
+            />
+          </div>
+        </div>
+      )}
+    />
+  );
+}
+
+export function ProfilesEditor() {
+  return (
+    <SectionEditor<Profile>
+      sectionKey="profiles"
+      title="Profiles"
+      icon="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+      createItem={() => ({
+        id: generateId(),
+        visible: true,
+        network: "",
+        username: "",
+        icon: "",
+        url: createEmptyUrl(),
+      })}
+      getItemTitle={(item) => item.network || item.username}
+      getItemSubtitle={(item) => (item.network && item.username ? `@${item.username}` : "")}
+      renderItem={(item, _index, update) => (
+        <div class="space-y-4">
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Network"
+              placeholder="GitHub"
+              value={item.network}
+              onInput={(v) => update({ network: v, icon: v.toLowerCase() })}
+            />
+            <Input
+              label="Username"
+              placeholder="johndoe"
+              value={item.username}
+              onInput={(v) => update({ username: v })}
+            />
+          </div>
+          <Input
+            label="Icon"
+            placeholder="github (auto-set from network)"
+            value={item.icon}
+            onInput={(v) => update({ icon: v })}
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Link Label"
+              placeholder="Profile"
+              value={item.url.label}
+              onInput={(v) => update({ url: { ...item.url, label: v } })}
+            />
+            <Input
+              label="Link URL"
+              type="url"
+              placeholder="https://github.com/johndoe"
+              value={item.url.href}
+              onInput={(v) => update({ url: { ...item.url, href: v } })}
+            />
+          </div>
+        </div>
+      )}
+    />
+  );
+}
+
+export function AwardsEditor() {
+  return (
+    <SectionEditor<Award>
+      sectionKey="awards"
+      title="Awards"
+      icon="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
+      createItem={() => ({
+        id: generateId(),
+        visible: true,
+        title: "",
+        awarder: "",
+        date: "",
+        summary: "",
+        url: createEmptyUrl(),
+      })}
+      getItemTitle={(item) => item.title}
+      getItemSubtitle={(item) => item.awarder}
+      renderItem={(item, _index, update) => (
+        <div class="space-y-4">
+          <Input
+            label="Title"
+            placeholder="Best Paper Award"
+            value={item.title}
+            onInput={(v) => update({ title: v })}
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Awarder"
+              placeholder="IEEE"
+              value={item.awarder}
+              onInput={(v) => update({ awarder: v })}
+            />
+            <Input
+              label="Date"
+              placeholder="2023"
+              value={item.date}
+              onInput={(v) => update({ date: v })}
+            />
+          </div>
+          <RichTextEditor
+            label="Summary"
+            placeholder="Describe the award and why you received it..."
+            value={item.summary}
+            onInput={(v) => update({ summary: v })}
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Link Label"
+              placeholder="Award page"
+              value={item.url.label}
+              onInput={(v) => update({ url: { ...item.url, label: v } })}
+            />
+            <Input
+              label="Link URL"
+              type="url"
+              placeholder="https://..."
+              value={item.url.href}
+              onInput={(v) => update({ url: { ...item.url, href: v } })}
+            />
+          </div>
+        </div>
+      )}
+    />
+  );
+}
+
+export function CertificationsEditor() {
+  return (
+    <SectionEditor<Certification>
+      sectionKey="certifications"
+      title="Certifications"
+      icon="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"
+      createItem={() => ({
+        id: generateId(),
+        visible: true,
+        name: "",
+        issuer: "",
+        date: "",
+        summary: "",
+        url: createEmptyUrl(),
+      })}
+      getItemTitle={(item) => item.name}
+      getItemSubtitle={(item) => item.issuer}
+      renderItem={(item, _index, update) => (
+        <div class="space-y-4">
+          <Input
+            label="Certification Name"
+            placeholder="AWS Solutions Architect"
+            value={item.name}
+            onInput={(v) => update({ name: v })}
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Issuer"
+              placeholder="Amazon Web Services"
+              value={item.issuer}
+              onInput={(v) => update({ issuer: v })}
+            />
+            <Input
+              label="Date"
+              placeholder="2023"
+              value={item.date}
+              onInput={(v) => update({ date: v })}
+            />
+          </div>
+          <RichTextEditor
+            label="Summary"
+            placeholder="Details about the certification..."
+            value={item.summary}
+            onInput={(v) => update({ summary: v })}
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Link Label"
+              placeholder="Verify credential"
+              value={item.url.label}
+              onInput={(v) => update({ url: { ...item.url, label: v } })}
+            />
+            <Input
+              label="Link URL"
+              type="url"
+              placeholder="https://..."
+              value={item.url.href}
+              onInput={(v) => update({ url: { ...item.url, href: v } })}
+            />
+          </div>
+        </div>
+      )}
+    />
+  );
+}
+
+export function PublicationsEditor() {
+  return (
+    <SectionEditor<Publication>
+      sectionKey="publications"
+      title="Publications"
+      icon="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+      createItem={() => ({
+        id: generateId(),
+        visible: true,
+        name: "",
+        publisher: "",
+        date: "",
+        summary: "",
+        url: createEmptyUrl(),
+      })}
+      getItemTitle={(item) => item.name}
+      getItemSubtitle={(item) => item.publisher}
+      renderItem={(item, _index, update) => (
+        <div class="space-y-4">
+          <Input
+            label="Publication Name"
+            placeholder="Machine Learning in Practice"
+            value={item.name}
+            onInput={(v) => update({ name: v })}
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Publisher"
+              placeholder="IEEE / ACM / Springer"
+              value={item.publisher}
+              onInput={(v) => update({ publisher: v })}
+            />
+            <Input
+              label="Date"
+              placeholder="2023"
+              value={item.date}
+              onInput={(v) => update({ date: v })}
+            />
+          </div>
+          <RichTextEditor
+            label="Summary"
+            placeholder="Abstract or description of the publication..."
+            value={item.summary}
+            onInput={(v) => update({ summary: v })}
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Link Label"
+              placeholder="Read paper"
+              value={item.url.label}
+              onInput={(v) => update({ url: { ...item.url, label: v } })}
+            />
+            <Input
+              label="Link URL"
+              type="url"
+              placeholder="https://doi.org/..."
+              value={item.url.href}
+              onInput={(v) => update({ url: { ...item.url, href: v } })}
+            />
+          </div>
+        </div>
+      )}
+    />
+  );
+}
+
+export function LanguagesEditor() {
+  return (
+    <SectionEditor<Language>
+      sectionKey="languages"
+      title="Languages"
+      icon="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"
+      createItem={() => ({
+        id: generateId(),
+        visible: true,
+        name: "",
+        description: "",
+        level: 0,
+      })}
+      getItemTitle={(item) => item.name}
+      getItemSubtitle={(item) => item.description}
+      renderItem={(item, _index, update) => (
+        <div class="space-y-4">
+          <Input
+            label="Language"
+            placeholder="English"
+            value={item.name}
+            onInput={(v) => update({ name: v })}
+          />
+          <Input
+            label="Proficiency"
+            placeholder="Native, Fluent, Intermediate, Basic"
+            value={item.description}
+            onInput={(v) => update({ description: v })}
+          />
+          <div>
+            <label class="font-mono text-xs uppercase tracking-wider text-stone block mb-2">
+              Level ({item.level}/5)
+            </label>
+            <input
+              type="range"
+              min="0"
+              max="5"
+              value={item.level}
+              onInput={(e) => update({ level: parseInt(e.currentTarget.value) })}
+              class="w-full accent-accent"
+            />
+          </div>
+        </div>
+      )}
+    />
+  );
+}
+
+export function InterestsEditor() {
+  return (
+    <SectionEditor<Interest>
+      sectionKey="interests"
+      title="Interests"
+      icon="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+      createItem={() => ({
+        id: generateId(),
+        visible: true,
+        name: "",
+        keywords: [],
+      })}
+      getItemTitle={(item) => item.name}
+      getItemSubtitle={(item) => item.keywords.slice(0, 3).join(", ")}
+      renderItem={(item, _index, update) => (
+        <div class="space-y-4">
+          <Input
+            label="Interest"
+            placeholder="Open Source"
+            value={item.name}
+            onInput={(v) => update({ name: v })}
+          />
+          <Input
+            label="Keywords"
+            placeholder="Linux, Rust, WebAssembly (comma separated)"
+            value={item.keywords.join(", ")}
+            onInput={(v) =>
+              update({
+                keywords: v
+                  .split(",")
+                  .map((k) => k.trim())
+                  .filter(Boolean),
+              })
+            }
+          />
+        </div>
+      )}
+    />
+  );
+}
+
+export function VolunteerEditor() {
+  return (
+    <SectionEditor<Volunteer>
+      sectionKey="volunteer"
+      title="Volunteer"
+      icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+      createItem={() => ({
+        id: generateId(),
+        visible: true,
+        organization: "",
+        position: "",
+        location: "",
+        date: "",
+        summary: "",
+        url: createEmptyUrl(),
+      })}
+      getItemTitle={(item) => item.position || item.organization}
+      getItemSubtitle={(item) => (item.organization && item.position ? item.organization : "")}
+      renderItem={(item, _index, update) => (
+        <div class="space-y-4">
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Position"
+              placeholder="Volunteer Coordinator"
+              value={item.position}
+              onInput={(v) => update({ position: v })}
+            />
+            <Input
+              label="Organization"
+              placeholder="Red Cross"
+              value={item.organization}
+              onInput={(v) => update({ organization: v })}
+            />
+          </div>
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Location"
+              placeholder="New York, NY"
+              value={item.location}
+              onInput={(v) => update({ location: v })}
+            />
+            <Input
+              label="Date"
+              placeholder="Jan 2020 - Present"
+              value={item.date}
+              onInput={(v) => update({ date: v })}
+            />
+          </div>
+          <RichTextEditor
+            label="Summary"
+            placeholder="Describe your volunteer activities and impact..."
+            value={item.summary}
+            onInput={(v) => update({ summary: v })}
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Link Label"
+              placeholder="Organization website"
+              value={item.url.label}
+              onInput={(v) => update({ url: { ...item.url, label: v } })}
+            />
+            <Input
+              label="Link URL"
+              type="url"
+              placeholder="https://..."
+              value={item.url.href}
+              onInput={(v) => update({ url: { ...item.url, href: v } })}
+            />
+          </div>
+        </div>
+      )}
+    />
+  );
+}
+
+export function ReferencesEditor() {
+  return (
+    <SectionEditor<Reference>
+      sectionKey="references"
+      title="References"
+      icon="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+      createItem={() => ({
+        id: generateId(),
+        visible: true,
+        name: "",
+        description: "",
+        summary: "",
+        url: createEmptyUrl(),
+      })}
+      getItemTitle={(item) => item.name}
+      getItemSubtitle={(item) => item.description}
+      renderItem={(item, _index, update) => (
+        <div class="space-y-4">
+          <Input
+            label="Name"
+            placeholder="Jane Smith"
+            value={item.name}
+            onInput={(v) => update({ name: v })}
+          />
+          <Input
+            label="Description"
+            placeholder="Former Manager at Acme Inc."
+            value={item.description}
+            onInput={(v) => update({ description: v })}
+          />
+          <RichTextEditor
+            label="Summary"
+            placeholder="Reference details or testimonial..."
+            value={item.summary}
+            onInput={(v) => update({ summary: v })}
+          />
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label="Link Label"
+              placeholder="LinkedIn"
               value={item.url.label}
               onInput={(v) => update({ url: { ...item.url, label: v } })}
             />

--- a/apps/web/src/components/builder/index.ts
+++ b/apps/web/src/components/builder/index.ts
@@ -8,4 +8,12 @@ export {
   EducationEditor,
   SkillsEditor,
   ProjectsEditor,
+  ProfilesEditor,
+  AwardsEditor,
+  CertificationsEditor,
+  PublicationsEditor,
+  LanguagesEditor,
+  InterestsEditor,
+  VolunteerEditor,
+  ReferencesEditor,
 } from "./SectionEditor";

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -12,6 +12,14 @@ import {
   EducationEditor,
   SkillsEditor,
   ProjectsEditor,
+  ProfilesEditor,
+  AwardsEditor,
+  CertificationsEditor,
+  PublicationsEditor,
+  LanguagesEditor,
+  InterestsEditor,
+  VolunteerEditor,
+  ReferencesEditor,
 } from "../components/builder";
 import { Preview } from "../components/preview";
 import { TemplatePicker, ThemeEditor } from "../components/templates";
@@ -29,6 +37,14 @@ type EditorTab =
   | "education"
   | "skills"
   | "projects"
+  | "profiles"
+  | "awards"
+  | "certifications"
+  | "publications"
+  | "languages"
+  | "interests"
+  | "volunteer"
+  | "references"
   | "theme";
 
 const TABS: SidebarItem[] = [
@@ -66,6 +82,46 @@ const TABS: SidebarItem[] = [
     id: "projects",
     label: "Projects",
     icon: "M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10",
+  },
+  {
+    id: "profiles",
+    label: "Profiles",
+    icon: "M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1",
+  },
+  {
+    id: "awards",
+    label: "Awards",
+    icon: "M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z",
+  },
+  {
+    id: "certifications",
+    label: "Certs",
+    icon: "M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z",
+  },
+  {
+    id: "publications",
+    label: "Pubs",
+    icon: "M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253",
+  },
+  {
+    id: "languages",
+    label: "Langs",
+    icon: "M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129",
+  },
+  {
+    id: "interests",
+    label: "Interests",
+    icon: "M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z",
+  },
+  {
+    id: "volunteer",
+    label: "Volunteer",
+    icon: "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z",
+  },
+  {
+    id: "references",
+    label: "Refs",
+    icon: "M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z",
   },
   {
     id: "theme",
@@ -148,6 +204,22 @@ export default function Editor() {
         return <SkillsEditor />;
       case "projects":
         return <ProjectsEditor />;
+      case "profiles":
+        return <ProfilesEditor />;
+      case "awards":
+        return <AwardsEditor />;
+      case "certifications":
+        return <CertificationsEditor />;
+      case "publications":
+        return <PublicationsEditor />;
+      case "languages":
+        return <LanguagesEditor />;
+      case "interests":
+        return <InterestsEditor />;
+      case "volunteer":
+        return <VolunteerEditor />;
+      case "references":
+        return <ReferencesEditor />;
       case "theme":
         return <ThemeEditor />;
       default:

--- a/apps/web/src/stores/__tests__/resume.test.ts
+++ b/apps/web/src/stores/__tests__/resume.test.ts
@@ -255,3 +255,460 @@ describe("useResumeStore", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Section editor parity — add/edit/remove/reorder/visibility for all types
+// ---------------------------------------------------------------------------
+
+describe("section editor parity — all section types", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- Profiles ---
+  describe("profiles", () => {
+    it("add/edit/remove/reorder/visibility", () => {
+      createRoot((dispose) => {
+        const {
+          store,
+          createNewResume,
+          addSectionItem,
+          updateSectionItem,
+          removeSectionItem,
+          reorderSectionItem,
+          toggleSectionVisibility,
+        } = useResumeStore();
+        createNewResume("profiles-test");
+
+        // Toggle visibility
+        const visBefore = store.resume!.sections.profiles.visible;
+        toggleSectionVisibility("profiles");
+        expect(store.resume!.sections.profiles.visible).toBe(!visBefore);
+        toggleSectionVisibility("profiles");
+        expect(store.resume!.sections.profiles.visible).toBe(visBefore);
+
+        // Add
+        addSectionItem("profiles", {
+          id: "p1",
+          visible: true,
+          network: "GitHub",
+          username: "alice",
+          icon: "github",
+          url: { label: "", href: "https://github.com/alice" },
+        });
+        addSectionItem("profiles", {
+          id: "p2",
+          visible: true,
+          network: "LinkedIn",
+          username: "alice-ln",
+          icon: "linkedin",
+          url: { label: "", href: "" },
+        });
+        expect(store.resume!.sections.profiles.items.length).toBe(2);
+        expect(store.resume!.sections.profiles.items[0].network).toBe("GitHub");
+
+        // Edit
+        updateSectionItem("profiles", 0, { username: "alice-updated" });
+        expect(store.resume!.sections.profiles.items[0].username).toBe("alice-updated");
+
+        // Reorder
+        reorderSectionItem("profiles", 0, 1);
+        expect(store.resume!.sections.profiles.items[0].network).toBe("LinkedIn");
+        expect(store.resume!.sections.profiles.items[1].network).toBe("GitHub");
+
+        // Toggle item visibility
+        updateSectionItem("profiles", 0, { visible: false });
+        expect(store.resume!.sections.profiles.items[0].visible).toBe(false);
+
+        // Remove
+        removeSectionItem("profiles", 0);
+        expect(store.resume!.sections.profiles.items.length).toBe(1);
+        expect(store.resume!.sections.profiles.items[0].network).toBe("GitHub");
+
+        dispose();
+      });
+    });
+  });
+
+  // --- Awards ---
+  describe("awards", () => {
+    it("add/edit/remove/reorder/visibility", () => {
+      createRoot((dispose) => {
+        const {
+          store,
+          createNewResume,
+          addSectionItem,
+          updateSectionItem,
+          removeSectionItem,
+          reorderSectionItem,
+          toggleSectionVisibility,
+        } = useResumeStore();
+        createNewResume("awards-test");
+
+        const initial = store.resume!.sections.awards.visible;
+        toggleSectionVisibility("awards");
+        expect(store.resume!.sections.awards.visible).toBe(!initial);
+
+        addSectionItem("awards", {
+          id: "a1",
+          visible: true,
+          title: "Best Paper",
+          awarder: "IEEE",
+          date: "2023",
+          summary: "",
+          url: { label: "", href: "" },
+        });
+        addSectionItem("awards", {
+          id: "a2",
+          visible: true,
+          title: "Innovation Award",
+          awarder: "ACM",
+          date: "2024",
+          summary: "",
+          url: { label: "", href: "" },
+        });
+        expect(store.resume!.sections.awards.items.length).toBe(2);
+
+        updateSectionItem("awards", 0, { title: "Best Paper 2023" });
+        expect(store.resume!.sections.awards.items[0].title).toBe("Best Paper 2023");
+
+        reorderSectionItem("awards", 0, 1);
+        expect(store.resume!.sections.awards.items[0].title).toBe("Innovation Award");
+
+        updateSectionItem("awards", 1, { visible: false });
+        expect(store.resume!.sections.awards.items[1].visible).toBe(false);
+
+        removeSectionItem("awards", 0);
+        expect(store.resume!.sections.awards.items.length).toBe(1);
+
+        dispose();
+      });
+    });
+  });
+
+  // --- Certifications ---
+  describe("certifications", () => {
+    it("add/edit/remove/reorder/visibility", () => {
+      createRoot((dispose) => {
+        const {
+          store,
+          createNewResume,
+          addSectionItem,
+          updateSectionItem,
+          removeSectionItem,
+          reorderSectionItem,
+          toggleSectionVisibility,
+        } = useResumeStore();
+        createNewResume("certs-test");
+
+        const initial = store.resume!.sections.certifications.visible;
+        toggleSectionVisibility("certifications");
+        expect(store.resume!.sections.certifications.visible).toBe(!initial);
+
+        addSectionItem("certifications", {
+          id: "c1",
+          visible: true,
+          name: "AWS SA",
+          issuer: "Amazon",
+          date: "2023",
+          summary: "",
+          url: { label: "", href: "" },
+        });
+        addSectionItem("certifications", {
+          id: "c2",
+          visible: true,
+          name: "GCP Engineer",
+          issuer: "Google",
+          date: "2024",
+          summary: "",
+          url: { label: "", href: "" },
+        });
+        expect(store.resume!.sections.certifications.items.length).toBe(2);
+
+        updateSectionItem("certifications", 0, { issuer: "AWS" });
+        expect(store.resume!.sections.certifications.items[0].issuer).toBe("AWS");
+
+        reorderSectionItem("certifications", 0, 1);
+        expect(store.resume!.sections.certifications.items[0].name).toBe("GCP Engineer");
+
+        removeSectionItem("certifications", 1);
+        expect(store.resume!.sections.certifications.items.length).toBe(1);
+
+        dispose();
+      });
+    });
+  });
+
+  // --- Publications ---
+  describe("publications", () => {
+    it("add/edit/remove/reorder/visibility", () => {
+      createRoot((dispose) => {
+        const {
+          store,
+          createNewResume,
+          addSectionItem,
+          updateSectionItem,
+          removeSectionItem,
+          reorderSectionItem,
+          toggleSectionVisibility,
+        } = useResumeStore();
+        createNewResume("pubs-test");
+
+        const initial = store.resume!.sections.publications.visible;
+        toggleSectionVisibility("publications");
+        expect(store.resume!.sections.publications.visible).toBe(!initial);
+
+        addSectionItem("publications", {
+          id: "pub1",
+          visible: true,
+          name: "ML Paper",
+          publisher: "IEEE",
+          date: "2023",
+          summary: "",
+          url: { label: "", href: "" },
+        });
+        addSectionItem("publications", {
+          id: "pub2",
+          visible: true,
+          name: "Systems Paper",
+          publisher: "ACM",
+          date: "2024",
+          summary: "",
+          url: { label: "", href: "" },
+        });
+        expect(store.resume!.sections.publications.items.length).toBe(2);
+
+        updateSectionItem("publications", 1, { name: "Distributed Systems" });
+        expect(store.resume!.sections.publications.items[1].name).toBe("Distributed Systems");
+
+        reorderSectionItem("publications", 1, 0);
+        expect(store.resume!.sections.publications.items[0].name).toBe("Distributed Systems");
+
+        removeSectionItem("publications", 0);
+        expect(store.resume!.sections.publications.items.length).toBe(1);
+        expect(store.resume!.sections.publications.items[0].name).toBe("ML Paper");
+
+        dispose();
+      });
+    });
+  });
+
+  // --- Languages ---
+  describe("languages", () => {
+    it("add/edit/remove/reorder/visibility", () => {
+      createRoot((dispose) => {
+        const {
+          store,
+          createNewResume,
+          addSectionItem,
+          updateSectionItem,
+          removeSectionItem,
+          reorderSectionItem,
+          toggleSectionVisibility,
+        } = useResumeStore();
+        createNewResume("langs-test");
+
+        const initial = store.resume!.sections.languages.visible;
+        toggleSectionVisibility("languages");
+        expect(store.resume!.sections.languages.visible).toBe(!initial);
+
+        addSectionItem("languages", {
+          id: "l1",
+          visible: true,
+          name: "English",
+          description: "Native",
+          level: 5,
+        });
+        addSectionItem("languages", {
+          id: "l2",
+          visible: true,
+          name: "Spanish",
+          description: "Intermediate",
+          level: 3,
+        });
+        expect(store.resume!.sections.languages.items.length).toBe(2);
+
+        updateSectionItem("languages", 1, { level: 4, description: "Advanced" });
+        expect(store.resume!.sections.languages.items[1].level).toBe(4);
+        expect(store.resume!.sections.languages.items[1].description).toBe("Advanced");
+
+        reorderSectionItem("languages", 0, 1);
+        expect(store.resume!.sections.languages.items[0].name).toBe("Spanish");
+
+        removeSectionItem("languages", 0);
+        expect(store.resume!.sections.languages.items.length).toBe(1);
+        expect(store.resume!.sections.languages.items[0].name).toBe("English");
+
+        dispose();
+      });
+    });
+  });
+
+  // --- Interests ---
+  describe("interests", () => {
+    it("add/edit/remove/reorder/visibility", () => {
+      createRoot((dispose) => {
+        const {
+          store,
+          createNewResume,
+          addSectionItem,
+          updateSectionItem,
+          removeSectionItem,
+          reorderSectionItem,
+          toggleSectionVisibility,
+        } = useResumeStore();
+        createNewResume("interests-test");
+
+        const initial = store.resume!.sections.interests.visible;
+        toggleSectionVisibility("interests");
+        expect(store.resume!.sections.interests.visible).toBe(!initial);
+
+        addSectionItem("interests", {
+          id: "i1",
+          visible: true,
+          name: "Open Source",
+          keywords: ["Linux", "Rust"],
+        });
+        addSectionItem("interests", {
+          id: "i2",
+          visible: true,
+          name: "Music",
+          keywords: ["Piano", "Guitar"],
+        });
+        expect(store.resume!.sections.interests.items.length).toBe(2);
+
+        updateSectionItem("interests", 0, { keywords: ["Linux", "Rust", "WASM"] });
+        expect(store.resume!.sections.interests.items[0].keywords).toEqual([
+          "Linux",
+          "Rust",
+          "WASM",
+        ]);
+
+        reorderSectionItem("interests", 0, 1);
+        expect(store.resume!.sections.interests.items[0].name).toBe("Music");
+
+        removeSectionItem("interests", 1);
+        expect(store.resume!.sections.interests.items.length).toBe(1);
+
+        dispose();
+      });
+    });
+  });
+
+  // --- Volunteer ---
+  describe("volunteer", () => {
+    it("add/edit/remove/reorder/visibility", () => {
+      createRoot((dispose) => {
+        const {
+          store,
+          createNewResume,
+          addSectionItem,
+          updateSectionItem,
+          removeSectionItem,
+          reorderSectionItem,
+          toggleSectionVisibility,
+        } = useResumeStore();
+        createNewResume("volunteer-test");
+
+        const initial = store.resume!.sections.volunteer.visible;
+        toggleSectionVisibility("volunteer");
+        expect(store.resume!.sections.volunteer.visible).toBe(!initial);
+
+        addSectionItem("volunteer", {
+          id: "v1",
+          visible: true,
+          organization: "Red Cross",
+          position: "Coordinator",
+          location: "NYC",
+          date: "2020 - 2022",
+          summary: "",
+          url: { label: "", href: "" },
+        });
+        addSectionItem("volunteer", {
+          id: "v2",
+          visible: true,
+          organization: "Habitat",
+          position: "Builder",
+          location: "LA",
+          date: "2023",
+          summary: "",
+          url: { label: "", href: "" },
+        });
+        expect(store.resume!.sections.volunteer.items.length).toBe(2);
+
+        updateSectionItem("volunteer", 0, { position: "Lead Coordinator" });
+        expect(store.resume!.sections.volunteer.items[0].position).toBe("Lead Coordinator");
+
+        reorderSectionItem("volunteer", 0, 1);
+        expect(store.resume!.sections.volunteer.items[0].organization).toBe("Habitat");
+
+        updateSectionItem("volunteer", 1, { visible: false });
+        expect(store.resume!.sections.volunteer.items[1].visible).toBe(false);
+
+        removeSectionItem("volunteer", 0);
+        expect(store.resume!.sections.volunteer.items.length).toBe(1);
+
+        dispose();
+      });
+    });
+  });
+
+  // --- References ---
+  describe("references", () => {
+    it("add/edit/remove/reorder/visibility", () => {
+      createRoot((dispose) => {
+        const {
+          store,
+          createNewResume,
+          addSectionItem,
+          updateSectionItem,
+          removeSectionItem,
+          reorderSectionItem,
+          toggleSectionVisibility,
+        } = useResumeStore();
+        createNewResume("refs-test");
+
+        const initial = store.resume!.sections.references.visible;
+        toggleSectionVisibility("references");
+        expect(store.resume!.sections.references.visible).toBe(!initial);
+
+        addSectionItem("references", {
+          id: "r1",
+          visible: true,
+          name: "Jane Smith",
+          description: "Manager at Acme",
+          summary: "Great colleague",
+          url: { label: "", href: "" },
+        });
+        addSectionItem("references", {
+          id: "r2",
+          visible: true,
+          name: "Bob Jones",
+          description: "CTO at Startup",
+          summary: "",
+          url: { label: "", href: "" },
+        });
+        expect(store.resume!.sections.references.items.length).toBe(2);
+
+        updateSectionItem("references", 0, { description: "Senior Manager at Acme" });
+        expect(store.resume!.sections.references.items[0].description).toBe(
+          "Senior Manager at Acme",
+        );
+
+        reorderSectionItem("references", 0, 1);
+        expect(store.resume!.sections.references.items[0].name).toBe("Bob Jones");
+
+        removeSectionItem("references", 0);
+        expect(store.resume!.sections.references.items.length).toBe(1);
+        expect(store.resume!.sections.references.items[0].name).toBe("Jane Smith");
+
+        dispose();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(web): complete section editor parity for all types`
- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The resume builder had 13 section types in the Rust schema but only 4 had editor UIs (Experience, Education, Skills, Projects). This adds the remaining 8 section editors to achieve full parity.

- **Profiles** — network, username, icon (auto-set from network), URL
- **Awards** — title, awarder, date, summary (RTE), URL
- **Certifications** — name, issuer, date, summary (RTE), URL
- **Publications** — name, publisher, date, summary (RTE), URL
- **Languages** — name, description, level slider (0-5)
- **Interests** — name, comma-separated keywords
- **Volunteer** — organization, position, location, date, summary (RTE), URL
- **References** — name, description, summary (RTE), URL

All editors support add/edit/remove/reorder/visibility toggle. Custom sections noted as needing separate handling (dynamic key structure).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`bun run build && bunx vitest run`)

## Closes

- Closes #60

## Details

**Implementation pattern:** All 8 editors follow the existing generic `SectionEditor<T>` pattern. RichTextEditor (TipTap) used for summary fields. Fields verified against Rust schema types — all match exactly.

**Files changed:**
- `SectionEditor.tsx` — 8 new editor components
- `index.ts` — barrel exports
- `Editor.tsx` — sidebar tabs and switch cases for all 8 sections
- `resume.test.ts` — 8 new test suites covering CRUD operations per section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added eight new resume sections to the editor: Profiles, Awards, Certifications, Publications, Languages, Interests, Volunteer, and References.
  * Each section supports full management: add, edit, remove, and reorder items, plus visibility toggling.
  * New sections appear as dedicated tabs in the resume builder interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->