### PR TITLE
fix(ci): use upstream actions in scorecard workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: block
           allowed-endpoints: >


### PR DESCRIPTION
## Summary
- Replace `lgtm-hq/lgtm-ci/.github/actions/harden-runner` with upstream `step-security/harden-runner` (pinned by SHA)
- Replace `lgtm-hq/lgtm-ci/.github/actions/secure-checkout` with upstream `actions/checkout` (pinned by SHA)
- Add `agent.api.stepsecurity.io:443` to allowed egress endpoints

## Context
The OpenSSF Scorecard API validates workflows when publishing results and only allows a [hardcoded set of actions](https://github.com/ossf/scorecard-action#workflow-restrictions):
- `actions/checkout`
- `actions/upload-artifact`
- `github/codeql-action/upload-sarif`
- `ossf/scorecard-action`
- `step-security/harden-runner`

The custom `lgtm-ci` composite actions were rejected with:
```
workflow verification failed: job has unallowed step: lgtm-hq/lgtm-ci/.github/actions/harden-runner
```

This is specific to the scorecard workflow — other workflows can continue using the `lgtm-ci` composite actions.

## Test plan
- [ ] Trigger the scorecard workflow manually via `workflow_dispatch` and verify it passes
- [ ] Confirm SARIF results are uploaded to the Security tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI security configuration: replaced runner with a hardened variant and refined network allowlist for external endpoints.
  * Adjusted checkout behavior to disable persisted credentials during runs.
  * No changes to public APIs or runtime behavior; changes affect build and verification processes only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->