### PR TITLE
fix(docker): pin web-builder to amd64 for wasm-bindgen

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,15 +76,20 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TA
 
 # =============================================================================
 # Stage 4: Web builder (WASM bindings + Vite static bundle)
+# Pinned to amd64: wasm-pack/wasm-bindgen produce arch-independent output and
+# the toolchain is more reliable on x86_64 (avoids arm64 wasm-bindgen crashes).
 # =============================================================================
-FROM chef AS web-builder
+# DL3029: intentional — WASM output is arch-independent; arm64 wasm-bindgen crashes (exit 255)
+# hadolint ignore=DL3029
+FROM --platform=linux/amd64 rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS web-builder
 
+WORKDIR /app
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 ENV BUN_INSTALL=/usr/local/bun
 ENV PATH="${BUN_INSTALL}/bin:${PATH}"
 
-RUN apk add --no-cache bash unzip ca-certificates && \
+RUN apk add --no-cache musl-dev bash unzip ca-certificates && \
     rustup target add wasm32-unknown-unknown && \
     cargo install wasm-pack --locked && \
     curl -fsSL https://bun.sh/install | bash


### PR DESCRIPTION
## Summary

- The Docker build for `linux/arm64` failed on main because `wasm-bindgen` exits with status 255 when running on ARM64 Alpine.
- Pin the web-builder stage to `--platform=linux/amd64` since WASM compilation produces architecture-independent output and the built JS/WASM bundle is just copied into the final multi-arch runtime image.

## Test plan

- [ ] Docker build succeeds for both `linux/amd64` and `linux/arm64` platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker build platform configuration to pin the architecture used for the WASM toolchain, improving build consistency and reproducibility.
  * Added inline comments and linter directives to document and allow the deliberate platform pinning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/Rustume/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->