### PR TITLE
ci(scorecard): allow api.deps.dev in egress policy

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -39,6 +39,7 @@ jobs:
             ossf.github.io:443
             www.bestpractices.dev:443
             api.osv.dev:443
+            api.deps.dev:443
             api.scorecard.dev:443
             oss-fuzz-build-logs.storage.googleapis.com:443
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `ci(scorecard): allow api.deps.dev in egress policy`

- Type:
  - [x] chore / ci / style

- Breaking change:
  - N/A

## What's Changing

The OpenSSF Scorecard workflow [fails on main](https://github.com/lgtm-hq/Rustume/actions/runs/22053188871) because the scorecard-action now queries `api.deps.dev` for dependency analysis, but harden-runner's egress policy blocks the domain since it wasn't in the allowlist.

Adds `api.deps.dev:443` to the `allowed-endpoints` in `.github/workflows/scorecards.yml`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated — N/A (CI workflow config only)
- [ ] Docs updated if user-facing — N/A
- [ ] Local CI passed (`cargo test && cargo clippy`) — N/A (no code changes)

## Related Issues

Related to [failed run #22053188871](https://github.com/lgtm-hq/Rustume/actions/runs/22053188871)

## Details

The harden-runner step uses `egress-policy: block` and an explicit allowlist. The scorecard-action added a dependency on `api.deps.dev` for its dependency analysis checks, which wasn't in the original allowlist. This one-line addition unblocks it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->