### PR TITLE
fix(ci): use GitHub App token for release PR creation

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -65,6 +65,16 @@ jobs:
           CURRENT_VERSION: ${{ steps.current.outputs.version }}
         run: ./scripts/ci/release/check-bump-needed.sh
 
+      - name: Create GitHub App installation token
+        if: steps.needs_bump.outputs.required == 'true'
+        id: app-token
+        # yamllint disable-line rule:line-length
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0-beta.2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Update Cargo.toml version
         if: steps.needs_bump.outputs.required == 'true'
         run: >
@@ -77,7 +87,7 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: >-
             chore(release): cut ${{ steps.semrel.outputs.next-version }}
           title: >-
@@ -96,6 +106,6 @@ jobs:
       - name: Enable auto-merge for Release PR
         if: steps.cpr.outputs.pull-request-number != ''
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: ./scripts/ci/release/enable-auto-merge.sh


### PR DESCRIPTION
## Summary

- Use `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` GitHub App token instead of `GITHUB_TOKEN` for release PR creation and auto-merge
- Matches the pattern already used by the Auto Tag workflow (`auto-tag-on-main.yml`)

## Problem

When the release PR auto-merges, the merge commit is pushed by `github-actions` bot (via `GITHUB_TOKEN`). GitHub intentionally does not trigger workflows for pushes made by `GITHUB_TOKEN` to prevent infinite loops. This means the **Auto Tag** workflow never runs, the version tag is never created, and the release pipeline gets stuck:

1. `#171` merged → release workflow created PR `#175` (`0.12.0`) using `GITHUB_TOKEN`
2. PR `#175` auto-merged → but the push didn't trigger Auto Tag
3. `v0.12.0` tag was never created
4. All subsequent merges compute `next=0.12.0`, see `current=0.12.0`, skip → **stuck**

## Fix

Replace `secrets.GITHUB_TOKEN` with a GitHub App installation token (same app used by Auto Tag) for both `create-pull-request` and `enable-auto-merge`. Pushes from GitHub App tokens **do** trigger workflows.

## Test plan

- [ ] Merge this PR → should trigger release workflow
- [ ] Release workflow should create a release PR using the app token
- [ ] When that release PR auto-merges, Auto Tag should trigger and create the version tag
- [ ] After tagging, manually push `v0.12.0` tag to unblock the current stuck state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow automation by updating authentication mechanisms for improved security and reliability in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->