### PR TITLE
fix(docker): add curl to web-builder for bun install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 ENV BUN_INSTALL=/usr/local/bun
 ENV PATH="${BUN_INSTALL}/bin:${PATH}"
 
-RUN apk add --no-cache musl-dev bash unzip ca-certificates && \
+RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
     rustup target add wasm32-unknown-unknown && \
     cargo install wasm-pack --locked && \
     curl -fsSL https://bun.sh/install | bash


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(docker): add curl to web-builder for bun install
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

PR #228 moved the web-builder stage off `chef` onto a standalone `rust:alpine` image but omitted `curl`, which the bun install script requires. Main Docker builds failed on both amd64 and arm64 with `/bin/ash: curl: not found` (exit 127).

This adds `curl` to the web-builder `apk add` line. No other packages are missing for that stage (`make` is only needed for jemalloc in the server builder, not WASM).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`)

## Closes

- Relates to #228

## Details

**Dependency audit (web-builder vs chef):**

| Package | chef | web-builder | Needed? |
| --- | --- | --- | --- |
| musl-dev | yes | yes | WASM/native link |
| make | yes | no | jemalloc server build only |
| curl | yes | yes (this PR) | bun install script |
| bash | no | yes | bun install `| bash` |
| unzip | no | yes | wasm-pack archives |
| ca-certificates | no | yes | HTTPS |

Docker image builds only run on push to `main` (not on PRs), so this regression was not caught before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build environment configuration with additional system packages to enhance build capabilities and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/Rustume/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->