### PR TITLE
fix(ci): address post-v0.16.0 Docker pipeline E2E validation findings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,17 @@ UI is downloaded at compile time using system TLS (not `curl` with a hardcoded
 CA path). If the error persists, ensure network access to GitHub releases and
 run `cargo clean -p utoipa-swagger-ui` before rebuilding.
 
+Behind TLS-intercepting proxies, the download may still fail with
+`InvalidCertificate(UnknownIssuer)`. Point the build at a local copy of the
+Swagger UI zip instead (see the
+[swagger-ui releases](https://github.com/swagger-api/swagger-ui/tags) for the
+version pinned in `utoipa-swagger-ui`):
+
+```bash
+export SWAGGER_UI_DOWNLOAD_URL="file:///path/to/swagger-ui-5.17.14.zip"
+cargo build -p rustume-server
+```
+
 ### `docker build` fails installing bun (SSL or Rosetta)
 
 The Dockerfile runs `update-ca-certificates` before any `curl` to GitHub. If

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -64,7 +64,7 @@ const DEFAULT_STATIC_DIR: &str = "/app/web";
 #[openapi(
     info(
         title = "Rustume API",
-        version = "0.1.0",
+        version = env!("CARGO_PKG_VERSION"),
         description = "REST API for resume parsing, rendering, and validation.\n\n## Features\n\n- **Parse**: Import resumes from JSON Resume, LinkedIn exports, or Reactive Resume v3\n- **Render**: Generate PDF or PNG previews of resumes\n- **Validate**: Check resume data against the schema\n- **Templates**: List available resume templates with theme colors",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Rustume", url = "https://github.com/lgtm-hq/Rustume")
@@ -1328,6 +1328,7 @@ mod tests {
         let spec: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(spec["info"]["title"], "Rustume API");
+        assert_eq!(spec["info"]["version"], env!("CARGO_PKG_VERSION"));
         assert!(spec["paths"].as_object().unwrap().contains_key("/health"));
         assert!(spec["paths"]
             .as_object()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,8 +76,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TA
 
 # =============================================================================
 # Stage 4: Web builder (WASM bindings + Vite static bundle)
-# Uses TARGETPLATFORM so bun/wasm tools match the image arch (buildx sets this per
-# matrix leg). Local builds: pass --platform linux/arm64 on Apple Silicon.
+# Buildx sets the target platform per matrix leg; explicit --platform=$TARGETPLATFORM
+# is redundant (BuildKit RedundantTargetPlatform) because it matches the default.
+# Local builds: pass --platform linux/arm64 on Apple Silicon.
 # =============================================================================
 FROM rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS web-builder
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TA
 # Uses TARGETPLATFORM so bun/wasm tools match the image arch (buildx sets this per
 # matrix leg). Local builds: pass --platform linux/arm64 on Apple Silicon.
 # =============================================================================
-FROM --platform=$TARGETPLATFORM rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS web-builder
+FROM rust:1.95-alpine@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS web-builder
 
 # Re-declare — ARGs do not cross FROM boundaries
 ARG TARGETARCH

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,7 +71,7 @@ Published release images are signed with Sigstore keyless signing via the
 ```bash
 cosign verify ghcr.io/lgtm-hq/rustume:latest \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp="github.com/lgtm-hq/"
+  --certificate-identity-regexp="github.com/lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml"
 ```
 
 SLSA provenance and SBOM attestations are attached during publish. Verify
@@ -80,7 +80,7 @@ provenance with:
 ```bash
 cosign verify-attestation --type https://slsa.dev/provenance/v1 ghcr.io/lgtm-hq/rustume:latest \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp="github.com/lgtm-hq/"
+  --certificate-identity-regexp="github.com/lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml"
 ```
 
 ## Image Tags

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,7 +71,7 @@ Published release images are signed with Sigstore keyless signing via the
 ```bash
 cosign verify ghcr.io/lgtm-hq/rustume:latest \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp="github.com/lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml"
+  --certificate-identity-regexp='^https://github\.com/lgtm-hq/lgtm-ci/\.github/workflows/reusable-docker\.yml@refs/.*$'
 ```
 
 SLSA provenance and SBOM attestations are attached during publish. Verify
@@ -80,7 +80,7 @@ provenance with:
 ```bash
 cosign verify-attestation --type https://slsa.dev/provenance/v1 ghcr.io/lgtm-hq/rustume:latest \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp="github.com/lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml"
+  --certificate-identity-regexp='^https://github\.com/lgtm-hq/lgtm-ci/\.github/workflows/reusable-docker\.yml@refs/.*$'
 ```
 
 ## Image Tags

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,16 +71,16 @@ Published release images are signed with Sigstore keyless signing via the
 ```bash
 cosign verify ghcr.io/lgtm-hq/rustume:latest \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp="github.com/lgtm-hq/Rustume"
+  --certificate-identity-regexp="github.com/lgtm-hq/"
 ```
 
 SLSA provenance and SBOM attestations are attached during publish. Verify
 provenance with:
 
 ```bash
-cosign verify-attestation --type slsaprovenance ghcr.io/lgtm-hq/rustume:latest \
+cosign verify-attestation --type https://slsa.dev/provenance/v1 ghcr.io/lgtm-hq/rustume:latest \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp="github.com/lgtm-hq/Rustume"
+  --certificate-identity-regexp="github.com/lgtm-hq/"
 ```
 
 ## Image Tags


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(deploy): address post-v0.16.0 Docker pipeline E2E validation findings
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Fixes post-v0.16.0 Docker pipeline E2E validation findings: deployment verification
docs now match the lgtm-ci reusable workflow signer and current SLSA predicate type,
OpenAPI reports the crate version from `Cargo.toml`, the Dockerfile drops a redundant
BuildKit platform directive, and CONTRIBUTING documents a Swagger UI download
workaround for TLS-intercepting proxies.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`cargo test && cargo clippy`)

## Closes

- Closes #238

## Details

- **Deployment docs:** anchored RE2 regex for the reusable-docker workflow identity;
  SLSA attestation type updated to `https://slsa.dev/provenance/v1`
- **OpenAPI:** `info.version` uses `env!("CARGO_PKG_VERSION")` with test assertion
- **Dockerfile:** remove redundant `--platform=$TARGETPLATFORM` on web-builder `FROM`
  (BuildKit default; clears `RedundantTargetPlatform` warning)
- **CONTRIBUTING:** document `SWAGGER_UI_DOWNLOAD_URL=file://...` for corporate TLS
  interception

**Testing:** `uv run lintro chk`, `uv run lintro tst`, `cargo test -p rustume-server
test_openapi_spec`, CodeRabbit review (0 findings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for build failures in TLS-intercepting proxy environments with configuration workarounds.
  * Updated container deployment verification instructions with revised signature validation parameters.

* **Infrastructure**
  * OpenAPI documentation now automatically reflects the current build version.
  * Optimized Docker build configuration for multi-platform support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/Rustume/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->