### PR TITLE
ci: adopt lgtm-ci for phase 1 security workflows (#266)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,8 @@
 name: Security - CodeQL Code Scanning
 # GitHub CodeQL static analysis for security vulnerabilities.
 # Scans Rust and GitHub Actions code, uploads results to Security tab.
+# Inline (not reusable-codeql): reusable passes build-mode to init, which fails
+# when actions and rust are combined (actions does not support autobuild).
 
 "on":
   push:
@@ -22,24 +24,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  codeql:
-    # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
-    with:
-      languages: actions,rust
-      build-mode: autobuild
-      category: "/language:all"
-      job-name: "🔬 CodeQL Analysis"
-      tooling-ref: '69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4
-      egress-policy: block
-      egress-preset: github-tooling
-      allowed-endpoints-mode: append
-      allowed-endpoints: >
-        static.rust-lang.org:443
-        sh.rustup.rs:443
-        crates.io:443
-        static.crates.io:443
-        index.crates.io:443
+  analyze:
+    name: 🔬 CodeQL Analysis
     permissions:
       contents: read
       security-events: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            objects.githubusercontent.com:443
+            static.rust-lang.org:443
+            sh.rustup.rs:443
+            crates.io:443
+            static.crates.io:443
+            index.crates.io:443
+
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
+
+      - name: Initialize CodeQL
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          languages: actions, rust
+
+      - name: Autobuild
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+
+      - name: Perform CodeQL Analysis
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          category: "/language:all"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@
 name: Security - CodeQL Code Scanning
 # GitHub CodeQL static analysis for security vulnerabilities.
 # Scans Rust and GitHub Actions code, uploads results to Security tab.
-# Rust endpoints are allowed so the extractor can download dependencies
-# for type resolution and macro expansion.
 
 "on":
   push:
@@ -19,53 +17,29 @@ name: Security - CodeQL Code Scanning
 
 permissions: {}
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  analyze:
-    name: 🔬 CodeQL Analysis
+  codeql:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
+    with:
+      languages: actions,rust
+      build-mode: autobuild
+      category: "/language:all"
+      job-name: "🔬 CodeQL Analysis"
+      tooling-ref: '69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4
+      egress-policy: block
+      egress-preset: github-tooling
+      allowed-endpoints-mode: append
+      allowed-endpoints: >
+        static.rust-lang.org:443
+        sh.rustup.rs:443
+        crates.io:443
+        static.crates.io:443
+        index.crates.io:443
     permissions:
       contents: read
       security-events: write
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    concurrency:
-      group: codeql-${{ github.ref }}
-      cancel-in-progress: true
-
-    steps:
-      - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            codeload.github.com:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            objects.githubusercontent.com:443
-            static.rust-lang.org:443
-            sh.rustup.rs:443
-            crates.io:443
-            static.crates.io:443
-            index.crates.io:443
-
-      - name: Checkout
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Initialize CodeQL
-        # yamllint disable-line rule:line-length
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-        with:
-          languages: actions, rust
-
-      - name: Autobuild
-        # yamllint disable-line rule:line-length
-        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-
-      - name: Perform CodeQL Analysis
-        # yamllint disable-line rule:line-length
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-        with:
-          category: "/language:all"

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -2,6 +2,8 @@
 ---
 name: Maintenance - GHCR Registry Cleanup
 # Weekly cleanup of untagged and aged tagged container images from GHCR.
+# Untagged pruning uses lgtm-ci reusable-ghcr-cleanup; tagged retention policy
+# stays inline (reusable has no tagged-prune inputs).
 
 "on":
   schedule:
@@ -33,40 +35,20 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   prune-untagged:
-    name: 🧹 Prune Untagged Images
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      packages: write
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Prune untagged GHCR versions
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GHCR_PRUNE_MIN_AGE_DAYS: >-
-            ${{ format('{0}', inputs.min_age_days) || '7' }}
-          GHCR_PRUNE_DRY_RUN: >-
-            ${{ inputs.dry_run == true && '1' || '0' }}
-        run: ./scripts/ci/maintenance/ghcr-prune-untagged.sh
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
+    with:
+      package-name: rustume
+      min-age-days: ${{ inputs.min_age_days || 7 }}
+      dry-run: ${{ inputs.dry_run == true }}
+      tooling-ref: '69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4
+      egress-policy: audit
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   prune-tagged:
     name: 🏷️ Prune Aged Tagged Images
@@ -81,12 +63,14 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:
           persist-credentials: false
 

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -41,6 +41,9 @@ jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
+    permissions:
+      contents: read
+      packages: write
     with:
       package-name: rustume
       min-age-days: ${{ inputs.min_age_days || 7 }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,8 +10,7 @@ name: Maintenance - Renovate Dependencies
     - cron: "0 22 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   renovate:
@@ -27,7 +26,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -46,7 +45,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -26,6 +26,9 @@ jobs:
       allowed-endpoints-mode: append
       allowed-endpoints: >
         agent.api.stepsecurity.io:443
+        api.deps.dev:443
+        api.osv.dev:443
+        api.scorecard.dev:443
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443
         sigstore.dev:443

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -8,62 +8,33 @@ name: Security - OpenSSF Scorecard Analysis
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: scorecards-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  analysis:
-    name: 🛡️ Scorecard Analysis
-    runs-on: ubuntu-24.04
+  scorecards:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
+    with:
+      job-name: "🛡️ Scorecard Analysis"
+      tooling-ref: '69d5990a1d877f752ecd47bd961851b5f6feea36' # v0.32.4
+      egress-policy: block
+      egress-preset: scorecard
+      allowed-endpoints-mode: append
+      allowed-endpoints: >
+        agent.api.stepsecurity.io:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        release-assets.githubusercontent.com:443
+        oss-fuzz-build-logs.storage.googleapis.com:443
+        ossf.github.io:443
+        www.bestpractices.dev:443
     permissions:
       contents: read
       security-events: write
       id-token: write
-    timeout-minutes: 10
-
-    steps:
-      - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            agent.api.stepsecurity.io:443
-            api.deps.dev:443
-            api.github.com:443
-            api.osv.dev:443
-            api.scorecard.dev:443
-            codeload.github.com:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            objects.githubusercontent.com:443
-            oss-fuzz-build-logs.storage.googleapis.com:443
-            ossf.github.io:443
-            rekor.sigstore.dev:443
-            sigstore.dev:443
-            tuf-repo-cdn.sigstore.dev:443
-            www.bestpractices.dev:443
-
-      - name: Checkout
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Run Scorecards analysis
-        # yamllint disable-line rule:line-length
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          results_file: results.sarif
-          results_format: sarif
-          # yamllint disable-line rule:line-length
-          publish_results: >-
-            ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-
-      - name: Upload SARIF to code scanning
-        # yamllint disable-line rule:line-length
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-        with:
-          sarif_file: results.sarif

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -33,6 +33,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden Runner
+        if: ${{ !env.ACT }}
         # yamllint disable-line rule:line-length
         uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:
@@ -85,6 +86,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden Runner
+        if: ${{ !env.ACT }}
         # yamllint disable-line rule:line-length
         uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -1,7 +1,8 @@
+# SPDX-License-Identifier: MIT
 ---
 name: Security - Dependency Vulnerability Scan
 
-'on':
+"on":
   pull_request:
   merge_group:
     types: [checks_requested]
@@ -9,7 +10,7 @@ name: Security - Dependency Vulnerability Scan
     branches: [main]
   schedule:
     # Weekly scan: Monday 05:30 UTC
-    - cron: '30 5 * * 1'
+    - cron: "30 5 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -31,8 +32,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        if: ${{ !env.ACT }}
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -45,7 +47,9 @@ jobs:
             pkg-containers.githubusercontent.com:443
             codeload.github.com:443
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
 
       - name: Pull py-lintro Docker image
         run: ./scripts/ci/pull-lintro-image.sh
@@ -80,8 +84,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        if: ${{ !env.ACT }}
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -90,7 +95,9 @@ jobs:
             codeload.github.com:443
             objects.githubusercontent.com:443
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
 
       - name: Download comment artifact
         id: download_comment_artifact
@@ -99,7 +106,8 @@ jobs:
           name: security-audit-comment
 
       - name: Post PR comment
-        uses: ./.github/actions/post-pr-comment
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@69d5990a1d877f752ecd47bd961851b5f6feea36 # v0.32.4
 
       - name: Install osv-scanner
         run: scripts/utils/install-osv-scanner.sh


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci: adopt lgtm-ci for phase 1 security workflows (#266)
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Phase 1 of #266: migrate security and maintenance workflows to lgtm-ci reusables
and composites at v0.32.4, removing all `step-security/harden-runner` usage from
these workflows.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Relates to #266

## Details

**Reusable migrations**
- `codeql.yml` → `reusable-codeql` (actions + rust, autobuild)
- `scorecards.yml` → `reusable-scorecards`
- `ghcr-cleanup.yml` → `reusable-ghcr-cleanup` for untagged images

**Composite migrations**
- `security-dependency-review.yml` → lgtm-ci `harden-runner`, `secure-checkout`,
  upstream `post-pr-comment`
- `renovate.yml` → lgtm-ci `harden-runner` + `secure-checkout`
- `vuln-suppression-check.yml` → lgtm-ci composites (script unchanged)

**Exceptions**
- `ghcr-cleanup.yml` tagged retention (`ghcr-prune-tags.sh`) stays inline — reusable
  has no tagged-prune inputs

**Validation**
- `ENFORCE=1 bash scripts/ci/maintenance/validate-action-pinning.sh`
- `uv run lintro chk` (actionlint included)
- Greptile: fixed missing `packages: write` on GHCR reusable caller
- CodeRabbit: 0 findings

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adopt lgtm-ci actions and reusable workflows for phase 1 security CI
> - Replaces `step-security/harden-runner` and `actions/checkout` with `lgtm-hq/lgtm-ci` equivalents across all security workflows (CodeQL, Renovate, dependency review, vuln suppression).
> - Converts the GHCR untagged image pruning and OpenSSF Scorecards jobs to reusable `lgtm-hq/lgtm-ci` workflows with explicit inputs and secrets instead of inline steps.
> - Sets top-level `permissions: {}` on several workflows, keeping explicit write permissions at the job level.
> - Moves concurrency controls from job level to workflow level for CodeQL and Scorecards.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30e9361.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI workflows to use pinned, centralized tooling for runner hardening, secure checkout, and maintenance tasks.
  * Introduced top-level permissions and concurrency controls to reduce redundant runs and tighten access.
  * Replaced several inline workflow steps with reusable workflow calls and narrowed external endpoints for safer, more consistent automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates six GitHub Actions security and maintenance workflows from inline `step-security/harden-runner` + `actions/checkout` to `lgtm-hq/lgtm-ci` composite actions and reusable workflows, all pinned to SHA `69d5990a` (v0.32.4).

- `codeql.yml` and `scorecards.yml` gain workflow-level concurrency controls; scorecards is fully delegated to `reusable-scorecards` while CodeQL stays inline (documented: reusable's `build-mode` conflicts with the `actions`+`rust` multi-language setup).
- `ghcr-cleanup.yml` delegates untagged pruning to `reusable-ghcr-cleanup` with correct `packages: write` and `secrets.token` forwarding; tagged pruning stays inline with lgtm-ci composites.
- `security-dependency-review.yml`, `renovate.yml`, and `vuln-suppression-check.yml` swap action refs in place; the `if: ${{ !env.ACT }}` guard is preserved on both harden-runner steps in the dependency review workflow.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all action refs are SHA-pinned, permissions are correctly scoped at job level, and the two open questions from previous threads (scorecard egress preset coverage, act-guard preservation) are either addressed by the current code or already tracked.

The migration is mechanical and well-scoped: composites and reusables are pinned to the same SHA across all six files, job-level permission grants are explicit and appropriate, the GHCR reusable caller correctly forwards `packages: write` and the `GITHUB_TOKEN` secret, and inline exceptions are documented with clear rationale. No new auth, data, or correctness gaps were introduced by this PR.

scorecards.yml — the egress allowlist relies on `egress-preset: scorecard` to supply core GitHub API endpoints; worth confirming the preset definition before the next scheduled run.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql.yml | Replaced step-security/harden-runner and actions/checkout with lgtm-ci composites; moved concurrency from job-level to workflow-level (no behavioral difference for a single-job workflow); comment updated to explain why the reusable-codeql workflow is not used. |
| .github/workflows/ghcr-cleanup.yml | prune-untagged migrated to reusable-ghcr-cleanup with correct permissions (contents: read, packages: write) and secrets forwarding; prune-tagged retains inline script but switches to lgtm-ci composites; top-level permissions: {} correctly defers to job-level grants. |
| .github/workflows/scorecards.yml | Fully migrated to reusable-scorecards with egress-preset: scorecard and allowed-endpoints-mode: append; api.github.com, github.com, codeload.github.com, and objects.githubusercontent.com are absent from the explicit list and must be covered by the preset (flagged in a previous thread). |
| .github/workflows/security-dependency-review.yml | Both harden-runner steps preserve the if: ${{ !env.ACT }} guard; checkout steps migrated to secure-checkout; local .github/actions/post-pr-comment replaced with upstream lgtm-ci composite pinned to the same SHA. |
| .github/workflows/renovate.yml | Top-level permissions narrowed to {}; job-level retains contents: write, issues: write, pull-requests: write; harden-runner and checkout migrated to lgtm-ci composites; persist-credentials: true correctly kept for Renovate's push operations. |
| .github/workflows/vuln-suppression-check.yml | Minimal change — harden-runner and checkout action refs replaced with lgtm-ci composites pinned to the same SHA; script and permissions unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (step-security / actions)"]
        A1["step-security/harden-runner"] --> A2["actions/checkout"]
        A2 --> A3["Inline job steps"]
        A4["local .github/actions/post-pr-comment"]
    end

    subgraph After["After (lgtm-ci composites & reusables)"]
        B1["lgtm-ci/harden-runner\n@69d5990a"] --> B2["lgtm-ci/secure-checkout\n@69d5990a"]
        B2 --> B3["Inline or reusable job steps"]
        B4["lgtm-ci/post-pr-comment\n@69d5990a"]

        subgraph Reusables["Fully reusable"]
            R1["reusable-scorecards\n(scorecards.yml)"]
            R2["reusable-ghcr-cleanup\n(ghcr-cleanup / prune-untagged)"]
        end
    end

    subgraph Inline["Stays inline (documented exceptions)"]
        I1["codeql.yml\n(autobuild multi-lang conflict)"]
        I2["ghcr-cleanup / prune-tagged\n(no tagged-prune inputs in reusable)"]
        I3["security-dependency-review.yml\nrenovate.yml\nvuln-suppression-check.yml"]
    end

    After --> Reusables
    After --> Inline
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: fix CodeQL autobuild and address PR ..."](https://github.com/lgtm-hq/rustume/commit/30e9361f5a25eb9df7fea194ddb965ec3856451c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36004725)</sub>

<!-- /greptile_comment -->