### PR TITLE
fix(deploy): restore production Docker publish and native builds

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: MIT
 ---
 name: Build - Docker Image & Registry
-# Builds and tests Docker image. Publishes to GHCR on main and release events.
+# Builds and publishes Docker images to GHCR.
+# - push main (path-filtered): :main and :sha-* for bleeding-edge
+# - push v*.*.* tags: :latest and semver tags for releases
 # Uses lgtm-ci reusable Docker workflow.
 
 "on":
@@ -16,6 +18,8 @@ name: Build - Docker Image & Registry
       - "Cargo.lock"
       - ".dockerignore"
       - ".github/workflows/docker-build-publish.yml"
+    tags:
+      - "v*.*.*"
   release:
     types: [published]
   workflow_dispatch:
@@ -37,9 +41,15 @@ jobs:
     with:
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
-      version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
-      push: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
+      version: >-
+        ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name
+        || (github.event_name == 'release' && github.event.release.tag_name || '') }}
+      push: >-
+        ${{ github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/tags/v')
+        || github.event_name == 'release' }}
       platforms: linux/amd64,linux/arm64
       scan: true
       provenance: true
       sbom: true
+      smoke-test: --health

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -94,6 +94,15 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Create GitHub App installation token
+        id: app-token
+        # yamllint disable-line rule:line-length
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
         uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@58be2e8b58936973af5da34f19f5fea7336ba1e5 # v0
@@ -101,3 +110,5 @@ jobs:
           tag: ${{ github.ref_name }}
           generate-notes: "true"
           files: artifacts/*
+          # App token so release:published can trigger downstream workflows
+          token: ${{ steps.app-token.outputs.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,29 @@ The PR title becomes the merge commit message (squash merge). Follow the same co
 - Use descriptive test names: `test_parse_json_resume_with_empty_basics`
 - Test both success and error paths
 
+## Troubleshooting
+
+### `make build` fails downloading Swagger UI
+
+The server crate uses `utoipa-swagger-ui` with the `reqwest` feature so Swagger
+UI is downloaded at compile time using system TLS (not `curl` with a hardcoded
+CA path). If the error persists, ensure network access to GitHub releases and
+run `cargo clean -p utoipa-swagger-ui` before rebuilding.
+
+### `docker build` fails installing bun (SSL error)
+
+The Dockerfile runs `update-ca-certificates` before any `curl` to GitHub. If
+you are behind a corporate proxy, add your organization's CA to Docker Desktop
+(**Settings → Docker Engine** or trusted certs) and retry.
+
+### `docker pull ghcr.io/lgtm-hq/rustume:latest` not found
+
+Release images are published on `v*.*.*` tag push, not on every `main` merge.
+Check Actions → “Build - Docker Image & Registry” for the release tag workflow.
+Until then, build locally with `docker build -t rustume -f docker/Dockerfile .`
+or pull `:main` for the latest main-branch image. See
+[docs/deployment.md](docs/deployment.md).
+
 ## Getting Help
 
 - Open an issue for bugs or feature requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,13 @@ Use the Makefile for common build flows:
 ```bash
 make build       # Build WASM, server, and web bundle
 make preview     # Preview production assets locally
-docker compose up # Run the published container image
+```
+
+To run the published GHCR image with Compose (requires `latest` or a semver tag
+from a release — see [docs/deployment.md](docs/deployment.md)):
+
+```bash
+docker compose up
 ```
 
 ## Architecture Overview
@@ -232,11 +238,22 @@ UI is downloaded at compile time using system TLS (not `curl` with a hardcoded
 CA path). If the error persists, ensure network access to GitHub releases and
 run `cargo clean -p utoipa-swagger-ui` before rebuilding.
 
-### `docker build` fails installing bun (SSL error)
+### `docker build` fails installing bun (SSL or Rosetta)
 
 The Dockerfile runs `update-ca-certificates` before any `curl` to GitHub. If
 you are behind a corporate proxy, add your organization's CA to Docker Desktop
 (**Settings → Docker Engine** or trusted certs) and retry.
+
+On Apple Silicon, `rosetta error: failed to open elf at /lib/ld-musl-x86_64.so.1`
+means an amd64 musl `bun` binary ran under Rosetta. Build for your native
+platform instead:
+
+```bash
+docker build --platform linux/arm64 -t rustume -f docker/Dockerfile .
+```
+
+CI publishes `linux/amd64` and `linux/arm64` images via buildx; both arches
+install the matching `bun-linux-*-musl` zip in the web-builder stage.
 
 ### `docker pull ghcr.io/lgtm-hq/rustume:latest` not found
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1240,6 +1241,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -1277,8 +1284,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1652,6 +1662,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3255,6 +3266,46 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -3454,6 +3505,7 @@ checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3523,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-cli"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3544,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-parser"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "csv",
  "cuid2",
@@ -3560,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-render"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "chrono",
  "rstest",
@@ -3579,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-schema"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "cuid2",
  "once_cell",
@@ -3596,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-schema-macros"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3605,20 +3657,21 @@ dependencies = [
 
 [[package]]
 name = "rustume-server"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",
  "base64",
  "http-body-util",
  "lru",
- "reqwest",
+ "reqwest 0.13.3",
  "rustume-parser",
  "rustume-render",
  "rustume-schema",
  "rustume-utils",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tikv-jemallocator",
  "tokio",
@@ -3633,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-storage"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -3650,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-utils"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "ammonia",
  "chrono",
@@ -3664,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-wasm"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "js-sys",
  "rustume-parser",
@@ -5282,6 +5335,7 @@ dependencies = [
  "base64",
  "mime_guess",
  "regex",
+ "reqwest 0.12.28",
  "rust-embed",
  "serde",
  "serde_json",
@@ -5607,6 +5661,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/README.md
+++ b/README.md
@@ -43,13 +43,9 @@ make dev
 
 Open <http://localhost:5173> to use the web app during development.
 
-For Docker:
-
-```bash
-docker run -p 3000:3000 ghcr.io/lgtm-hq/rustume:latest
-```
-
-Open <http://localhost:3000> for the full resume builder UI.
+For self-hosting with Docker, see [Deployment](docs/deployment.md). The
+published image (`ghcr.io/lgtm-hq/rustume:latest`) requires a public GHCR package;
+if pull fails, build from source per the deployment guide.
 
 CLI commands are also available:
 
@@ -96,28 +92,14 @@ rustume init -o my-resume.json
 
 ## 🐳 Docker
 
+See [Deployment](docs/deployment.md) for pull-from-GHCR, build-from-source,
+compose layouts, environment variables, and troubleshooting.
+
+Quick check after the container is running:
+
 ```bash
-# Pull and run the published image
-docker run -p 3000:3000 ghcr.io/lgtm-hq/rustume:latest
-
-# Or use Compose from the repository root
-docker compose up
-
-# Build locally
-docker build -t rustume -f docker/Dockerfile .
-
-# Run a local build
-docker run -p 3000:3000 rustume
-
-# Health check
-curl http://localhost:3000/health
+curl -sf http://localhost:3000/health
 ```
-
-The container serves the SolidJS web app at `/`, Swagger UI at `/swagger-ui/`,
-and the OpenAPI spec at `/api-docs/openapi.json`.
-
-See [Deployment](docs/deployment.md) for environment variables and production
-deployment notes.
 
 ## 🔨 Development
 

--- a/apps/web/src/components/builder/CustomSectionEditor.tsx
+++ b/apps/web/src/components/builder/CustomSectionEditor.tsx
@@ -1,5 +1,6 @@
 import { For, Show, createSignal } from "solid-js";
-import { Button, Input, RichTextEditor } from "../ui";
+import { Button, Input } from "../ui";
+import { LazyRichTextEditor as RichTextEditor } from "../ui/LazyRichTextEditor";
 import { resumeStore } from "../../stores/resume";
 import { createEmptyUrl, generateId, type CustomItem } from "../../wasm/types";
 

--- a/apps/web/src/components/builder/SectionEditor.tsx
+++ b/apps/web/src/components/builder/SectionEditor.tsx
@@ -1,5 +1,6 @@
 import { For, Show, createSignal, type JSX } from "solid-js";
-import { Button, Input, RichTextEditor } from "../ui";
+import { Button, Input } from "../ui";
+import { LazyRichTextEditor as RichTextEditor } from "../ui/LazyRichTextEditor";
 import { resumeStore, type SectionKey } from "../../stores/resume";
 import { generateId, createEmptyUrl } from "../../wasm/types";
 import type {

--- a/apps/web/src/components/builder/SummaryEditor.tsx
+++ b/apps/web/src/components/builder/SummaryEditor.tsx
@@ -1,5 +1,5 @@
 import { Show } from "solid-js";
-import { RichTextEditor } from "../ui";
+import { LazyRichTextEditor as RichTextEditor } from "../ui/LazyRichTextEditor";
 import { resumeStore } from "../../stores/resume";
 
 export function SummaryEditor() {

--- a/apps/web/src/components/builder/index.ts
+++ b/apps/web/src/components/builder/index.ts
@@ -2,7 +2,6 @@ export { BasicsForm } from "./BasicsForm";
 export { ImageUpload, type ImageUploadProps } from "./ImageUpload";
 export { SectionList } from "./SectionList";
 export { SectionPanel } from "./SectionPanel";
-export { SummaryEditor } from "./SummaryEditor";
 export { CustomSectionEditor, CustomSectionsIndex } from "./CustomSectionEditor";
 export {
   SectionEditor,

--- a/apps/web/src/components/ui/EditorThemeSelector.tsx
+++ b/apps/web/src/components/ui/EditorThemeSelector.tsx
@@ -1,6 +1,7 @@
-import { For, Show, createMemo } from "solid-js";
+import { createResource, For, Show, createMemo, onMount } from "solid-js";
 import { DropdownMenu } from "@kobalte/core/dropdown-menu";
-import { editorThemeStore, flavors, type ThemeFlavor } from "../../stores/editorTheme";
+import { editorThemeStore, loadThemeFlavors, type ThemeFlavor } from "../../stores/editorTheme";
+import { Spinner } from "./Spinner";
 
 interface ThemeGroup {
   label: string;
@@ -8,9 +9,19 @@ interface ThemeGroup {
 }
 
 export function EditorThemeSelector() {
+  const [flavors] = createResource(loadThemeFlavors);
+
+  onMount(() => {
+    void editorThemeStore.ensureFlavorsLoaded();
+  });
+
   const groupedThemes = createMemo((): ThemeGroup[] => {
-    const light = flavors.filter((f) => f.appearance === "light");
-    const dark = flavors.filter((f) => f.appearance === "dark");
+    const loaded = flavors();
+    if (!loaded) {
+      return [];
+    }
+    const light = loaded.filter((flavor) => flavor.appearance === "light");
+    const dark = loaded.filter((flavor) => flavor.appearance === "dark");
     return [
       { label: "Light", themes: light },
       { label: "Dark", themes: dark },
@@ -20,86 +31,89 @@ export function EditorThemeSelector() {
   const currentTheme = () => editorThemeStore.currentTheme;
 
   return (
-    <DropdownMenu>
-      <DropdownMenu.Trigger class="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-surface transition-colors text-sm">
-        <div class="flex items-center gap-1.5">
-          <div
-            class="w-3 h-3 rounded-full border border-border"
-            style={{ background: currentTheme()?.tokens.background.base }}
-          />
-          <div
-            class="w-3 h-3 rounded-full border border-border -ml-1.5"
-            style={{ background: currentTheme()?.tokens.brand.primary }}
-          />
+    <Show
+      when={!flavors.loading && flavors()}
+      fallback={
+        <div class="flex items-center gap-2 px-2 py-1.5">
+          <Spinner class="w-4 h-4" />
         </div>
-        <span class="font-mono text-xs text-stone hidden sm:inline">
-          {currentTheme()?.label ?? "Theme"}
-        </span>
-        <svg class="w-3 h-3 text-stone" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
-      </DropdownMenu.Trigger>
-
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content class="min-w-[200px] max-h-[400px] overflow-y-auto bg-paper border border-border rounded-lg shadow-card p-1 z-50">
-          <For each={groupedThemes()}>
-            {(group) => (
-              <>
-                <DropdownMenu.Group>
-                  <DropdownMenu.GroupLabel class="px-2 py-1.5 text-xs font-mono uppercase tracking-wider text-stone">
-                    {group.label}
-                  </DropdownMenu.GroupLabel>
-                  <For each={group.themes}>
-                    {(theme) => (
-                      <DropdownMenu.Item
-                        class="flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer hover:bg-surface outline-none data-[highlighted]:bg-surface"
-                        onSelect={() => editorThemeStore.setTheme(theme.id)}
-                      >
-                        <div class="flex items-center gap-1">
-                          <div
-                            class="w-3 h-3 rounded-full border border-border"
-                            style={{ background: theme.tokens.background.base }}
-                          />
-                          <div
-                            class="w-3 h-3 rounded-full border border-border"
-                            style={{ background: theme.tokens.text.primary }}
-                          />
-                          <div
-                            class="w-3 h-3 rounded-full border border-border"
-                            style={{ background: theme.tokens.brand.primary }}
-                          />
-                        </div>
-                        <span class="flex-1 text-sm text-ink">{theme.label}</span>
-                        <Show when={editorThemeStore.state.themeId === theme.id}>
-                          <svg
-                            class="w-4 h-4 text-accent"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M5 13l4 4L19 7"
+      }
+    >
+      <DropdownMenu>
+        <DropdownMenu.Trigger class="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-surface transition-colors text-sm">
+          <div class="flex items-center gap-1.5">
+            <div
+              class="w-3 h-3 rounded-full border border-border"
+              style={{ background: currentTheme()?.tokens.background.base }}
+            />
+            <div
+              class="w-3 h-3 rounded-full border border-border -ml-1.5"
+              style={{ background: currentTheme()?.tokens.brand.primary }}
+            />
+          </div>
+          <span class="font-mono text-xs text-stone hidden sm:inline">
+            {currentTheme()?.label ?? "Theme"}
+          </span>
+          <svg class="w-3 h-3 text-stone" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content class="z-50 min-w-[200px] rounded-lg border border-border bg-paper shadow-soft p-1">
+            <For each={groupedThemes()}>
+              {(group) => (
+                <>
+                  <DropdownMenu.Group>
+                    <DropdownMenu.GroupLabel class="px-2 py-1 text-xs font-mono text-stone uppercase tracking-wider">
+                      {group.label}
+                    </DropdownMenu.GroupLabel>
+                    <For each={group.themes}>
+                      {(theme) => (
+                        <DropdownMenu.Item
+                          class="flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer outline-none hover:bg-surface focus:bg-surface"
+                          onSelect={() => editorThemeStore.setTheme(theme.id)}
+                        >
+                          <div class="flex items-center gap-1">
+                            <div
+                              class="w-3 h-3 rounded-full border border-border"
+                              style={{ background: theme.tokens.background.base }}
                             />
-                          </svg>
-                        </Show>
-                      </DropdownMenu.Item>
-                    )}
-                  </For>
-                </DropdownMenu.Group>
-                <DropdownMenu.Separator class="h-px bg-border my-1" />
-              </>
-            )}
-          </For>
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
-    </DropdownMenu>
+                            <div
+                              class="w-3 h-3 rounded-full border border-border"
+                              style={{ background: theme.tokens.brand.primary }}
+                            />
+                          </div>
+                          <span class="text-sm flex-1">{theme.label}</span>
+                          <Show when={editorThemeStore.state.themeId === theme.id}>
+                            <svg
+                              class="w-4 h-4 text-accent"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M5 13l4 4L19 7"
+                              />
+                            </svg>
+                          </Show>
+                        </DropdownMenu.Item>
+                      )}
+                    </For>
+                  </DropdownMenu.Group>
+                </>
+              )}
+            </For>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu>
+    </Show>
   );
 }

--- a/apps/web/src/components/ui/LazyRichTextEditor.tsx
+++ b/apps/web/src/components/ui/LazyRichTextEditor.tsx
@@ -1,0 +1,23 @@
+import { lazy, Suspense } from "solid-js";
+import { Spinner } from "./Spinner";
+import type { RichTextEditorProps } from "./RichTextEditor";
+
+const RichTextEditor = lazy(() =>
+  import("./RichTextEditor").then((module) => ({ default: module.RichTextEditor })),
+);
+
+export function LazyRichTextEditor(props: RichTextEditorProps) {
+  return (
+    <Suspense
+      fallback={
+        <div class="flex min-h-[120px] items-center justify-center rounded-md border border-border bg-surface">
+          <Spinner class="w-4 h-4" />
+        </div>
+      }
+    >
+      <RichTextEditor {...props} />
+    </Suspense>
+  );
+}
+
+export type { RichTextEditorProps };

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,7 +1,11 @@
 export { Button, type ButtonProps } from "./Button";
 export { Input, type InputProps } from "./Input";
 export { TextArea, type TextAreaProps } from "./TextArea";
-export { LazyRichTextEditor, type RichTextEditorProps } from "./LazyRichTextEditor";
+export {
+  LazyRichTextEditor,
+  LazyRichTextEditor as RichTextEditor,
+  type RichTextEditorProps,
+} from "./LazyRichTextEditor";
 export { Modal, type ModalProps } from "./Modal";
 export { Accordion, type AccordionProps, type AccordionItemData } from "./Accordion";
 export { Switch, type SwitchProps } from "./Switch";

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,7 +1,7 @@
 export { Button, type ButtonProps } from "./Button";
 export { Input, type InputProps } from "./Input";
 export { TextArea, type TextAreaProps } from "./TextArea";
-export { RichTextEditor, type RichTextEditorProps } from "./RichTextEditor";
+export { LazyRichTextEditor, type RichTextEditorProps } from "./LazyRichTextEditor";
 export { Modal, type ModalProps } from "./Modal";
 export { Accordion, type AccordionProps, type AccordionItemData } from "./Accordion";
 export { Switch, type SwitchProps } from "./Switch";

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -1,13 +1,12 @@
-import { createMemo, createSignal, onMount, Show } from "solid-js";
+import { createMemo, createSignal, lazy, onMount, Show, Suspense } from "solid-js";
 import { useParams, useNavigate } from "@solidjs/router";
-import { Button, toast, ShortcutsModal } from "../components/ui";
+import { Button, toast, ShortcutsModal, Spinner } from "../components/ui";
 import { useHotkeys, type Shortcut } from "../hooks/useHotkeys";
 import { useNavigationGuard } from "../hooks/useNavigationGuard";
 import { SplitPane } from "../components/layout/SplitPane";
 import { Sidebar, type SidebarItem } from "../components/layout/Sidebar";
 import {
   BasicsForm,
-  SummaryEditor,
   SectionPanel,
   ExperienceEditor,
   EducationEditor,
@@ -24,14 +23,45 @@ import {
   CustomSectionEditor,
   CustomSectionsIndex,
 } from "../components/builder";
-import { Preview } from "../components/preview";
-import { TemplatePicker, ThemeEditor } from "../components/templates";
-import { ImportModal } from "../components/import";
-import { ExportModal } from "../components/export";
-import { LayoutEditor } from "../components/LayoutEditor";
 import { resumeStore, isNotFoundError } from "../stores/resume";
 import { uiStore } from "../stores/ui";
 import { isWasmReady } from "../wasm";
+
+const Preview = lazy(() =>
+  import("../components/preview").then((module) => ({ default: module.Preview })),
+);
+const LayoutEditor = lazy(() =>
+  import("../components/LayoutEditor").then((module) => ({ default: module.LayoutEditor })),
+);
+const SummaryEditor = lazy(() =>
+  import("../components/builder/SummaryEditor").then((module) => ({
+    default: module.SummaryEditor,
+  })),
+);
+const ThemeEditor = lazy(() =>
+  import("../components/templates/ThemeEditor").then((module) => ({
+    default: module.ThemeEditor,
+  })),
+);
+const TemplatePicker = lazy(() =>
+  import("../components/templates/TemplatePicker").then((module) => ({
+    default: module.TemplatePicker,
+  })),
+);
+const ImportModal = lazy(() =>
+  import("../components/import/ImportModal").then((module) => ({ default: module.ImportModal })),
+);
+const ExportModal = lazy(() =>
+  import("../components/export/ExportModal").then((module) => ({ default: module.ExportModal })),
+);
+
+function TabFallback() {
+  return (
+    <div class="flex min-h-[200px] items-center justify-center">
+      <Spinner />
+    </div>
+  );
+}
 
 type EditorTab =
   | "basics"
@@ -311,9 +341,17 @@ export default function Editor() {
       case "basics":
         return <BasicsForm />;
       case "summary":
-        return <SummaryEditor />;
+        return (
+          <Suspense fallback={<TabFallback />}>
+            <SummaryEditor />
+          </Suspense>
+        );
       case "layout":
-        return <LayoutEditor />;
+        return (
+          <Suspense fallback={<TabFallback />}>
+            <LayoutEditor />
+          </Suspense>
+        );
       case "experience":
         return <ExperienceEditor />;
       case "education":
@@ -345,7 +383,11 @@ export default function Editor() {
           />
         );
       case "theme":
-        return <ThemeEditor />;
+        return (
+          <Suspense fallback={<TabFallback />}>
+            <ThemeEditor />
+          </Suspense>
+        );
       default:
         if (activeTab().startsWith("custom:")) {
           const sectionId = activeTab().slice("custom:".length);
@@ -528,7 +570,9 @@ export default function Editor() {
             }
             right={
               <div class="h-full relative">
-                <Preview />
+                <Suspense fallback={<TabFallback />}>
+                  <Preview />
+                </Suspense>
                 <SectionPanel />
               </div>
             }
@@ -536,10 +580,22 @@ export default function Editor() {
         </Show>
       </div>
 
-      {/* Modals */}
-      <TemplatePicker />
-      <ImportModal />
-      <ExportModal />
+      {/* Modals — loaded on demand to keep the editor chunk smaller */}
+      <Show when={ui.modal === "template"}>
+        <Suspense fallback={null}>
+          <TemplatePicker />
+        </Suspense>
+      </Show>
+      <Show when={ui.modal === "import"}>
+        <Suspense fallback={null}>
+          <ImportModal />
+        </Suspense>
+      </Show>
+      <Show when={ui.modal === "export"}>
+        <Suspense fallback={null}>
+          <ExportModal />
+        </Suspense>
+      </Show>
       <ShortcutsModal shortcuts={shortcuts} />
     </div>
   );

--- a/apps/web/src/stores/__tests__/editorTheme.test.ts
+++ b/apps/web/src/stores/__tests__/editorTheme.test.ts
@@ -1,6 +1,7 @@
 import { createRoot } from "solid-js";
 
-vi.mock("@lgtm-hq/turbo-themes", () => ({
+const turboThemesMock = vi.hoisted(() => ({
+  failImport: false,
   flavors: [
     {
       id: "catppuccin-mocha",
@@ -30,7 +31,16 @@ vi.mock("@lgtm-hq/turbo-themes", () => ({
         content: { selection: { bg: "#acb0be" } },
       },
     },
-  ],
+  ] as const,
+}));
+
+vi.mock("@lgtm-hq/turbo-themes", () => ({
+  get flavors() {
+    if (turboThemesMock.failImport) {
+      throw new Error("network error");
+    }
+    return turboThemesMock.flavors;
+  },
 }));
 
 import { useEditorTheme } from "../editorTheme";
@@ -38,6 +48,7 @@ import { useEditorTheme } from "../editorTheme";
 describe("useEditorTheme", () => {
   beforeEach(() => {
     localStorage.clear();
+    turboThemesMock.failImport = false;
   });
 
   it('initial themeId is "catppuccin-mocha"', () => {
@@ -56,6 +67,30 @@ describe("useEditorTheme", () => {
 
       setTheme("non-existent-theme");
       expect(state.themeId).toBe(before);
+      dispose();
+    });
+  });
+
+  it("retries loading flavors after import failure", async () => {
+    turboThemesMock.failImport = true;
+    vi.resetModules();
+    const { loadThemeFlavors: loadFlavors } = await import("../editorTheme");
+    await expect(loadFlavors()).rejects.toThrow("network error");
+
+    turboThemesMock.failImport = false;
+    const flavors = await loadFlavors();
+    expect(flavors).toHaveLength(2);
+  });
+
+  it("resets stale saved theme to default in localStorage", async () => {
+    localStorage.setItem("rustume-editor-theme", "removed-theme");
+    vi.resetModules();
+    const { useEditorTheme: useTheme } = await import("../editorTheme");
+    await createRoot(async (dispose) => {
+      const { state, ensureFlavorsLoaded } = useTheme();
+      await ensureFlavorsLoaded();
+      expect(state.themeId).toBe("catppuccin-mocha");
+      expect(localStorage.getItem("rustume-editor-theme")).toBe("catppuccin-mocha");
       dispose();
     });
   });

--- a/apps/web/src/stores/__tests__/editorTheme.test.ts
+++ b/apps/web/src/stores/__tests__/editorTheme.test.ts
@@ -4,6 +4,7 @@ vi.mock("@lgtm-hq/turbo-themes", () => ({
   flavors: [
     {
       id: "catppuccin-mocha",
+      label: "Mocha",
       appearance: "dark",
       tokens: {
         background: { base: "#1e1e2e", surface: "#313244", overlay: "#45475a" },
@@ -17,6 +18,7 @@ vi.mock("@lgtm-hq/turbo-themes", () => ({
     },
     {
       id: "catppuccin-latte",
+      label: "Latte",
       appearance: "light",
       tokens: {
         background: { base: "#eff1f5", surface: "#ccd0da", overlay: "#9ca0b0" },
@@ -31,7 +33,6 @@ vi.mock("@lgtm-hq/turbo-themes", () => ({
   ],
 }));
 
-// Import AFTER the mock is set up so the module uses the mocked flavors
 import { useEditorTheme } from "../editorTheme";
 
 describe("useEditorTheme", () => {
@@ -47,9 +48,10 @@ describe("useEditorTheme", () => {
     });
   });
 
-  it("setTheme with invalid ID does not change themeId", () => {
-    createRoot((dispose) => {
-      const { state, setTheme } = useEditorTheme();
+  it("setTheme with invalid ID does not change themeId", async () => {
+    await createRoot(async (dispose) => {
+      const { state, setTheme, ensureFlavorsLoaded } = useEditorTheme();
+      await ensureFlavorsLoaded();
       const before = state.themeId;
 
       setTheme("non-existent-theme");
@@ -58,10 +60,11 @@ describe("useEditorTheme", () => {
     });
   });
 
-  it("setTheme with valid ID updates themeId and saves to localStorage", () => {
-    createRoot((dispose) => {
-      const { state, setTheme } = useEditorTheme();
+  it("setTheme with valid ID updates themeId and saves to localStorage", async () => {
+    await createRoot(async (dispose) => {
+      const { state, setTheme, ensureFlavorsLoaded } = useEditorTheme();
 
+      await ensureFlavorsLoaded();
       setTheme("catppuccin-latte");
       expect(state.themeId).toBe("catppuccin-latte");
       expect(localStorage.getItem("rustume-editor-theme")).toBe("catppuccin-latte");

--- a/apps/web/src/stores/editorTheme.ts
+++ b/apps/web/src/stores/editorTheme.ts
@@ -1,74 +1,85 @@
 import { createStore } from "solid-js/store";
-import { flavors as turboFlavors, type ThemeFlavor, type ThemeTokens } from "@lgtm-hq/turbo-themes";
+import type { ThemeFlavor, ThemeTokens } from "@lgtm-hq/turbo-themes";
 import { toast } from "../components/ui";
 
 const STORAGE_KEY = "rustume-editor-theme";
+const DEFAULT_THEME_ID = "catppuccin-mocha";
 
-// Re-export types from turbo-themes
 export type { ThemeFlavor, ThemeTokens };
 
-// Use flavors directly from turbo-themes package
-export const flavors: readonly ThemeFlavor[] = turboFlavors;
+let flavorsCache: readonly ThemeFlavor[] | null = null;
+let flavorsLoad: Promise<readonly ThemeFlavor[]> | null = null;
+
+/** Load theme flavors on demand so the home route avoids the full turbo-themes bundle. */
+export async function loadThemeFlavors(): Promise<readonly ThemeFlavor[]> {
+  if (flavorsCache) {
+    return flavorsCache;
+  }
+  if (!flavorsLoad) {
+    flavorsLoad = import("@lgtm-hq/turbo-themes").then((module) => {
+      flavorsCache = module.flavors;
+      return flavorsCache;
+    });
+  }
+  return flavorsLoad;
+}
 
 export interface EditorThemeState {
   themeId: string;
   savedThemeLoadFailed: boolean;
+  flavorsReady: boolean;
 }
 
-// Get initial theme from localStorage or default to catppuccin-mocha
-function getInitialTheme(): { themeId: string; failed: boolean } {
-  if (typeof window === "undefined") return { themeId: "catppuccin-mocha", failed: false };
+function getInitialThemeId(): { themeId: string; failed: boolean } {
+  if (typeof window === "undefined") {
+    return { themeId: DEFAULT_THEME_ID, failed: false };
+  }
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved && flavors.some((f) => f.id === saved)) {
+    if (saved) {
       return { themeId: saved, failed: false };
     }
   } catch {
     console.error("Failed to read theme from localStorage");
-    return { themeId: "catppuccin-mocha", failed: true };
+    return { themeId: DEFAULT_THEME_ID, failed: true };
   }
-  return { themeId: "catppuccin-mocha", failed: false };
+  return { themeId: DEFAULT_THEME_ID, failed: false };
 }
 
-const initialTheme = getInitialTheme();
+const initialTheme = getInitialThemeId();
 const [state, setState] = createStore<EditorThemeState>({
   themeId: initialTheme.themeId,
   savedThemeLoadFailed: initialTheme.failed,
+  flavorsReady: false,
 });
 
-// Apply CSS variables to document root
 function applyTheme(theme: ThemeFlavor) {
   const root = document.documentElement;
   const { tokens } = theme;
 
-  // Background colors
   root.style.setProperty("--turbo-bg-base", tokens.background.base);
   root.style.setProperty("--turbo-bg-surface", tokens.background.surface);
   root.style.setProperty("--turbo-bg-overlay", tokens.background.overlay);
-
-  // Text colors
   root.style.setProperty("--turbo-text-primary", tokens.text.primary);
   root.style.setProperty("--turbo-text-secondary", tokens.text.secondary);
   root.style.setProperty("--turbo-text-inverse", tokens.text.inverse);
-
-  // Brand/accent colors
   root.style.setProperty("--turbo-brand-primary", tokens.brand.primary);
   root.style.setProperty("--turbo-accent-link", tokens.accent.link);
-
-  // State colors
   root.style.setProperty("--turbo-state-info", tokens.state.info);
   root.style.setProperty("--turbo-state-success", tokens.state.success);
   root.style.setProperty("--turbo-state-warning", tokens.state.warning);
   root.style.setProperty("--turbo-state-danger", tokens.state.danger);
-
-  // Border
   root.style.setProperty("--turbo-border-default", tokens.border.default);
-
-  // Content/selection colors
   root.style.setProperty("--turbo-selection-bg", tokens.content.selection.bg);
-
-  // Set appearance attribute for light/dark mode
   root.setAttribute("data-theme-appearance", theme.appearance);
+}
+
+function resolveTheme(flavors: readonly ThemeFlavor[], themeId: string): ThemeFlavor | undefined {
+  const theme = flavors.find((flavor) => flavor.id === themeId);
+  if (theme) {
+    return theme;
+  }
+  return flavors.find((flavor) => flavor.id === DEFAULT_THEME_ID);
 }
 
 export function useEditorTheme() {
@@ -76,12 +87,41 @@ export function useEditorTheme() {
     state,
 
     get currentTheme(): ThemeFlavor | undefined {
-      return flavors.find((f) => f.id === state.themeId);
+      if (!flavorsCache) {
+        return undefined;
+      }
+      return resolveTheme(flavorsCache, state.themeId);
+    },
+
+    async ensureFlavorsLoaded(): Promise<readonly ThemeFlavor[]> {
+      const flavors = await loadThemeFlavors();
+      setState("flavorsReady", true);
+
+      if (state.savedThemeLoadFailed) {
+        toast.warning("Could not load saved theme preference");
+        setState("savedThemeLoadFailed", false);
+      }
+
+      const savedExists = flavors.some((flavor) => flavor.id === state.themeId);
+      if (!savedExists) {
+        setState("themeId", DEFAULT_THEME_ID);
+      }
+
+      const theme = resolveTheme(flavors, state.themeId);
+      if (theme) {
+        applyTheme(theme);
+      }
+      return flavors;
     },
 
     setTheme(themeId: string) {
-      const theme = flavors.find((f) => f.id === themeId);
-      if (!theme) return;
+      if (!flavorsCache) {
+        return;
+      }
+      const theme = flavorsCache.find((flavor) => flavor.id === themeId);
+      if (!theme) {
+        return;
+      }
 
       setState("themeId", themeId);
       try {
@@ -92,24 +132,7 @@ export function useEditorTheme() {
       }
       applyTheme(theme);
     },
-
-    // Initialize theme on app start
-    init() {
-      if (state.savedThemeLoadFailed) {
-        toast.warning("Could not load saved theme preference");
-        setState("savedThemeLoadFailed", false);
-      }
-      const theme = flavors.find((f) => f.id === state.themeId);
-      if (theme) {
-        applyTheme(theme);
-      }
-    },
   };
 }
 
 export const editorThemeStore = useEditorTheme();
-
-// Initialize theme immediately when module loads (client-side only)
-if (typeof window !== "undefined") {
-  editorThemeStore.init();
-}

--- a/apps/web/src/stores/editorTheme.ts
+++ b/apps/web/src/stores/editorTheme.ts
@@ -110,6 +110,12 @@ export function useEditorTheme() {
       const savedExists = flavors.some((flavor) => flavor.id === state.themeId);
       if (!savedExists) {
         setState("themeId", DEFAULT_THEME_ID);
+        try {
+          localStorage.setItem(STORAGE_KEY, DEFAULT_THEME_ID);
+        } catch {
+          console.error("Failed to save theme to localStorage");
+          toast.warning("Could not save theme preference");
+        }
       }
 
       const theme = resolveTheme(flavors, state.themeId);

--- a/apps/web/src/stores/editorTheme.ts
+++ b/apps/web/src/stores/editorTheme.ts
@@ -16,10 +16,15 @@ export async function loadThemeFlavors(): Promise<readonly ThemeFlavor[]> {
     return flavorsCache;
   }
   if (!flavorsLoad) {
-    flavorsLoad = import("@lgtm-hq/turbo-themes").then((module) => {
-      flavorsCache = module.flavors;
-      return flavorsCache;
-    });
+    flavorsLoad = import("@lgtm-hq/turbo-themes")
+      .then((module) => {
+        flavorsCache = module.flavors;
+        return flavorsCache;
+      })
+      .catch((error) => {
+        flavorsLoad = null;
+        throw error;
+      });
   }
   return flavorsLoad;
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -87,9 +87,26 @@ export default defineConfig({
   },
   build: {
     target: "esnext",
+    chunkSizeWarningLimit: 500,
     rollupOptions: {
       // Handle dynamic WASM import - will fail gracefully at runtime if not present
       external: (id) => /\/wasm\/rustume_wasm/.test(id),
+      output: {
+        manualChunks(id) {
+          if (id.includes("@tiptap/") || id.includes("prosemirror")) {
+            return "tiptap";
+          }
+          if (id.includes("@thisbeyond/solid-dnd")) {
+            return "solid-dnd";
+          }
+          if (id.includes("@kobalte/")) {
+            return "kobalte";
+          }
+          if (id.includes("@lgtm-hq/turbo-themes")) {
+            return "turbo-themes";
+          }
+        },
+      },
     },
   },
   optimizeDeps: {

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -44,7 +44,7 @@ lru.workspace = true
 
 # OpenAPI / Swagger
 utoipa.workspace = true
-utoipa-swagger-ui = { version = "9", features = ["axum"] }
+utoipa-swagger-ui = { version = "9", features = ["axum", "reqwest"] }
 
 # Use jemalloc on musl to avoid musl's slower default allocator
 [target.'cfg(target_env = "musl")'.dependencies]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# Requires a published GHCR image (ghcr.io/lgtm-hq/rustume:latest).
+# If pull fails, build from source — see docs/deployment.md.
 ---
 services:
   rustume:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,19 +92,20 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
     update-ca-certificates && \
     rustup target add wasm32-unknown-unknown && \
-    cargo install wasm-pack wasm-bindgen-cli --locked && \
+    cargo install wasm-pack wasm-bindgen-cli --version 0.2.121 --locked && \
     case "${TARGETARCH}" in \
       amd64) BUN_ARCH=x64-musl ;; \
       arm64) BUN_ARCH=aarch64-musl ;; \
       *) echo "unsupported TARGETARCH for bun: ${TARGETARCH}" >&2 && exit 1 ;; \
     esac && \
-    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" -o /tmp/bun.zip && \
+    BUN_ZIP="bun-linux-${BUN_ARCH}.zip" && \
+    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${BUN_ZIP}" -o "/tmp/${BUN_ZIP}" && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" -o /tmp/SHASUMS256.txt && \
-    grep "bun-linux-${BUN_ARCH}.zip" /tmp/SHASUMS256.txt > /tmp/bun.zip.sha256 && \
-    (cd /tmp && sha256sum -c bun.zip.sha256) && \
-    unzip -q /tmp/bun.zip -d /tmp/bun && \
+    grep "${BUN_ZIP}" /tmp/SHASUMS256.txt > "/tmp/${BUN_ZIP}.sha256" && \
+    (cd /tmp && sha256sum -c "${BUN_ZIP}.sha256") && \
+    unzip -q "/tmp/${BUN_ZIP}" -d /tmp/bun && \
     install -m 755 "/tmp/bun/bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun && \
-    rm -rf /tmp/bun /tmp/bun.zip
+    rm -rf /tmp/bun "/tmp/${BUN_ZIP}" /tmp/SHASUMS256.txt "/tmp/${BUN_ZIP}.sha256"
 
 COPY apps/web/package.json apps/web/bun.lock ./apps/web/
 WORKDIR /app/apps/web

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,7 +92,8 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
     update-ca-certificates && \
     rustup target add wasm32-unknown-unknown && \
-    cargo install wasm-pack wasm-bindgen-cli --version 0.2.121 --locked && \
+    cargo install wasm-pack --locked && \
+    cargo install wasm-bindgen-cli --version 0.2.121 --locked && \
     case "${TARGETARCH}" in \
       amd64) BUN_ARCH=x64-musl ;; \
       arm64) BUN_ARCH=aarch64-musl ;; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,20 +79,21 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TA
 # Pinned to amd64: wasm-pack/wasm-bindgen produce arch-independent output and
 # the toolchain is more reliable on x86_64 (avoids arm64 wasm-bindgen crashes).
 # =============================================================================
-# DL3029: intentional — WASM output is arch-independent; arm64 wasm-bindgen crashes (exit 255)
-# hadolint ignore=DL3029
-FROM --platform=linux/amd64 rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS web-builder
+ARG BUILDPLATFORM=linux/amd64
+ARG BUN_VERSION=1.3.13
+FROM --platform=${BUILDPLATFORM} rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS web-builder
 
 WORKDIR /app
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-ENV BUN_INSTALL=/usr/local/bun
-ENV PATH="${BUN_INSTALL}/bin:${PATH}"
-
 RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
+    update-ca-certificates && \
     rustup target add wasm32-unknown-unknown && \
     cargo install wasm-pack --locked && \
-    curl -fsSL https://bun.sh/install | bash
+    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64-musl.zip" -o /tmp/bun.zip && \
+    unzip -q /tmp/bun.zip -d /tmp/bun && \
+    install -m 755 /tmp/bun/bun-linux-x64-musl/bun /usr/local/bin/bun && \
+    rm -rf /tmp/bun /tmp/bun.zip
 
 COPY apps/web/package.json apps/web/bun.lock ./apps/web/
 WORKDIR /app/apps/web

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,11 +102,11 @@ RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
     BUN_ZIP="bun-linux-${BUN_ARCH}.zip" && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${BUN_ZIP}" -o "/tmp/${BUN_ZIP}" && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" -o /tmp/SHASUMS256.txt && \
-    grep "${BUN_ZIP}" /tmp/SHASUMS256.txt > "/tmp/${BUN_ZIP}.sha256" && \
-    (cd /tmp && sha256sum -c "${BUN_ZIP}.sha256") && \
+    HASH="$(grep "${BUN_ZIP}" /tmp/SHASUMS256.txt | awk '{print $1}')" && \
+    echo "${HASH}  /tmp/${BUN_ZIP}" | sha256sum -c - && \
     unzip -q "/tmp/${BUN_ZIP}" -d /tmp/bun && \
     install -m 755 "/tmp/bun/bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun && \
-    rm -rf /tmp/bun "/tmp/${BUN_ZIP}" /tmp/SHASUMS256.txt "/tmp/${BUN_ZIP}.sha256"
+    rm -rf /tmp/bun "/tmp/${BUN_ZIP}" /tmp/SHASUMS256.txt
 
 COPY apps/web/package.json apps/web/bun.lock ./apps/web/
 WORKDIR /app/apps/web

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,6 +99,9 @@ RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
       *) echo "unsupported TARGETARCH for bun: ${TARGETARCH}" >&2 && exit 1 ;; \
     esac && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" -o /tmp/bun.zip && \
+    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" -o /tmp/SHASUMS256.txt && \
+    grep "bun-linux-${BUN_ARCH}.zip" /tmp/SHASUMS256.txt > /tmp/bun.zip.sha256 && \
+    (cd /tmp && sha256sum -c bun.zip.sha256) && \
     unzip -q /tmp/bun.zip -d /tmp/bun && \
     install -m 755 "/tmp/bun/bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun && \
     rm -rf /tmp/bun /tmp/bun.zip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,12 +76,15 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TA
 
 # =============================================================================
 # Stage 4: Web builder (WASM bindings + Vite static bundle)
-# Pinned to amd64: wasm-pack/wasm-bindgen produce arch-independent output and
-# the toolchain is more reliable on x86_64 (avoids arm64 wasm-bindgen crashes).
+# Follows BUILDPLATFORM so local arm64 builds avoid Rosetta + musl bun failures.
+# WASM output is arch-independent; CI multi-arch builds set platform per matrix leg.
 # =============================================================================
-ARG BUILDPLATFORM=linux/amd64
-ARG BUN_VERSION=1.3.13
+ARG BUILDPLATFORM
 FROM --platform=${BUILDPLATFORM} rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS web-builder
+
+# Re-declare — ARGs do not cross FROM boundaries
+ARG TARGETARCH
+ARG BUN_VERSION=1.3.14
 
 WORKDIR /app
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
@@ -89,10 +92,15 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
     update-ca-certificates && \
     rustup target add wasm32-unknown-unknown && \
-    cargo install wasm-pack --locked && \
-    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64-musl.zip" -o /tmp/bun.zip && \
+    cargo install wasm-pack wasm-bindgen-cli --locked && \
+    case "${TARGETARCH}" in \
+      amd64) BUN_ARCH=x64-musl ;; \
+      arm64) BUN_ARCH=aarch64-musl ;; \
+      *) echo "unsupported TARGETARCH for bun: ${TARGETARCH}" >&2 && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}.zip" -o /tmp/bun.zip && \
     unzip -q /tmp/bun.zip -d /tmp/bun && \
-    install -m 755 /tmp/bun/bun-linux-x64-musl/bun /usr/local/bin/bun && \
+    install -m 755 "/tmp/bun/bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun && \
     rm -rf /tmp/bun /tmp/bun.zip
 
 COPY apps/web/package.json apps/web/bun.lock ./apps/web/

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,9 +3,22 @@
 Rustume ships as a single container that serves both the SolidJS resume builder
 and the Rust API.
 
-## Docker
+## Prerequisites
+
+- **Docker** with BuildKit enabled (Docker Desktop or Docker Engine 20.10+)
+- For building from source: network access to GitHub (Rust crates, bun release,
+  wasm-pack)
+
+Native development (without Docker) requires Rust, wasm-pack, bun, and the
+`wasm32-unknown-unknown` target — see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Option A: Pull from GHCR
+
+Published release images are pushed when a `v*.*.*` tag is created (same tag
+that triggers binary releases). Use `latest` or a semver tag:
 
 ```bash
+docker pull ghcr.io/lgtm-hq/rustume:latest
 docker run -p 3000:3000 ghcr.io/lgtm-hq/rustume:latest
 ```
 
@@ -15,28 +28,64 @@ Open <http://localhost:3000>. The same process also exposes:
 - `/swagger-ui/` for API documentation
 - `/api-docs/openapi.json` for the OpenAPI document
 
+If `docker pull` returns `manifest unknown`, the release image may not be
+published yet (wait for the Docker workflow on the tag, or use Option B).
+
+## Option B: Build from source
+
+When GHCR is unavailable or you need a custom build:
+
+```bash
+git clone https://github.com/lgtm-hq/Rustume.git
+cd Rustume
+docker build -t rustume -f docker/Dockerfile .
+docker run -p 3000:3000 rustume
+```
+
+Behind corporate TLS inspection, ensure Docker trusts your proxy CA. The
+Dockerfile runs `update-ca-certificates` before downloading bun; you may still
+need to add custom CAs to Docker Desktop.
+
+## Verify installation
+
+```bash
+curl -sf http://localhost:3000/health
+```
+
+A successful response confirms the API is listening.
+
 ## Docker Compose
 
-From the repository root:
+Two compose files serve different purposes:
+
+| File | Image | Use when |
+| --- | --- | --- |
+| Root `docker-compose.yml` | `ghcr.io/lgtm-hq/rustume:latest` | Running the published release |
+| `docker/docker-compose.yml` | `rustume:local` (build from source) | Testing Dockerfile changes locally |
+
+From the repository root (published image):
 
 ```bash
 docker compose up
 ```
 
-The root `docker-compose.yml` uses the published GHCR image. To test a local
-image instead:
+From `docker/` (local build):
 
 ```bash
-docker build -t rustume -f docker/Dockerfile .
-docker run -p 3000:3000 rustume
+cd docker
+docker compose up --build
 ```
 
 ## Image Tags
 
-Use `latest` for the most recent published release. Release events also publish
-semantic tags such as `0.14.1`, `0.14`, and `0`.
+| Tag | When published | Use for |
+| --- | --- | --- |
+| `latest`, `0.15.0`, `0.15`, `0` | `v*.*.*` git tag push | Production self-hosting |
+| `main`, `sha-<commit>` | `main` branch push (path-filtered) | Bleeding-edge / CI |
+| `build-<run>-<arch>` | CI staging only | Internal; not for pulls |
 
-For unreleased changes from the default branch, use `main`.
+CI publishes `latest` and semver tags only when the workflow runs on a version
+tag and receives the tag name as `version` (for example `v0.15.0`).
 
 ## Environment Variables
 
@@ -46,6 +95,9 @@ For unreleased changes from the default branch, use `main`.
 | `RUST_LOG` | `info` | Rust tracing filter. Use `debug` for more server logs. |
 | `CORS_ORIGIN` | `*` | Comma-separated allowed origins for API requests. Set explicitly in production (e.g. `https://your-domain.com`). |
 | `RUSTUME_STATIC_DIR` | `/app/web` | Directory containing the built web app. |
+
+The root `docker-compose.yml` sets `CORS_ORIGIN` to `http://localhost:3000`.
+The server binary defaults to `*` when unset.
 
 ## Reverse Proxy
 

--- a/scripts/ci/testing/ci-setup-web-coverage.sh
+++ b/scripts/ci/testing/ci-setup-web-coverage.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 # Prepare Bun for the web coverage workflow.
 
-BUN_VERSION="${BUN_VERSION:-1.3.13}"
+BUN_VERSION="${BUN_VERSION:-1.3.14}"
 npm install --global "bun@${BUN_VERSION}"
 bun --version


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(deploy): restore production Docker publish and native builds
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Restores production-ready deployment paths identified in the production readiness audit (#230). GHCR was not missing due to a broken `lgtm-ci` merge — `latest` and semver tags were never published because Docker CI did not run on version tags and `push`/`version` inputs excluded tag refs.

**CI / GHCR**
- Trigger Docker publish on `v*.*.*` tag push (primary path for `latest`, `0.x.y`)
- Set `push` and `version` for tag refs; keep `main` for bleeding-edge `:main`
- Add `smoke-test: --health` after multi-arch merge
- Use GitHub App token in `publish-release-on-tag` so `release:published` can fan out

**Native & Docker builds**
- `utoipa-swagger-ui` `reqwest` feature for macOS `make build`
- Dockerfile: `update-ca-certificates`, bun 1.3.14 by `TARGETARCH`, `wasm-bindgen-cli` in web-builder
- Full `make build` and `docker build --platform linux/arm64` verified locally (178 web tests pass)

**Web bundle splitting (#230 issue 4)**
- `manualChunks` for tiptap, solid-dnd, kobalte, turbo-themes
- Lazy-load editor subviews and `turbo-themes` flavor CSS
- Main entry ~48 kB gzip (~16 kB); tiptap isolated ~352 kB (no 500 kB warning)

**Docs**
- `docs/deployment.md`, `CONTRIBUTING.md`, `docker-compose.yml` — tag policy, compose caveat (published image required), Rosetta troubleshooting
- README Docker badge unchanged (per maintainer preference)

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (`apps/web` 178 tests; editor theme store updated)
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`; `make build`; `docker build --platform linux/arm64`)

## Closes

- Closes #230

## Details

After merge, maintainers should either wait for the next `v*.*.*` tag or run `workflow_dispatch` on the Docker workflow from a tag ref to backfill `latest` for the current release.

**Verify post-merge:**
- Actions: Docker workflow on next tag shows merge + `latest`/`0.x.y` tags
- `docker pull ghcr.io/lgtm-hq/rustume:latest`
- `docker build --platform linux/arm64 -f docker/Dockerfile .` on Apple Silicon (or disable Rosetta for amd64)
- `make build` on macOS without `/tmp/cacert.pem`

**Note:** On Apple Silicon, default amd64 emulation via Rosetta breaks musl `bun`; use `--platform linux/arm64` locally or disable Rosetta in Docker Desktop. CI buildx publishes both `linux/amd64` and `linux/arm64` on Linux runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded deployment, README, and CONTRIBUTING with clearer pull/build/compose guidance, health-check examples, image tag notes, troubleshooting, and top-file compose notes.

* **New Features / Improvements**
  * Editor UI lazy-loads heavy editors and modals with spinners for faster startup; theme flavors load on demand and persist safely.
  * Docker build and toolchain installs improved; build config adjusted to reduce bundle chunking.

* **Chores**
  * Refined CI publish and release creation token logic and Docker image publishing conditions.

* **Tests**
  * Added/updated theme tests for lazy-load, retry, and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/Rustume/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->