### PR TITLE
feat(docker): add multi-arch build support (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -36,7 +36,7 @@ jobs:
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       push: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       scan: true
       provenance: true
       sbom: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,10 +8,20 @@
 # =============================================================================
 FROM rust:1.94-alpine@sha256:7f752ee8ea5deb9f4863d8c3f228a216a6466619882f09a44b9eda9617dc7770 AS chef
 
+# BuildKit auto-populates TARGETARCH per --platform (amd64 | arm64)
+ARG TARGETARCH
+
 WORKDIR /app
 # musl-dev + make: required for tikv-jemalloc-sys to compile jemalloc from C source
+# Map TARGETARCH → Rust triple and persist for downstream stages
 RUN apk add --no-cache musl-dev make curl && \
-    cargo install cargo-chef@0.1.77 --locked
+    cargo install cargo-chef@0.1.77 --locked && \
+    case "${TARGETARCH}" in \
+      amd64) echo "x86_64-unknown-linux-musl" > /tmp/rust_target ;; \
+      arm64) echo "aarch64-unknown-linux-musl" > /tmp/rust_target ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2 && exit 1 ;; \
+    esac && \
+    rustup target add "$(cat /tmp/rust_target)"
 
 # =============================================================================
 # Stage 2: Planner (compute dependency recipe from workspace manifests)
@@ -32,6 +42,9 @@ RUN cargo chef prepare --recipe-path recipe.json
 # (triggered only when Cargo.toml or Cargo.lock change via recipe.json).
 FROM chef AS builder
 
+# Re-declare — ARGs do not cross FROM boundaries
+ARG TARGETARCH
+
 # Install fonts (data files for copying to runtime)
 RUN apk add --no-cache font-liberation font-dejavu
 
@@ -42,22 +55,25 @@ RUN apk add --no-cache font-liberation font-dejavu
 # NOTE: the /app/target cache mount is LOAD-BEARING across the cook and build
 # RUNs below — cook writes compiled deps there, build reads them. Cache mounts
 # are ephemeral (not captured in layers), so BOTH RUNs must mount the same id
-# (rustume-target). Removing the mount on cook breaks the hand-off and forces
-# build to recompile all deps from scratch even on warm cache.
+# (rustume-target-<arch>). Removing the mount on cook breaks the hand-off and
+# forces build to recompile all deps from scratch even on warm cache.
+# Cache ids are scoped per-arch so concurrent amd64/arm64 builds don't collide.
 COPY --from=planner /app/recipe.json recipe.json
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/app/target,id=rustume-target \
-    cargo chef cook --release --target x86_64-unknown-linux-musl \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TARGETARCH} \
+    --mount=type=cache,target=/app/target,id=rustume-target-${TARGETARCH} \
+    RUST_TARGET="$(cat /tmp/rust_target)" && \
+    cargo chef cook --release --target "${RUST_TARGET}" \
       --recipe-path recipe.json -p rustume-server
 
 # Copy workspace source and build (reuses cooked deps via shared target cache mount)
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY bindings ./bindings
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/app/target,id=rustume-target \
-    cargo build --release --target x86_64-unknown-linux-musl -p rustume-server && \
-    cp target/x86_64-unknown-linux-musl/release/rustume-server /app/rustume-server
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TARGETARCH} \
+    --mount=type=cache,target=/app/target,id=rustume-target-${TARGETARCH} \
+    RUST_TARGET="$(cat /tmp/rust_target)" && \
+    cargo build --release --target "${RUST_TARGET}" -p rustume-server && \
+    cp "target/${RUST_TARGET}/release/rustume-server" /app/rustume-server
 
 # =============================================================================
 # Stage 4: Runtime (distroless/static — no libc, no CVEs)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,7 @@ RUN apk add --no-cache musl-dev make curl && \
       amd64) echo "x86_64-unknown-linux-musl" > /tmp/rust_target ;; \
       arm64) echo "aarch64-unknown-linux-musl" > /tmp/rust_target ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2 && exit 1 ;; \
-    esac && \
-    rustup target add "$(cat /tmp/rust_target)"
+    esac
 
 # =============================================================================
 # Stage 2: Planner (compute dependency recipe from workspace manifests)


### PR DESCRIPTION
## Summary

- Map BuildKit `TARGETARCH` to Rust target triple via shell case statement
- Scope cache mount IDs per-arch to prevent concurrent build collisions
- Enable `linux/arm64` platform in CI workflow alongside existing `linux/amd64`

- Closes #163.

## Changes

**`docker/Dockerfile`:**
- Added `ARG TARGETARCH` in chef and builder stages
- Compute and persist Rust triple to `/tmp/rust_target` (inherited by builder via `FROM chef`)
- Replaced hardcoded `x86_64-unknown-linux-musl` with `$RUST_TARGET` in cook, build, and cp paths
- Scoped cache mount IDs: `rustume-target-${TARGETARCH}`, `rustume-registry-${TARGETARCH}`

**`.github/workflows/docker-build-publish.yml`:**
- Changed `platforms: linux/amd64` to `platforms: linux/amd64,linux/arm64`

## Notes

- Base images verified as manifest lists (multi-arch): `rust:1.94-alpine` and `gcr.io/distroless/static:nonroot`
- QEMU setup already handled by the reusable `lgtm-ci` workflow
- No cross-compilation env vars needed — QEMU emulates native builds
- arm64 builds under QEMU will be slower (~5-10x); native arm64 runners can be added later if needed

## Test plan

- [ ] Verify `docker buildx build --platform linux/amd64 -f docker/Dockerfile .` succeeds
- [ ] Verify `docker buildx build --platform linux/arm64 -f docker/Dockerfile .` succeeds
- [ ] Verify CI workflow builds both platforms
- [ ] Verify resulting image runs on both amd64 and arm64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images now build and publish for both x86-64 and ARM64 architectures, enabling broader platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->