### PR TITLE
ci: quote and sync lgtm-ci tooling-ref pins to v0.32.4

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+      tooling-ref: '69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4
       job-name: "🦀 Rust Coverage"
       coverage: true
       upload-pages-coverage-html: true
@@ -46,7 +46,7 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+      tooling-ref: '69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -41,7 +41,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+      tooling-ref: '69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -41,7 +41,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+      tooling-ref: '69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+          ref: '69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci: quote and sync lgtm-ci tooling-ref pins to v0.32.4
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Phase 0 of lgtm-ci adoption (#266): sync five stale `tooling-ref` / manual `ref:` pins from v0.32.3 to v0.32.4 and quote them so Renovate can track them alongside `uses:` SHAs.

This unblocks GitHub Pages deploy — sparse-checked-out `.lgtm-ci-tooling` was still at v0.32.3, missing the v0.32.4 `GH_TOKEN` fix in `bundle-workflow-artifacts`.

**Files updated:**
- `deploy-pages.yml` — `tooling-ref`
- `coverage.yml` — `tooling-ref` (rust + web jobs)
- `docker-build-publish.yml` — `tooling-ref`
- `site-quality.yml` — manual lgtm-ci checkout `ref:`

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Relates to #266

## Details

- All `tooling-ref` / `ref:` pins now use single-quoted format: `'69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4`
- `uses:` pins were already at v0.32.4; only sparse-checkout refs were stale
- Validated with `ENFORCE=1 bash scripts/ci/maintenance/validate-action-pinning.sh` (0 non-pinned refs)
- Greptile: 5/5 confidence, no comments
- CodeRabbit: 0 findings

**Post-merge:** Re-run **Deploy - GitHub Pages** on `main` and confirm `https://lgtm-hq.github.io/Rustume/` loads.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update lgtm-ci `tooling-ref` pins to v0.32.4 across CI workflows
> Bumps the `tooling-ref` SHA from `f469f4d` (v0.32.3) to `69d5990` (v0.32.4) in all four CI workflow files: [coverage.yml](.github/workflows/coverage.yml), [deploy-pages.yml](.github/workflows/deploy-pages.yml), [docker-build-publish.yml](.github/workflows/docker-build-publish.yml), and [site-quality.yml](.github/workflows/site-quality.yml). The new SHAs are also quoted for YAML correctness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6dc3f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment workflow configurations to reference the latest tooling versions, enhancing build consistency and deployment reliability across all pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR syncs five stale `tooling-ref` / `ref:` pins in four workflow files from lgtm-ci v0.32.3 to v0.32.4 and wraps the SHA values in single quotes so Renovate can track them consistently alongside `uses:` pins.

- **`coverage.yml`** — both the `rust-coverage` and `web-coverage` job `tooling-ref` inputs updated to `'69d5990a1d877f752ecd47bd961851b5f6feea36'` (v0.32.4).
- **`deploy-pages.yml`** and **`docker-build-publish.yml`** — each had one `tooling-ref` input updated to the same SHA.
- **`site-quality.yml`** — the manual `actions/checkout ref:` for the sparse-checkout of `.lgtm-ci-tooling` updated; this was the pin that blocked the GitHub Pages deploy by missing the v0.32.4 `GH_TOKEN` fix in `bundle-workflow-artifacts`.
</details>

<h3>Confidence Score: 5/5</h3>

All five SHA pins are now consistent at v0.32.4 across the entire workflow directory; no stale v0.32.3 references remain.

Every changed line is a mechanical SHA update and quote-addition. Cross-referencing the full `.github/workflows/` tree confirms no other files still reference the old v0.32.3 SHA, and all `uses:` pins were already at v0.32.4 before this change. The diff is exactly what the PR description claims.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/coverage.yml | Both `tooling-ref` inputs in the rust-coverage and web-coverage jobs updated from v0.32.3 to v0.32.4 SHA, with single quotes added; consistent with the `uses:` lines already pinned to v0.32.4. |
| .github/workflows/deploy-pages.yml | `tooling-ref` input bumped to v0.32.4 SHA with single-quote formatting; `uses:` line was already at v0.32.4 before this PR. |
| .github/workflows/docker-build-publish.yml | `tooling-ref` input updated to v0.32.4 SHA with single-quote formatting; aligns with the `uses:` pin already at v0.32.4. |
| .github/workflows/site-quality.yml | Manual `actions/checkout` `ref:` for sparse-checked-out `.lgtm-ci-tooling` bumped from v0.32.3 to v0.32.4 SHA with single quotes; the only stale non-`uses:` pin in this file. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[lgtm-ci v0.32.4\n69d5990a] --> B[coverage.yml\nrust-coverage tooling-ref]
    A --> C[coverage.yml\nweb-coverage tooling-ref]
    A --> D[deploy-pages.yml\ntooling-ref]
    A --> E[docker-build-publish.yml\ntooling-ref]
    A --> F[site-quality.yml\nactions/checkout ref:]

    B:::updated
    C:::updated
    D:::updated
    E:::updated
    F:::updated

    classDef updated fill:#22c55e,color:#fff,stroke:#16a34a
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: quote and sync lgtm-ci tooling-ref p..."](https://github.com/lgtm-hq/rustume/commit/f6dc3f1a3241420f8956582208e2ceee7e38354e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35995881)</sub>

<!-- /greptile_comment -->