### PR TITLE
fix(ci): update reusable-docker workflow pin to lgtm-ci v0.8.2

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -25,7 +25,7 @@ jobs:
   docker:
     name: 🐳 Docker Build & Publish
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@6686f5e98911343d73c4bd0e173b4749c5086423 # v0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@a5b0b3aba611730e5e75feab8d0920bbd7080a3e # v0.8.2
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): update reusable-docker workflow pin to lgtm-ci v0.8.2`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The Docker Build & Publish workflow pins `lgtm-ci`'s reusable-docker workflow by SHA. The previous pin (`6686f5e9...`) predated lgtm-ci#95 which fixed the `aquasecurity/trivy-action` SHA to resolve a deleted `setup-trivy@v0.2.2` tag upstream.

This updates the pin to `v0.8.2` (`a5b0b3ab...`) which includes the fix. Renovate is configured to track this pin going forward.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`cargo test && cargo clippy`)

## Closes

- Closes #122

## Details

The `aquasecurity/setup-trivy` maintainers deleted all tags except `v0.2.6`. The old `trivy-action` SHA internally referenced `setup-trivy@v0.2.2` by tag (not SHA), causing runtime resolution failures. The updated `trivy-action` in lgtm-ci v0.8.2 pins `setup-trivy` by SHA, avoiding this class of breakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment workflow infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->