### PR TITLE
ci(release): gate release PR on test suite passing

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -5,8 +5,21 @@ name: Release - Automated PR Creation
 # Uses lgtm-ci calculate-version action for version computation.
 
 "on":
+  # Gate releases on CI passing: only trigger after the Rust test suite
+  # completes on main. The job condition below rejects failed runs.
+  workflow_run:
+    workflows: ["Test - Rust Test Suite"]
+    branches: [main]
+    types: [completed]
+  # For commits that don't touch Rust source (docs, scripts, templates, etc.)
+  # the test suite never runs, so fall back to a direct push trigger.
   push:
     branches: [main]
+    paths-ignore:
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/test-rust.yml"
   workflow_dispatch:
 
 permissions:
@@ -16,6 +29,13 @@ jobs:
   open-release-pr:
     name: Compute next version and open Release PR
     runs-on: ubuntu-24.04
+    # When triggered by workflow_run, only proceed if the test suite passed.
+    # Push and workflow_dispatch triggers always proceed (no Rust CI to gate on).
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -11,15 +11,21 @@ name: Release - Automated PR Creation
     workflows: ["Test - Rust Test Suite"]
     branches: [main]
     types: [completed]
-  # For commits that don't touch Rust source (docs, scripts, templates, etc.)
+  # For commits that don't touch Rust source (docs, scripts, Docker, etc.)
   # the test suite never runs, so fall back to a direct push trigger.
+  # Using an explicit include list (paths) ensures Rust-only commits never
+  # fire this trigger. Mixed commits may still fire both paths, but the
+  # branch protection required-checks gate auto-merge on the release PR.
   push:
     branches: [main]
-    paths-ignore:
-      - "**.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/test-rust.yml"
+    paths:
+      - "docs/**"
+      - "scripts/**"
+      - "docker/**"
+      - "**.md"
+      - "renovate.json"
+      - ".github/**"
+      - "Makefile"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -14,11 +14,6 @@ name: Test - Rust Test Suite
       - ".github/workflows/test-rust.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "**.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/test-rust.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci(release): gate release PR on test suite passing
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Fixes a recurring issue where a release PR was created and auto-merged immediately after any PR merged to `main`, even if CI was still running or had failed.

**Root cause:** `semantic-release.yml` triggered on any `push` to `main`, then enabled auto-merge on the release PR. With no required status checks configured in branch protection, GitHub merged the release PR instantly — nothing to wait for.

**Fix — two parts:**

1. **Workflow trigger change** (`semantic-release.yml`): Replace the bare `push` trigger with a `workflow_run` trigger on `"Test - Rust Test Suite"`. The release PR is now only created after the test suite completes on `main`, and a job-level `if` condition rejects runs where `conclusion != 'success'`. A `paths-ignore` `push` fallback handles commits that don't touch Rust source (docs, scripts, templates) where the test suite never runs.

2. **Branch protection enabled** on `main` with `🧪 Run Tests` and `🔨 Build Check` as required status checks. This means auto-merge on release PRs now waits for CI to pass rather than merging immediately.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`cargo test && cargo clippy`)

## Details

### Trigger logic after this change

| What changed | Trigger path | Release PR created? |
|---|---|---|
| Rust source / `Cargo.toml` / `Cargo.lock` | `workflow_run` fires after tests complete | Only if tests pass |
| Docs, scripts, templates, other workflows | `push` fires immediately (paths-ignore) | Yes, no Rust CI to gate on |
| Manual | `workflow_dispatch` | Yes |

### Branch protection settings applied

- Required checks: `🧪 Run Tests`, `🔨 Build Check`
- `enforce_admins`: false (admins can still bypass if needed)
- `allow_force_pushes`: true (preserves existing workflow)
- No PR review requirements added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated: release workflow will also trigger from upstream test runs and now only proceeds when those upstream runs succeed; release job runs for direct pushes and manual dispatches.
  * Test workflow updated: PR-trigger behavior broadened so Rust test suite runs for all pull requests targeting main (no longer limited by file-path filters).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->