### PR TITLE
feat(web): drag-and-drop layout editor

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -10,6 +10,7 @@
         "@solidjs/router": "^0.15.4",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.18",
+        "@thisbeyond/solid-dnd": "^0.7.5",
         "@tiptap/core": "^3.19.0",
         "@tiptap/extension-link": "^3.19.0",
         "@tiptap/extension-placeholder": "^3.19.0",
@@ -466,6 +467,8 @@
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@thisbeyond/solid-dnd": ["@thisbeyond/solid-dnd@0.7.5", "", { "peerDependencies": { "solid-js": "^1.5" } }, "sha512-DfI5ff+yYGpK9M21LhYwIPlbP2msKxN2ARwuu6GF8tT1GgNVDTI8VCQvH4TJFoVApP9d44izmAcTh/iTCH2UUw=="],
 
     "@tiptap/core": ["@tiptap/core@3.19.0", "", { "peerDependencies": { "@tiptap/pm": "^3.19.0" } }, "sha512-bpqELwPW+DG8gWiD8iiFtSl4vIBooG5uVJod92Qxn3rA9nFatyXRr4kNbMJmOZ66ezUvmCjXVe/5/G4i5cyzKA=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@solidjs/router": "^0.15.4",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",
+    "@thisbeyond/solid-dnd": "^0.7.5",
     "@tiptap/core": "^3.19.0",
     "@tiptap/extension-link": "^3.19.0",
     "@tiptap/extension-placeholder": "^3.19.0",

--- a/apps/web/src/components/LayoutEditor/ColumnControls.tsx
+++ b/apps/web/src/components/LayoutEditor/ColumnControls.tsx
@@ -1,0 +1,53 @@
+interface ColumnControlsProps {
+  /** Current number of columns (1-3). */
+  columnCount: number;
+  /** Called when the user picks a new column count. */
+  onChange: (count: number) => void;
+}
+
+const PRESETS = [
+  { count: 1, label: "1 Column", icon: "M4 4h16v16H4z" },
+  {
+    count: 2,
+    label: "2 Columns",
+    icon: "M4 4h7v16H4zM13 4h7v16h-7z",
+  },
+  {
+    count: 3,
+    label: "3 Columns",
+    icon: "M4 4h4v16H4zM10 4h4v16h-4zM16 4h4v16h-4z",
+  },
+] as const;
+
+export function ColumnControls(props: ColumnControlsProps) {
+  return (
+    <div class="flex items-center gap-1">
+      {PRESETS.map((preset) => (
+        <button
+          type="button"
+          class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-mono
+            transition-colors border"
+          classList={{
+            "bg-accent/10 text-accent border-accent/30": props.columnCount === preset.count,
+            "text-stone hover:text-ink hover:bg-surface border-transparent":
+              props.columnCount !== preset.count,
+          }}
+          onClick={() => props.onChange(preset.count)}
+          title={preset.label}
+          aria-label={preset.label}
+          aria-pressed={props.columnCount === preset.count}
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d={preset.icon}
+            />
+          </svg>
+          <span class="hidden sm:inline">{preset.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/LayoutEditor/DraggableSection.tsx
+++ b/apps/web/src/components/LayoutEditor/DraggableSection.tsx
@@ -1,0 +1,64 @@
+import { Show } from "solid-js";
+import { createSortable, transformStyle, useDragDropContext } from "@thisbeyond/solid-dnd";
+import { SECTIONS, type SectionInfo } from "../builder/constants";
+
+interface DraggableSectionProps {
+  id: string;
+}
+
+/** Look up the human-friendly label and icon for a section ID. */
+function getSectionInfo(id: string): SectionInfo | undefined {
+  return SECTIONS.find((s) => s.key === id);
+}
+
+export function DraggableSection(props: DraggableSectionProps) {
+  const sortable = createSortable(props.id);
+  const ctx = useDragDropContext();
+
+  const isActive = () => ctx?.[0].active.draggable?.id === props.id;
+
+  const info = () => getSectionInfo(props.id);
+
+  return (
+    <div
+      ref={sortable.ref}
+      class="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-paper
+        transition-all duration-150 cursor-grab active:cursor-grabbing select-none group"
+      classList={{
+        "opacity-25 border-dashed": sortable.isActiveDraggable,
+        "shadow-md ring-2 ring-accent/30 scale-[1.02]": isActive() && !sortable.isActiveDraggable,
+      }}
+      style={transformStyle(sortable.transform)}
+      {...sortable.dragActivators}
+    >
+      {/* Drag Handle */}
+      <svg
+        class="w-4 h-4 text-stone/50 group-hover:text-stone flex-shrink-0 transition-colors"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
+      </svg>
+
+      {/* Section Icon */}
+      <Show when={info()} keyed>
+        {(i) => (
+          <svg
+            class="w-4 h-4 text-stone flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d={i.icon} />
+          </svg>
+        )}
+      </Show>
+
+      {/* Section Label */}
+      <span class="text-sm font-body text-ink truncate">{info()?.name ?? props.id}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/LayoutEditor/DroppableColumn.tsx
+++ b/apps/web/src/components/LayoutEditor/DroppableColumn.tsx
@@ -1,0 +1,64 @@
+import { For, Show } from "solid-js";
+import { SortableProvider, createDroppable } from "@thisbeyond/solid-dnd";
+import { DraggableSection } from "./DraggableSection";
+
+interface DroppableColumnProps {
+  /** Unique identifier for this column droppable (e.g. "col-0", "col-1"). */
+  columnId: string;
+  /** Column index (0-based). */
+  index: number;
+  /** Ordered section IDs in this column. */
+  sectionIds: string[];
+  /** Total number of columns (used for labelling). */
+  totalColumns: number;
+}
+
+const COLUMN_LABELS: Record<number, string[]> = {
+  1: ["Full Width"],
+  2: ["Main", "Sidebar"],
+  3: ["Left", "Center", "Right"],
+};
+
+export function DroppableColumn(props: DroppableColumnProps) {
+  const droppable = createDroppable(props.columnId);
+
+  const label = () => {
+    const labels = COLUMN_LABELS[props.totalColumns] ?? [];
+    return labels[props.index] ?? `Column ${props.index + 1}`;
+  };
+
+  return (
+    <div
+      ref={droppable.ref}
+      class="flex-1 min-w-0 rounded-lg border-2 border-dashed transition-colors duration-150 p-2"
+      classList={{
+        "border-accent/50 bg-accent/5": droppable.isActiveDroppable,
+        "border-border bg-surface/30": !droppable.isActiveDroppable,
+      }}
+    >
+      {/* Column Header */}
+      <div class="flex items-center justify-between px-2 py-1 mb-2">
+        <span class="text-xs font-mono font-semibold text-stone uppercase tracking-wider">
+          {label()}
+        </span>
+        <span class="text-xs font-mono text-stone/60">
+          {props.sectionIds.length} {props.sectionIds.length === 1 ? "section" : "sections"}
+        </span>
+      </div>
+
+      {/* Sortable Section List */}
+      <div class="space-y-1.5 min-h-[48px]">
+        <SortableProvider ids={props.sectionIds}>
+          <For each={props.sectionIds}>{(sectionId) => <DraggableSection id={sectionId} />}</For>
+        </SortableProvider>
+
+        {/* Empty state */}
+        <Show when={props.sectionIds.length === 0}>
+          <div class="flex items-center justify-center h-12 text-xs text-stone/50 italic">
+            Drop sections here
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/LayoutEditor/LayoutEditor.tsx
+++ b/apps/web/src/components/LayoutEditor/LayoutEditor.tsx
@@ -1,0 +1,327 @@
+import { createEffect, createSignal, on, untrack, For, Show } from "solid-js";
+import {
+  DragDropProvider,
+  DragDropSensors,
+  DragOverlay,
+  closestCenter,
+} from "@thisbeyond/solid-dnd";
+import type { DragEvent } from "@thisbeyond/solid-dnd";
+import { resumeStore } from "../../stores/resume";
+import { toast } from "../ui";
+import { SECTIONS } from "../builder/constants";
+import { DroppableColumn } from "./DroppableColumn";
+import { DraggableSection } from "./DraggableSection";
+import { ColumnControls } from "./ColumnControls";
+
+/** Column droppable IDs follow the pattern "col-{index}". */
+function columnId(index: number): string {
+  return `col-${index}`;
+}
+
+/** Parse a column index from a droppable ID. Returns -1 if not a column ID. */
+function parseColumnIndex(id: string | number): number {
+  const str = String(id);
+  if (!str.startsWith("col-")) return -1;
+  const n = Number(str.slice(4));
+  return Number.isFinite(n) ? n : -1;
+}
+
+/** All known section keys from the constants file. */
+export const ALL_SECTION_IDS = SECTIONS.map((s) => s.key);
+
+/**
+ * Ensures every known section ID appears in exactly one column.
+ * Sections missing from the layout are appended to the last column.
+ * Duplicate or unknown IDs are silently removed.
+ */
+export function normalizeLayout(columns: string[][]): string[][] {
+  if (columns.length === 0) {
+    return [ALL_SECTION_IDS.slice()];
+  }
+  const seen = new Set<string>();
+  const result: string[][] = columns.map((col) => {
+    const filtered: string[] = [];
+    for (const id of col) {
+      if (ALL_SECTION_IDS.includes(id as (typeof ALL_SECTION_IDS)[number]) && !seen.has(id)) {
+        seen.add(id);
+        filtered.push(id);
+      }
+    }
+    return filtered;
+  });
+
+  // Append missing sections to the last column
+  const missing = ALL_SECTION_IDS.filter((id) => !seen.has(id));
+  if (missing.length > 0) {
+    const lastCol = result[result.length - 1] ?? [];
+    result[result.length - 1] = [...lastCol, ...missing];
+  }
+
+  return result;
+}
+
+export function LayoutEditor() {
+  const { store, updateLayout } = resumeStore;
+
+  // Local mutable copy of the columns (page 0 only for now).
+  // We work with a flat column array and wrap in the page dimension on save.
+  const [columns, setColumns] = createSignal<string[][]>([]);
+  const [activeId, setActiveId] = createSignal<string | null>(null);
+
+  // Sync from store -> local state on initial load and external layout changes.
+  // Uses `on()` to track only the layout reference, and `untrack` in persistLayout
+  // to avoid a write->effect->re-normalize loop during drag operations.
+  let isPersisting = false;
+  createEffect(
+    on(
+      () => store.resume?.metadata.layout,
+      (layout) => {
+        if (isPersisting) return; // Skip re-sync caused by our own persist
+        if (!layout || layout.length === 0) {
+          setColumns(normalizeLayout([ALL_SECTION_IDS.slice()]));
+          return;
+        }
+        const page0 = layout[0] ?? [];
+        setColumns(normalizeLayout(page0.map((col) => [...col])));
+      },
+      { defer: false },
+    ),
+  );
+
+  // --- Helpers ---
+
+  /** Persist the current local column state back to the store. */
+  function persistLayout(cols: string[][]) {
+    // Wrap columns back into the pages array. We only edit page 0.
+    isPersisting = true;
+    try {
+      const existingLayout = untrack(() => store.resume?.metadata.layout ?? []);
+      const newLayout = existingLayout.map((page) => page.map((col) => [...col]));
+      newLayout[0] = cols;
+      updateLayout(newLayout);
+    } finally {
+      isPersisting = false;
+    }
+  }
+
+  /** Find which column contains a given section ID. */
+  function findColumnOfSection(sectionId: string): number {
+    const cols = columns();
+    for (let i = 0; i < cols.length; i++) {
+      if (cols[i].includes(sectionId)) return i;
+    }
+    return -1;
+  }
+
+  /**
+   * Resolve the container (column index) for a draggable or droppable ID.
+   * A section ID resolves to its parent column. A column ID resolves to itself.
+   */
+  function resolveColumnIndex(id: string | number): number {
+    const colIdx = parseColumnIndex(id);
+    if (colIdx >= 0) return colIdx;
+    return findColumnOfSection(String(id));
+  }
+
+  // --- DnD Callbacks ---
+
+  function onDragStart({ draggable }: DragEvent) {
+    setActiveId(String(draggable.id));
+  }
+
+  function onDragOver({ draggable, droppable }: DragEvent) {
+    if (!droppable) return;
+
+    const draggableId = String(draggable.id);
+    const fromCol = resolveColumnIndex(draggable.id);
+    const toCol = resolveColumnIndex(droppable.id);
+
+    if (fromCol < 0 || toCol < 0 || fromCol === toCol) return;
+
+    // Move section to the new column (append at the end for now; onDragEnd handles ordering)
+    setColumns((prev) => {
+      const next = prev.map((col) => [...col]);
+      // Remove from source
+      next[fromCol] = next[fromCol].filter((id) => id !== draggableId);
+      // Append to target
+      if (!next[toCol].includes(draggableId)) {
+        // Insert before the droppable section if it's a section, else append
+        const droppableIdx = parseColumnIndex(droppable.id);
+        if (droppableIdx >= 0) {
+          // Dropped on column itself -> append
+          next[toCol].push(draggableId);
+        } else {
+          // Dropped on a sibling section -> insert at that position
+          const targetIdx = next[toCol].indexOf(String(droppable.id));
+          if (targetIdx >= 0) {
+            next[toCol].splice(targetIdx, 0, draggableId);
+          } else {
+            next[toCol].push(draggableId);
+          }
+        }
+      }
+      return next;
+    });
+  }
+
+  function onDragEnd({ draggable, droppable }: DragEvent) {
+    setActiveId(null);
+
+    if (!droppable) {
+      // Revert to persisted layout
+      const layout = store.resume?.metadata.layout;
+      if (layout && layout.length > 0 && layout[0]) {
+        setColumns(normalizeLayout(layout[0].map((col) => [...col])));
+      } else {
+        setColumns(normalizeLayout([ALL_SECTION_IDS.slice()]));
+      }
+      return;
+    }
+
+    const draggableId = String(draggable.id);
+    const droppableId = String(droppable.id);
+
+    // Same item dropped on itself -> no-op
+    if (draggableId === droppableId) {
+      persistLayout(columns());
+      return;
+    }
+
+    const fromCol = resolveColumnIndex(draggable.id);
+    const toCol = resolveColumnIndex(droppable.id);
+
+    if (fromCol < 0 || toCol < 0) {
+      persistLayout(columns());
+      return;
+    }
+
+    const currentCols = columns();
+    const newCols = currentCols.map((col) => [...col]);
+
+    if (fromCol === toCol) {
+      // Reorder within the same column
+      const col = newCols[fromCol];
+      const fromIdx = col.indexOf(draggableId);
+      let toIdx = col.indexOf(droppableId);
+      if (fromIdx >= 0 && toIdx >= 0 && fromIdx !== toIdx) {
+        col.splice(fromIdx, 1);
+        // After removal, indices shift down for items below fromIdx
+        if (fromIdx < toIdx) {
+          toIdx--;
+        }
+        col.splice(toIdx, 0, draggableId);
+      }
+    }
+    // Cross-column moves are already handled in onDragOver
+
+    setColumns(newCols);
+    persistLayout(newCols);
+  }
+
+  // --- Column count changes ---
+
+  function handleColumnCountChange(newCount: number) {
+    if (!Number.isFinite(newCount) || newCount < 1 || newCount > 3) return;
+
+    const current = columns();
+    const currentCount = current.length;
+
+    if (newCount === currentCount) return;
+
+    let newColumns: string[][];
+
+    if (newCount > currentCount) {
+      // Adding columns: add empty columns at the end
+      newColumns = [...current];
+      for (let i = currentCount; i < newCount; i++) {
+        newColumns.push([]);
+      }
+    } else {
+      // Removing columns: merge trailing columns into the last remaining column
+      newColumns = current.slice(0, newCount);
+      const overflow = current.slice(newCount).flat();
+      newColumns[newCount - 1] = [...newColumns[newCount - 1], ...overflow];
+    }
+
+    const normalized = normalizeLayout(newColumns);
+    setColumns(normalized);
+    persistLayout(normalized);
+    toast.success(`Layout updated to ${newCount} column${newCount > 1 ? "s" : ""}`);
+  }
+
+  return (
+    <div class="space-y-4">
+      {/* Header */}
+      <div class="flex items-center gap-3 pb-4 border-b border-border">
+        <div class="w-10 h-10 bg-accent/10 rounded-lg flex items-center justify-center">
+          <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
+            />
+          </svg>
+        </div>
+        <div>
+          <h2 class="font-display text-lg font-semibold text-ink">Layout</h2>
+          <p class="text-sm text-stone">Drag sections between columns to rearrange</p>
+        </div>
+      </div>
+
+      {/* Column Controls */}
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-body text-stone">Columns</span>
+        <ColumnControls columnCount={columns().length} onChange={handleColumnCountChange} />
+      </div>
+
+      {/* DnD Layout Area */}
+      <Show when={columns().length > 0}>
+        <DragDropProvider
+          onDragStart={onDragStart}
+          onDragOver={onDragOver}
+          onDragEnd={onDragEnd}
+          collisionDetector={closestCenter}
+        >
+          <DragDropSensors />
+
+          <div
+            class="flex gap-3"
+            classList={{
+              "flex-col": columns().length === 1,
+              "flex-row": columns().length > 1,
+            }}
+          >
+            <For each={columns()}>
+              {(col, index) => (
+                <DroppableColumn
+                  columnId={columnId(index())}
+                  index={index()}
+                  sectionIds={col}
+                  totalColumns={columns().length}
+                />
+              )}
+            </For>
+          </div>
+
+          {/* Drag Overlay - shows a floating copy of the dragged item */}
+          <DragOverlay>
+            <Show when={activeId()}>
+              {(id) => (
+                <div class="pointer-events-none">
+                  <DraggableSection id={id()} />
+                </div>
+              )}
+            </Show>
+          </DragOverlay>
+        </DragDropProvider>
+      </Show>
+
+      {/* Help Text */}
+      <p class="text-xs text-stone/60 leading-relaxed">
+        Drag sections to reorder them within a column or move them between columns. The layout
+        determines how sections appear in your resume PDF.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/LayoutEditor/__tests__/LayoutEditor.test.ts
+++ b/apps/web/src/components/LayoutEditor/__tests__/LayoutEditor.test.ts
@@ -1,0 +1,140 @@
+import { createRoot } from "solid-js";
+import { createDefaultResume } from "../../../wasm/defaults";
+import { useResumeStore } from "../../../stores/resume";
+import { normalizeLayout, ALL_SECTION_IDS } from "../LayoutEditor";
+
+vi.mock("../../../wasm", () => ({
+  createEmptyResume: () => createDefaultResume(),
+  saveResume: vi.fn().mockResolvedValue(undefined),
+  getResume: vi.fn(),
+  isWasmReady: () => false,
+}));
+
+// ---------------------------------------------------------------------------
+// normalizeLayout — pure function tests
+// ---------------------------------------------------------------------------
+
+describe("normalizeLayout", () => {
+  it("returns one column with all section IDs when given an empty array", () => {
+    const result = normalizeLayout([]);
+    expect(result.length).toBe(1);
+    expect([...result[0]].sort()).toEqual([...ALL_SECTION_IDS].sort());
+  });
+
+  it("returns all section IDs when given an empty column", () => {
+    const result = normalizeLayout([[]]);
+    const flat = result.flat();
+    expect(flat.sort()).toEqual([...ALL_SECTION_IDS].sort());
+  });
+
+  it("distributes sections across two columns", () => {
+    const col1 = ["summary", "experience", "education"];
+    const col2 = ["skills", "projects"];
+    const result = normalizeLayout([col1, col2]);
+
+    // First two columns should contain their assigned sections
+    expect(result[0]).toEqual(col1);
+    expect(result[1]).toContain("skills");
+    expect(result[1]).toContain("projects");
+
+    // All missing sections should be appended to column 2
+    const allInResult = result.flat();
+    for (const id of ALL_SECTION_IDS) {
+      expect(allInResult).toContain(id);
+    }
+  });
+
+  it("removes duplicate section IDs", () => {
+    const result = normalizeLayout([
+      ["summary", "summary", "experience"],
+      ["skills", "summary"],
+    ]);
+    const flat = result.flat();
+    const summaryCount = flat.filter((id) => id === "summary").length;
+    expect(summaryCount).toBe(1);
+  });
+
+  it("removes unknown section IDs", () => {
+    const result = normalizeLayout([["summary", "unknown_section", "experience"]]);
+    const flat = result.flat();
+    expect(flat).not.toContain("unknown_section");
+    expect(flat).toContain("summary");
+    expect(flat).toContain("experience");
+  });
+
+  it("handles three columns", () => {
+    const result = normalizeLayout([["summary"], ["skills"], ["experience"]]);
+    const flat = result.flat();
+    expect(flat.sort()).toEqual([...ALL_SECTION_IDS].sort());
+    expect(result[0]).toContain("summary");
+    expect(result[1]).toContain("skills");
+    expect(result[2]).toContain("experience");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateLayout store integration tests
+// ---------------------------------------------------------------------------
+
+describe("updateLayout store integration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("updateLayout updates metadata.layout", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, updateLayout } = useResumeStore();
+      createNewResume("layout-test-1");
+
+      const newLayout: string[][][] = [
+        [
+          ["summary", "experience"],
+          ["skills", "education"],
+        ],
+      ];
+
+      updateLayout(newLayout);
+      expect(store.resume!.metadata.layout).toEqual(newLayout);
+      dispose();
+    });
+  });
+
+  it("updateLayout marks store as dirty", async () => {
+    await createRoot(async (dispose) => {
+      const { store, createNewResume, updateLayout, forceSave } = useResumeStore();
+      createNewResume("layout-test-2");
+
+      // Force save to clear dirty state
+      await forceSave();
+      vi.advanceTimersByTime(2000);
+
+      updateLayout([[["summary"], ["skills"]]]);
+
+      expect(store.isDirty).toBe(true);
+      dispose();
+    });
+  });
+
+  it("preserves other pages when updating page 0", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, updateLayout } = useResumeStore();
+      createNewResume("layout-test-3");
+
+      // Simulate multi-page layout
+      const multiPageLayout: string[][][] = [
+        [["summary", "experience"], ["skills"]],
+        [["education"], ["projects"]],
+      ];
+
+      updateLayout(multiPageLayout);
+      expect(store.resume!.metadata.layout.length).toBe(2);
+      expect(store.resume!.metadata.layout[1]).toEqual([["education"], ["projects"]]);
+      dispose();
+    });
+  });
+});

--- a/apps/web/src/components/LayoutEditor/index.ts
+++ b/apps/web/src/components/LayoutEditor/index.ts
@@ -1,0 +1,4 @@
+export { LayoutEditor, normalizeLayout, ALL_SECTION_IDS } from "./LayoutEditor";
+export { DraggableSection } from "./DraggableSection";
+export { DroppableColumn } from "./DroppableColumn";
+export { ColumnControls } from "./ColumnControls";

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -25,6 +25,7 @@ import { Preview } from "../components/preview";
 import { TemplatePicker, ThemeEditor } from "../components/templates";
 import { ImportModal } from "../components/import";
 import { ExportModal } from "../components/export";
+import { LayoutEditor } from "../components/LayoutEditor";
 import { resumeStore, isNotFoundError } from "../stores/resume";
 import { uiStore } from "../stores/ui";
 import { isWasmReady } from "../wasm";
@@ -33,6 +34,7 @@ type EditorTab =
   | "basics"
   | "summary"
   | "sections"
+  | "layout"
   | "experience"
   | "education"
   | "skills"
@@ -62,6 +64,11 @@ const TABS: SidebarItem[] = [
     id: "sections",
     label: "Sections",
     icon: "M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z",
+  },
+  {
+    id: "layout",
+    label: "Layout",
+    icon: "M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z",
   },
   {
     id: "experience",
@@ -193,6 +200,8 @@ export default function Editor() {
         return <SummaryEditor />;
       case "sections":
         return <SectionList />;
+      case "layout":
+        return <LayoutEditor />;
       case "experience":
         return <ExperienceEditor />;
       case "education":

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -380,6 +380,18 @@ export function useResumeStore() {
       markDirty();
     },
 
+    // Layout updates (pages -> columns -> section IDs)
+    updateLayout(layout: string[][][]) {
+      setStore(
+        produce((s) => {
+          if (s.resume) {
+            s.resume.metadata.layout = layout;
+          }
+        }),
+      );
+      markDirty();
+    },
+
     // Import resume data
     importResume(data: ResumeData) {
       batch(() => {


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(web): drag-and-drop layout editor`
- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds a drag-and-drop layout editor that lets users rearrange resume sections and assign them to 1-3 columns. Uses `@thisbeyond/solid-dnd`, a SolidJS-native DnD library.

- **LayoutEditor** — orchestrates DnD context, normalizes layout, persists to store
- **DraggableSection** — draggable section chip with icon and label
- **DroppableColumn** — sortable column container with drop zone highlights
- **ColumnControls** — 1/2/3 column preset buttons with SVG previews
- `normalizeLayout()` ensures all 13 section types are always present, removes duplicates/unknowns, handles empty arrays
- `updateLayout()` store method with auto-save via `markDirty()`
- Reactive sync uses `on()` with persist guard to avoid write→effect→re-normalize loop
- Column count changes redistribute sections (merge overflow when reducing)
- Drag overlay ghost for visual feedback during drag

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`bun run build && bunx vitest run`)

## Closes

- Closes #21

## Details

**Architecture:**
- Layout data structure is `string[][][]` (pages → columns → section IDs), matching the Rust schema in `metadata.rs`
- Editor reads page 0, normalizes, and works with a local `columns` signal for responsive drag UX
- Persists back to the store on `onDragEnd` and column count changes, triggering auto-save and preview re-render

**Key fixes from code review:**
- Fixed reactive sync loop: `on()` with `isPersisting` guard instead of bare `createEffect`
- Fixed persist-before-settle race: capture computed value from `setColumns` updater
- Fixed `normalizeLayout([])` crash: early guard returns single column with all sections
- Fixed `sortable.style` TypeScript error: use `transformStyle(sortable.transform)` from solid-dnd
- Deep copy for multi-page layouts in `persistLayout`

**Test coverage:**
- `normalizeLayout` pure function tests (empty columns, multi-column, duplicates, unknowns, three-column)
- `updateLayout` store integration (metadata update, dirty flag, multi-page preservation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layout Editor with drag-and-drop to reorganize resume sections across up to 3 columns
  * Preset column layouts (1/2/3), per-column controls, empty-column placeholder, draggable handles, droppable areas, and live drag overlay
  * New "Layout" tab to access editor; column-count changes merge/reduce columns and persist

* **Tests**
  * Added tests for layout normalization, drag/drop behavior, and persistence

* **Chores**
  * Added drag-and-drop dependency for the web app and exposed a public layout update API in the resume store
<!-- end of auto-generated comment: release notes by coderabbit.ai -->