### PR TITLE
fix(ci): use GitHub App token for auto-tag authentication

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -52,6 +52,16 @@ jobs:
         if: steps.guard.outputs.ok != 'true'
         run: ./scripts/ci/ci-log.sh "Not a release bump commit; skipping."
 
+      - name: Create GitHub App installation token
+        if: steps.guard.outputs.ok == 'true'
+        id: app-token
+        # yamllint disable-line rule:line-length
+        uses: actions/create-github-app-token@bf559f85448f9380bcfa2899dbdc01eb5b37be3a # v3.0.0-beta.2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Read version from Cargo.toml
         if: steps.guard.outputs.ok == 'true'
         id: version
@@ -83,7 +93,7 @@ jobs:
           steps.prev.outputs.version != steps.version.outputs.version &&
           steps.check.outputs.exists == 'false'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: ./scripts/ci/maintenance/auto-tag.sh configure-auth
 
       - name: Create and push tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-cli"
-version = "0.1.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-parser"
-version = "0.1.0"
+version = "0.6.1"
 dependencies = [
  "csv",
  "cuid2",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-render"
-version = "0.1.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "rstest",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-schema"
-version = "0.1.0"
+version = "0.6.1"
 dependencies = [
  "cuid2",
  "once_cell",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-schema-macros"
-version = "0.1.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-server"
-version = "0.1.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-storage"
-version = "0.1.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-utils"
-version = "0.1.0"
+version = "0.6.1"
 dependencies = [
  "ammonia",
  "chrono",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-wasm"
-version = "0.1.0"
+version = "0.6.1"
 dependencies = [
  "js-sys",
  "rustume-parser",

--- a/scripts/ci/maintenance/auto-tag.sh
+++ b/scripts/ci/maintenance/auto-tag.sh
@@ -101,10 +101,7 @@ configure-auth)
 	fi
 	git config user.name "github-actions[bot]"
 	git config user.email "github-actions[bot]@users.noreply.github.com"
-	# Use credential helper to avoid token in URL (defense-in-depth)
-	# shellcheck disable=SC2016  # Single quotes intentional - variable evaluated by credential helper at runtime
-	git config credential.helper '!f() { echo "password=${GITHUB_TOKEN}"; }; f'
-	git remote set-url origin "https://github-actions[bot]@github.com/${GITHUB_REPOSITORY}.git"
+	git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 	echo "Git auth configured"
 	;;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): use GitHub App token for auto-tag authentication`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

The auto-tag workflow failed to push tags because it used `secrets.GITHUB_TOKEN` with a
broken credential helper (missing `username`) and the wrong git username (`github-actions[bot]`
instead of `x-access-token`).

This PR switches to the same GitHub App token pattern used by py-lintro, turbo-themes,
and lgtm-ci:
- Add `create-github-app-token` step using org-level `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`
- Fix `configure-auth` to use `x-access-token` with URL-based auth
- Sync stale `Cargo.lock` versions (0.1.0 → 0.6.1)

> **Note:** The `v0.6.1` tag was manually created (signed) and pushed to unblock the release pipeline.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated — CI-only change, no testable application code
- [ ] Docs updated if user-facing — not user-facing
- [x] Local CI passed (`cargo test && cargo clippy`)

## Related Issues

Related to the failed auto-tag run on `chore(release): prepare 0.6.1 (#102)`

## Details

**Root cause:** The `configure-auth` command in `auto-tag.sh` had two issues:
1. The credential helper only echoed `password=${GITHUB_TOKEN}` without a `username` line
2. The remote URL used `github-actions[bot]` as the username — GitHub HTTPS token auth requires `x-access-token`

**Fix:** Align with the auth pattern used across all other org projects — use a GitHub App
installation token and set the remote URL to `https://x-access-token:<token>@github.com/<repo>.git`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced authentication flow for the automated version tagging process in continuous integration pipelines, improving the security and reliability of the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->