### PR TITLE
fix(render): wire theme presets to all 11 remaining Typst templates

### DIFF
--- a/crates/render/src/typst_engine/templates/azurill.typ
+++ b/crates/render/src/typst_engine/templates/azurill.typ
@@ -3,368 +3,374 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#d97706")
-#let text-color = rgb("#1f2937")
-#let muted-color = rgb("#6b7280")
-#let light-bg = rgb("#fef3c7")
-#let sidebar-bg = rgb("#fffbeb")
-#let bar-empty = rgb("#e5e7eb")
-
-// Section heading for main content area (right column)
-#let main-section-heading(title) = {
-  v(14pt)
-  text(weight: "bold", size: 11pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
-  v(2pt)
-  line(length: 100%, stroke: 1.5pt + primary-color)
-  v(8pt)
-}
-
-// Section heading for sidebar (left column) - smaller, different style
-#let sidebar-section-heading(title) = {
-  v(12pt)
-  text(weight: "semibold", size: 9pt, fill: primary-color, tracking: 0.1em)[#upper(title)]
-  v(2pt)
-  line(length: 100%, stroke: 0.75pt + primary-color)
-  v(6pt)
-}
-
-// Rating bars helper (0-5 scale)
-#let rating-bars(level) = {
-  rating-indicators(level, 14pt, 4pt, primary-color, bar-empty, 2pt, 2pt)
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 10pt)[#item.company]
-      #v(1pt)
-      #text(size: 9pt, fill: muted-color)[#item.position]
-    ],
-    align(right)[
-      #text(size: 9pt, fill: muted-color)[#item.date]
-      #if item.location != "" {
-        v(1pt)
-        text(size: 8pt, fill: muted-color)[#item.location]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 10pt)[#item.institution]
-      #if item.studyType != "" or item.area != "" {
-        v(1pt)
-        let degree = format-degree(item.studyType, item.area)
-        text(size: 9pt, fill: muted-color)[#degree]
-      }
-    ],
-    align(right)[
-      #text(size: 9pt, fill: muted-color)[#item.date]
-    ]
-  )
-
-  if item.score != "" {
-    v(2pt)
-    text(size: 8pt, fill: muted-color)[Score: #item.score]
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "bold")[#item.name]
-
-  if item.description != "" {
-    v(1pt)
-    render-rich-text(item.description, size: 8pt, fill: muted-color)
-  }
-
-  let level = clamp-level(item.level)
-  if level > 0 {
-    v(2pt)
-    rating-bars(level)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(8pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "bold")[#item.name]
-
-  if item.description != "" {
-    v(1pt)
-    render-rich-text(item.description, size: 8pt, fill: muted-color)
-  }
-
-  let level = clamp-level(item.level)
-  if level > 0 {
-    v(2pt)
-    rating-bars(level)
-  }
-
-  v(8pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  text(size: 8pt, fill: muted-color)[#item.network]
-  v(1pt)
-  if has-url(item) {
-    link(item.url.href)[#text(size: 9pt, fill: primary-color)[#item.username]]
-  } else {
-    text(size: 9pt)[#item.username]
-  }
-  v(6pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    text(weight: "bold", size: 10pt)[#item.name],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  if has-keywords(item) {
-    v(3pt)
-    for keyword in item.keywords {
-      box(
-        fill: light-bg,
-        radius: 3pt,
-        inset: (x: 5pt, y: 2pt),
-        text(size: 8pt, fill: primary-color)[#keyword]
-      )
-      h(3pt)
-    }
-  }
-
-  v(10pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 10pt)[#item.name]
-      #if item.issuer != "" {
-        v(1pt)
-        text(size: 9pt, fill: muted-color)[#item.issuer]
-      }
-    ],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 10pt)[#item.title]
-      #if item.awarder != "" {
-        v(1pt)
-        text(size: 9pt, fill: muted-color)[#item.awarder]
-      }
-    ],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "bold")[#item.name]
-
-  if has-keywords(item) {
-    v(2pt)
-    for keyword in item.keywords {
-      box(
-        fill: light-bg,
-        radius: 3pt,
-        inset: (x: 5pt, y: 2pt),
-        text(size: 8pt, fill: primary-color)[#keyword]
-      )
-      h(3pt)
-    }
-  }
-
-  v(8pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 10pt)[#item.name]
-      #if item.publisher != "" {
-        v(1pt)
-        text(size: 9pt, fill: muted-color)[#item.publisher]
-      }
-    ],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 10pt)[#item.organization]
-      #if item.position != "" {
-        v(1pt)
-        text(size: 9pt, fill: muted-color)[#item.position]
-      }
-    ],
-    align(right)[
-      #text(size: 9pt, fill: muted-color)[#item.date]
-      #if item.location != "" {
-        v(1pt)
-        text(size: 8pt, fill: muted-color)[#item.location]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt)[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt, fill: muted-color)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 10pt)[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt)
-      }
-    ],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.location != "" {
-    v(1pt)
-    text(size: 8pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-
-  render-url(item, primary-color)
-  v(10pt)
-}
 
 #let template(data) = {
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#d97706"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = rgb("#6b7280")
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let light-bg = rgb("#fef3c7")
+  let sidebar-bg = rgb("#fffbeb")
+  let bar-empty = rgb("#e5e7eb")
+
+  // Section heading for main content area (right column)
+  let main-section-heading(title) = {
+    v(14pt)
+    text(weight: "bold", size: 11pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+    v(2pt)
+    line(length: 100%, stroke: 1.5pt + primary-color)
+    v(8pt)
+  }
+
+  // Section heading for sidebar (left column) - smaller, different style
+  let sidebar-section-heading(title) = {
+    v(12pt)
+    text(weight: "semibold", size: 9pt, fill: primary-color, tracking: 0.1em)[#upper(title)]
+    v(2pt)
+    line(length: 100%, stroke: 0.75pt + primary-color)
+    v(6pt)
+  }
+
+  // Rating bars helper (0-5 scale)
+  let rating-bars(level) = {
+    rating-indicators(level, 14pt, 4pt, primary-color, bar-empty, 2pt, 2pt)
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 10pt)[#item.company]
+        #v(1pt)
+        #text(size: 9pt, fill: muted-color)[#item.position]
+      ],
+      align(right)[
+        #text(size: 9pt, fill: muted-color)[#item.date]
+        #if item.location != "" {
+          v(1pt)
+          text(size: 8pt, fill: muted-color)[#item.location]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 10pt)[#item.institution]
+        #if item.studyType != "" or item.area != "" {
+          v(1pt)
+          let degree = format-degree(item.studyType, item.area)
+          text(size: 9pt, fill: muted-color)[#degree]
+        }
+      ],
+      align(right)[
+        #text(size: 9pt, fill: muted-color)[#item.date]
+      ]
+    )
+
+    if item.score != "" {
+      v(2pt)
+      text(size: 8pt, fill: muted-color)[Score: #item.score]
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "bold")[#item.name]
+
+    if item.description != "" {
+      v(1pt)
+      render-rich-text(item.description, size: 8pt, fill: muted-color)
+    }
+
+    let level = clamp-level(item.level)
+    if level > 0 {
+      v(2pt)
+      rating-bars(level)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(8pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "bold")[#item.name]
+
+    if item.description != "" {
+      v(1pt)
+      render-rich-text(item.description, size: 8pt, fill: muted-color)
+    }
+
+    let level = clamp-level(item.level)
+    if level > 0 {
+      v(2pt)
+      rating-bars(level)
+    }
+
+    v(8pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    text(size: 8pt, fill: muted-color)[#item.network]
+    v(1pt)
+    if has-url(item) {
+      link(item.url.href)[#text(size: 9pt, fill: primary-color)[#item.username]]
+    } else {
+      text(size: 9pt)[#item.username]
+    }
+    v(6pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      text(weight: "bold", size: 10pt)[#item.name],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    if has-keywords(item) {
+      v(3pt)
+      for keyword in item.keywords {
+        box(
+          fill: light-bg,
+          radius: 3pt,
+          inset: (x: 5pt, y: 2pt),
+          text(size: 8pt, fill: primary-color)[#keyword]
+        )
+        h(3pt)
+      }
+    }
+
+    v(10pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 10pt)[#item.name]
+        #if item.issuer != "" {
+          v(1pt)
+          text(size: 9pt, fill: muted-color)[#item.issuer]
+        }
+      ],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 10pt)[#item.title]
+        #if item.awarder != "" {
+          v(1pt)
+          text(size: 9pt, fill: muted-color)[#item.awarder]
+        }
+      ],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "bold")[#item.name]
+
+    if has-keywords(item) {
+      v(2pt)
+      for keyword in item.keywords {
+        box(
+          fill: light-bg,
+          radius: 3pt,
+          inset: (x: 5pt, y: 2pt),
+          text(size: 8pt, fill: primary-color)[#keyword]
+        )
+        h(3pt)
+      }
+    }
+
+    v(8pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 10pt)[#item.name]
+        #if item.publisher != "" {
+          v(1pt)
+          text(size: 9pt, fill: muted-color)[#item.publisher]
+        }
+      ],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 10pt)[#item.organization]
+        #if item.position != "" {
+          v(1pt)
+          text(size: 9pt, fill: muted-color)[#item.position]
+        }
+      ],
+      align(right)[
+        #text(size: 9pt, fill: muted-color)[#item.date]
+        #if item.location != "" {
+          v(1pt)
+          text(size: 8pt, fill: muted-color)[#item.location]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt)[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt, fill: muted-color)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 10pt)[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt)
+        }
+      ],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.location != "" {
+      v(1pt)
+      text(size: 8pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    render-url(item, primary-color)
+    v(10pt)
+  }
+
   // Page setup
-  set page(
+  set page(fill: bg-color, 
     margin: 48pt,
   )
 

--- a/crates/render/src/typst_engine/templates/azurill.typ
+++ b/crates/render/src/typst_engine/templates/azurill.typ
@@ -10,7 +10,7 @@
   let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#6b7280")
+  let muted-color = text-color.lighten(40%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
@@ -146,12 +146,20 @@
   let render-profile(item) = {
     if item.visible == false { return }
 
-    text(size: 8pt, fill: muted-color)[#item.network]
-    v(1pt)
-    if has-url(item) {
-      link(item.url.href)[#text(size: 9pt, fill: primary-color)[#item.username]]
-    } else {
-      text(size: 9pt)[#item.username]
+    let network = if "network" in item and item.network != none { item.network } else { "" }
+    let username = if "username" in item and item.username != none { item.username } else { "" }
+
+    if network != "" {
+      text(size: 8pt, fill: muted-color)[#network]
+      v(1pt)
+    }
+    let label = if username != "" { username } else if has-url(item) { item.url.href } else { "" }
+    if label != "" {
+      if has-url(item) {
+        link(item.url.href)[#text(size: 9pt, fill: primary-color)[#label]]
+      } else {
+        text(size: 9pt)[#label]
+      }
     }
     v(6pt)
   }

--- a/crates/render/src/typst_engine/templates/azurill.typ
+++ b/crates/render/src/typst_engine/templates/azurill.typ
@@ -14,9 +14,9 @@
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
-  let light-bg = rgb("#fef3c7")
-  let sidebar-bg = rgb("#fffbeb")
-  let bar-empty = rgb("#e5e7eb")
+  let light-bg = primary-color.lighten(90%)
+  let sidebar-bg = primary-color.lighten(95%)
+  let bar-empty = bg-color.darken(10%)
 
   // Section heading for main content area (right column)
   let main-section-heading(title) = {

--- a/crates/render/src/typst_engine/templates/azurill.typ
+++ b/crates/render/src/typst_engine/templates/azurill.typ
@@ -15,7 +15,6 @@
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
   let light-bg = primary-color.lighten(90%)
-  let sidebar-bg = primary-color.lighten(95%)
   let bar-empty = bg-color.darken(10%)
 
   // Section heading for main content area (right column)

--- a/crates/render/src/typst_engine/templates/bronzor.typ
+++ b/crates/render/src/typst_engine/templates/bronzor.typ
@@ -4,316 +4,321 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#0891b2")
-#let text-color = rgb("#1f2937")
-#let muted-color = rgb("#6b7280")
-
-#let section-heading(title) = {
-  v(12pt)
-  text(weight: "bold", size: 11pt, fill: primary-color)[#upper(title)]
-  v(2pt)
-  line(length: 100%, stroke: 0.5pt + primary-color)
-  v(6pt)
-}
-
-#let entry-header(left-content, right-content) = {
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    left-content,
-    align(right)[
-      #text(size: 9pt, fill: muted-color)[#right-content]
-    ]
-  )
-}
-
-#let skill-bar(level) = {
-  h(4pt)
-  rating-indicators(level, 8pt, 8pt, primary-color, rgb("#e5e5e5"), 2pt, 2pt)
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.company]
-      #if item.position != "" [ — #item.position]
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    text(size: 9pt, fill: muted-color)[#item.location]
-    v(2pt)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(10pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [#text(weight: "bold")[#item.institution]],
-    item.date
-  )
-
-  if item.area != "" or item.studyType != "" {
-    let degree-text = format-degree(item.studyType, item.area)
-    text(size: 10pt)[#degree-text]
-    v(2pt)
-  }
-
-  if item.score != "" {
-    text(size: 9pt, fill: muted-color)[#item.score]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    [
-      #text(size: 10pt, weight: "bold")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt)
-      }
-    ],
-    skill-bar(item.level)
-  )
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(8pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    [
-      #text(size: 10pt, weight: "bold")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt)
-      }
-    ],
-    skill-bar(item.level)
-  )
-
-  v(6pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  if has-url(item) {
-    let label = if item.username != "" { item.username } else { item.url.href }
-    link(item.url.href)[#text(fill: primary-color)[#label]]
-  } else {
-    [#item.network: #item.username]
-  }
-  v(4pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [#text(weight: "bold", size: 10pt)[#item.name]],
-    item.date
-  )
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(8pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.name]
-      #if item.issuer != "" {
-        text(fill: muted-color)[ — #item.issuer]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.title]
-      #if item.awarder != "" {
-        text(fill: muted-color)[ — #item.awarder]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 10pt, weight: "bold")[#item.name]
-
-  if has-keywords(item) {
-    text(size: 9pt, fill: muted-color)[ — #item.keywords.join(", ")]
-  }
-
-  v(4pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.name]
-      #if item.publisher != "" {
-        v(1pt)
-        text(size: 9pt)[#item.publisher]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.organization]
-      #if item.position != "" [ — #item.position]
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    text(size: 9pt, fill: muted-color)[#item.location]
-    v(2pt)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(10pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold")[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt)
-      }
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    text(size: 9pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-
-  render-url(item, primary-color)
-  v(8pt)
-}
 
 #let template(data) = {
-  set page(
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#0891b2"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = rgb("#6b7280")
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let section-heading(title) = {
+    v(12pt)
+    text(weight: "bold", size: 11pt, fill: primary-color)[#upper(title)]
+    v(2pt)
+    line(length: 100%, stroke: 0.5pt + primary-color)
+    v(6pt)
+  }
+
+  let entry-header(left-content, right-content) = {
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      left-content,
+      align(right)[
+        #text(size: 9pt, fill: muted-color)[#right-content]
+      ]
+    )
+  }
+
+  let skill-bar(level) = {
+    h(4pt)
+    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.company]
+        #if item.position != "" [ — #item.position]
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      text(size: 9pt, fill: muted-color)[#item.location]
+      v(2pt)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [#text(weight: "bold")[#item.institution]],
+      item.date
+    )
+
+    if item.area != "" or item.studyType != "" {
+      let degree-text = format-degree(item.studyType, item.area)
+      text(size: 10pt)[#degree-text]
+      v(2pt)
+    }
+
+    if item.score != "" {
+      text(size: 9pt, fill: muted-color)[#item.score]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      [
+        #text(size: 10pt, weight: "bold")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt)
+        }
+      ],
+      skill-bar(item.level)
+    )
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(8pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      [
+        #text(size: 10pt, weight: "bold")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt)
+        }
+      ],
+      skill-bar(item.level)
+    )
+
+    v(6pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    if has-url(item) {
+      let label = if item.username != "" { item.username } else { item.url.href }
+      link(item.url.href)[#text(fill: primary-color)[#label]]
+    } else {
+      [#item.network: #item.username]
+    }
+    v(4pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [#text(weight: "bold", size: 10pt)[#item.name]],
+      item.date
+    )
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(8pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.name]
+        #if item.issuer != "" {
+          text(fill: muted-color)[ — #item.issuer]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.title]
+        #if item.awarder != "" {
+          text(fill: muted-color)[ — #item.awarder]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 10pt, weight: "bold")[#item.name]
+
+    if has-keywords(item) {
+      text(size: 9pt, fill: muted-color)[ — #item.keywords.join(", ")]
+    }
+
+    v(4pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.name]
+        #if item.publisher != "" {
+          v(1pt)
+          text(size: 9pt)[#item.publisher]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.organization]
+        #if item.position != "" [ — #item.position]
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      text(size: 9pt, fill: muted-color)[#item.location]
+      v(2pt)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold")[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt)
+        }
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      text(size: 9pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    render-url(item, primary-color)
+    v(8pt)
+  }
+
+  set page(fill: bg-color, 
     margin: (x: 48pt, y: 48pt),
   )
 

--- a/crates/render/src/typst_engine/templates/chikorita.typ
+++ b/crates/render/src/typst_engine/templates/chikorita.typ
@@ -3,365 +3,371 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#16a34a")
-#let text-color = rgb("#166534")
-#let muted-color = rgb("#6b7280")
-#let light-bg = rgb("#f0fdf4")
-#let accent-bg = rgb("#dcfce7")
-#let border-color = rgb("#bbf7d0")
-
-#let main-section(title) = {
-  v(14pt)
-  box(
-    width: 100%,
-    stroke: (bottom: 2pt + primary-color),
-    inset: (bottom: 4pt),
-    text(weight: "bold", size: 10pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
-  )
-  v(10pt)
-}
-
-#let sidebar-section(title) = {
-  v(12pt)
-  text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.08em)[#upper(title)]
-  v(2pt)
-  line(length: 100%, stroke: 0.5pt + border-color)
-  v(6pt)
-}
-
-#let rating-dots(level) = {
-  rating-indicators(level, 6pt, 6pt, primary-color, border-color, 50%, 3pt)
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "bold", size: 11pt)[#item.company]
-      #v(2pt)
-      #text(size: 10pt, fill: primary-color)[#item.position]
-    ],
-    align(right)[
-      #text(size: 9pt, fill: muted-color)[#item.date]
-      #if item.location != "" {
-        v(2pt)
-        text(size: 9pt, fill: muted-color)[#item.location]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(12pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "bold", size: 11pt)[#item.institution]
-      #if item.studyType != "" or item.area != "" {
-        v(2pt)
-        let degree = format-degree(item.studyType, item.area)
-        text(size: 10pt)[#degree]
-      }
-    ],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.score != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.score]
-  }
-
-  v(12pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "bold")[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 8pt, fill: muted-color)
-  }
-
-  let level = clamp-level(item.level)
-  if level > 0 {
-    v(2pt)
-    rating-dots(level)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(8pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "bold")[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 8pt, fill: muted-color)
-  }
-
-  let level = clamp-level(item.level)
-  if level > 0 {
-    v(2pt)
-    rating-dots(level)
-  }
-
-  v(8pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "medium")[#item.network]
-
-  if item.username != "" {
-    text(size: 8pt, fill: muted-color)[ #item.username]
-  }
-
-  if has-url(item) {
-    v(1pt)
-    link(item.url.href)[#text(size: 8pt, fill: primary-color)[#item.url.href]]
-  }
-
-  v(6pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    text(weight: "bold", size: 10pt)[#item.name],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt, fill: muted-color)
-  }
-
-  if has-keywords(item) {
-    v(4pt)
-    for keyword in item.keywords {
-      box(
-        fill: accent-bg,
-        radius: 3pt,
-        inset: (x: 6pt, y: 2pt),
-        text(size: 8pt, fill: primary-color)[#keyword]
-      )
-      h(4pt)
-    }
-  }
-
-  v(12pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "medium", size: 10pt)[#item.name]
-      #if item.issuer != "" {
-        text(size: 9pt, fill: muted-color)[ -- #item.issuer]
-      }
-    ],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "medium", size: 10pt)[#item.title]
-      #if item.awarder != "" {
-        text(size: 9pt, fill: muted-color)[ -- #item.awarder]
-      }
-    ],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "medium")[#item.name]
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(6pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "medium", size: 10pt)[#item.name]
-      #if item.publisher != "" {
-        text(size: 9pt, fill: muted-color)[ -- #item.publisher]
-      }
-    ],
-    text(size: 9pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(12pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "bold", size: 11pt)[#item.organization]
-      #v(2pt)
-      #text(size: 10pt, fill: primary-color)[#item.position]
-    ],
-    align(right)[
-      #text(size: 9pt, fill: muted-color)[#item.date]
-      #if item.location != "" {
-        v(2pt)
-        text(size: 9pt, fill: muted-color)[#item.location]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(12pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt)[#item.name]
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    box(
-      stroke: (left: 2pt + primary-color),
-      inset: (left: 10pt, y: 2pt),
-      render-rich-text(item.summary, size: 9pt, style: "italic", fill: muted-color)
-    )
-  }
-
-  v(12pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt)[#item.name]
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if item.date != "" or item.location != "" {
-    v(2pt)
-    if item.date != "" {
-      text(size: 9pt, fill: muted-color)[#item.date]
-    }
-    if item.date != "" and item.location != "" {
-      h(8pt)
-    }
-    if item.location != "" {
-      text(size: 9pt, fill: muted-color)[#item.location]
-    }
-  }
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  if has-keywords(item) {
-    v(4pt)
-    for keyword in item.keywords {
-      box(
-        fill: accent-bg,
-        radius: 3pt,
-        inset: (x: 6pt, y: 2pt),
-        text(size: 8pt, fill: primary-color)[#keyword]
-      )
-      h(4pt)
-    }
-  }
-
-
-  render-url(item, primary-color)
-  v(12pt)
-}
 
 #let template(data) = {
-  set page(
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#16a34a"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#166534"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = rgb("#6b7280")
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let light-bg = primary-color.lighten(92%)
+  let accent-bg = primary-color.lighten(85%)
+  let border-color = primary-color.lighten(75%)
+
+  let main-section(title) = {
+    v(14pt)
+    box(
+      width: 100%,
+      stroke: (bottom: 2pt + primary-color),
+      inset: (bottom: 4pt),
+      text(weight: "bold", size: 10pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+    )
+    v(10pt)
+  }
+
+  let sidebar-section(title) = {
+    v(12pt)
+    text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.08em)[#upper(title)]
+    v(2pt)
+    line(length: 100%, stroke: 0.5pt + border-color)
+    v(6pt)
+  }
+
+  let rating-dots(level) = {
+    rating-indicators(level, 6pt, 6pt, primary-color, border-color, 50%, 3pt)
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "bold", size: 11pt)[#item.company]
+        #v(2pt)
+        #text(size: 10pt, fill: primary-color)[#item.position]
+      ],
+      align(right)[
+        #text(size: 9pt, fill: muted-color)[#item.date]
+        #if item.location != "" {
+          v(2pt)
+          text(size: 9pt, fill: muted-color)[#item.location]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(12pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "bold", size: 11pt)[#item.institution]
+        #if item.studyType != "" or item.area != "" {
+          v(2pt)
+          let degree = format-degree(item.studyType, item.area)
+          text(size: 10pt)[#degree]
+        }
+      ],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.score != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.score]
+    }
+
+    v(12pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "bold")[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 8pt, fill: muted-color)
+    }
+
+    let level = clamp-level(item.level)
+    if level > 0 {
+      v(2pt)
+      rating-dots(level)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(8pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "bold")[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 8pt, fill: muted-color)
+    }
+
+    let level = clamp-level(item.level)
+    if level > 0 {
+      v(2pt)
+      rating-dots(level)
+    }
+
+    v(8pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "medium")[#item.network]
+
+    if item.username != "" {
+      text(size: 8pt, fill: muted-color)[ #item.username]
+    }
+
+    if has-url(item) {
+      v(1pt)
+      link(item.url.href)[#text(size: 8pt, fill: primary-color)[#item.url.href]]
+    }
+
+    v(6pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      text(weight: "bold", size: 10pt)[#item.name],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt, fill: muted-color)
+    }
+
+    if has-keywords(item) {
+      v(4pt)
+      for keyword in item.keywords {
+        box(
+          fill: accent-bg,
+          radius: 3pt,
+          inset: (x: 6pt, y: 2pt),
+          text(size: 8pt, fill: primary-color)[#keyword]
+        )
+        h(4pt)
+      }
+    }
+
+    v(12pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "medium", size: 10pt)[#item.name]
+        #if item.issuer != "" {
+          text(size: 9pt, fill: muted-color)[ -- #item.issuer]
+        }
+      ],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "medium", size: 10pt)[#item.title]
+        #if item.awarder != "" {
+          text(size: 9pt, fill: muted-color)[ -- #item.awarder]
+        }
+      ],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "medium")[#item.name]
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(6pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "medium", size: 10pt)[#item.name]
+        #if item.publisher != "" {
+          text(size: 9pt, fill: muted-color)[ -- #item.publisher]
+        }
+      ],
+      text(size: 9pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(12pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "bold", size: 11pt)[#item.organization]
+        #v(2pt)
+        #text(size: 10pt, fill: primary-color)[#item.position]
+      ],
+      align(right)[
+        #text(size: 9pt, fill: muted-color)[#item.date]
+        #if item.location != "" {
+          v(2pt)
+          text(size: 9pt, fill: muted-color)[#item.location]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(12pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt)[#item.name]
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      box(
+        stroke: (left: 2pt + primary-color),
+        inset: (left: 10pt, y: 2pt),
+        render-rich-text(item.summary, size: 9pt, style: "italic", fill: muted-color)
+      )
+    }
+
+    v(12pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt)[#item.name]
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if item.date != "" or item.location != "" {
+      v(2pt)
+      if item.date != "" {
+        text(size: 9pt, fill: muted-color)[#item.date]
+      }
+      if item.date != "" and item.location != "" {
+        h(8pt)
+      }
+      if item.location != "" {
+        text(size: 9pt, fill: muted-color)[#item.location]
+      }
+    }
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    if has-keywords(item) {
+      v(4pt)
+      for keyword in item.keywords {
+        box(
+          fill: accent-bg,
+          radius: 3pt,
+          inset: (x: 6pt, y: 2pt),
+          text(size: 8pt, fill: primary-color)[#keyword]
+        )
+        h(4pt)
+      }
+    }
+
+    render-url(item, primary-color)
+    v(12pt)
+  }
+
+  set page(fill: bg-color, 
     margin: 48pt,
   )
 

--- a/crates/render/src/typst_engine/templates/ditto.typ
+++ b/crates/render/src/typst_engine/templates/ditto.typ
@@ -3,368 +3,374 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#0891b2")
-#let text-color = rgb("#1f2937")
-#let muted-color = rgb("#6b7280")
-#let light-bg = rgb("#ecfeff")
-#let sidebar-bg = rgb("#f0fdfa")
-#let white = rgb("#ffffff")
-
-#let sidebar-heading(title) = {
-  v(10pt)
-  text(weight: "bold", size: 8pt, fill: primary-color, tracking: 0.08em)[#upper(title)]
-  v(2pt)
-  line(length: 100%, stroke: 0.5pt + primary-color)
-  v(6pt)
-}
-
-#let section-heading(title) = {
-  v(10pt)
-  box(
-    width: 100%,
-    stroke: (bottom: 1.5pt + primary-color),
-    inset: (bottom: 3pt),
-    text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
-  )
-  v(8pt)
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #if has-url(item) {
-        link(item.url.href)[#text(weight: "bold", size: 9pt, fill: primary-color)[#item.company]]
-      } else {
-        text(weight: "bold", size: 9pt)[#item.company]
-      }
-      #v(1pt)
-      #text(size: 9pt)[#item.position]
-    ],
-    align(right)[
-      #text(size: 8pt, fill: muted-color)[#item.date]
-      #if item.location != "" {
-        v(1pt)
-        text(size: 8pt, fill: muted-color)[#item.location]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 9pt)[#item.institution]
-      #if item.studyType != "" or item.area != "" {
-        v(1pt)
-        let degree = format-degree(item.studyType, item.area)
-        text(size: 9pt)[#degree]
-      }
-    ],
-    align(right)[
-      #text(size: 8pt, fill: muted-color)[#item.date]
-    ]
-  )
-
-  if item.score != "" {
-    v(2pt)
-    text(size: 8pt, fill: muted-color)[#item.score]
-  }
-
-  v(10pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  text(size: 8pt, weight: "bold")[#item.name]
-
-  if item.description != "" {
-    v(1pt)
-    render-rich-text(item.description, size: 7pt, fill: muted-color)
-  }
-
-  let level = clamp-level(item.level)
-  if level > 0 {
-    v(2pt)
-    rating-indicators(level, 6pt, 6pt, primary-color, rgb("#d1d5db"), 50%, 2pt)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 7pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(6pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  text(size: 8pt, weight: "bold")[#item.name]
-
-  if item.description != "" {
-    { set text(size: 7pt, fill: muted-color); [ -- ]; render-rich-text(item.description) }
-  }
-
-  let level = clamp-level(item.level)
-  if level > 0 {
-    v(2pt)
-    rating-indicators(level, 6pt, 6pt, primary-color, rgb("#d1d5db"), 50%, 2pt)
-  }
-
-  v(6pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  text(size: 8pt, weight: "medium")[#item.network]
-
-  if has-url(item) {
-    v(1pt)
-    link(item.url.href)[#text(size: 7pt, fill: primary-color)[#item.username]]
-  } else {
-    v(1pt)
-    text(size: 7pt, fill: muted-color)[#item.username]
-  }
-
-  v(6pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [#text(weight: "bold", size: 9pt)[#item.name]],
-    text(size: 8pt, fill: muted-color)[#item.date]
-  )
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  if has-keywords(item) {
-    v(3pt)
-    for keyword in item.keywords {
-      box(
-        fill: light-bg,
-        radius: 2pt,
-        inset: (x: 4pt, y: 1pt),
-        text(size: 7pt, fill: primary-color)[#keyword]
-      )
-      h(3pt)
-    }
-  }
-
-  v(10pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "medium", size: 9pt)[#item.name]
-      #if item.issuer != "" {
-        text(size: 8pt, fill: muted-color)[ -- #item.issuer]
-      }
-    ],
-    text(size: 8pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "medium", size: 9pt)[#item.title]
-      #if item.awarder != "" {
-        text(size: 8pt, fill: muted-color)[ -- #item.awarder]
-      }
-    ],
-    text(size: 8pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 8pt, weight: "medium")[#item.name]
-
-  if has-keywords(item) {
-    v(2pt)
-    for keyword in item.keywords {
-      box(
-        fill: light-bg,
-        radius: 2pt,
-        inset: (x: 4pt, y: 1pt),
-        text(size: 7pt, fill: primary-color)[#keyword]
-      )
-      h(3pt)
-    }
-  }
-
-  v(6pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 9pt)[#item.name]
-      #if item.publisher != "" {
-        v(1pt)
-        text(size: 8pt, fill: muted-color)[#item.publisher]
-      }
-    ],
-    text(size: 8pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 9pt)[#item.organization]
-      #if item.position != "" {
-        text(size: 9pt)[ -- #item.position]
-      }
-    ],
-    text(size: 8pt, fill: muted-color)[#item.date]
-  )
-
-  if item.location != "" {
-    v(1pt)
-    text(size: 8pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 9pt)[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 8pt, fill: muted-color)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 9pt)[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 8pt, fill: muted-color)
-      }
-    ],
-    text(size: 8pt, fill: muted-color)[#item.date]
-  )
-
-  if item.location != "" {
-    v(1pt)
-    text(size: 8pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  if has-keywords(item) {
-    v(3pt)
-    for keyword in item.keywords {
-      box(
-        fill: light-bg,
-        radius: 2pt,
-        inset: (x: 4pt, y: 1pt),
-        text(size: 7pt, fill: primary-color)[#keyword]
-      )
-      h(3pt)
-    }
-  }
-
-
-  render-url(item, primary-color)
-  v(8pt)
-}
 
 #let template(data) = {
-  set page(
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#0891b2"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = rgb("#6b7280")
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let light-bg = primary-color.lighten(92%)
+  let sidebar-bg = primary-color.lighten(95%)
+  let white = rgb("#ffffff")
+
+  let sidebar-heading(title) = {
+    v(10pt)
+    text(weight: "bold", size: 8pt, fill: primary-color, tracking: 0.08em)[#upper(title)]
+    v(2pt)
+    line(length: 100%, stroke: 0.5pt + primary-color)
+    v(6pt)
+  }
+
+  let section-heading(title) = {
+    v(10pt)
+    box(
+      width: 100%,
+      stroke: (bottom: 1.5pt + primary-color),
+      inset: (bottom: 3pt),
+      text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+    )
+    v(8pt)
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #if has-url(item) {
+          link(item.url.href)[#text(weight: "bold", size: 9pt, fill: primary-color)[#item.company]]
+        } else {
+          text(weight: "bold", size: 9pt)[#item.company]
+        }
+        #v(1pt)
+        #text(size: 9pt)[#item.position]
+      ],
+      align(right)[
+        #text(size: 8pt, fill: muted-color)[#item.date]
+        #if item.location != "" {
+          v(1pt)
+          text(size: 8pt, fill: muted-color)[#item.location]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 9pt)[#item.institution]
+        #if item.studyType != "" or item.area != "" {
+          v(1pt)
+          let degree = format-degree(item.studyType, item.area)
+          text(size: 9pt)[#degree]
+        }
+      ],
+      align(right)[
+        #text(size: 8pt, fill: muted-color)[#item.date]
+      ]
+    )
+
+    if item.score != "" {
+      v(2pt)
+      text(size: 8pt, fill: muted-color)[#item.score]
+    }
+
+    v(10pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    text(size: 8pt, weight: "bold")[#item.name]
+
+    if item.description != "" {
+      v(1pt)
+      render-rich-text(item.description, size: 7pt, fill: muted-color)
+    }
+
+    let level = clamp-level(item.level)
+    if level > 0 {
+      v(2pt)
+      rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 7pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(6pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    text(size: 8pt, weight: "bold")[#item.name]
+
+    if item.description != "" {
+      { set text(size: 7pt, fill: muted-color); [ -- ]; render-rich-text(item.description) }
+    }
+
+    let level = clamp-level(item.level)
+    if level > 0 {
+      v(2pt)
+      rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+    }
+
+    v(6pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    text(size: 8pt, weight: "medium")[#item.network]
+
+    if has-url(item) {
+      v(1pt)
+      link(item.url.href)[#text(size: 7pt, fill: primary-color)[#item.username]]
+    } else {
+      v(1pt)
+      text(size: 7pt, fill: muted-color)[#item.username]
+    }
+
+    v(6pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [#text(weight: "bold", size: 9pt)[#item.name]],
+      text(size: 8pt, fill: muted-color)[#item.date]
+    )
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    if has-keywords(item) {
+      v(3pt)
+      for keyword in item.keywords {
+        box(
+          fill: light-bg,
+          radius: 2pt,
+          inset: (x: 4pt, y: 1pt),
+          text(size: 7pt, fill: primary-color)[#keyword]
+        )
+        h(3pt)
+      }
+    }
+
+    v(10pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "medium", size: 9pt)[#item.name]
+        #if item.issuer != "" {
+          text(size: 8pt, fill: muted-color)[ -- #item.issuer]
+        }
+      ],
+      text(size: 8pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "medium", size: 9pt)[#item.title]
+        #if item.awarder != "" {
+          text(size: 8pt, fill: muted-color)[ -- #item.awarder]
+        }
+      ],
+      text(size: 8pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 8pt, weight: "medium")[#item.name]
+
+    if has-keywords(item) {
+      v(2pt)
+      for keyword in item.keywords {
+        box(
+          fill: light-bg,
+          radius: 2pt,
+          inset: (x: 4pt, y: 1pt),
+          text(size: 7pt, fill: primary-color)[#keyword]
+        )
+        h(3pt)
+      }
+    }
+
+    v(6pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 9pt)[#item.name]
+        #if item.publisher != "" {
+          v(1pt)
+          text(size: 8pt, fill: muted-color)[#item.publisher]
+        }
+      ],
+      text(size: 8pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 9pt)[#item.organization]
+        #if item.position != "" {
+          text(size: 9pt)[ -- #item.position]
+        }
+      ],
+      text(size: 8pt, fill: muted-color)[#item.date]
+    )
+
+    if item.location != "" {
+      v(1pt)
+      text(size: 8pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 9pt)[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 8pt, fill: muted-color)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 9pt)[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 8pt, fill: muted-color)
+        }
+      ],
+      text(size: 8pt, fill: muted-color)[#item.date]
+    )
+
+    if item.location != "" {
+      v(1pt)
+      text(size: 8pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    if has-keywords(item) {
+      v(3pt)
+      for keyword in item.keywords {
+        box(
+          fill: light-bg,
+          radius: 2pt,
+          inset: (x: 4pt, y: 1pt),
+          text(size: 7pt, fill: primary-color)[#keyword]
+        )
+        h(3pt)
+      }
+    }
+
+    render-url(item, primary-color)
+    v(8pt)
+  }
+
+  set page(fill: bg-color, 
     margin: 0pt,
   )
 
@@ -389,7 +395,7 @@
 
       #if data.basics.headline != "" {
         v(4pt)
-        text(size: 11pt, fill: rgb("#cffafe"))[#data.basics.headline]
+        text(size: 11pt, fill: primary-color.lighten(80%))[#data.basics.headline]
       }
 
       #v(8pt)
@@ -397,7 +403,7 @@
       #let contact-items = build-contact-items(data.basics)
       #if has-url(data.basics) { contact-items = contact-items + (link(data.basics.url.href)[#text(fill: white)[#data.basics.url.href]],) }
 
-      #text(size: 8pt, fill: rgb("#e0f2fe"))[#contact-items.join("  |  ")]
+      #text(size: 8pt, fill: primary-color.lighten(85%))[#contact-items.join("  |  ")]
     ]
   )
 

--- a/crates/render/src/typst_engine/templates/gengar.typ
+++ b/crates/render/src/typst_engine/templates/gengar.typ
@@ -4,356 +4,362 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#67b8c8")
-#let text-color = rgb("#1f2937")
-#let muted-color = rgb("#6b7280")
-#let sidebar-bg = rgb("#e8f4f7")
-#let white = rgb("#ffffff")
-
-#let sidebar-section-heading(title) = {
-  v(12pt)
-  text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.05em)[#upper(title)]
-  v(2pt)
-  line(length: 100%, stroke: 1pt + primary-color)
-  v(8pt)
-}
-
-#let main-section-heading(title) = {
-  v(14pt)
-  text(weight: "bold", size: 11pt, fill: text-color, tracking: 0.04em)[#upper(title)]
-  v(3pt)
-  line(length: 100%, stroke: 1.5pt + primary-color)
-  v(10pt)
-}
-
-#let entry-header(left-content, right-content) = {
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    left-content,
-    align(right)[
-      #text(size: 9pt, fill: muted-color)[#right-content]
-    ]
-  )
-}
-
-#let rating-boxes(level) = {
-  rating-indicators(level, 8pt, 8pt, primary-color, rgb("#d1d5db"), 1pt, 2pt)
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #if has-url(item) {
-        link(item.url.href)[#text(weight: "bold", size: 10pt)[#item.company]]
-      } else {
-        text(weight: "bold", size: 10pt)[#item.company]
-      }
-      #v(2pt)
-      #text(size: 10pt, fill: text-color)[#item.position]
-    ],
-    [
-      #item.date
-      #if item.location != "" {
-        v(2pt)
-        text(size: 9pt, fill: muted-color)[#item.location]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(12pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 10pt)[#item.institution]
-      #if item.area != "" or item.studyType != "" {
-        v(2pt)
-        let degree = format-degree(item.studyType, item.area)
-        text(size: 9.5pt)[#degree]
-      }
-    ],
-    [
-      #item.date
-      #if item.score != "" {
-        v(2pt)
-        text(size: 9pt, fill: muted-color)[#item.score]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(10pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 4pt,
-    [
-      #text(size: 9pt, weight: "bold")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 8pt, fill: muted-color)
-      }
-    ],
-    rating-boxes(item.level)
-  )
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(8pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 4pt,
-    [
-      #text(size: 9pt, weight: "bold")[#item.name]
-      #if item.description != "" {
-        h(4pt)
-        render-rich-text(item.description, size: 8pt, fill: muted-color)
-      }
-    ],
-    rating-boxes(item.level)
-  )
-
-  v(6pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "medium", fill: text-color)[#item.network]
-  v(1pt)
-  if has-url(item) {
-    link(item.url.href)[#text(size: 8pt, fill: primary-color)[#item.username]]
-  } else {
-    text(size: 8pt, fill: muted-color)[#item.username]
-  }
-  v(6pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #if has-url(item) {
-        link(item.url.href)[#text(weight: "bold", size: 10pt)[#item.name]]
-      } else {
-        text(weight: "bold", size: 10pt)[#item.name]
-      }
-      #if item.description != "" {
-        v(2pt)
-        render-rich-text(item.description, size: 9.5pt)
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  if has-keywords(item) {
-    v(4pt)
-    for keyword in item.keywords {
-      box(
-        fill: sidebar-bg,
-        radius: 3pt,
-        inset: (x: 5pt, y: 2pt),
-        text(size: 8pt, fill: primary-color)[#keyword]
-      )
-      h(4pt)
-    }
-  }
-
-  v(12pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 10pt)[#item.name]
-      #if item.issuer != "" {
-        text(size: 9pt, fill: muted-color)[ -- #item.issuer]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(8pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 10pt)[#item.title]
-      #if item.awarder != "" {
-        text(size: 9pt, fill: muted-color)[ -- #item.awarder]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(8pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "bold")[#item.name]
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(6pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 10pt)[#item.name]
-      #if item.publisher != "" {
-        v(2pt)
-        text(size: 9pt, fill: muted-color)[#item.publisher]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(8pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 10pt)[#item.organization]
-      #if item.position != "" {
-        v(2pt)
-        text(size: 9.5pt)[#item.position]
-      }
-    ],
-    [
-      #item.date
-      #if item.location != "" {
-        v(2pt)
-        text(size: 9pt, fill: muted-color)[#item.location]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(10pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt)[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt, fill: muted-color)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(8pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 10pt)[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt, fill: muted-color)
-      }
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-
-  render-url(item, primary-color)
-  v(8pt)
-}
 
 #let template(data) = {
-  set page(
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#67b8c8"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = rgb("#6b7280")
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let sidebar-bg = primary-color.lighten(90%)
+  let sidebar-text = primary-color.darken(50%)
+
+  let sidebar-section-heading(title) = {
+    v(12pt)
+    text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.05em)[#upper(title)]
+    v(2pt)
+    line(length: 100%, stroke: 1pt + primary-color)
+    v(8pt)
+  }
+
+  let main-section-heading(title) = {
+    v(14pt)
+    text(weight: "bold", size: 11pt, fill: text-color, tracking: 0.04em)[#upper(title)]
+    v(3pt)
+    line(length: 100%, stroke: 1.5pt + primary-color)
+    v(10pt)
+  }
+
+  let entry-header(left-content, right-content) = {
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      left-content,
+      align(right)[
+        #text(size: 9pt, fill: muted-color)[#right-content]
+      ]
+    )
+  }
+
+  let rating-boxes(level) = {
+    rating-indicators(level, 8pt, 8pt, primary-color, rgb("#d1d5db"), 1pt, 2pt)
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #if has-url(item) {
+          link(item.url.href)[#text(weight: "bold", size: 10pt)[#item.company]]
+        } else {
+          text(weight: "bold", size: 10pt)[#item.company]
+        }
+        #v(2pt)
+        #text(size: 10pt, fill: text-color)[#item.position]
+      ],
+      [
+        #item.date
+        #if item.location != "" {
+          v(2pt)
+          text(size: 9pt, fill: muted-color)[#item.location]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(12pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 10pt)[#item.institution]
+        #if item.area != "" or item.studyType != "" {
+          v(2pt)
+          let degree = format-degree(item.studyType, item.area)
+          text(size: 9.5pt)[#degree]
+        }
+      ],
+      [
+        #item.date
+        #if item.score != "" {
+          v(2pt)
+          text(size: 9pt, fill: muted-color)[#item.score]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 4pt,
+      [
+        #text(size: 9pt, weight: "bold")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 8pt, fill: muted-color)
+        }
+      ],
+      rating-boxes(item.level)
+    )
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(8pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 4pt,
+      [
+        #text(size: 9pt, weight: "bold")[#item.name]
+        #if item.description != "" {
+          h(4pt)
+          render-rich-text(item.description, size: 8pt, fill: muted-color)
+        }
+      ],
+      rating-boxes(item.level)
+    )
+
+    v(6pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "medium", fill: sidebar-text)[#item.network]
+    v(1pt)
+    if has-url(item) {
+      link(item.url.href)[#text(size: 8pt, fill: primary-color)[#item.username]]
+    } else {
+      text(size: 8pt, fill: muted-color)[#item.username]
+    }
+    v(6pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #if has-url(item) {
+          link(item.url.href)[#text(weight: "bold", size: 10pt)[#item.name]]
+        } else {
+          text(weight: "bold", size: 10pt)[#item.name]
+        }
+        #if item.description != "" {
+          v(2pt)
+          render-rich-text(item.description, size: 9.5pt)
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    if has-keywords(item) {
+      v(4pt)
+      for keyword in item.keywords {
+        box(
+          fill: sidebar-bg,
+          radius: 3pt,
+          inset: (x: 5pt, y: 2pt),
+          text(size: 8pt, fill: primary-color)[#keyword]
+        )
+        h(4pt)
+      }
+    }
+
+    v(12pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 10pt)[#item.name]
+        #if item.issuer != "" {
+          text(size: 9pt, fill: muted-color)[ -- #item.issuer]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 10pt)[#item.title]
+        #if item.awarder != "" {
+          text(size: 9pt, fill: muted-color)[ -- #item.awarder]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "bold")[#item.name]
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(6pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 10pt)[#item.name]
+        #if item.publisher != "" {
+          v(2pt)
+          text(size: 9pt, fill: muted-color)[#item.publisher]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 10pt)[#item.organization]
+        #if item.position != "" {
+          v(2pt)
+          text(size: 9.5pt)[#item.position]
+        }
+      ],
+      [
+        #item.date
+        #if item.location != "" {
+          v(2pt)
+          text(size: 9pt, fill: muted-color)[#item.location]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt)[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt, fill: muted-color)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 10pt)[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt, fill: muted-color)
+        }
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    render-url(item, primary-color)
+    v(8pt)
+  }
+
+  set page(fill: bg-color, 
     margin: 0pt,
   )
 
@@ -379,9 +385,11 @@
       height: 100%,
       fill: sidebar-bg,
       inset: (x: 16pt, y: 28pt),
+      {
+      set text(fill: sidebar-text)
       [
         // Header: Name, headline, contact info
-        #text(size: 18pt, weight: "bold", fill: text-color)[#data.basics.name]
+        #text(size: 18pt, weight: "bold", fill: sidebar-text)[#data.basics.name]
 
         #if data.basics.headline != "" {
           v(6pt)
@@ -392,15 +400,15 @@
 
         // Contact info
         #if data.basics.email != "" {
-          text(size: 8pt, fill: text-color)[#data.basics.email]
+          text(size: 8pt, fill: sidebar-text)[#data.basics.email]
           v(4pt)
         }
         #if data.basics.phone != "" {
-          text(size: 8pt, fill: text-color)[#data.basics.phone]
+          text(size: 8pt, fill: sidebar-text)[#data.basics.phone]
           v(4pt)
         }
         #if data.basics.location != "" {
-          text(size: 8pt, fill: text-color)[#data.basics.location]
+          text(size: 8pt, fill: sidebar-text)[#data.basics.location]
           v(4pt)
         }
         #if has-url(data.basics) {
@@ -440,6 +448,7 @@
           }
         }
       ]
+      }
     ),
 
     // ── RIGHT MAIN ──

--- a/crates/render/src/typst_engine/templates/gengar.typ
+++ b/crates/render/src/typst_engine/templates/gengar.typ
@@ -46,7 +46,7 @@
   }
 
   let rating-boxes(level) = {
-    rating-indicators(level, 8pt, 8pt, primary-color, rgb("#d1d5db"), 1pt, 2pt)
+    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 1pt, 2pt)
   }
 
   let render-experience(item) = {

--- a/crates/render/src/typst_engine/templates/kakuna.typ
+++ b/crates/render/src/typst_engine/templates/kakuna.typ
@@ -147,7 +147,7 @@
     let display = if network != "" and username != "" { [#network: #username] } else if network != "" { network } else { username }
 
     if has-url(item) {
-      let label = if username != "" { display } else { item.url.href }
+      let label = if network != "" or username != "" { display } else { item.url.href }
       link(item.url.href)[#text(fill: primary-color)[#label]]
     } else if network != "" or username != "" {
       text(size: 10pt)[#display]

--- a/crates/render/src/typst_engine/templates/kakuna.typ
+++ b/crates/render/src/typst_engine/templates/kakuna.typ
@@ -11,12 +11,12 @@
   let text-color = rgb(data.metadata.theme.at("text", default: "#422006"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#a8a29e")
+  let muted-color = text-color.lighten(40%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
-  let light-bg = rgb("#faf5f0")
-  let border-color = rgb("#d6d3d1")
+  let light-bg = primary-color.lighten(92%)
+  let border-color = bg-color.darken(15%)
 
   let section-heading(title) = {
     v(16pt)
@@ -31,7 +31,7 @@
 
   let skill-bar(level) = {
     h(4pt)
-    rating-indicators(level, 8pt, 8pt, primary-color, border-color, 50%, 2pt)
+    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 50%, 2pt)
   }
 
   let entry-header(left-content, right-content) = {

--- a/crates/render/src/typst_engine/templates/kakuna.typ
+++ b/crates/render/src/typst_engine/templates/kakuna.typ
@@ -144,11 +144,13 @@
     let network = if "network" in item and item.network != none { item.network } else { "" }
     let username = if "username" in item and item.username != none { item.username } else { "" }
 
+    let display = if network != "" and username != "" { [#network: #username] } else if network != "" { network } else { username }
+
     if has-url(item) {
-      let label = if username != "" { [#network: #username] } else { item.url.href }
+      let label = if username != "" { display } else { item.url.href }
       link(item.url.href)[#text(fill: primary-color)[#label]]
     } else if network != "" or username != "" {
-      text(size: 10pt)[#network: #username]
+      text(size: 10pt)[#display]
     }
     h(14pt)
   }

--- a/crates/render/src/typst_engine/templates/kakuna.typ
+++ b/crates/render/src/typst_engine/templates/kakuna.typ
@@ -4,337 +4,343 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#78716c")
-#let text-color = rgb("#422006")
-#let muted-color = rgb("#a8a29e")
-#let light-bg = rgb("#faf5f0")
-#let border-color = rgb("#d6d3d1")
-
-#let section-heading(title) = {
-  v(16pt)
-  grid(
-    columns: (auto, 1fr),
-    column-gutter: 10pt,
-    text(weight: "semibold", size: 10pt, fill: primary-color, tracking: 0.06em)[#upper(title)],
-    line(start: (0pt, 5pt), length: 100%, stroke: 0.75pt + primary-color)
-  )
-  v(10pt)
-}
-
-#let skill-bar(level) = {
-  h(4pt)
-  rating-indicators(level, 8pt, 8pt, primary-color, border-color, 50%, 2pt)
-}
-
-#let entry-header(left-content, right-content) = {
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    left-content,
-    align(right, text(size: 9pt, fill: muted-color)[#right-content])
-  )
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "semibold", size: 10pt)[#item.position]
-      #if item.company != "" {
-        text(size: 10pt, fill: muted-color)[ — #item.company]
-      }
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(14pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "semibold", size: 10pt)[#item.institution]
-      #if item.studyType != "" or item.area != "" {
-        v(2pt)
-        let degree = format-degree(item.studyType, item.area)
-        text(size: 10pt)[#degree]
-      }
-    ],
-    item.date
-  )
-
-  if item.score != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.score]
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(14pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    [
-      #text(size: 10pt, weight: "medium")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt, fill: muted-color)
-      }
-    ],
-    skill-bar(item.level)
-  )
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(8pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    [
-      #text(size: 10pt, weight: "medium")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt, fill: muted-color)
-      }
-    ],
-    skill-bar(item.level)
-  )
-
-  v(6pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  let network = if "network" in item and item.network != none { item.network } else { "" }
-  let username = if "username" in item and item.username != none { item.username } else { "" }
-
-  if has-url(item) {
-    let label = if username != "" { [#network: #username] } else { item.url.href }
-    link(item.url.href)[#text(fill: primary-color)[#label]]
-  } else if network != "" or username != "" {
-    text(size: 10pt)[#network: #username]
-  }
-  h(14pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [#text(weight: "semibold", size: 10pt)[#item.name]],
-    item.date
-  )
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  if has-keywords(item) {
-    v(4pt)
-    for keyword in item.keywords {
-      box(
-        fill: light-bg,
-        radius: 3pt,
-        inset: (x: 6pt, y: 2pt),
-        text(size: 8pt, fill: primary-color)[#keyword]
-      )
-      h(4pt)
-    }
-  }
-
-  v(12pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "medium", size: 10pt)[#item.name]
-      #if item.issuer != "" {
-        text(size: 9pt, fill: muted-color)[ — #item.issuer]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "medium", size: 10pt)[#item.title]
-      #if item.awarder != "" {
-        text(size: 9pt, fill: muted-color)[ — #item.awarder]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 10pt, weight: "medium")[#item.name]
-
-  if has-keywords(item) {
-    text(size: 9pt, fill: muted-color)[ — #item.keywords.join(", ")]
-  }
-
-  v(6pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "semibold", size: 10pt)[#item.name]
-      #if item.publisher != "" {
-        v(1pt)
-        text(size: 9pt, fill: muted-color)[#item.publisher]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "semibold", size: 10pt)[#item.organization]
-      #if item.position != "" {
-        text(size: 10pt, fill: muted-color)[ — #item.position]
-      }
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(14pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "semibold", size: 10pt)[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt, fill: muted-color)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "semibold", size: 10pt)[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt)
-      }
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-
-  render-url(item, primary-color)
-  v(8pt)
-}
 
 #let template(data) = {
-  set page(
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#78716c"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#422006"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = rgb("#a8a29e")
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let light-bg = rgb("#faf5f0")
+  let border-color = rgb("#d6d3d1")
+
+  let section-heading(title) = {
+    v(16pt)
+    grid(
+      columns: (auto, 1fr),
+      column-gutter: 10pt,
+      text(weight: "semibold", size: 10pt, fill: primary-color, tracking: 0.06em)[#upper(title)],
+      line(start: (0pt, 5pt), length: 100%, stroke: 0.75pt + primary-color)
+    )
+    v(10pt)
+  }
+
+  let skill-bar(level) = {
+    h(4pt)
+    rating-indicators(level, 8pt, 8pt, primary-color, border-color, 50%, 2pt)
+  }
+
+  let entry-header(left-content, right-content) = {
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      left-content,
+      align(right, text(size: 9pt, fill: muted-color)[#right-content])
+    )
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "semibold", size: 10pt)[#item.position]
+        #if item.company != "" {
+          text(size: 10pt, fill: muted-color)[ — #item.company]
+        }
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(14pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "semibold", size: 10pt)[#item.institution]
+        #if item.studyType != "" or item.area != "" {
+          v(2pt)
+          let degree = format-degree(item.studyType, item.area)
+          text(size: 10pt)[#degree]
+        }
+      ],
+      item.date
+    )
+
+    if item.score != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.score]
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(14pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      [
+        #text(size: 10pt, weight: "medium")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt, fill: muted-color)
+        }
+      ],
+      skill-bar(item.level)
+    )
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(8pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      [
+        #text(size: 10pt, weight: "medium")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt, fill: muted-color)
+        }
+      ],
+      skill-bar(item.level)
+    )
+
+    v(6pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    let network = if "network" in item and item.network != none { item.network } else { "" }
+    let username = if "username" in item and item.username != none { item.username } else { "" }
+
+    if has-url(item) {
+      let label = if username != "" { [#network: #username] } else { item.url.href }
+      link(item.url.href)[#text(fill: primary-color)[#label]]
+    } else if network != "" or username != "" {
+      text(size: 10pt)[#network: #username]
+    }
+    h(14pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [#text(weight: "semibold", size: 10pt)[#item.name]],
+      item.date
+    )
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    if has-keywords(item) {
+      v(4pt)
+      for keyword in item.keywords {
+        box(
+          fill: light-bg,
+          radius: 3pt,
+          inset: (x: 6pt, y: 2pt),
+          text(size: 8pt, fill: primary-color)[#keyword]
+        )
+        h(4pt)
+      }
+    }
+
+    v(12pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "medium", size: 10pt)[#item.name]
+        #if item.issuer != "" {
+          text(size: 9pt, fill: muted-color)[ — #item.issuer]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "medium", size: 10pt)[#item.title]
+        #if item.awarder != "" {
+          text(size: 9pt, fill: muted-color)[ — #item.awarder]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 10pt, weight: "medium")[#item.name]
+
+    if has-keywords(item) {
+      text(size: 9pt, fill: muted-color)[ — #item.keywords.join(", ")]
+    }
+
+    v(6pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "semibold", size: 10pt)[#item.name]
+        #if item.publisher != "" {
+          v(1pt)
+          text(size: 9pt, fill: muted-color)[#item.publisher]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "semibold", size: 10pt)[#item.organization]
+        #if item.position != "" {
+          text(size: 10pt, fill: muted-color)[ — #item.position]
+        }
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(14pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "semibold", size: 10pt)[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt, fill: muted-color)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "semibold", size: 10pt)[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt)
+        }
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    render-url(item, primary-color)
+    v(8pt)
+  }
+
+  set page(fill: bg-color, 
     margin: 48pt,
   )
 

--- a/crates/render/src/typst_engine/templates/leafish.typ
+++ b/crates/render/src/typst_engine/templates/leafish.typ
@@ -3,378 +3,386 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#9f1239")
-#let text-color = rgb("#1f2937")
-#let muted-color = rgb("#6b7280")
-#let header-bg = rgb("#fde8ef")
-#let contact-bar-bg = rgb("#9f1239")
-#let tag-bg = rgb("#fde8ef")
-
-#let section-heading(title) = {
-  v(10pt)
-  box(
-    width: 100%,
-    stroke: (bottom: 1.5pt + primary-color),
-    inset: (bottom: 4pt),
-    text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
-  )
-  v(8pt)
-}
-
-#let rating-dots(level) = {
-  rating-indicators(level, 6pt, 6pt, primary-color, rgb("#e5e7eb"), 50%, 2pt)
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #if has-url(item) {
-        link(item.url.href)[#text(weight: "bold", size: 10pt, fill: primary-color)[#item.company]]
-      } else {
-        text(weight: "bold", size: 10pt)[#item.company]
-      }
-      #if item.position != "" {
-        v(2pt)
-        text(size: 9.5pt)[#item.position]
-      }
-    ],
-    align(right)[
-      #text(size: 8.5pt, fill: muted-color)[#item.date]
-      #if item.location != "" {
-        v(1pt)
-        text(size: 8.5pt, fill: muted-color)[#item.location]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(10pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 10pt)[#item.institution]
-      #if item.area != "" or item.studyType != "" {
-        v(2pt)
-        let degree = format-degree(item.studyType, item.area)
-        text(size: 9.5pt)[#degree]
-      }
-    ],
-    align(right)[
-      #text(size: 8.5pt, fill: muted-color)[#item.date]
-    ]
-  )
-
-  if item.score != "" {
-    v(2pt)
-    text(size: 8.5pt, fill: muted-color)[#item.score]
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(10pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 4pt,
-    [
-      #text(size: 9.5pt, weight: "bold")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 8.5pt, fill: muted-color)
-      }
-    ],
-    rating-dots(item.level)
-  )
-
-  if has-keywords(item) {
-    v(3pt)
-    for keyword in item.keywords {
-      box(
-        fill: tag-bg,
-        radius: 3pt,
-        inset: (x: 5pt, y: 2pt),
-        text(size: 7.5pt, fill: primary-color)[#keyword]
-      )
-      h(3pt)
-    }
-  }
-
-  v(8pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 4pt,
-    [
-      #text(size: 9.5pt, weight: "bold")[#item.name]
-      #if item.description != "" {
-        h(4pt)
-        render-rich-text(item.description, size: 8.5pt, fill: muted-color)
-      }
-    ],
-    rating-dots(item.level)
-  )
-
-  v(6pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt, weight: "medium", fill: muted-color)[#item.network]
-  h(4pt)
-  if has-url(item) {
-    link(item.url.href)[#text(size: 9pt, fill: primary-color)[#item.username]]
-  } else {
-    text(size: 9pt)[#item.username]
-  }
-
-  v(5pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 9.5pt)[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt)
-  }
-
-  if item.date != "" {
-    v(2pt)
-    text(size: 8.5pt, fill: muted-color)[#item.date]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  if has-keywords(item) {
-    v(3pt)
-    for keyword in item.keywords {
-      box(
-        fill: tag-bg,
-        radius: 3pt,
-        inset: (x: 5pt, y: 2pt),
-        text(size: 7.5pt, fill: primary-color)[#keyword]
-      )
-      h(3pt)
-    }
-  }
-
-  v(10pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 9.5pt)[#item.name]
-
-  if item.issuer != "" {
-    v(2pt)
-    text(size: 8.5pt, fill: muted-color)[#item.issuer]
-  }
-
-  if item.date != "" {
-    h(6pt)
-    text(size: 8.5pt, fill: muted-color)[#item.date]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 9.5pt)[#item.title]
-      #if item.awarder != "" {
-        v(1pt)
-        text(size: 8.5pt, fill: muted-color)[#item.awarder]
-      }
-    ],
-    text(size: 8.5pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 9.5pt, weight: "medium")[#item.name]
-
-  if has-keywords(item) {
-    v(2pt)
-    for keyword in item.keywords {
-      box(
-        fill: tag-bg,
-        radius: 3pt,
-        inset: (x: 5pt, y: 2pt),
-        text(size: 7.5pt, fill: primary-color)[#keyword]
-      )
-      h(3pt)
-    }
-  }
-
-  v(6pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 9.5pt)[#item.name]
-      #if item.publisher != "" {
-        v(1pt)
-        text(size: 8.5pt, fill: muted-color)[#item.publisher]
-      }
-    ],
-    text(size: 8.5pt, fill: muted-color)[#item.date]
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(weight: "bold", size: 10pt)[#item.organization]
-      #if item.position != "" {
-        v(2pt)
-        text(size: 9.5pt)[#item.position]
-      }
-    ],
-    align(right)[
-      #text(size: 8.5pt, fill: muted-color)[#item.date]
-      #if item.location != "" {
-        v(1pt)
-        text(size: 8.5pt, fill: muted-color)[#item.location]
-      }
-    ]
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9.5pt)
-  }
-
-  v(10pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 9.5pt)[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 8.5pt, fill: muted-color)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 9.5pt)[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt)
-  }
-
-  if item.date != "" or item.location != "" {
-    v(2pt)
-    let meta = ()
-    if item.date != "" { meta = meta + (item.date,) }
-    if item.location != "" { meta = meta + (item.location,) }
-    text(size: 8.5pt, fill: muted-color)[#meta.join(" · ")]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  if has-keywords(item) {
-    v(3pt)
-    for keyword in item.keywords {
-      box(
-        fill: tag-bg,
-        radius: 3pt,
-        inset: (x: 5pt, y: 2pt),
-        text(size: 7.5pt, fill: primary-color)[#keyword]
-      )
-      h(3pt)
-    }
-  }
-
-
-  render-url(item, primary-color)
-  v(8pt)
-}
 
 #let template(data) = {
-  set page(
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#9f1239"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = text-color.lighten(40%)
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let header-bg = primary-color.lighten(90%)
+  let header-text-color = primary-color.darken(40%)
+  let contact-bar-bg = primary-color
+  let separator-color = primary-color.lighten(60%)
+  let tag-bg = primary-color.lighten(90%)
+
+  let section-heading(title) = {
+    v(10pt)
+    box(
+      width: 100%,
+      stroke: (bottom: 1.5pt + primary-color),
+      inset: (bottom: 4pt),
+      text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+    )
+    v(8pt)
+  }
+
+  let rating-dots(level) = {
+    rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #if has-url(item) {
+          link(item.url.href)[#text(weight: "bold", size: 10pt, fill: primary-color)[#item.company]]
+        } else {
+          text(weight: "bold", size: 10pt)[#item.company]
+        }
+        #if item.position != "" {
+          v(2pt)
+          text(size: 9.5pt)[#item.position]
+        }
+      ],
+      align(right)[
+        #text(size: 8.5pt, fill: muted-color)[#item.date]
+        #if item.location != "" {
+          v(1pt)
+          text(size: 8.5pt, fill: muted-color)[#item.location]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 10pt)[#item.institution]
+        #if item.area != "" or item.studyType != "" {
+          v(2pt)
+          let degree = format-degree(item.studyType, item.area)
+          text(size: 9.5pt)[#degree]
+        }
+      ],
+      align(right)[
+        #text(size: 8.5pt, fill: muted-color)[#item.date]
+      ]
+    )
+
+    if item.score != "" {
+      v(2pt)
+      text(size: 8.5pt, fill: muted-color)[#item.score]
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 4pt,
+      [
+        #text(size: 9.5pt, weight: "bold")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 8.5pt, fill: muted-color)
+        }
+      ],
+      rating-dots(item.level)
+    )
+
+    if has-keywords(item) {
+      v(3pt)
+      for keyword in item.keywords {
+        box(
+          fill: tag-bg,
+          radius: 3pt,
+          inset: (x: 5pt, y: 2pt),
+          text(size: 7.5pt, fill: primary-color)[#keyword]
+        )
+        h(3pt)
+      }
+    }
+
+    v(8pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 4pt,
+      [
+        #text(size: 9.5pt, weight: "bold")[#item.name]
+        #if item.description != "" {
+          h(4pt)
+          render-rich-text(item.description, size: 8.5pt, fill: muted-color)
+        }
+      ],
+      rating-dots(item.level)
+    )
+
+    v(6pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt, weight: "medium", fill: muted-color)[#item.network]
+    h(4pt)
+    if has-url(item) {
+      link(item.url.href)[#text(size: 9pt, fill: primary-color)[#item.username]]
+    } else {
+      text(size: 9pt)[#item.username]
+    }
+
+    v(5pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 9.5pt)[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt)
+    }
+
+    if item.date != "" {
+      v(2pt)
+      text(size: 8.5pt, fill: muted-color)[#item.date]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    if has-keywords(item) {
+      v(3pt)
+      for keyword in item.keywords {
+        box(
+          fill: tag-bg,
+          radius: 3pt,
+          inset: (x: 5pt, y: 2pt),
+          text(size: 7.5pt, fill: primary-color)[#keyword]
+        )
+        h(3pt)
+      }
+    }
+
+    v(10pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 9.5pt)[#item.name]
+
+    if item.issuer != "" {
+      v(2pt)
+      text(size: 8.5pt, fill: muted-color)[#item.issuer]
+    }
+
+    if item.date != "" {
+      h(6pt)
+      text(size: 8.5pt, fill: muted-color)[#item.date]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 9.5pt)[#item.title]
+        #if item.awarder != "" {
+          v(1pt)
+          text(size: 8.5pt, fill: muted-color)[#item.awarder]
+        }
+      ],
+      text(size: 8.5pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 9.5pt, weight: "medium")[#item.name]
+
+    if has-keywords(item) {
+      v(2pt)
+      for keyword in item.keywords {
+        box(
+          fill: tag-bg,
+          radius: 3pt,
+          inset: (x: 5pt, y: 2pt),
+          text(size: 7.5pt, fill: primary-color)[#keyword]
+        )
+        h(3pt)
+      }
+    }
+
+    v(6pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 9.5pt)[#item.name]
+        #if item.publisher != "" {
+          v(1pt)
+          text(size: 8.5pt, fill: muted-color)[#item.publisher]
+        }
+      ],
+      text(size: 8.5pt, fill: muted-color)[#item.date]
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(weight: "bold", size: 10pt)[#item.organization]
+        #if item.position != "" {
+          v(2pt)
+          text(size: 9.5pt)[#item.position]
+        }
+      ],
+      align(right)[
+        #text(size: 8.5pt, fill: muted-color)[#item.date]
+        #if item.location != "" {
+          v(1pt)
+          text(size: 8.5pt, fill: muted-color)[#item.location]
+        }
+      ]
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9.5pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 9.5pt)[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 8.5pt, fill: muted-color)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 9.5pt)[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt)
+    }
+
+    if item.date != "" or item.location != "" {
+      v(2pt)
+      let meta = ()
+      if item.date != "" { meta = meta + (item.date,) }
+      if item.location != "" { meta = meta + (item.location,) }
+      text(size: 8.5pt, fill: muted-color)[#meta.join(" · ")]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    if has-keywords(item) {
+      v(3pt)
+      for keyword in item.keywords {
+        box(
+          fill: tag-bg,
+          radius: 3pt,
+          inset: (x: 5pt, y: 2pt),
+          text(size: 7.5pt, fill: primary-color)[#keyword]
+        )
+        h(3pt)
+      }
+    }
+
+    render-url(item, primary-color)
+    v(8pt)
+  }
+
+  set page(fill: bg-color, 
     margin: (x: 48pt, y: 40pt),
   )
 
@@ -404,7 +412,7 @@
         #text(size: 24pt, weight: "bold", fill: primary-color)[#data.basics.name]
         #if data.basics.headline != "" {
           v(4pt)
-          text(size: 11pt, fill: text-color)[#data.basics.headline]
+          text(size: 11pt, fill: header-text-color)[#data.basics.headline]
         }
       ],
       align(right + horizon)[
@@ -424,7 +432,7 @@
     {
       let contact-items = build-contact-items(data.basics)
 
-      text(size: 9pt, fill: white)[#contact-items.join([#h(8pt)#text(fill: rgb("#f9a8c9"))[|]#h(8pt)])]
+      text(size: 9pt, fill: white)[#contact-items.join([#h(8pt)#text(fill: separator-color)[|]#h(8pt)])]
     }
   )
 

--- a/crates/render/src/typst_engine/templates/nosepass.typ
+++ b/crates/render/src/typst_engine/templates/nosepass.typ
@@ -3,323 +3,328 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#3b82f6")
-#let dark-blue = rgb("#1e3a5f")
-#let text-color = rgb("#1f2937")
-#let muted-color = rgb("#4b5563")
-#let light-gray = rgb("#f3f4f6")
-#let border-color = rgb("#d1d5db")
-
-#let section-heading(title) = {
-  v(14pt)
-  grid(
-    columns: (auto, 1fr),
-    column-gutter: 12pt,
-    text(weight: "bold", size: 11pt, fill: dark-blue)[#title],
-    line(start: (0pt, 6pt), length: 100%, stroke: 1pt + border-color)
-  )
-  v(10pt)
-}
-
-#let date-badge(date) = {
-  box(
-    fill: light-gray,
-    radius: 2pt,
-    inset: (x: 6pt, y: 2pt),
-    text(size: 9pt, fill: muted-color)[#date]
-  )
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "bold", size: 11pt, fill: dark-blue)[#item.position]
-      #v(2pt)
-      #text(size: 10pt)[#item.company]
-      #if item.location != "" {
-        text(size: 9pt, fill: muted-color)[ · #item.location]
-      }
-    ],
-    date-badge(item.date)
-  )
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(12pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "bold", size: 11pt, fill: dark-blue)[#item.institution]
-      #v(2pt)
-      #if item.studyType != "" or item.area != "" {
-        let degree = format-degree(item.studyType, item.area)
-        text(size: 10pt)[#degree]
-      }
-      #if item.score != "" {
-        text(size: 9pt, fill: muted-color)[ · GPA: #item.score]
-      }
-    ],
-    date-badge(item.date)
-  )
-
-  v(12pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  box(
-    stroke: 1pt + border-color,
-    radius: 3pt,
-    inset: (x: 8pt, y: 4pt),
-    [
-      #text(size: 9pt, weight: "medium")[#item.name]
-      #let level = clamp-level(item.level)
-      #if level > 0 {
-        h(4pt)
-        for i in range(level) {
-          text(fill: primary-color)[●]
-        }
-        for i in range(5 - level) {
-          text(fill: border-color)[●]
-        }
-      }
-    ]
-  )
-  h(6pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (auto, 1fr, auto),
-    column-gutter: 8pt,
-    text(size: 10pt, weight: "medium")[#item.name],
-    line(start: (0pt, 5pt), length: 100%, stroke: (dash: "dotted") + border-color),
-    render-rich-text(item.description, size: 9pt, fill: muted-color)
-  )
-  v(6pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  if has-url(item) {
-    link(item.url.href)[#text(fill: primary-color)[#item.network: #item.username]]
-  } else {
-    text(size: 10pt)[#item.network: #item.username]
-  }
-  v(4pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt, fill: dark-blue)[#item.name]
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if has-keywords(item) {
-    v(4pt)
-    for keyword in item.keywords {
-      box(
-        fill: light-gray,
-        radius: 2pt,
-        inset: (x: 5pt, y: 2pt),
-        text(size: 8pt)[#keyword]
-      )
-      h(4pt)
-    }
-  }
-
-  v(10pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "medium", size: 10pt)[#item.name]
-      #if item.issuer != "" {
-        text(size: 9pt, fill: muted-color)[ — #item.issuer]
-      }
-    ],
-    date-badge(item.date)
-  )
-  v(8pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "medium", size: 10pt)[#item.title]
-      #if item.awarder != "" {
-        text(size: 9pt, fill: muted-color)[ — #item.awarder]
-      }
-    ],
-    date-badge(item.date)
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  box(
-    fill: light-gray,
-    radius: 3pt,
-    inset: (x: 8pt, y: 4pt),
-    text(size: 9pt)[#item.name]
-  )
-  h(6pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "bold", size: 10pt, fill: dark-blue)[#item.name]
-      #if item.publisher != "" {
-        v(2pt)
-        text(size: 9pt, fill: muted-color)[#item.publisher]
-      }
-    ],
-    date-badge(item.date)
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(10pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "bold", size: 11pt, fill: dark-blue)[#item.organization]
-      #if item.position != "" {
-        v(2pt)
-        text(size: 10pt)[#item.position]
-      }
-      #if item.location != "" {
-        text(size: 9pt, fill: muted-color)[ · #item.location]
-      }
-    ],
-    date-badge(item.date)
-  )
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(12pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt, fill: dark-blue)[#item.name]
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(10pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 12pt,
-    [
-      #text(weight: "bold", size: 10pt, fill: dark-blue)[#item.name]
-      #if item.description != "" {
-        v(2pt)
-        render-rich-text(item.description, size: 10pt)
-      }
-    ],
-    date-badge(item.date)
-  )
-
-  if item.location != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  if has-keywords(item) {
-    v(4pt)
-    for keyword in item.keywords {
-      box(
-        fill: light-gray,
-        radius: 2pt,
-        inset: (x: 5pt, y: 2pt),
-        text(size: 8pt)[#keyword]
-      )
-      h(4pt)
-    }
-  }
-
-
-  render-url(item, primary-color)
-  v(10pt)
-}
 
 #let template(data) = {
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#3b82f6"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = text-color.lighten(30%)
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let light-gray = bg-color.darken(5%)
+  let border-color = bg-color.darken(15%)
+
+  let section-heading(title) = {
+    v(14pt)
+    grid(
+      columns: (auto, 1fr),
+      column-gutter: 12pt,
+      text(weight: "bold", size: 11pt, fill: primary-color)[#title],
+      line(start: (0pt, 6pt), length: 100%, stroke: 1pt + border-color)
+    )
+    v(10pt)
+  }
+
+  let date-badge(date) = {
+    box(
+      fill: light-gray,
+      radius: 2pt,
+      inset: (x: 6pt, y: 2pt),
+      text(size: 9pt, fill: muted-color)[#date]
+    )
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "bold", size: 11pt, fill: primary-color)[#item.position]
+        #v(2pt)
+        #text(size: 10pt)[#item.company]
+        #if item.location != "" {
+          text(size: 9pt, fill: muted-color)[ · #item.location]
+        }
+      ],
+      date-badge(item.date)
+    )
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(12pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "bold", size: 11pt, fill: primary-color)[#item.institution]
+        #v(2pt)
+        #if item.studyType != "" or item.area != "" {
+          let degree = format-degree(item.studyType, item.area)
+          text(size: 10pt)[#degree]
+        }
+        #if item.score != "" {
+          text(size: 9pt, fill: muted-color)[ · GPA: #item.score]
+        }
+      ],
+      date-badge(item.date)
+    )
+
+    v(12pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    box(
+      stroke: 1pt + border-color,
+      radius: 3pt,
+      inset: (x: 8pt, y: 4pt),
+      [
+        #text(size: 9pt, weight: "medium")[#item.name]
+        #let level = clamp-level(item.level)
+        #if level > 0 {
+          h(4pt)
+          for i in range(level) {
+            text(fill: primary-color)[●]
+          }
+          for i in range(5 - level) {
+            text(fill: border-color)[●]
+          }
+        }
+      ]
+    )
+    h(6pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (auto, 1fr, auto),
+      column-gutter: 8pt,
+      text(size: 10pt, weight: "medium")[#item.name],
+      line(start: (0pt, 5pt), length: 100%, stroke: (dash: "dotted") + border-color),
+      render-rich-text(item.description, size: 9pt, fill: muted-color)
+    )
+    v(6pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    if has-url(item) {
+      link(item.url.href)[#text(fill: primary-color)[#item.network: #item.username]]
+    } else {
+      text(size: 10pt)[#item.network: #item.username]
+    }
+    v(4pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt, fill: primary-color)[#item.name]
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if has-keywords(item) {
+      v(4pt)
+      for keyword in item.keywords {
+        box(
+          fill: light-gray,
+          radius: 2pt,
+          inset: (x: 5pt, y: 2pt),
+          text(size: 8pt)[#keyword]
+        )
+        h(4pt)
+      }
+    }
+
+    v(10pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "medium", size: 10pt)[#item.name]
+        #if item.issuer != "" {
+          text(size: 9pt, fill: muted-color)[ — #item.issuer]
+        }
+      ],
+      date-badge(item.date)
+    )
+    v(8pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "medium", size: 10pt)[#item.title]
+        #if item.awarder != "" {
+          text(size: 9pt, fill: muted-color)[ — #item.awarder]
+        }
+      ],
+      date-badge(item.date)
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    box(
+      fill: light-gray,
+      radius: 3pt,
+      inset: (x: 8pt, y: 4pt),
+      text(size: 9pt)[#item.name]
+    )
+    h(6pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "bold", size: 10pt, fill: primary-color)[#item.name]
+        #if item.publisher != "" {
+          v(2pt)
+          text(size: 9pt, fill: muted-color)[#item.publisher]
+        }
+      ],
+      date-badge(item.date)
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "bold", size: 11pt, fill: primary-color)[#item.organization]
+        #if item.position != "" {
+          v(2pt)
+          text(size: 10pt)[#item.position]
+        }
+        #if item.location != "" {
+          text(size: 9pt, fill: muted-color)[ · #item.location]
+        }
+      ],
+      date-badge(item.date)
+    )
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(12pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt, fill: primary-color)[#item.name]
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 12pt,
+      [
+        #text(weight: "bold", size: 10pt, fill: primary-color)[#item.name]
+        #if item.description != "" {
+          v(2pt)
+          render-rich-text(item.description, size: 10pt)
+        }
+      ],
+      date-badge(item.date)
+    )
+
+    if item.location != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    if has-keywords(item) {
+      v(4pt)
+      for keyword in item.keywords {
+        box(
+          fill: light-gray,
+          radius: 2pt,
+          inset: (x: 5pt, y: 2pt),
+          text(size: 8pt)[#keyword]
+        )
+        h(4pt)
+      }
+    }
+
+    render-url(item, primary-color)
+    v(10pt)
+  }
+
   // Page setup
-  set page(
+  set page(fill: bg-color, 
     margin: (x: 54pt, y: 48pt),
   )
 
@@ -340,7 +345,7 @@
     stroke: (bottom: 3pt + primary-color),
     inset: (bottom: 12pt),
     [
-      #text(size: 28pt, weight: "bold", fill: dark-blue)[#data.basics.name]
+      #text(size: 28pt, weight: "bold", fill: primary-color)[#data.basics.name]
 
       #if data.basics.headline != "" {
         v(4pt)
@@ -379,7 +384,7 @@
       radius: 4pt,
       inset: 12pt,
       [
-        #text(weight: "bold", size: 10pt, fill: dark-blue)[Professional Summary]
+        #text(weight: "bold", size: 10pt, fill: primary-color)[Professional Summary]
         #v(6pt)
         #render-rich-text(data.sections.summary.content, size: 10pt)
       ]

--- a/crates/render/src/typst_engine/templates/onyx.typ
+++ b/crates/render/src/typst_engine/templates/onyx.typ
@@ -37,7 +37,7 @@
   }
 
   let rating-squares(level) = {
-    rating-indicators(level, 8pt, 8pt, primary-color, rgb("#e5e7eb"), 0pt, 2pt)
+    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 0pt, 2pt)
   }
 
   let render-experience(item) = {
@@ -111,7 +111,7 @@
       v(2pt)
       for keyword in item.keywords {
         box(
-          fill: rgb("#fef2f2"),
+          fill: primary-color.lighten(92%),
           radius: 3pt,
           inset: (x: 6pt, y: 2pt),
           text(size: 8pt, fill: primary-color)[#keyword]
@@ -175,7 +175,7 @@
       v(4pt)
       for keyword in item.keywords {
         box(
-          fill: rgb("#fef2f2"),
+          fill: primary-color.lighten(92%),
           radius: 3pt,
           inset: (x: 6pt, y: 2pt),
           text(size: 8pt, fill: primary-color)[#keyword]
@@ -335,7 +335,7 @@
       v(2pt)
       for keyword in item.keywords {
         box(
-          fill: rgb("#fef2f2"),
+          fill: primary-color.lighten(92%),
           radius: 3pt,
           inset: (x: 6pt, y: 2pt),
           text(size: 8pt, fill: primary-color)[#keyword]

--- a/crates/render/src/typst_engine/templates/onyx.typ
+++ b/crates/render/src/typst_engine/templates/onyx.typ
@@ -3,347 +3,352 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#dc2626")
-#let text-color = rgb("#111827")
-#let muted-color = rgb("#6b7280")
-
-#let section-heading(title) = {
-  v(14pt)
-  box(
-    width: 100%,
-    stroke: (bottom: 1.5pt + primary-color),
-    inset: (bottom: 4pt),
-    text(weight: "bold", size: 10pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
-  )
-  v(10pt)
-}
-
-#let entry-header(left-content, right-content) = {
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    left-content,
-    align(right)[
-      #text(size: 9pt, fill: muted-color)[#right-content]
-    ]
-  )
-}
-
-#let rating-squares(level) = {
-  rating-indicators(level, 8pt, 8pt, primary-color, rgb("#e5e7eb"), 0pt, 2pt)
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 11pt, fill: text-color)[#item.position]
-      #v(2pt)
-      #text(size: 10pt, fill: primary-color)[#item.company]
-      #if item.location != "" {
-        text(size: 9pt, fill: muted-color)[ · #item.location]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt, fill: text-color)
-  }
-
-  v(12pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 11pt, fill: text-color)[#item.institution]
-      #if item.studyType != "" or item.area != "" {
-        v(2pt)
-        let degree = format-degree(item.studyType, item.area)
-        text(size: 10pt, fill: text-color)[#degree]
-      }
-    ],
-    item.date
-  )
-
-  if item.score != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.score]
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt, fill: text-color)
-  }
-
-  v(12pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(size: 10pt, weight: "medium", fill: text-color)[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt, fill: muted-color)
-      }
-    ],
-    rating-squares(item.level)
-  )
-
-  if has-keywords(item) {
-    v(2pt)
-    for keyword in item.keywords {
-      box(
-        fill: rgb("#fef2f2"),
-        radius: 3pt,
-        inset: (x: 6pt, y: 2pt),
-        text(size: 8pt, fill: primary-color)[#keyword]
-      )
-      h(4pt)
-    }
-  }
-
-  v(8pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    [
-      #text(size: 10pt, weight: "medium", fill: text-color)[#item.name]
-      #if item.description != "" {
-        h(6pt)
-        render-rich-text(item.description, size: 9pt, fill: muted-color)
-      }
-    ],
-    rating-squares(item.level)
-  )
-
-  v(6pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  if has-url(item) {
-    link(item.url.href)[#text(fill: primary-color)[#item.network]]
-  } else {
-    text(size: 10pt, fill: text-color)[#item.network: #item.username]
-  }
-  h(14pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [#text(weight: "bold", size: 10pt, fill: text-color)[#item.name]],
-    item.date
-  )
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt, fill: text-color)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt, fill: text-color)
-  }
-
-  if has-keywords(item) {
-    v(4pt)
-    for keyword in item.keywords {
-      box(
-        fill: rgb("#fef2f2"),
-        radius: 3pt,
-        inset: (x: 6pt, y: 2pt),
-        text(size: 8pt, fill: primary-color)[#keyword]
-      )
-      h(4pt)
-    }
-  }
-
-  v(12pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "medium", size: 10pt, fill: text-color)[#item.name]
-      #if item.issuer != "" {
-        text(size: 9pt, fill: muted-color)[ — #item.issuer]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt, fill: text-color)
-  }
-
-  v(8pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "medium", size: 10pt, fill: text-color)[#item.title]
-      #if item.awarder != "" {
-        text(size: 9pt, fill: muted-color)[ — #item.awarder]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt, fill: text-color)
-  }
-
-  v(8pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 10pt, weight: "medium", fill: text-color)[#item.name]
-
-  if has-keywords(item) {
-    text(size: 9pt, fill: muted-color)[ — #item.keywords.join(", ")]
-  }
-
-  v(6pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 10pt, fill: text-color)[#item.name]
-      #if item.publisher != "" {
-        v(1pt)
-        text(size: 9pt, fill: muted-color)[#item.publisher]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 9pt, fill: text-color)
-  }
-
-  v(8pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 11pt, fill: text-color)[#item.organization]
-      #if item.position != "" {
-        text(size: 10pt, fill: text-color)[ — #item.position]
-      }
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt, fill: text-color)
-  }
-
-  v(12pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt, fill: text-color)[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt, fill: muted-color)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt, fill: text-color)
-  }
-
-  v(8pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold", size: 10pt, fill: text-color)[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt, fill: muted-color)
-      }
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt, fill: text-color)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    for keyword in item.keywords {
-      box(
-        fill: rgb("#fef2f2"),
-        radius: 3pt,
-        inset: (x: 6pt, y: 2pt),
-        text(size: 8pt, fill: primary-color)[#keyword]
-      )
-      h(4pt)
-    }
-  }
-
-
-  render-url(item, primary-color)
-  v(8pt)
-}
 
 #let template(data) = {
-  set page(
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#dc2626"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#111827"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = rgb("#6b7280")
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let section-heading(title) = {
+    v(14pt)
+    box(
+      width: 100%,
+      stroke: (bottom: 1.5pt + primary-color),
+      inset: (bottom: 4pt),
+      text(weight: "bold", size: 10pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+    )
+    v(10pt)
+  }
+
+  let entry-header(left-content, right-content) = {
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      left-content,
+      align(right)[
+        #text(size: 9pt, fill: muted-color)[#right-content]
+      ]
+    )
+  }
+
+  let rating-squares(level) = {
+    rating-indicators(level, 8pt, 8pt, primary-color, rgb("#e5e7eb"), 0pt, 2pt)
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 11pt, fill: text-color)[#item.position]
+        #v(2pt)
+        #text(size: 10pt, fill: primary-color)[#item.company]
+        #if item.location != "" {
+          text(size: 9pt, fill: muted-color)[ · #item.location]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt, fill: text-color)
+    }
+
+    v(12pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 11pt, fill: text-color)[#item.institution]
+        #if item.studyType != "" or item.area != "" {
+          v(2pt)
+          let degree = format-degree(item.studyType, item.area)
+          text(size: 10pt, fill: text-color)[#degree]
+        }
+      ],
+      item.date
+    )
+
+    if item.score != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.score]
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt, fill: text-color)
+    }
+
+    v(12pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(size: 10pt, weight: "medium", fill: text-color)[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt, fill: muted-color)
+        }
+      ],
+      rating-squares(item.level)
+    )
+
+    if has-keywords(item) {
+      v(2pt)
+      for keyword in item.keywords {
+        box(
+          fill: rgb("#fef2f2"),
+          radius: 3pt,
+          inset: (x: 6pt, y: 2pt),
+          text(size: 8pt, fill: primary-color)[#keyword]
+        )
+        h(4pt)
+      }
+    }
+
+    v(8pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      [
+        #text(size: 10pt, weight: "medium", fill: text-color)[#item.name]
+        #if item.description != "" {
+          h(6pt)
+          render-rich-text(item.description, size: 9pt, fill: muted-color)
+        }
+      ],
+      rating-squares(item.level)
+    )
+
+    v(6pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    if has-url(item) {
+      link(item.url.href)[#text(fill: primary-color)[#item.network]]
+    } else {
+      text(size: 10pt, fill: text-color)[#item.network: #item.username]
+    }
+    h(14pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [#text(weight: "bold", size: 10pt, fill: text-color)[#item.name]],
+      item.date
+    )
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt, fill: text-color)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt, fill: text-color)
+    }
+
+    if has-keywords(item) {
+      v(4pt)
+      for keyword in item.keywords {
+        box(
+          fill: rgb("#fef2f2"),
+          radius: 3pt,
+          inset: (x: 6pt, y: 2pt),
+          text(size: 8pt, fill: primary-color)[#keyword]
+        )
+        h(4pt)
+      }
+    }
+
+    v(12pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "medium", size: 10pt, fill: text-color)[#item.name]
+        #if item.issuer != "" {
+          text(size: 9pt, fill: muted-color)[ — #item.issuer]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt, fill: text-color)
+    }
+
+    v(8pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "medium", size: 10pt, fill: text-color)[#item.title]
+        #if item.awarder != "" {
+          text(size: 9pt, fill: muted-color)[ — #item.awarder]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt, fill: text-color)
+    }
+
+    v(8pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 10pt, weight: "medium", fill: text-color)[#item.name]
+
+    if has-keywords(item) {
+      text(size: 9pt, fill: muted-color)[ — #item.keywords.join(", ")]
+    }
+
+    v(6pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 10pt, fill: text-color)[#item.name]
+        #if item.publisher != "" {
+          v(1pt)
+          text(size: 9pt, fill: muted-color)[#item.publisher]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 9pt, fill: text-color)
+    }
+
+    v(8pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 11pt, fill: text-color)[#item.organization]
+        #if item.position != "" {
+          text(size: 10pt, fill: text-color)[ — #item.position]
+        }
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt, fill: text-color)
+    }
+
+    v(12pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt, fill: text-color)[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt, fill: muted-color)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt, fill: text-color)
+    }
+
+    v(8pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold", size: 10pt, fill: text-color)[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt, fill: muted-color)
+        }
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt, fill: text-color)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      for keyword in item.keywords {
+        box(
+          fill: rgb("#fef2f2"),
+          radius: 3pt,
+          inset: (x: 6pt, y: 2pt),
+          text(size: 8pt, fill: primary-color)[#keyword]
+        )
+        h(4pt)
+      }
+    }
+
+    render-url(item, primary-color)
+    v(8pt)
+  }
+
+  set page(fill: bg-color, 
     margin: (x: 48pt, y: 48pt),
   )
 

--- a/crates/render/src/typst_engine/templates/pikachu.typ
+++ b/crates/render/src/typst_engine/templates/pikachu.typ
@@ -36,7 +36,7 @@
   }
 
   let skill-dots(level) = {
-    rating-indicators(level, 6pt, 6pt, primary-color, rgb("#d6d3d1"), 50%, 3pt)
+    rating-indicators(level, 6pt, 6pt, primary-color, sidebar-bg.darken(15%), 50%, 3pt)
   }
 
   let render-experience(item) = {

--- a/crates/render/src/typst_engine/templates/pikachu.typ
+++ b/crates/render/src/typst_engine/templates/pikachu.typ
@@ -3,269 +3,276 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#ca8a04")
-#let sidebar-bg = rgb("#fef9c3")
-#let text-color = rgb("#1c1917")
-#let muted-color = rgb("#78716c")
-#let white = rgb("#ffffff")
-
-#let sidebar-section(title) = {
-  v(12pt)
-  text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.08em)[#upper(title)]
-  v(6pt)
-}
-
-#let main-section(title) = {
-  v(14pt)
-  box(
-    fill: primary-color,
-    inset: (x: 8pt, y: 4pt),
-    radius: 2pt,
-    text(weight: "bold", size: 10pt, fill: white, tracking: 0.05em)[#upper(title)]
-  )
-  v(10pt)
-}
-
-#let skill-dots(level) = {
-  rating-indicators(level, 6pt, 6pt, primary-color, rgb("#d6d3d1"), 50%, 3pt)
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 11pt)[#item.position]
-  v(2pt)
-  text(size: 10pt, fill: primary-color)[#item.company]
-  h(8pt)
-  text(size: 9pt, fill: muted-color)[#item.date]
-
-  if item.location != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[📍 #item.location]
-  }
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(14pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt)[#item.institution]
-  v(2pt)
-
-  if item.studyType != "" or item.area != "" {
-    let degree = format-degree(item.studyType, item.area)
-    text(size: 10pt)[#degree]
-    h(8pt)
-  }
-
-  text(size: 9pt, fill: muted-color)[#item.date]
-
-  if item.score != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.score]
-  }
-
-  v(12pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    text(size: 9pt)[#item.name],
-    skill-dots(item.level)
-  )
-  v(6pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    text(size: 9pt)[#item.name],
-    skill-dots(item.level)
-  )
-
-  if item.description != "" {
-    render-rich-text(item.description, size: 8pt, fill: muted-color)
-  }
-
-  v(6pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  if has-url(item) {
-    link(item.url.href)[
-      #text(size: 9pt, fill: text-color)[#item.network]
-    ]
-  } else {
-    text(size: 9pt)[#item.network]
-  }
-  v(4pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt)[#item.name]
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if has-keywords(item) {
-    v(4pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(" · ")]
-  }
-
-  v(12pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  text(weight: "medium", size: 10pt)[#item.name]
-  if item.issuer != "" {
-    text(size: 9pt, fill: muted-color)[ — #item.issuer]
-  }
-  h(8pt)
-  text(size: 9pt, fill: muted-color)[#item.date]
-  v(8pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  text(weight: "medium", size: 10pt)[#item.title]
-  if item.awarder != "" {
-    text(size: 9pt, fill: muted-color)[ — #item.awarder]
-  }
-  h(8pt)
-  text(size: 9pt, fill: muted-color)[#item.date]
-  v(8pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 9pt)[#item.name]
-  v(4pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  text(weight: "medium", size: 10pt)[#item.name]
-  if item.publisher != "" {
-    text(size: 9pt, fill: muted-color)[ — #item.publisher]
-  }
-  h(8pt)
-  text(size: 9pt, fill: muted-color)[#item.date]
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(12pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 11pt)[#item.position]
-  v(2pt)
-  text(size: 10pt, fill: primary-color)[#item.organization]
-  h(8pt)
-  text(size: 9pt, fill: muted-color)[#item.date]
-
-  if item.location != "" {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[📍 #item.location]
-  }
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(14pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "medium", size: 10pt)[#item.name]
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if item.summary != "" {
-    v(6pt)
-    box(
-      stroke: (left: 2pt + primary-color),
-      inset: (left: 10pt, y: 2pt),
-      render-rich-text(item.summary, size: 9pt, style: "italic", fill: muted-color)
-    )
-  }
-
-  v(12pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold", size: 10pt)[#item.name]
-
-  if item.description != "" {
-    v(4pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if item.date != "" or item.location != "" {
-    v(2pt)
-    if item.date != "" {
-      text(size: 9pt, fill: muted-color)[#item.date]
-    }
-    if item.date != "" and item.location != "" {
-      h(8pt)
-    }
-    if item.location != "" {
-      text(size: 9pt, fill: muted-color)[📍 #item.location]
-    }
-  }
-
-  if item.summary != "" {
-    v(6pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  if has-keywords(item) {
-    v(4pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(" · ")]
-  }
-
-
-  render-url(item, primary-color)
-  v(12pt)
-}
 
 #let template(data) = {
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#ca8a04"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#1c1917"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = rgb("#78716c")
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let white = rgb("#ffffff")
+  let sidebar-bg = primary-color.lighten(85%)
+  let sidebar-text-color = primary-color.darken(60%)
+
+  let sidebar-section(title) = {
+    v(12pt)
+    text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.08em)[#upper(title)]
+    v(6pt)
+  }
+
+  let main-section(title) = {
+    v(14pt)
+    box(
+      fill: primary-color,
+      inset: (x: 8pt, y: 4pt),
+      radius: 2pt,
+      text(weight: "bold", size: 10pt, fill: white, tracking: 0.05em)[#upper(title)]
+    )
+    v(10pt)
+  }
+
+  let skill-dots(level) = {
+    rating-indicators(level, 6pt, 6pt, primary-color, rgb("#d6d3d1"), 50%, 3pt)
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 11pt)[#item.position]
+    v(2pt)
+    text(size: 10pt, fill: primary-color)[#item.company]
+    h(8pt)
+    text(size: 9pt, fill: muted-color)[#item.date]
+
+    if item.location != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[📍 #item.location]
+    }
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(14pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt)[#item.institution]
+    v(2pt)
+
+    if item.studyType != "" or item.area != "" {
+      let degree = format-degree(item.studyType, item.area)
+      text(size: 10pt)[#degree]
+      h(8pt)
+    }
+
+    text(size: 9pt, fill: muted-color)[#item.date]
+
+    if item.score != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.score]
+    }
+
+    v(12pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      text(size: 9pt)[#item.name],
+      skill-dots(item.level)
+    )
+    v(6pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      text(size: 9pt)[#item.name],
+      skill-dots(item.level)
+    )
+
+    if item.description != "" {
+      render-rich-text(item.description, size: 8pt, fill: muted-color)
+    }
+
+    v(6pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    if has-url(item) {
+      link(item.url.href)[
+        #text(size: 9pt, fill: sidebar-text-color)[#item.network]
+      ]
+    } else {
+      text(size: 9pt)[#item.network]
+    }
+    v(4pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt)[#item.name]
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if has-keywords(item) {
+      v(4pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(" · ")]
+    }
+
+    v(12pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    text(weight: "medium", size: 10pt)[#item.name]
+    if item.issuer != "" {
+      text(size: 9pt, fill: muted-color)[ — #item.issuer]
+    }
+    h(8pt)
+    text(size: 9pt, fill: muted-color)[#item.date]
+    v(8pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    text(weight: "medium", size: 10pt)[#item.title]
+    if item.awarder != "" {
+      text(size: 9pt, fill: muted-color)[ — #item.awarder]
+    }
+    h(8pt)
+    text(size: 9pt, fill: muted-color)[#item.date]
+    v(8pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 9pt)[#item.name]
+    v(4pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    text(weight: "medium", size: 10pt)[#item.name]
+    if item.publisher != "" {
+      text(size: 9pt, fill: muted-color)[ — #item.publisher]
+    }
+    h(8pt)
+    text(size: 9pt, fill: muted-color)[#item.date]
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(12pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 11pt)[#item.position]
+    v(2pt)
+    text(size: 10pt, fill: primary-color)[#item.organization]
+    h(8pt)
+    text(size: 9pt, fill: muted-color)[#item.date]
+
+    if item.location != "" {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[📍 #item.location]
+    }
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(14pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "medium", size: 10pt)[#item.name]
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if item.summary != "" {
+      v(6pt)
+      box(
+        stroke: (left: 2pt + primary-color),
+        inset: (left: 10pt, y: 2pt),
+        render-rich-text(item.summary, size: 9pt, style: "italic", fill: muted-color)
+      )
+    }
+
+    v(12pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold", size: 10pt)[#item.name]
+
+    if item.description != "" {
+      v(4pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if item.date != "" or item.location != "" {
+      v(2pt)
+      if item.date != "" {
+        text(size: 9pt, fill: muted-color)[#item.date]
+      }
+      if item.date != "" and item.location != "" {
+        h(8pt)
+      }
+      if item.location != "" {
+        text(size: 9pt, fill: muted-color)[📍 #item.location]
+      }
+    }
+
+    if item.summary != "" {
+      v(6pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    if has-keywords(item) {
+      v(4pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(" · ")]
+    }
+
+    render-url(item, primary-color)
+    v(12pt)
+  }
+
   // Page setup - no margin, we'll handle it in the grid
-  set page(
+  set page(fill: bg-color, 
     margin: 0pt,
   )
 
@@ -291,6 +298,8 @@
       width: 100%,
       height: 100%,
       inset: (x: 16pt, y: 32pt),
+      {
+      set text(fill: sidebar-text-color)
       [
         // Profile photo placeholder (initials)
         #align(center)[
@@ -368,6 +377,7 @@
           }
         }
       ]
+      }
     ),
 
     // MAIN CONTENT

--- a/crates/render/src/typst_engine/templates/rhyhorn.typ
+++ b/crates/render/src/typst_engine/templates/rhyhorn.typ
@@ -4,311 +4,316 @@
 
 #import "_common.typ": *
 
-#let primary-color = rgb("#65a30d")
-#let text-color = rgb("#000000")
-#let muted-color = rgb("#6b7280")
-
-#let section-heading(title) = {
-  v(12pt)
-  text(weight: "bold", size: 11pt, fill: primary-color)[#upper(title)]
-  v(2pt)
-  line(length: 100%, stroke: 0.5pt + primary-color)
-  v(6pt)
-}
-
-#let entry-header(left-content, right-content) = {
-  grid(
-    columns: (1fr, auto),
-    column-gutter: 8pt,
-    left-content,
-    align(right)[
-      #text(size: 9pt, fill: muted-color)[#right-content]
-    ]
-  )
-}
-
-#let skill-bar(level) = {
-  h(4pt)
-  rating-indicators(level, 8pt, 8pt, primary-color, rgb("#e5e5e5"), 2pt, 2pt)
-}
-
-#let render-experience(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.company]
-      #if item.position != "" [ — #item.position]
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    text(size: 9pt, fill: muted-color)[#item.location]
-    v(2pt)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(10pt)
-}
-
-#let render-education(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [#text(weight: "bold")[#item.institution]],
-    item.date
-  )
-
-  if item.area != "" or item.studyType != "" {
-    let degree-text = format-degree(item.studyType, item.area)
-    text(size: 10pt)[#degree-text]
-    v(2pt)
-  }
-
-  if item.score != "" {
-    text(size: 9pt, fill: muted-color)[#item.score]
-  }
-
-  v(10pt)
-}
-
-#let render-skill(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    [
-      #text(size: 10pt, weight: "bold")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt)
-      }
-    ],
-    skill-bar(item.level)
-  )
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(8pt)
-}
-
-#let render-language(item) = {
-  if item.visible == false { return }
-
-  grid(
-    columns: (1fr, auto),
-    [
-      #text(size: 10pt, weight: "bold")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt)
-      }
-    ],
-    skill-bar(item.level)
-  )
-
-  v(6pt)
-}
-
-#let render-profile(item) = {
-  if item.visible == false { return }
-
-  if has-url(item) {
-    let label = if item.username != "" { item.username } else { item.url.href }
-    link(item.url.href)[#label]
-  } else {
-    [#item.network: #item.username]
-  }
-  v(4pt)
-}
-
-#let render-project(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [#text(weight: "bold", size: 10pt)[#item.name]],
-    item.date
-  )
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 10pt)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-  v(8pt)
-}
-
-#let render-certification(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.name]
-      #if item.issuer != "" {
-        text(fill: muted-color)[ — #item.issuer]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-award(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.title]
-      #if item.awarder != "" {
-        text(fill: muted-color)[ — #item.awarder]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-interest(item) = {
-  if item.visible == false { return }
-
-  text(size: 10pt, weight: "bold")[#item.name]
-
-  if has-keywords(item) {
-    text(size: 9pt, fill: muted-color)[ — #item.keywords.join(", ")]
-  }
-
-  v(4pt)
-}
-
-#let render-publication(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.name]
-      #if item.publisher != "" {
-        v(1pt)
-        text(size: 9pt)[#item.publisher]
-      }
-    ],
-    item.date
-  )
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-volunteer(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.organization]
-      #if item.position != "" [ — #item.position]
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    text(size: 9pt, fill: muted-color)[#item.location]
-    v(2pt)
-  }
-
-  if item.summary != "" {
-    v(4pt)
-    render-rich-text(item.summary, size: 10pt)
-  }
-
-  v(10pt)
-}
-
-#let render-reference(item) = {
-  if item.visible == false { return }
-
-  text(weight: "bold")[#item.name]
-
-  if item.description != "" {
-    v(2pt)
-    render-rich-text(item.description, size: 9pt)
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  v(8pt)
-}
-
-#let render-custom(item) = {
-  if item.visible == false { return }
-
-  entry-header(
-    [
-      #text(weight: "bold")[#item.name]
-      #if item.description != "" {
-        v(1pt)
-        render-rich-text(item.description, size: 9pt)
-      }
-    ],
-    item.date
-  )
-
-  if item.location != "" {
-    text(size: 9pt, fill: muted-color)[#item.location]
-  }
-
-  if item.summary != "" {
-    v(2pt)
-    render-rich-text(item.summary, size: 9pt)
-  }
-
-  if has-keywords(item) {
-    v(2pt)
-    text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
-  }
-
-
-  render-url(item, primary-color)
-  v(8pt)
-}
 
 #let template(data) = {
-  set page(
+  // ── Theme colors from resume metadata (with sensible fallbacks) ──
+  let primary-color = rgb(data.metadata.theme.at("primary", default: "#65a30d"))
+  let text-color = rgb(data.metadata.theme.at("text", default: "#000000"))
+  let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  // Derived colors (not in schema — computed from theme values)
+  let muted-color = rgb("#6b7280")
+
+  // ── Helper functions (capture theme colors from enclosing scope) ──
+
+  let section-heading(title) = {
+    v(12pt)
+    text(weight: "bold", size: 11pt, fill: primary-color)[#upper(title)]
+    v(2pt)
+    line(length: 100%, stroke: 0.5pt + primary-color)
+    v(6pt)
+  }
+
+  let entry-header(left-content, right-content) = {
+    grid(
+      columns: (1fr, auto),
+      column-gutter: 8pt,
+      left-content,
+      align(right)[
+        #text(size: 9pt, fill: muted-color)[#right-content]
+      ]
+    )
+  }
+
+  let skill-bar(level) = {
+    h(4pt)
+    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
+  }
+
+  let render-experience(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.company]
+        #if item.position != "" [ — #item.position]
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      text(size: 9pt, fill: muted-color)[#item.location]
+      v(2pt)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-education(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [#text(weight: "bold")[#item.institution]],
+      item.date
+    )
+
+    if item.area != "" or item.studyType != "" {
+      let degree-text = format-degree(item.studyType, item.area)
+      text(size: 10pt)[#degree-text]
+      v(2pt)
+    }
+
+    if item.score != "" {
+      text(size: 9pt, fill: muted-color)[#item.score]
+    }
+
+    v(10pt)
+  }
+
+  let render-skill(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      [
+        #text(size: 10pt, weight: "bold")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt)
+        }
+      ],
+      skill-bar(item.level)
+    )
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(8pt)
+  }
+
+  let render-language(item) = {
+    if item.visible == false { return }
+
+    grid(
+      columns: (1fr, auto),
+      [
+        #text(size: 10pt, weight: "bold")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt)
+        }
+      ],
+      skill-bar(item.level)
+    )
+
+    v(6pt)
+  }
+
+  let render-profile(item) = {
+    if item.visible == false { return }
+
+    if has-url(item) {
+      let label = if item.username != "" { item.username } else { item.url.href }
+      link(item.url.href)[#label]
+    } else {
+      [#item.network: #item.username]
+    }
+    v(4pt)
+  }
+
+  let render-project(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [#text(weight: "bold", size: 10pt)[#item.name]],
+      item.date
+    )
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 10pt)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    v(8pt)
+  }
+
+  let render-certification(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.name]
+        #if item.issuer != "" {
+          text(fill: muted-color)[ — #item.issuer]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-award(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.title]
+        #if item.awarder != "" {
+          text(fill: muted-color)[ — #item.awarder]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-interest(item) = {
+    if item.visible == false { return }
+
+    text(size: 10pt, weight: "bold")[#item.name]
+
+    if has-keywords(item) {
+      text(size: 9pt, fill: muted-color)[ — #item.keywords.join(", ")]
+    }
+
+    v(4pt)
+  }
+
+  let render-publication(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.name]
+        #if item.publisher != "" {
+          v(1pt)
+          text(size: 9pt)[#item.publisher]
+        }
+      ],
+      item.date
+    )
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-volunteer(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.organization]
+        #if item.position != "" [ — #item.position]
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      text(size: 9pt, fill: muted-color)[#item.location]
+      v(2pt)
+    }
+
+    if item.summary != "" {
+      v(4pt)
+      render-rich-text(item.summary, size: 10pt)
+    }
+
+    v(10pt)
+  }
+
+  let render-reference(item) = {
+    if item.visible == false { return }
+
+    text(weight: "bold")[#item.name]
+
+    if item.description != "" {
+      v(2pt)
+      render-rich-text(item.description, size: 9pt)
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    v(8pt)
+  }
+
+  let render-custom(item) = {
+    if item.visible == false { return }
+
+    entry-header(
+      [
+        #text(weight: "bold")[#item.name]
+        #if item.description != "" {
+          v(1pt)
+          render-rich-text(item.description, size: 9pt)
+        }
+      ],
+      item.date
+    )
+
+    if item.location != "" {
+      text(size: 9pt, fill: muted-color)[#item.location]
+    }
+
+    if item.summary != "" {
+      v(2pt)
+      render-rich-text(item.summary, size: 9pt)
+    }
+
+    if has-keywords(item) {
+      v(2pt)
+      text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
+    }
+
+    render-url(item, primary-color)
+    v(8pt)
+  }
+
+  set page(fill: bg-color, 
     margin: (x: 48pt, y: 48pt),
   )
 


### PR DESCRIPTION
## Summary

- Move hardcoded `#let primary-color` / `#let text-color` / `#let muted-color` from module scope into `template(data)` for all 11 non-glalie templates
- Derive `primary-color` and `text-color` from `data.metadata.theme.at(...)` with each template's original colors as fallback defaults
- Add `bg-color` (from `data.metadata.theme.background`) and wire it into `set page(fill: bg-color)` for dark theme preset support
- Keep `muted-color` hardcoded per template (not part of user-facing schema)
- Move all helper functions (section-heading, entry-header, render-*, etc.) inside `template(data)` so they capture the theme-aware color variables

Templates fixed: rhyhorn, azurill, pikachu, nosepass, bronzor, chikorita, ditto, gengar, kakuna, leafish, onyx

Closes #162

## Test plan

- [ ] Select each template and verify it renders with default colors (visual regression)
- [ ] Select a non-default theme preset (e.g. Cyan) and verify colors change in the preview
- [ ] Test dark theme presets (Charcoal, Midnight) — background should change
- [ ] Verify glalie (reference implementation) is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates now read theme metadata for primary, text, and background colors (with sensible fallbacks); page background and component fills follow the selected theme.

* **Refactor**
  * Per-template refactor: all theme resolution and rendering helpers are now encapsulated inside each template entrypoint so styling (bars, sidebars, headers, pills, ratings) consistently derives from the active theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->