### PR TITLE
ci: gate release auto-merge to patch bumps

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -130,7 +130,9 @@ jobs:
             release-bump
 
       - name: Enable auto-merge for Release PR
-        if: steps.cpr.outputs.pull-request-number != ''
+        if: >-
+          steps.cpr.outputs.pull-request-number != ''
+          && steps.semrel.outputs.bump-type == 'patch'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Summary

Limits release PR auto-merge to patch version bumps only, using `bump-type` from the calculate-version action.

## Type of Change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [x] ci

## Related Issues

Part of org ruleset consistency rollout.