### PR TITLE
feat(web): add content overflow alert with page count indicator

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -54,21 +54,8 @@ export async function post<T>(endpoint: string, body?: unknown): Promise<T> {
 }
 
 export async function fetchBlob(endpoint: string, body?: unknown): Promise<Blob> {
-  const url = `${API_BASE}${endpoint}`;
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new ApiError(response.status, text || response.statusText);
-  }
-
-  return response.blob();
+  const { blob } = await fetchBlobWithHeaders(endpoint, body);
+  return blob;
 }
 
 export interface BlobResponse {

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -70,3 +70,29 @@ export async function fetchBlob(endpoint: string, body?: unknown): Promise<Blob>
 
   return response.blob();
 }
+
+export interface BlobResponse {
+  blob: Blob;
+  headers: Headers;
+}
+
+export async function fetchBlobWithHeaders(
+  endpoint: string,
+  body?: unknown,
+): Promise<BlobResponse> {
+  const url = `${API_BASE}${endpoint}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new ApiError(response.status, text || response.statusText);
+  }
+
+  return { blob: await response.blob(), headers: response.headers };
+}

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -49,7 +49,7 @@ export async function get<T>(endpoint: string): Promise<T> {
 export async function post<T>(endpoint: string, body?: unknown): Promise<T> {
   return request<T>(endpoint, {
     method: "POST",
-    body: body ? JSON.stringify(body) : undefined,
+    body: body !== undefined && body !== null ? JSON.stringify(body) : undefined,
   });
 }
 
@@ -73,7 +73,7 @@ export async function fetchBlobWithHeaders(
     headers: {
       "Content-Type": "application/json",
     },
-    body: body ? JSON.stringify(body) : undefined,
+    body: body !== undefined && body !== null ? JSON.stringify(body) : undefined,
   });
 
   if (!response.ok) {

--- a/apps/web/src/api/render.ts
+++ b/apps/web/src/api/render.ts
@@ -1,4 +1,4 @@
-import { fetchBlob, get, post } from "./client";
+import { fetchBlob, fetchBlobWithHeaders, get, post } from "./client";
 import type { ResumeData, TemplateInfo, ValidationResult } from "../wasm/types";
 
 export interface RenderRequest {
@@ -16,8 +16,13 @@ export interface ParseRequest {
   base64?: boolean;
 }
 
+export interface PreviewResult {
+  url: string;
+  totalPages: number;
+}
+
 // Preview cache to avoid redundant fetches
-const previewCache = new Map<string, { url: string; timestamp: number }>();
+const previewCache = new Map<string, { url: string; totalPages: number; timestamp: number }>();
 const CACHE_TTL = 60000; // 1 minute
 
 function getCacheKey(resume: ResumeData, template: string, page: number): string {
@@ -47,7 +52,7 @@ export async function renderPreview(
   resume: ResumeData,
   page: number = 0,
   template?: string,
-): Promise<string> {
+): Promise<PreviewResult> {
   // Clean up expired entries before processing
   cleanupExpiredCache();
 
@@ -57,14 +62,16 @@ export async function renderPreview(
   // Check cache
   const cached = previewCache.get(cacheKey);
   if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-    return cached.url;
+    return { url: cached.url, totalPages: cached.totalPages };
   }
 
-  const blob = await fetchBlob("/render/preview", {
+  const { blob, headers } = await fetchBlobWithHeaders("/render/preview", {
     resume,
     template: templateName,
     page,
   } satisfies PreviewRequest);
+
+  const totalPages = parseInt(headers.get("X-Total-Pages") || "1", 10);
 
   // Revoke old URL if exists
   if (cached) {
@@ -72,9 +79,9 @@ export async function renderPreview(
   }
 
   const url = URL.createObjectURL(blob);
-  previewCache.set(cacheKey, { url, timestamp: Date.now() });
+  previewCache.set(cacheKey, { url, totalPages, timestamp: Date.now() });
 
-  return url;
+  return { url, totalPages };
 }
 
 export async function renderPdf(resume: ResumeData, template?: string): Promise<Blob> {

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -15,6 +15,7 @@ export function Preview() {
   const [isLoading, setIsLoading] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [lastCachedUrl, setLastCachedUrl] = createSignal<string | null>(null);
+  const [totalPages, setTotalPages] = createSignal(1);
 
   // Request ID to guard against race conditions
   let resumeRequestId = 0;
@@ -52,10 +53,11 @@ export function Preview() {
     setError(null);
 
     renderPreview(store.resume, ui.previewPage)
-      .then((url) => {
+      .then((result) => {
         if (currentRequestId !== resumeRequestId) return;
-        setPreviewUrl(url);
-        setLastCachedUrl(url);
+        setPreviewUrl(result.url);
+        setLastCachedUrl(result.url);
+        setTotalPages(result.totalPages);
         setError(null);
         lastToastedError = "";
       })
@@ -103,10 +105,11 @@ export function Preview() {
     setError(null);
 
     renderPreview(store.resume, page)
-      .then((url) => {
+      .then((result) => {
         if (currentRequestId !== pageRequestId) return;
-        setPreviewUrl(url);
-        setLastCachedUrl(url);
+        setPreviewUrl(result.url);
+        setLastCachedUrl(result.url);
+        setTotalPages(result.totalPages);
         setError(null);
         lastToastedError = "";
       })
@@ -151,11 +154,13 @@ export function Preview() {
             </svg>
           </button>
           <span class="text-sm font-mono text-stone min-w-[60px] text-center">
-            Page {ui.previewPage + 1}
+            {ui.previewPage + 1} / {totalPages()}
           </span>
           <button
-            class="p-1.5 text-stone hover:text-ink hover:bg-surface rounded transition-colors"
+            class="p-1.5 text-stone hover:text-ink hover:bg-surface rounded transition-colors
+              disabled:opacity-30 disabled:cursor-not-allowed"
             onClick={() => setPreviewPage(ui.previewPage + 1)}
+            disabled={ui.previewPage >= totalPages() - 1}
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
@@ -168,7 +173,27 @@ export function Preview() {
           </button>
         </div>
 
-        <div class="flex items-center gap-1">
+        <div class="flex items-center gap-2">
+          <Show when={totalPages() > 1}>
+            <span
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-mono"
+              style={{
+                background: "color-mix(in srgb, var(--turbo-state-warning) 15%, transparent)",
+                color: "var(--turbo-state-warning)",
+              }}
+              title={`Content spans ${totalPages()} pages`}
+            >
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              {totalPages()} pages
+            </span>
+          </Show>
           <button
             class="p-1.5 text-stone hover:text-ink hover:bg-surface rounded transition-colors"
             onClick={zoomOut}

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -58,6 +58,10 @@ export function Preview() {
         setPreviewUrl(result.url);
         setLastCachedUrl(result.url);
         setTotalPages(result.totalPages);
+        // Clamp page index when content shrinks (e.g., user deletes text)
+        if (ui.previewPage >= result.totalPages) {
+          setPreviewPage(Math.max(0, result.totalPages - 1));
+        }
         setError(null);
         lastToastedError = "";
       })

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -347,7 +347,7 @@ fn cmd_preview(
     resume.validate().context("Resume validation failed")?;
 
     let renderer = TypstRenderer::new();
-    let png = renderer
+    let (png, _total_pages) = renderer
         .render_preview(&resume, page)
         .context("Failed to render preview")?;
 

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -15,7 +15,7 @@
 //! let pdf_bytes = renderer.render_pdf(&resume)?;
 //!
 //! // Generate preview image
-//! let png_bytes = renderer.render_preview(&resume, 0)?;
+//! let (png_bytes, _total_pages) = renderer.render_preview(&resume, 0)?;
 //! ```
 
 mod traits;

--- a/crates/render/src/traits.rs
+++ b/crates/render/src/traits.rs
@@ -26,5 +26,10 @@ pub trait Renderer {
 
     /// Render resume preview image (PNG).
     /// `page` is zero-based (0 = first page).
-    fn render_preview(&self, resume: &ResumeData, page: usize) -> Result<Vec<u8>, RenderError>;
+    /// Returns `(png_bytes, total_page_count)`.
+    fn render_preview(
+        &self,
+        resume: &ResumeData,
+        page: usize,
+    ) -> Result<(Vec<u8>, usize), RenderError>;
 }

--- a/crates/render/src/typst_engine/engine.rs
+++ b/crates/render/src/typst_engine/engine.rs
@@ -286,9 +286,14 @@ impl Renderer for TypstRenderer {
     }
 
     #[instrument(skip(self, resume), fields(page))]
-    fn render_preview(&self, resume: &ResumeData, page: usize) -> Result<Vec<u8>, RenderError> {
+    fn render_preview(
+        &self,
+        resume: &ResumeData,
+        page: usize,
+    ) -> Result<(Vec<u8>, usize), RenderError> {
         debug!("Rendering preview for page {}", page);
         let document = self.compile(resume)?;
+        let total_pages = document.pages.len();
 
         // Get the requested page
         let page_content = document
@@ -306,7 +311,7 @@ impl Renderer for TypstRenderer {
             .encode_png()
             .map_err(|e| RenderError::RenderFailed(format!("PNG encoding failed: {}", e)))?;
 
-        Ok(png_bytes)
+        Ok((png_bytes, total_pages))
     }
 }
 

--- a/crates/render/tests/integration_tests.rs
+++ b/crates/render/tests/integration_tests.rs
@@ -330,12 +330,13 @@ fn test_render_preview_page_0() {
         result.err()
     );
 
-    let png = result.unwrap();
+    let (png, total_pages) = result.unwrap();
     // PNG files start with the PNG signature
     assert!(
         png.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
         "Output is not a valid PNG"
     );
+    assert!(total_pages >= 1, "Should have at least one page");
 }
 
 #[test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -472,7 +472,7 @@ async fn template_thumbnail(Path(id): Path<String>) -> Result<Response, ApiError
     resume.metadata.theme.background = theme.background.clone();
 
     let renderer = TypstRenderer::new();
-    let png = renderer
+    let (png, _total_pages) = renderer
         .render_preview(&resume, 0)
         .map_err(|e| ApiError::internal(format!("Failed to render thumbnail: {}", e)))?;
 
@@ -608,11 +608,15 @@ async fn render_preview(Json(req): Json<RenderPreviewRequest>) -> Result<Respons
 
     // Render
     let renderer = TypstRenderer::new();
-    let png = renderer
+    let (png, total_pages) = renderer
         .render_preview(&resume, req.page)
         .map_err(|e| ApiError::internal(format!("Failed to render preview: {}", e)))?;
 
-    Ok((StatusCode::OK, [(header::CONTENT_TYPE, "image/png")], png).into_response())
+    let mut response = (StatusCode::OK, [(header::CONTENT_TYPE, "image/png")], png).into_response();
+    response
+        .headers_mut()
+        .insert("X-Total-Pages", total_pages.to_string().parse().unwrap());
+    Ok(response)
 }
 
 /// Validate resume data
@@ -724,7 +728,8 @@ fn create_router() -> Router {
     let cors = {
         let base = CorsLayer::new()
             .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
-            .allow_headers([header::CONTENT_TYPE, header::ACCEPT]);
+            .allow_headers([header::CONTENT_TYPE, header::ACCEPT])
+            .expose_headers(["X-Total-Pages".parse::<header::HeaderName>().unwrap()]);
 
         match std::env::var("CORS_ORIGIN").ok() {
             Some(origin) if !origin.is_empty() && origin != "*" => {

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1065,6 +1065,7 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers().get("content-type").unwrap(), "image/png");
+        assert!(response.headers().contains_key("x-total-pages"));
 
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await


### PR DESCRIPTION
## Summary

- Return total page count from the render API via `X-Total-Pages` response header
- Display bounded page navigation (`X / Y`) with disabled controls at bounds
- Show a warning badge when content spans multiple pages, styled with `--turbo-state-warning`
- Clamp page index when total pages decreases (e.g., user deletes content)

- Closes #93.

## Changes

**Rust (render crate):**
- Changed `Renderer::render_preview` return type to `(Vec<u8>, usize)` to include total page count
- Updated all callers: server handler, CLI, template thumbnail

**Rust (server):**
- Added `X-Total-Pages` response header to `/api/render/preview`
- Exposed header via CORS `expose_headers`
- Added header assertion to `test_render_preview`

**Frontend:**
- Added `fetchBlobWithHeaders` to API client, refactored `fetchBlob` to use it
- `renderPreview` now returns `{ url, totalPages }` with cache support
- `Preview.tsx` shows `X / Y` page controls, disables next at bounds, displays warning badge for multi-page resumes

## Test plan

- [ ] Verify single-page resume shows `1 / 1` with no warning badge
- [ ] Verify multi-page resume shows `1 / N` with warning badge
- [ ] Verify page navigation buttons disable at bounds
- [ ] Verify deleting content that reduces page count clamps the page index
- [ ] Verify `X-Total-Pages` header present in preview API response
- [ ] Run `cargo test` — all pass
- [ ] Run `bun run tsc --noEmit` — no type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview now shows total page count (e.g., "Page 1 of 5") and a badge when >1 page.
  * Next-page control is disabled on the final page.
  * Previews populate and return page-count metadata for more accurate pagination.

* **Bug Fixes**
  * Page navigation now clamps to the available page range when preview content shrinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->