### PR TITLE
feat(ci): deploy docs site with bundled coverage on GitHub Pages

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.ci]
+retries = 0
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/pages-bundle-manifest.json
+++ b/.github/pages-bundle-manifest.json
@@ -1,0 +1,19 @@
+{
+  "strict": false,
+  "bundles": [
+    {
+      "id": "rust-coverage",
+      "workflow": "Coverage Reports",
+      "artifact": "rust-coverage-html",
+      "dest": "coverage-rust",
+      "require_success": true
+    },
+    {
+      "id": "web-coverage",
+      "workflow": "Coverage Reports",
+      "artifact": "web-coverage-html",
+      "dest": "coverage-web",
+      "require_success": true
+    }
+  ]
+}

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -43,14 +43,14 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: audit
 
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -43,14 +43,14 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: audit
 
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -43,14 +43,14 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: audit
 
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -43,14 +43,14 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: audit
 
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -71,7 +71,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.fork == false
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           file: pr-comment.txt
           marker: "<!-- lintro-report -->"

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -71,7 +71,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.fork == false
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           file: pr-comment.txt
           marker: "<!-- lintro-report -->"

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -71,7 +71,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.fork == false
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           file: pr-comment.txt
           marker: "<!-- lintro-report -->"

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -71,7 +71,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.fork == false
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           file: pr-comment.txt
           marker: "<!-- lintro-report -->"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,12 +24,12 @@ permissions:
 jobs:
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+      tooling-ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
       job-name: "🦀 Rust Coverage"
       coverage: true
       upload-pages-coverage-html: true
@@ -41,12 +41,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+      tooling-ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
 name: Coverage Reports
-# Runs Rust and Web coverage and posts separate PR comments.
 
 "on":
   push:
@@ -14,11 +13,7 @@ name: Coverage Reports
       - "Cargo.lock"
       - "apps/web/**"
       - ".github/workflows/coverage.yml"
-      - "scripts/ci/testing/ci-rust-coverage.sh"
-      - "scripts/ci/testing/ci-setup-rust-coverage.sh"
-      - "scripts/ci/testing/ci-setup-web-coverage.sh"
-      - "scripts/ci/testing/ci-web-coverage.sh"
-      - "scripts/ci/testing/fail-on-coverage.sh"
+      - "scripts/ci/testing/**"
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -28,201 +23,42 @@ permissions:
 
 jobs:
   rust-coverage:
-    name: "rust-coverage / 🦀 Rust Coverage"
-    runs-on: ubuntu-24.04
-    outputs:
-      rust_pr_comment_ready: ${{ steps.generate-rust-comment.outcome == 'success' }}
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
     permissions:
       contents: read
-    timeout-minutes: 45
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false
-    defaults:
-      run:
-        shell: bash
-    concurrency:
-      group: rust-coverage-${{ github.ref }}
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Rust
-        run: ./scripts/ci/testing/ci-setup-rust-coverage.sh
-
-      - name: Run Rust coverage
-        id: rust-coverage
-        run: ./scripts/ci/testing/ci-rust-coverage.sh
-        continue-on-error: true
-
-      - name: Generate Rust coverage PR comment
-        id: generate-rust-comment
-        if: >-
-          always() &&
-          github.event_name == 'pull_request'
-        # yamllint disable rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/generate-coverage-comment@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
-        # yamllint enable rule:line-length
-        with:
-          coverage-file: rust-coverage.lcov
-          format: lcov
-          threshold-lines: "0"
-          threshold-branches: "0"
-          threshold-functions: "0"
-
-      - name: Write Rust coverage PR comment artifact
-        if: steps.generate-rust-comment.outcome == 'success'
-        env:
-          COMMENT_BODY: ${{ steps.generate-rust-comment.outputs.comment-body }}
-        run: >-
-          printf '%s\n' "$COMMENT_BODY" |
-          sed '1s/^## Coverage Report$/## Rust Coverage Report/' >
-          rust-coverage-pr-comment.txt
-
-      - name: Upload Rust coverage PR comment artifact
-        if: >-
-          steps.generate-rust-comment.outcome == 'success' &&
-          github.event.pull_request.head.repo.fork == false
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: rust-coverage-pr-comment
-          path: rust-coverage-pr-comment.txt
-
-      - name: Fail if Rust coverage failed
-        if: env.RUST_COVERAGE_EXIT_CODE != '0'
-        env:
-          COVERAGE_NAME: Rust
-        run: ./scripts/ci/testing/fail-on-coverage.sh
-
-  rust-coverage-pr-comment:
-    name: 💬 Rust coverage PR comment
-    runs-on: ubuntu-24.04
-    needs: rust-coverage
-    if: >-
-      always() &&
-      github.event_name == 'pull_request' &&
-      needs.rust-coverage.outputs.rust_pr_comment_ready == 'true'
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    timeout-minutes: 5
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: rust-coverage-pr-comment
-
-      - name: Comment PR with Rust coverage
-        # yamllint disable rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
-        # yamllint enable rule:line-length
-        with:
-          file: rust-coverage-pr-comment.txt
-          marker: rust-coverage-report
+      pull-requests: write # publish-test-summary on PRs
+    with:
+      tooling-ref: c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+      job-name: "🦀 Rust Coverage"
+      coverage: true
+      upload-pages-coverage-html: true
+      pages-coverage-artifact-name: rust-coverage-html
+      comment-marker: rust-coverage-report
+      publish-test-summary: true
+      runner-image: ubuntu-24.04
+      timeout-minutes: 45
 
   web-coverage:
-    name: "web-coverage / 🌐 Web Coverage"
-    runs-on: ubuntu-24.04
-    outputs:
-      web_pr_comment_ready: ${{ steps.generate-web-comment.outcome == 'success' }}
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
     permissions:
       contents: read
-    timeout-minutes: 30
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false
-    defaults:
-      run:
-        shell: bash
-    concurrency:
-      group: web-coverage-${{ github.ref }}
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Web coverage tools
-        run: ./scripts/ci/testing/ci-setup-web-coverage.sh
-
-      - name: Run Web coverage
-        id: web-coverage
-        run: ./scripts/ci/testing/ci-web-coverage.sh
-        continue-on-error: true
-
-      - name: Generate Web coverage PR comment
-        id: generate-web-comment
-        if: >-
-          always() &&
-          github.event_name == 'pull_request'
-        # yamllint disable rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/generate-coverage-comment@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
-        # yamllint enable rule:line-length
-        with:
-          coverage-file: apps/web/coverage/coverage-summary.json
-          format: istanbul
-          threshold-lines: "0"
-          threshold-branches: "0"
-          threshold-functions: "0"
-
-      - name: Write Web coverage PR comment artifact
-        if: steps.generate-web-comment.outcome == 'success'
-        env:
-          COMMENT_BODY: ${{ steps.generate-web-comment.outputs.comment-body }}
-        run: >-
-          printf '%s\n' "$COMMENT_BODY" |
-          sed '1s/^## Coverage Report$/## Web Coverage Report/' >
-          web-coverage-pr-comment.txt
-
-      - name: Upload Web coverage PR comment artifact
-        if: >-
-          steps.generate-web-comment.outcome == 'success' &&
-          github.event.pull_request.head.repo.fork == false
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: web-coverage-pr-comment
-          path: web-coverage-pr-comment.txt
-
-      - name: Fail if Web coverage failed
-        if: env.WEB_COVERAGE_EXIT_CODE != '0'
-        env:
-          COVERAGE_NAME: Web
-        run: ./scripts/ci/testing/fail-on-coverage.sh
-
-  web-coverage-pr-comment:
-    name: 💬 Web coverage PR comment
-    runs-on: ubuntu-24.04
-    needs: web-coverage
-    if: >-
-      always() &&
-      github.event_name == 'pull_request' &&
-      needs.web-coverage.outputs.web_pr_comment_ready == 'true'
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    timeout-minutes: 5
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: web-coverage-pr-comment
-
-      - name: Comment PR with Web coverage
-        # yamllint disable rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
-        # yamllint enable rule:line-length
-        with:
-          file: web-coverage-pr-comment.txt
-          marker: web-coverage-report
+      pull-requests: write # publish-test-summary on PRs
+    with:
+      tooling-ref: c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+      job-name: "🌐 Web Coverage"
+      node-version: "22"
+      working-directory: apps/web
+      package-manager: bun
+      coverage: true
+      coverage-format: html
+      comment-marker: web-coverage-report
+      coverage-summary-file: coverage/coverage-summary.json
+      upload-coverage: true
+      upload-pages-coverage-html: true
+      pages-coverage-artifact-name: web-coverage-html
+      pages-coverage-source-subpath: coverage
+      publish-test-summary: true
+      runner-image: ubuntu-24.04
+      timeout-minutes: 30

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,12 +24,12 @@ permissions:
 jobs:
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+      tooling-ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
       job-name: "🦀 Rust Coverage"
       coverage: true
       upload-pages-coverage-html: true
@@ -41,12 +41,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+      tooling-ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,12 +24,12 @@ permissions:
 jobs:
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+      tooling-ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
       job-name: "🦀 Rust Coverage"
       coverage: true
       upload-pages-coverage-html: true
@@ -41,12 +41,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+      tooling-ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -35,7 +35,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
 
       - name: Dependency review
         # yamllint disable-line rule:line-length

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -35,7 +35,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
 
       - name: Dependency review
         # yamllint disable-line rule:line-length

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -35,7 +35,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
 
       - name: Dependency review
         # yamllint disable-line rule:line-length

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -35,7 +35,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
 
       - name: Dependency review
         # yamllint disable-line rule:line-length

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
       actions: read
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -45,7 +45,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+      tooling-ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
       actions: read
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -45,7 +45,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+      tooling-ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
       actions: read
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -45,7 +45,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+      tooling-ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,34 +2,51 @@
 name: Deploy - GitHub Pages
 
 "on":
-  push:
-    branches: [main]
-    paths:
-      - 'apps/site/**'
-      - 'docs/**'
-      - 'scripts/ci/site/**'
-      - '.github/workflows/deploy-pages.yml'
+  workflow_run:
+    workflows:
+      - Coverage Reports
+      - Quality - Documentation Site
+    types:
+      - completed
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
-  group: deploy-pages-${{ github.ref }}
-  cancel-in-progress: true
+  group: pages-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  pages:
-    if: github.ref == 'refs/heads/main'
+  deploy:
+    if: >-
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository)
     permissions:
       contents: read
       pages: write
       id-token: write
+      actions: read
+    # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-pages.yml@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
     with:
+      site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
       package-manager: bun
-      source-path: apps/site/dist
       node-version: '22'
       working-directory: apps/site
+      bundle-manifest: .github/pages-bundle-manifest.json
+      commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
+      fallback-ref: main
+      tooling-ref: c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+      build-job-name: Build site and bundle reports
+      deploy-job-name: Deploy to GitHub Pages
+      runner-image: ubuntu-24.04
+      timeout-minutes: 20

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -33,7 +33,7 @@ jobs:
   docker:
     name: 🐳 Docker Build & Publish
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -33,7 +33,7 @@ jobs:
   docker:
     name: 🐳 Docker Build & Publish
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
     permissions:
       contents: read
       packages: write
@@ -41,6 +41,7 @@ jobs:
       attestations: write
       security-events: write
     with:
+      tooling-ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -33,7 +33,7 @@ jobs:
   docker:
     name: 🐳 Docker Build & Publish
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
     permissions:
       contents: read
       packages: write
@@ -41,7 +41,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+      tooling-ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -33,7 +33,7 @@ jobs:
   docker:
     name: 🐳 Docker Build & Publish
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
     permissions:
       contents: read
       packages: write
@@ -41,7 +41,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+      tooling-ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -41,7 +41,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -85,7 +85,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -105,7 +105,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -41,7 +41,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -85,7 +85,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -105,7 +105,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -41,7 +41,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -85,7 +85,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -105,7 +105,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -41,7 +41,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -85,7 +85,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -105,7 +105,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -37,7 +37,7 @@ jobs:
       - name: Validate PR title
         id: semantic
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           types: >-
             chore,ci,docs,feat,fix,perf,refactor,revert,style,test,build
@@ -45,7 +45,7 @@ jobs:
       - name: Post failure comment
         if: steps.semantic.outputs.valid != 'true'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           marker: "<!-- semantic-pr-title -->"
           body: |

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -37,7 +37,7 @@ jobs:
       - name: Validate PR title
         id: semantic
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           types: >-
             chore,ci,docs,feat,fix,perf,refactor,revert,style,test,build
@@ -45,7 +45,7 @@ jobs:
       - name: Post failure comment
         if: steps.semantic.outputs.valid != 'true'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           marker: "<!-- semantic-pr-title -->"
           body: |

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -37,7 +37,7 @@ jobs:
       - name: Validate PR title
         id: semantic
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           types: >-
             chore,ci,docs,feat,fix,perf,refactor,revert,style,test,build
@@ -45,7 +45,7 @@ jobs:
       - name: Post failure comment
         if: steps.semantic.outputs.valid != 'true'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           marker: "<!-- semantic-pr-title -->"
           body: |

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -37,7 +37,7 @@ jobs:
       - name: Validate PR title
         id: semantic
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           types: >-
             chore,ci,docs,feat,fix,perf,refactor,revert,style,test,build
@@ -45,7 +45,7 @@ jobs:
       - name: Post failure comment
         if: steps.semantic.outputs.valid != 'true'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           marker: "<!-- semantic-pr-title -->"
           body: |

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -76,7 +76,7 @@ jobs:
       - name: Calculate next version
         id: semrel
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           max-bump: minor
 

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -76,7 +76,7 @@ jobs:
       - name: Calculate next version
         id: semrel
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           max-bump: minor
 

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -76,7 +76,7 @@ jobs:
       - name: Calculate next version
         id: semrel
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           max-bump: minor
 

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -76,7 +76,7 @@ jobs:
       - name: Calculate next version
         id: semrel
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           max-bump: minor
 

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -51,11 +51,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           node-version: '22'
           working-directory: apps/site
@@ -72,7 +72,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+          ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -135,18 +135,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           node-version: '22'
           working-directory: apps/site

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -51,11 +51,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           node-version: '22'
           working-directory: apps/site
@@ -72,7 +72,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+          ref: 8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -135,18 +135,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           node-version: '22'
           working-directory: apps/site

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -51,11 +51,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           node-version: '22'
           working-directory: apps/site
@@ -72,7 +72,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+          ref: c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -109,10 +109,8 @@ jobs:
           path: apps/site/dist
           retention-days: 1
 
-  # Reusable-test-node caller needs pull-requests: write at job level (startup_failure
-  # without it). Full delegation blocked on lgtm-ci v0.19.2: test-custom wipes tooling
-  # when test-command is set; default vitest parse fails on Vitest JSON (TESTS_TOTAL
-  # unset).
+  # Site tests stay inline (not reusable-test-node): custom Vitest JSON layout and
+  # scripts/ci/site/test-all.sh do not match default Node reusable parsing.
   test:
     name: Test documentation site
     runs-on: ubuntu-24.04
@@ -120,7 +118,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -137,18 +135,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           node-version: '22'
           working-directory: apps/site

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -51,11 +51,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           node-version: '22'
           working-directory: apps/site
@@ -72,7 +72,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: 1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+          ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -135,18 +135,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           node-version: '22'
           working-directory: apps/site

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -55,11 +55,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
 
       - name: Build all crates
         run: cargo build --workspace --all-features

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -55,11 +55,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
 
       - name: Build all crates
         run: cargo build --workspace --all-features

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -55,11 +55,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
 
       - name: Build all crates
         run: cargo build --workspace --all-features

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -55,11 +55,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
 
       - name: Build all crates
         run: cargo build --workspace --all-features

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
 
       - name: Scan workflows for non-pinned actions
         run: ENFORCE=1 bash scripts/ci/maintenance/validate-action-pinning.sh

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
 
       - name: Scan workflows for non-pinned actions
         run: ENFORCE=1 bash scripts/ci/maintenance/validate-action-pinning.sh

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@fc77ab6ea10f84236e4b897835665e8b0a57fe11 # v0.19.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@c1f0c75eefbbcb0650adf823b4a7a303830d351b # v0.32.0
 
       - name: Scan workflows for non-pinned actions
         run: ENFORCE=1 bash scripts/ci/maintenance/validate-action-pinning.sh

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@8e50c1fdef21f010d207206e0a89557f47b24d1e # lgtm-ci#290 until v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1601552ddb98df595219996622568c46ed5bde63 # v0.32.1
 
       - name: Scan workflows for non-pinned actions
         run: ENFORCE=1 bash scripts/ci/maintenance/validate-action-pinning.sh

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ node_modules/
 htmlcov/
 coverage/
 coverage.xml
+rust-coverage-html/
+web-coverage-html/
+rust-coverage.lcov
+rust-coverage-output.txt
 *.cover
 *.py,cover
 .coverage

--- a/.lintro-ignore
+++ b/.lintro-ignore
@@ -51,6 +51,10 @@ test_samples/
 # Coverage reports
 htmlcov/
 coverage/
+rust-coverage-html/
+web-coverage-html/
+rust-coverage.lcov
+rust-coverage-output.txt
 .coverage
 *.cover
 

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ site-test:
 	./scripts/ci/site/test.sh
 
 site-preview: site-build
-	cd apps/site && ASTRO_BASE="$(SITE_ASTRO_BASE)" bun run preview
+	./scripts/ci/site/preview-serve.sh
 
 # Quick start for new developers
 setup: check-deps install wasm

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "node scripts/copy-assets.mjs && astro build && bun x pagefind --site dist --glob '**/*.html' --exclude-selectors '[data-pagefind-ignore]' --exclude-selectors 'nav' --exclude-selectors 'footer'",
-    "preview": "astro preview",
+    "preview": "bash ../../scripts/ci/site/preview-serve.sh",
     "test": "vitest run --coverage",
     "check": "astro check",
     "astro": "astro"

--- a/apps/site/public/assets/smart-link-fallback.svg
+++ b/apps/site/public/assets/smart-link-fallback.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" aria-hidden="true">
+  <path
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.25"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="M6.2 9.8 4.4 11.6a2.2 2.2 0 0 0 3.1 3.1l1.8-1.8M9.8 6.2l1.8-1.8a2.2 2.2 0 1 0-3.1-3.1L6.7 3.1M5.5 10.5l5-5"
+  />
+</svg>

--- a/apps/site/src/components/SmartLink.astro
+++ b/apps/site/src/components/SmartLink.astro
@@ -1,5 +1,6 @@
 ---
 import { joinBase } from "../data/landing";
+import { remoteFaviconUrl } from "../lib/favicon";
 import { hasUriScheme } from "../lib/url-utils";
 
 interface Props {
@@ -32,7 +33,9 @@ if (!isAbsoluteUrl && !href.startsWith("#")) {
   }
 }
 
-const favicon = joinBase(base, "favicon.svg");
+const fallbackIcon = joinBase(base, "assets/smart-link-fallback.svg");
+const remoteIcon = remoteFaviconUrl(url);
+const iconSrc = remoteIcon ?? fallbackIcon;
 ---
 
 <a
@@ -40,4 +43,14 @@ const favicon = joinBase(base, "favicon.svg");
   href={url}
   target={external && opensInNewTab ? "_blank" : undefined}
   rel={external && opensInNewTab ? "noopener noreferrer" : undefined}
-><img class="smart-link-icon" src={favicon} alt="" width="16" height="16" loading="lazy" decoding="async" /><span class="smart-link-label">{name}</span>{showArrow && <span class="smart-link-arrow" aria-hidden="true">↗</span>}</a>
+><img
+  class="smart-link-icon"
+  src={iconSrc}
+  data-fallback={fallbackIcon}
+  alt=""
+  width="16"
+  height="16"
+  loading="lazy"
+  decoding="async"
+  onerror="this.onerror=null;this.src=this.dataset.fallback||'';"
+/><span class="smart-link-label">{name}</span>{showArrow && <span class="smart-link-arrow" aria-hidden="true">↗</span>}</a>

--- a/apps/site/src/components/TemplateAccent.astro
+++ b/apps/site/src/components/TemplateAccent.astro
@@ -1,0 +1,21 @@
+---
+interface Props {
+  accent: string;
+  accentLabel: string;
+}
+
+const { accent, accentLabel } = Astro.props;
+---
+
+<span class="template-accent-cell">
+  <span
+    class="template-accent-swatch"
+    style={`background: ${accent}`}
+    title={accentLabel}
+    aria-hidden="true"
+  ></span>
+  <span class="template-accent-meta">
+    <span class="template-accent-label">{accentLabel}</span>
+    <code>{accent}</code>
+  </span>
+</span>

--- a/apps/site/src/lib/favicon.test.ts
+++ b/apps/site/src/lib/favicon.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { faviconDomain, remoteFaviconUrl } from "./favicon";
+
+describe("faviconDomain", () => {
+  it("returns hostname for public https URLs", () => {
+    expect(faviconDomain("https://www.docker.com/get-started")).toBe("docker.com");
+    expect(faviconDomain("https://vite.dev/guide/")).toBe("vite.dev");
+  });
+
+  it("returns undefined for internal paths and non-http schemes", () => {
+    expect(faviconDomain("/docs/deployment/docker/")).toBeUndefined();
+    expect(faviconDomain("mailto:team@example.com")).toBeUndefined();
+    expect(faviconDomain("#section")).toBeUndefined();
+  });
+
+  it("returns undefined for local development hosts", () => {
+    expect(faviconDomain("http://localhost:5173")).toBeUndefined();
+    expect(faviconDomain("http://127.0.0.1:3000/swagger-ui/")).toBeUndefined();
+  });
+});
+
+describe("remoteFaviconUrl", () => {
+  it("builds Google favicon URL for resolvable domains", () => {
+    expect(remoteFaviconUrl("https://github.com/lgtm-hq/Rustume")).toBe(
+      "https://www.google.com/s2/favicons?domain=github.com&sz=32",
+    );
+  });
+
+  it("returns undefined when domain cannot be resolved", () => {
+    expect(remoteFaviconUrl("http://localhost:3000")).toBeUndefined();
+    expect(remoteFaviconUrl("/docs/cloud/overview/")).toBeUndefined();
+  });
+});

--- a/apps/site/src/lib/favicon.ts
+++ b/apps/site/src/lib/favicon.ts
@@ -1,0 +1,41 @@
+import { hasUriScheme } from "./url-utils";
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/** Hostname for remote favicon lookup (no port, no leading www.). */
+export function faviconDomain(href: string): string | undefined {
+  if (!href || href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:")) {
+    return undefined;
+  }
+
+  try {
+    const normalized = href.startsWith("//") ? `https:${href}` : href;
+    if (!hasUriScheme(normalized) && !href.startsWith("//")) {
+      return undefined;
+    }
+
+    const { hostname, protocol } = new URL(normalized);
+    if (protocol !== "http:" && protocol !== "https:") {
+      return undefined;
+    }
+
+    const host = hostname.replace(/^www\./i, "");
+    if (!host || LOCAL_HOSTS.has(host)) {
+      return undefined;
+    }
+
+    return host;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Google favicon service URL for a public http(s) host, if applicable. */
+export function remoteFaviconUrl(href: string): string | undefined {
+  const domain = faviconDomain(href);
+  if (!domain) {
+    return undefined;
+  }
+
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=32`;
+}

--- a/apps/site/src/pages/docs/getting-started/templates.astro
+++ b/apps/site/src/pages/docs/getting-started/templates.astro
@@ -1,5 +1,6 @@
 ---
 import DocsStandaloneLayout from '../../../layouts/DocsStandaloneLayout.astro';
+import TemplateAccent from '../../../components/TemplateAccent.astro';
 import TemplateGallery from '../../../components/TemplateGallery.astro';
 import { layoutLabels, templates } from '../../../data/templates';
 
@@ -44,7 +45,7 @@ const base = import.meta.env.BASE_URL;
             <td><code>{template.id}</code></td>
             <td>{layoutLabels[template.layout]}</td>
             <td>
-              {template.accentLabel} <code>{template.accent}</code>
+              <TemplateAccent accent={template.accent} accentLabel={template.accentLabel} />
             </td>
           </tr>
         ))

--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -391,6 +391,32 @@ th {
   margin: 1.75rem 0 2rem;
 }
 
+.template-accent-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.template-accent-swatch {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: var(--radius-full);
+  border: 2px solid color-mix(in srgb, var(--turbo-text-primary) 12%, transparent);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28);
+}
+
+.template-accent-meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.5rem;
+}
+
+.template-accent-label {
+  color: var(--turbo-text-primary);
+}
+
 .prose pre {
   padding: 1.25rem 1.5rem;
   line-height: 1.5;

--- a/scripts/ci/site/README.md
+++ b/scripts/ci/site/README.md
@@ -8,6 +8,7 @@
 | `test-python.sh` | Pytest for `tests/scripts/ci/` |
 | `test-all.sh` | `test.sh` + `test-python.sh` |
 | `prepare-lychee-action-args.sh` | Strip duplicate lychee flags for `lychee-action` |
+| `preview-pages-local.sh` | Build dist + optional local coverage bundles for manual Pages preview |
 
 ## Astro base path
 
@@ -21,13 +22,48 @@ that value — do not duplicate the path elsewhere.
 | `site-quality.yml` link check build | `/` (root-relative hrefs under `dist/`) |
 | `deploy-pages.yml` production deploy | `ASTRO_BASE_DEFAULT` via `build.sh` |
 
-## GitHub Pages and repository About URL
+## GitHub Pages (Model B: site + bundled reports)
 
-1. **Pages** (already enabled): **Settings → Pages → Build and deployment → Source:
-   GitHub Actions**. The [`deploy-pages.yml`](../../../.github/workflows/deploy-pages.yml)
-   workflow publishes `apps/site/dist`.
-2. **About URL** (manual, one-time): On the repository home page, click **About** (gear) →
-   set **Website** to `https://lgtm-hq.github.io/Rustume/`. This is the link shown on the
-   repo profile; it does not affect the Pages deploy itself.
+Deploy uses **lgtm-ci**
+[`reusable-deploy-site-with-reports`](https://github.com/lgtm-hq/lgtm-ci/blob/main/.github/workflows/reusable-deploy-site-with-reports.yml)
+via [`.github/workflows/deploy-pages.yml`](../../../.github/workflows/deploy-pages.yml).
 
-Live docs URL: `https://lgtm-hq.github.io/Rustume/`
+1. **Coverage Reports** uploads HTML on `main` (`rust-coverage-html`, `web-coverage-html`).
+2. **Deploy - GitHub Pages** runs on `workflow_run` after **Coverage Reports** or
+   **Quality - Documentation Site** succeeds on `main`, or via `workflow_dispatch`.
+3. The reusable workflow builds `apps/site/dist`, merges artifacts per
+   [`.github/pages-bundle-manifest.json`](../../../.github/pages-bundle-manifest.json),
+   and publishes to GitHub Pages.
+
+| Published path | Content |
+| --- | --- |
+| `https://lgtm-hq.github.io/Rustume/` | Astro documentation site |
+| `https://lgtm-hq.github.io/Rustume/coverage-rust/` | Rust `cargo llvm-cov` HTML report |
+| `https://lgtm-hq.github.io/Rustume/coverage-web/` | Web Vitest HTML report |
+
+**Settings → Pages → Build and deployment → Source: GitHub Actions** (not “Deploy from a branch”).
+
+**About URL** (manual): repository **About** → **Website** → `https://lgtm-hq.github.io/Rustume/`.
+
+## Local preview (manual check before merge)
+
+```bash
+# Full preview: site + web + rust coverage (rust step is slow)
+./scripts/ci/site/preview-pages-local.sh
+
+# Docs only, then preview server
+PREVIEW_INCLUDE_RUST=0 PREVIEW_INCLUDE_WEB=0 ./scripts/ci/site/preview-pages-local.sh
+
+# Build dist only (no server)
+PREVIEW_SERVE=0 ./scripts/ci/site/preview-pages-local.sh
+```
+
+Open the URL from `astro preview` (serves with `/Rustume/` base). Coverage trees appear
+under `/Rustume/coverage-rust/` and `/Rustume/coverage-web/` when generated.
+
+## CI scripts (site quality)
+
+| Script | Purpose |
+| --- | --- |
+| `fix-markdown-docs.py` | Normalize docs markdown before build |
+| `generate-template-thumbnails.sh` | Regenerate template PNGs when needed |

--- a/scripts/ci/site/README.md
+++ b/scripts/ci/site/README.md
@@ -8,6 +8,7 @@
 | `test-python.sh` | Pytest for `tests/scripts/ci/` |
 | `test-all.sh` | `test.sh` + `test-python.sh` |
 | `prepare-lychee-action-args.sh` | Strip duplicate lychee flags for `lychee-action` |
+| `preview-serve.sh` | `astro preview` with `ASTRO_BASE` from `defaults.env` (required for `/Rustume/`) |
 | `preview-pages-local.sh` | Build dist + optional local coverage bundles for manual Pages preview |
 
 ## Astro base path
@@ -58,8 +59,11 @@ PREVIEW_INCLUDE_RUST=0 PREVIEW_INCLUDE_WEB=0 ./scripts/ci/site/preview-pages-loc
 PREVIEW_SERVE=0 ./scripts/ci/site/preview-pages-local.sh
 ```
 
-Open the URL from `astro preview` (serves with `/Rustume/` base). Coverage trees appear
-under `/Rustume/coverage-rust/` and `/Rustume/coverage-web/` when generated.
+Open **http://127.0.0.1:4321/Rustume/** (not `/` — root serves unstyled HTML if the build
+used `/Rustume/`). Use `make site-preview`, `bun run preview` in `apps/site`, or
+`preview-pages-local.sh`; all load `ASTRO_BASE` via `preview-serve.sh`.
+
+Coverage trees appear under `/Rustume/coverage-rust/` and `/Rustume/coverage-web/` when generated.
 
 ## CI scripts (site quality)
 

--- a/scripts/ci/site/README.md
+++ b/scripts/ci/site/README.md
@@ -59,9 +59,10 @@ PREVIEW_INCLUDE_RUST=0 PREVIEW_INCLUDE_WEB=0 ./scripts/ci/site/preview-pages-loc
 PREVIEW_SERVE=0 ./scripts/ci/site/preview-pages-local.sh
 ```
 
-Open **http://127.0.0.1:4321/Rustume/** (not `/` — root serves unstyled HTML if the build
-used `/Rustume/`). Use `make site-preview`, `bun run preview` in `apps/site`, or
-`preview-pages-local.sh`; all load `ASTRO_BASE` via `preview-serve.sh`.
+Open [http://127.0.0.1:4321/Rustume/](http://127.0.0.1:4321/Rustume/) — not `/`, which
+serves unstyled HTML when the build used `/Rustume/`. Use `make site-preview`,
+`bun run preview` in `apps/site`, or `preview-pages-local.sh`; all load `ASTRO_BASE`
+via `preview-serve.sh`.
 
 Coverage trees appear under `/Rustume/coverage-rust/` and `/Rustume/coverage-web/` when generated.
 

--- a/scripts/ci/site/preview-pages-local.sh
+++ b/scripts/ci/site/preview-pages-local.sh
@@ -88,5 +88,4 @@ if [[ "${PREVIEW_SERVE:-1}" == "0" ]]; then
 fi
 
 echo "==> Starting astro preview (Ctrl+C to stop)"
-cd "${SITE_DIR}"
-exec bun run preview -- --host 127.0.0.1
+exec "${SCRIPT_DIR}/preview-serve.sh" --host 127.0.0.1

--- a/scripts/ci/site/preview-pages-local.sh
+++ b/scripts/ci/site/preview-pages-local.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Build the docs site and optionally merge local coverage HTML for a Pages-like preview.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SITE_DIR="${ROOT}/apps/site"
+DIST_DIR="${SITE_DIR}/dist"
+
+INCLUDE_RUST="${PREVIEW_INCLUDE_RUST:-1}"
+INCLUDE_WEB="${PREVIEW_INCLUDE_WEB:-1}"
+SKIP_BUILD="${PREVIEW_SKIP_BUILD:-0}"
+
+usage() {
+	cat <<'EOF'
+Usage: ./scripts/ci/site/preview-pages-local.sh
+
+Builds apps/site/dist with production ASTRO_BASE (/Rustume/) and copies local
+coverage HTML into the same paths used on GitHub Pages (coverage-rust/, coverage-web/).
+
+Environment:
+  PREVIEW_SKIP_BUILD=1     Skip ./scripts/ci/site/build.sh
+  PREVIEW_INCLUDE_RUST=0   Skip Rust coverage HTML generation
+  PREVIEW_INCLUDE_WEB=0    Skip web Vitest coverage
+  PREVIEW_SERVE=0          Build only; do not start astro preview
+
+After the script runs, open the URL printed by "astro preview" (default base /Rustume/).
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+cd "${ROOT}"
+
+if [[ "${SKIP_BUILD}" != "1" ]]; then
+	echo "==> Building documentation site (ASTRO_BASE from defaults.env)"
+	./scripts/ci/site/build.sh
+fi
+
+if [[ ! -d "${DIST_DIR}" ]]; then
+	echo "Missing ${DIST_DIR}; run build first." >&2
+	exit 1
+fi
+
+copy_tree() {
+	local src="$1"
+	local dest="$2"
+	if [[ ! -d "${src}" ]]; then
+		echo "Skip copy: ${src} does not exist"
+		return 0
+	fi
+	rm -rf "${dest}"
+	mkdir -p "$(dirname "${dest}")"
+	cp -a "${src}" "${dest}"
+	echo "Copied ${src} -> ${dest}"
+}
+
+if [[ "${INCLUDE_WEB}" == "1" ]]; then
+	echo "==> Running web Vitest coverage (apps/web)"
+	(
+		cd "${ROOT}/apps/web"
+		bun install --frozen-lockfile
+		bun run test:coverage
+	)
+	copy_tree "${ROOT}/apps/web/coverage" "${DIST_DIR}/coverage-web"
+fi
+
+if [[ "${INCLUDE_RUST}" == "1" ]]; then
+	echo "==> Running Rust coverage + HTML (workspace; may take several minutes)"
+	./scripts/ci/testing/ci-setup-rust-coverage.sh
+	./scripts/ci/testing/ci-rust-coverage.sh
+	cargo llvm-cov report --html --output-dir rust-coverage-html
+	copy_tree "${ROOT}/rust-coverage-html" "${DIST_DIR}/coverage-rust"
+fi
+
+echo ""
+echo "Pages-like dist ready at: ${DIST_DIR}"
+echo "  Docs:     /Rustume/"
+echo "  Rust cov: /Rustume/coverage-rust/"
+echo "  Web cov:  /Rustume/coverage-web/"
+echo ""
+
+if [[ "${PREVIEW_SERVE:-1}" == "0" ]]; then
+	exit 0
+fi
+
+echo "==> Starting astro preview (Ctrl+C to stop)"
+cd "${SITE_DIR}"
+exec bun run preview -- --host 127.0.0.1

--- a/scripts/ci/site/preview-serve.sh
+++ b/scripts/ci/site/preview-serve.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Serve apps/site/dist with the same ASTRO_BASE used at build time (GitHub Pages subpath).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SITE_DIR="${ROOT}/apps/site"
+
+set -a
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/defaults.env"
+set +a
+
+export ASTRO_BASE="${ASTRO_BASE:-${ASTRO_BASE_DEFAULT}}"
+
+cd "${SITE_DIR}"
+if [[ ! -d dist ]]; then
+	echo "Missing ${SITE_DIR}/dist — run ./scripts/ci/site/build.sh or make site-build first." >&2
+	exit 1
+fi
+
+echo "Serving dist with ASTRO_BASE=${ASTRO_BASE}"
+echo "Open: http://127.0.0.1:4321${ASTRO_BASE}"
+exec bunx astro preview "$@"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ci): deploy docs site with bundled coverage on GitHub Pages
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Fixes the GitHub Pages 404 after the Astro docs site merge by deploying via **lgtm-ci Model B** (`reusable-deploy-site-with-reports`) instead of the broken `reusable-deploy-pages` pin (tag-object SHA). Coverage workflows on `main` now upload flat Rust/web HTML artifacts that the deploy workflow bundles under `/Rustume/coverage-rust/` and `/Rustume/coverage-web/`. All lgtm-ci pins are bumped to **v0.24.0** using the **commit SHA** (`f96f883`) with Renovate version comments.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` and `./scripts/ci/site/test-all.sh`)

## Closes

- Closes #263
- Relates to lgtm-hq/lgtm-ci#251

## Details

### CI / Pages

- Replace `deploy-pages.yml` with `reusable-deploy-site-with-reports` + `.github/pages-bundle-manifest.json`
- Trigger deploy on successful **Coverage Reports** or **Quality - Documentation Site** on `main`
- Extend `coverage.yml`: Rust HTML via `ci-rust-coverage-html.sh`, web repack job, `reusable-test-node` + `reusable-artifact-pr-comment`
- Pin every `lgtm-hq/lgtm-ci` action/workflow to `f96f883… # v0.24.0` (commit SHA, not tag object)

### Scripts / docs

- `preview-pages-local.sh` for local Model B preview
- `scripts/ci/site/README.md` documents published URLs and preview flow

### Testing strategy

- `uv run lintro chk` (pass)
- `./scripts/ci/site/test-all.sh` (Vitest + pytest for site scripts)
- After merge: verify Pages deploy workflow succeeds and live URLs load (`/Rustume/`, coverage paths)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deploy docs site with bundled coverage reports to GitHub Pages
> - Adds a [pages-bundle-manifest.json](.github/pages-bundle-manifest.json) describing `rust-coverage-html` and `web-coverage-html` artifacts from the Coverage Reports workflow to be bundled into the deployed site.
> - Refactors [deploy-pages.yml](.github/workflows/deploy-pages.yml) to trigger via `workflow_run` after successful Coverage Reports or site quality workflows on `main`, using a new reusable deploy workflow with explicit site root and manifest inputs.
> - Refactors [coverage.yml](.github/workflows/coverage.yml) to use reusable workflows for both Rust and web coverage, producing named HTML artifacts and publishing test summaries on PRs.
> - Adds [preview-pages-local.sh](scripts/ci/site/preview-pages-local.sh) so developers can locally preview the full Pages layout with coverage directories mirroring production.
> - Updates action pins to `v0.32.1` across all workflows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f971724.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pages deployment now publishes bundled Rust and Web coverage reports alongside the site.
  * Local preview tool to build and view the site plus coverage reports before deployment.
  * New runner hardening and egress allowlist helpers for CI.

* **Documentation**
  * CI/site README updated with deployment model, bundling behavior and local preview instructions.

* **Chores**
  * Repinned CI actions to newer revisions.
  * Ignored coverage artifacts and added CI test profile emitting JUnit output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Replaces the broken push-triggered Pages deploy with a `workflow_run`-driven "Model B" deployment that bundles Rust and web HTML coverage artifacts alongside the Astro docs site. All `lgtm-hq/lgtm-ci` action and reusable workflow references are bumped from `fc77ab6` (`v0.19.2`) to `3aa7280` (`v0.32.1`).

- Rewrites `deploy-pages.yml` to trigger on successful "Coverage Reports" or "Quality - Documentation Site" runs on `main`, with a correct `main`-branch guard on `workflow_dispatch` and a fork-origin check.
- Replaces ~200 lines of inline `rust-coverage` / `web-coverage` jobs in `coverage.yml` with two reusable workflow calls that upload HTML coverage artifacts; adds `.github/pages-bundle-manifest.json` to map those artifacts to `/coverage-rust/` and `/coverage-web/` under the Pages site.
- Adds `preview-pages-local.sh` for a local full-fidelity Pages preview, a `SmartLink` favicon lookup via Google s2 with SVG fallback, and a `TemplateAccent` component for the templates docs page.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the deploy wiring is correct and all previously flagged blocking issues have been resolved, with one behavioral change in coverage.yml worth confirming.

The migration from inline jobs to reusable workflows silently drops the explicit draft-PR guard that previously prevented 45- and 30-minute coverage jobs from running on every push to a draft PR. Whether it matters depends on whether the called reusable workflows handle draft-PR skipping internally.

.github/workflows/coverage.yml — confirm the reusable workflows skip draft PRs, or add an explicit job-level if: condition.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-pages.yml | Rewired from push-triggered to workflow_run-triggered deploy using new reusable workflow; correctly adds main-branch guard on workflow_dispatch and fork-origin check |
| .github/workflows/coverage.yml | ~200 lines of inline jobs replaced with two reusable workflow calls; removes explicit draft-PR guard that previously blocked coverage on draft PRs |
| .github/pages-bundle-manifest.json | New manifest mapping rust-coverage-html and web-coverage-html artifacts to Pages subpaths; top-level strict:false but require_success:true per bundle |
| apps/site/src/lib/favicon.ts | New module that constructs Google s2 favicon URLs for public http(s) hostnames; correctly guards localhost/127.0.0.1/[::1] and non-http schemes |
| apps/site/src/components/SmartLink.astro | Updated to use remoteFaviconUrl for external links with SVG fallback on onerror; data-fallback is always a static build-time URL, no XSS risk |
| scripts/ci/site/preview-pages-local.sh | New developer-facing script that builds dist and optionally merges local coverage HTML; correctly copies from rust-coverage-html/ (direct llvm-cov output dir) to dist/coverage-rust/ |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fcoverage.yml%3A25-40%0A**Draft%20PR%20guard%20removed%20when%20migrating%20to%20reusable%20workflows**%0A%0ABoth%20the%20old%20%60rust-coverage%60%20and%20%60web-coverage%60%20inline%20jobs%20had%20an%20explicit%20condition%20preventing%20runs%20on%20draft%20PRs%3A%20%60if%3A%20github.event_name%20!%3D%20'pull_request'%20%7C%7C%20github.event.pull_request.draft%20%3D%3D%20false%60.%20The%20new%20reusable%20workflow%20calls%20have%20no%20%60if%3A%60%20condition%20at%20the%20job%20level.%20If%20%60reusable-rust-test.yml%60%20and%20%60reusable-test-node.yml%60%20don't%20internally%20skip%20draft-PR%20events%2C%20every%20push%20to%20a%20draft%20PR%20will%20now%20trigger%20both%20a%2045-minute%20Rust%20coverage%20run%20and%20a%2030-minute%20web%20coverage%20run.%20Worth%20confirming%20whether%20the%20called%20reusable%20workflows%20handle%20this%2C%20or%20adding%20a%20job-level%20%60if%3A%60%20to%20each%20call.%0A%0A&pr=264&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fcoverage.yml%3A25-40%0A**Draft%20PR%20guard%20removed%20when%20migrating%20to%20reusable%20workflows**%0A%0ABoth%20the%20old%20%60rust-coverage%60%20and%20%60web-coverage%60%20inline%20jobs%20had%20an%20explicit%20condition%20preventing%20runs%20on%20draft%20PRs%3A%20%60if%3A%20github.event_name%20!%3D%20'pull_request'%20%7C%7C%20github.event.pull_request.draft%20%3D%3D%20false%60.%20The%20new%20reusable%20workflow%20calls%20have%20no%20%60if%3A%60%20condition%20at%20the%20job%20level.%20If%20%60reusable-rust-test.yml%60%20and%20%60reusable-test-node.yml%60%20don't%20internally%20skip%20draft-PR%20events%2C%20every%20push%20to%20a%20draft%20PR%20will%20now%20trigger%20both%20a%2045-minute%20Rust%20coverage%20run%20and%20a%2030-minute%20web%20coverage%20run.%20Worth%20confirming%20whether%20the%20called%20reusable%20workflows%20handle%20this%2C%20or%20adding%20a%20job-level%20%60if%3A%60%20to%20each%20call.%0A%0A&repo=lgtm-hq%2Frustume&pr=264&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F263-pages-model-b-coverage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F263-pages-model-b-coverage%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fcoverage.yml%3A25-40%0A**Draft%20PR%20guard%20removed%20when%20migrating%20to%20reusable%20workflows**%0A%0ABoth%20the%20old%20%60rust-coverage%60%20and%20%60web-coverage%60%20inline%20jobs%20had%20an%20explicit%20condition%20preventing%20runs%20on%20draft%20PRs%3A%20%60if%3A%20github.event_name%20!%3D%20'pull_request'%20%7C%7C%20github.event.pull_request.draft%20%3D%3D%20false%60.%20The%20new%20reusable%20workflow%20calls%20have%20no%20%60if%3A%60%20condition%20at%20the%20job%20level.%20If%20%60reusable-rust-test.yml%60%20and%20%60reusable-test-node.yml%60%20don't%20internally%20skip%20draft-PR%20events%2C%20every%20push%20to%20a%20draft%20PR%20will%20now%20trigger%20both%20a%2045-minute%20Rust%20coverage%20run%20and%20a%2030-minute%20web%20coverage%20run.%20Worth%20confirming%20whether%20the%20called%20reusable%20workflows%20handle%20this%2C%20or%20adding%20a%20job-level%20%60if%3A%60%20to%20each%20call.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (16): Last reviewed commit: ["docs(site): fix markdownlint in local pr..."](https://github.com/lgtm-hq/rustume/commit/f971724e4c515ae79af6aa3ab94aaab748467130) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34574489)</sub>

<!-- /greptile_comment -->