### PR TITLE
fix(docker): run web-builder on TARGETPLATFORM for arm64 CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,11 +76,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TA
 
 # =============================================================================
 # Stage 4: Web builder (WASM bindings + Vite static bundle)
-# Follows BUILDPLATFORM so local arm64 builds avoid Rosetta + musl bun failures.
-# WASM output is arch-independent; CI multi-arch builds set platform per matrix leg.
+# Uses TARGETPLATFORM so bun/wasm tools match the image arch (buildx sets this per
+# matrix leg). Local builds: pass --platform linux/arm64 on Apple Silicon.
 # =============================================================================
-ARG BUILDPLATFORM
-FROM --platform=${BUILDPLATFORM} rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS web-builder
+FROM --platform=$TARGETPLATFORM rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS web-builder
 
 # Re-declare — ARGs do not cross FROM boundaries
 ARG TARGETARCH


### PR DESCRIPTION
## Summary

- Fixes `Build linux/arm64` failure on main after #231 merge (`bun install` exit 255)
- web-builder stage now uses `TARGETPLATFORM` instead of `BUILDPLATFORM` so the bun binary arch matches the container runtime under buildx cross-builds

## Root cause

On GitHub-hosted amd64 runners, buildx sets `BUILDPLATFORM=linux/amd64` while `TARGETARCH=arm64` for the arm64 matrix leg. The Dockerfile installed `bun-linux-aarch64-musl` but ran it inside an amd64 stage (`FROM --platform=${BUILDPLATFORM}`), so `bun install` failed with exit code 255.

## Test plan

- [ ] Merge and verify Actions run **Build - Docker Image & Registry** passes both `linux/amd64` and `linux/arm64`
- [ ] Confirm image push to GHCR on main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to improve multi-architecture build support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/Rustume/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->