### PR TITLE
ci: pin reusable Docker workflow to lgtm-ci v0.10.2

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -25,7 +25,7 @@ jobs:
   docker:
     name: 🐳 Docker Build & Publish
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d4f6701dfe6c08c7c80f134aee084ed8debb489a # v0.12.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@3ce2f6cc0ae201d97ebe3a86f5770840947c9f04 # v0.10.2
     permissions:
       contents: read
       packages: write

--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -40,7 +40,9 @@
     },
   },
   "overrides": {
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
     "@rollup/plugin-terser": "^1.0.0",
+    "fast-uri": ">=3.1.2",
   },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
@@ -177,7 +179,7 @@
 
     "@babel/plugin-transform-modules-commonjs": ["@babel/plugin-transform-modules-commonjs@7.28.6", "", { "dependencies": { "@babel/helper-module-transforms": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA=="],
 
-    "@babel/plugin-transform-modules-systemjs": ["@babel/plugin-transform-modules-systemjs@7.29.0", "", { "dependencies": { "@babel/helper-module-transforms": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.29.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ=="],
+    "@babel/plugin-transform-modules-systemjs": ["@babel/plugin-transform-modules-systemjs@7.29.4", "", { "dependencies": { "@babel/helper-module-transforms": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.29.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w=="],
 
     "@babel/plugin-transform-modules-umd": ["@babel/plugin-transform-modules-umd@7.27.1", "", { "dependencies": { "@babel/helper-module-transforms": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w=="],
 
@@ -711,7 +713,7 @@
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 

--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -40,9 +40,9 @@
     },
   },
   "overrides": {
-    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "@rollup/plugin-terser": "^1.0.0",
-    "fast-uri": ">=3.1.2",
+    "fast-uri": "^3.1.2",
   },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,8 @@
     "typescript": "^5"
   },
   "overrides": {
-    "@rollup/plugin-terser": "^1.0.0"
+    "@rollup/plugin-terser": "^1.0.0",
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+    "fast-uri": ">=3.1.2"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,7 +47,7 @@
   },
   "overrides": {
     "@rollup/plugin-terser": "^1.0.0",
-    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
-    "fast-uri": ">=3.1.2"
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4",
+    "fast-uri": "^3.1.2"
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci: pin reusable Docker workflow to lgtm-ci v0.10.2
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

### 1. Docker workflow pin

Pins [`.github/workflows/docker-build-publish.yml`](.github/workflows/docker-build-publish.yml) from lgtm-ci `reusable-docker.yml` **v0.12.0** back to **v0.10.2** (`3ce2f6cc0ae201d97ebe3a86f5770840947c9f04`).

**Why:** v0.11.0+ expects caller repos to vendor `scripts/ci/actions/build-docker.sh`, `scripts/ci/lib/**`, and local composite actions under `.github/actions/`. That duplicates lgtm-ci and broke Docker builds on `main` (exit 127). v0.10.2 is self-contained and was the last known-good pin.

**Follow-up:** [lgtm-hq/lgtm-ci#137](https://github.com/lgtm-hq/lgtm-ci/issues/137) tracks refactoring the reusable Docker workflow to use the same `.lgtm-ci-tooling/` checkout pattern as release workflows, aligned with [#55](https://github.com/lgtm-hq/lgtm-ci/issues/55).

### 2. Security dependency overrides

Adds `overrides` in `apps/web/package.json` to patch vulnerable transitive dependencies:

| Override | Range | Fixes |
|---|---|---|
| `@babel/plugin-transform-modules-systemjs` | `^7.29.4` (was 7.29.0 via `@babel/preset-env`) | [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) |
| `fast-uri` | `^3.1.2` (was 3.1.0 via `ajv`) | [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6), [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) |

Caret ranges allow compatible patch/minor updates while preventing unrestricted major bumps.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`cargo test && cargo clippy`)

## Closes

- Relates to https://github.com/lgtm-hq/lgtm-ci/issues/137
- Relates to https://github.com/lgtm-hq/lgtm-ci/issues/55

## Details

- Stopgap only: restores green Docker builds without vendoring scripts into Rustume.
- After lgtm-ci#137 lands, Renovate can bump the pin again without per-repo script trees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow and dependency management configurations to maintain system stability and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/Rustume/pull/209)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->