### PR TITLE
chore(release): cut 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "bindings/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/lgtm-hq/Rustume"


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` workspace version from `0.1.0` to `0.6.0` to match the existing `v0.6.0` tag

## Context

The release pipeline was bootstrapped with retroactive tags (v0.1.0–v0.6.0), but the Cargo.toml version on main was never updated from `0.1.0`. This causes `verify-tag-version.sh` to fail (`v0.6.0 != v0.1.0`).

After merge, the `auto-tag-on-main` workflow will detect the `chore(release):` commit and check for an existing `v0.6.0` tag — since it already exists, no duplicate tag is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->