### PR TITLE
fix(ci): resolve Pages deploy startup failure from concurrency deadlock

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,10 +16,6 @@ permissions:
   contents: read
   actions: read
 
-concurrency:
-  group: pages-${{ github.repository }}-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   deploy:
     if: >-


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): resolve Pages deploy startup failure from concurrency deadlock
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Remove the workflow-level `concurrency` block from `deploy-pages.yml`. The caller and
the lgtm-ci reusable workflow (`reusable-deploy-site-with-reports.yml` v0.32.1) both used
`pages-${{ github.repository }}-${{ github.ref }}`, which deadlocked before any deploy job
could start. The reusable workflow already serializes Pages deploys.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #268

## Details

**Change:** Option A from the issue — delete the caller's `concurrency:` block in
`.github/workflows/deploy-pages.yml` only. No lgtm-ci pin bump required.

**Verification after merge:** Re-run **Deploy - GitHub Pages** via `workflow_dispatch` or
wait for the next successful Coverage / Site Quality run. Confirm the workflow shows a
`deploy` job with nested **Build site and bundle reports** and **Deploy to GitHub Pages**
jobs, and that `https://lgtm-hq.github.io/Rustume/` serves the site.

**Local checks:** `uv run lintro chk` passed (including actionlint). Rust workspace
tests passed via `cargo test --workspace`. Web vitest step in `make test` was skipped
locally (vitest not installed); unchanged by this workflow-only fix.

**Review:** CodeRabbit — 0 findings.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove concurrency group from Pages deploy workflow to fix startup deadlock
> The top-level `concurrency` block in [deploy-pages.yml](https://github.com/lgtm-hq/Rustume/pull/269/files#diff-0f132b0962009071404990a6789b3466dbd8723d1f7b744f6aca0312396a7900) caused a deadlock because `cancel-in-progress: false` serialized runs without allowing cancellation, preventing new runs from starting. Removing the block lets workflow runs execute without being queued in that concurrency group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdfdff2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Pages deployment workflow to allow parallel deployment runs instead of serializing them sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the four-line `concurrency` block from the caller workflow (`.github/workflows/deploy-pages.yml`). Both the caller and the called reusable workflow (`reusable-deploy-site-with-reports.yml` v0.32.1) registered the same group key (`pages-${{ github.repository }}-${{ github.ref }}`) with `cancel-in-progress: false`, so the caller held the lock while waiting for the reusable workflow, which could never acquire the same lock — a classic deadlock.

- Deletes the duplicate `concurrency:` block from the caller; serialization is now handled exclusively by the reusable workflow.
- All other workflow configuration (triggers, permissions, `if` guard, pinned SHA, and inputs) is unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal four-line deletion that removes a duplicate concurrency lock, unblocking Pages deploys without touching any build or deploy logic.

The change removes exactly the lines responsible for the deadlock and nothing else. Concurrency serialization remains intact inside the reusable workflow; the caller's guard was redundant and harmful. The `if` condition, permissions, pinned SHA, and all workflow inputs are untouched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-pages.yml | Removes the caller-level `concurrency` block that shared the same group key as the reusable workflow, causing a deadlock before any deploy job could start. The reusable workflow at v0.32.1 already owns Pages-deploy serialization. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Caller as deploy-pages.yml (caller)
    participant Reusable as reusable-deploy-site-with-reports.yml

    Note over GH,Reusable: BEFORE (deadlock)
    GH->>Caller: trigger workflow_run / workflow_dispatch
    Caller->>GH: acquire concurrency lock pages-repo-refs/heads/main
    Caller->>Reusable: call reusable workflow
    Reusable->>GH: acquire same concurrency lock (blocked — held by caller)
    Note over Caller,Reusable: Deadlock — caller waits on reusable, reusable waits on caller's lock

    Note over GH,Reusable: AFTER (fixed)
    GH->>Caller: trigger workflow_run / workflow_dispatch
    Note over Caller: no concurrency block
    Caller->>Reusable: call reusable workflow
    Reusable->>GH: acquire concurrency lock
    Reusable->>GH: deploy to Pages
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): remove caller concurrency to un..."](https://github.com/lgtm-hq/rustume/commit/cdfdff213965b88291532bc29bcef044effa92b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35800454)</sub>

<!-- /greptile_comment -->