### PR TITLE
fix(ci): use actions/checkout for Windows builds (#100)

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -48,8 +48,16 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
+        if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
         uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@v0
+
+      - name: Checkout (Windows)
+        if: runner.os == 'Windows'
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): use actions/checkout for Windows builds (#100)`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Windows binary builds fail at the checkout step because `lgtm-hq/lgtm-ci/.github/actions/secure-checkout` uses a relative bash script path that gets mangled by Git Bash on Windows (backslashes interpreted as escape characters → exit code 127).

This PR adds a platform-conditional checkout: non-Windows runners continue using `secure-checkout@v0`, while the Windows runner uses `actions/checkout@v4` (pinned to the same SHA) with `persist-credentials: false` to preserve the same security posture.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (CI-only change, no unit tests)
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`cargo test && cargo clippy`)

## Related Issues

Closes #100

## Details

**Implementation**: Platform-conditional checkout in `build-binary.yml` using `if: runner.os != 'Windows'` / `if: runner.os == 'Windows'`. The `actions/checkout` SHA (`11bd71901bbe5b1630ceea73d27597364c9af683`) matches what `secure-checkout` wraps internally.

**Testing**: Requires CI run on the Windows matrix entry (`x86_64-pc-windows-msvc` on `windows-latest`) to verify the fix.