### PR TITLE
chore(ci): bump lgtm-ci to v0.32.3

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -43,14 +43,14 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: audit
 
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -71,7 +71,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.fork == false
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           file: pr-comment.txt
           marker: "<!-- lintro-report -->"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,12 +24,12 @@ permissions:
 jobs:
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+      tooling-ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
       job-name: "🦀 Rust Coverage"
       coverage: true
       upload-pages-coverage-html: true
@@ -41,12 +41,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+      tooling-ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -35,7 +35,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
 
       - name: Dependency review
         # yamllint disable-line rule:line-length

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,7 +31,7 @@ jobs:
       actions: read
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -41,7 +41,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+      tooling-ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -33,7 +33,7 @@ jobs:
   docker:
     name: 🐳 Docker Build & Publish
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
     permissions:
       contents: read
       packages: write
@@ -41,7 +41,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+      tooling-ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -41,7 +41,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -85,7 +85,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -105,7 +105,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -37,7 +37,7 @@ jobs:
       - name: Validate PR title
         id: semantic
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/semantic-pr-title@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           types: >-
             chore,ci,docs,feat,fix,perf,refactor,revert,style,test,build
@@ -45,7 +45,7 @@ jobs:
       - name: Post failure comment
         if: steps.semantic.outputs.valid != 'true'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           marker: "<!-- semantic-pr-title -->"
           body: |

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -67,7 +67,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -76,7 +76,7 @@ jobs:
       - name: Calculate next version
         id: semrel
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/calculate-version@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           max-bump: minor
 

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -51,11 +51,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           node-version: '22'
           working-directory: apps/site
@@ -72,7 +72,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: 3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+          ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -135,18 +135,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           node-version: '22'
           working-directory: apps/site

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -55,11 +55,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
 
       - name: Build all crates
         run: cargo build --workspace --all-features

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3aa7280fd586e3293849b88a9790187ebc110061 # v0.32.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
 
       - name: Scan workflows for non-pinned actions
         run: ENFORCE=1 bash scripts/ci/maintenance/validate-action-pinning.sh


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ci): bump lgtm-ci to v0.32.3
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Bump all lgtm-ci workflow and composite-action pins from v0.32.1 to v0.32.3 (`f469f4d5c187f0700ccec4c023152fb68ee3dc89`).

After #269 fixed the Pages deploy concurrency deadlock, deploy jobs still fail in **Bundle workflow artifacts** with `unknown flag: --arg` (see [run 27005573294](https://github.com/lgtm-hq/Rustume/actions/runs/27005573294)). That is fixed upstream in lgtm-ci v0.32.2 (jq instead of `gh api --arg`). v0.32.3 also includes the `scripts/ci/` sparse-checkout fix needed for deploy/build scripts.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`)

## Closes

- Relates to #264
- Relates to #269

## Details

- 15 workflow files updated: `uses:` refs and matching `tooling-ref` inputs where present.
- No application code changes.
- After merge: re-run **Deploy - GitHub Pages** on `main` and confirm `https://lgtm-hq.github.io/Rustume/` serves the docs site.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump lgtm-ci to v0.32.3 across all CI workflows
> Updates all pinned commit references for `lgtm-hq/lgtm-ci` actions from `3aa7280` (v0.32.1) to `f469f4d` (v0.32.3) across 15 workflow files. Affects `harden-runner`, `secure-checkout`, `setup-rust`, and reusable workflow references used in build, test, release, and deployment jobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95a73c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR uniformly bumps all `lgtm-ci` composite-action and reusable-workflow pins from v0.32.1 (`3aa7280`) to v0.32.3 (`f469f4d`) across 15 GitHub Actions workflow files, with no application code changes.

- **`deploy-pages.yml`**: The most impactful update — v0.32.2 switched from `gh api --arg` to `jq` in the bundle-artifact step, fixing the `unknown flag: --arg` failure that blocked every deploy since #269.
- **`site-quality.yml`** and **`deploy-pages.yml`**: Also pick up the v0.32.3 `scripts/ci/` sparse-checkout fix required for build and deploy scripts to resolve correctly.
- All other files receive identical mechanical SHA + comment updates; every `tooling-ref:` input is kept in sync with its corresponding `uses:` ref.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are a mechanical SHA bump with no application code touched.

Every one of the 15 files makes the same two substitutions (old SHA → new SHA in `uses:` and `tooling-ref:`), and all are internally consistent. The new SHA directly unblocks the deploy pipeline failures described in the PR. No logic, permissions, or egress-policy settings were altered.

No files require special attention; all changes are identical in nature across the 15 workflow files.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-pages.yml | Bumps reusable workflow ref and tooling-ref from v0.32.1 to v0.32.3; directly fixes the `--arg` jq regression and sparse-checkout issue that blocked the deploy job. |
| .github/workflows/coverage.yml | Updates both reusable workflow refs and tooling-ref inputs for rust-coverage and web-coverage jobs from v0.32.1 to v0.32.3; no logic changes. |
| .github/workflows/site-quality.yml | Updates all composite-action pins and the explicit lgtm-ci tooling sparse-checkout ref from v0.32.1 to v0.32.3; most action references of any single file in this PR. |
| .github/workflows/docker-build-publish.yml | Bumps reusable-docker workflow ref and tooling-ref from v0.32.1 to v0.32.3; no other changes. |
| .github/workflows/publish-release-on-tag.yml | Updates harden-runner, secure-checkout, and create-github-release action pins from v0.32.1 to v0.32.3 across two jobs. |
| .github/workflows/validate-action-pinning.yml | Updates harden-runner and secure-checkout pins to v0.32.3; the script it runs will now validate the new SHA, which is consistent across the PR. |
| .github/workflows/build-binary.yml | Bumps harden-runner, secure-checkout, and setup-rust action refs to v0.32.3. |
| .github/workflows/semantic-release.yml | Updates harden-runner, secure-checkout, and calculate-version action pins from v0.32.1 to v0.32.3. |
| .github/workflows/ci-lintro-analysis.yml | Bumps harden-runner, secure-checkout, and post-pr-comment action pins to v0.32.3; no logic changes. |
| .github/workflows/auto-tag-on-main.yml | Updates harden-runner and secure-checkout pins from v0.32.1 to v0.32.3. |
| .github/workflows/test-rust.yml | Bumps harden-runner, secure-checkout, and setup-rust action pins to v0.32.3. |
| .github/workflows/dependency-review.yml | Updates harden-runner and secure-checkout pins from v0.32.1 to v0.32.3. |
| .github/workflows/pr-auto-assign.yml | Updates harden-runner pin from v0.32.1 to v0.32.3. |
| .github/workflows/pr-labeler.yml | Updates harden-runner pin from v0.32.1 to v0.32.3. |
| .github/workflows/semantic-pr-title.yml | Updates harden-runner, semantic-pr-title, and post-pr-comment action pins from v0.32.1 to v0.32.3. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR["PR #270\nlgtm-ci v0.32.1 → v0.32.3"] --> WF["15 Workflow Files\nuses: SHA updated\ntooling-ref: updated"]

    WF --> D1["deploy-pages.yml\n+ reusable-deploy-site-with-reports"]
    WF --> D2["coverage.yml\n+ reusable-rust-test\n+ reusable-test-node"]
    WF --> D3["docker-build-publish.yml\n+ reusable-docker"]
    WF --> D4["10 other workflows\n(composite actions only)"]

    D1 --> FIX1["✅ Fixes: unknown flag --arg\n(v0.32.2: jq replaces gh api --arg)"]
    D1 --> FIX2["✅ Fixes: scripts/ci/ sparse-checkout\n(v0.32.3)"]
    D2 --> OK2["✅ No behaviour change"]
    D3 --> OK3["✅ No behaviour change"]
    D4 --> OK4["✅ No behaviour change"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): bump lgtm-ci to v0.32.3"](https://github.com/lgtm-hq/rustume/commit/95a73c4c48517f5394acd2a308a9508668a8c38b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35831578)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions and automated workflow configurations across the entire CI/CD pipeline, including continuous integration testing, Docker image building, code quality analysis, semantic versioning and release processes, dependency validation, website builds, and deployment automation. All workflow updates use consistent, current versions of build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->