### PR TITLE
chore(license): relicense from MIT to AGPL-3.0 before public launch

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Release - Auto Tag
 # Automatically creates version tags when Cargo.toml version changes on main.

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Build - Cross-Platform Binaries
 # Builds Rustume CLI and server binaries for multiple platforms.

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Quality - Lint & Format
 # Runs lintro quality analysis on PRs and pushes using Docker.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Security - CodeQL Code Scanning
 # GitHub CodeQL static analysis for security vulnerabilities.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,7 @@ jobs:
     with:
       tooling-ref: '0c9b946ff6bb93e3e67ce1d1f4a3c419266dc79e' # v0.33.0
       job-name: "🦀 Rust Coverage"
+      # reusable-rust-test.yml sets INSTALL_COVERAGE_TOOLS from coverage: true for setup-script.
       setup-script: scripts/ci/testing/rust/setup-rust-nextest.sh
       coverage: true
       upload-pages-coverage-html: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Coverage Reports
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Security - Dependency Review
 # Reviews dependency changes in PRs for known security vulnerabilities.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Deploy - GitHub Pages
 

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Build - Docker Image & Registry
 # Builds and publishes Docker images to GHCR via lgtm-ci reusable-docker.

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Maintenance - GHCR Registry Cleanup
 # Weekly cleanup of untagged and aged tagged container images from GHCR.

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: PR - Auto Assign
 # Automatically assigns a random CODEOWNER to new pull requests.

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: PR - Auto Label
 # Automatically applies labels to pull requests based on changed files.

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Publish - GitHub Release
 # Creates GitHub Release when version tags are pushed.

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Maintenance - Renovate Dependencies
 # Automated dependency updates using Renovate bot. Runs daily to check for

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Security - OpenSSF Scorecard Analysis
 # Weekly OpenSSF Scorecard security analysis.

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Security - Dependency Vulnerability Scan
 

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: PR - Title Validation
 # Validates PR titles follow Conventional Commits format.

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Release - Automated PR Creation
 # Computes next semantic version using conventional commits and opens release PR.

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Quality - Documentation Site
 

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Rust Build (workspace)
 # Compiles the Rust workspace on PRs and pushes to main.

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Quality Check - Action Pinning Validation
 # Validates that external GitHub Actions are pinned to SHA commits.

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 ---
 name: Security - Vulnerability Suppression Check
 # Weekly check for stale or expired vulnerability suppressions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,4 +295,6 @@ or pull `:main` for the latest main-branch image. See
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the
+GNU Affero General Public License v3.0 only (AGPL-3.0-only). See [LICENSE](LICENSE)
+for details.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-cli"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-parser"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "csv",
  "cuid2",
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-render"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "rstest",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-schema"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "cuid2",
  "once_cell",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-schema-macros"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-server"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-storage"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "js-sys",
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-utils"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "ammonia",
  "chrono",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "rustume-wasm"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "js-sys",
  "rustume-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*", "bindings/*"]
 [workspace.package]
 version = "0.17.0"
 edition = "2021"
-license = "MIT"
+license = "AGPL-3.0-only"
 repository = "https://github.com/lgtm-hq/Rustume"
 
 [workspace.dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 Turbo Coder
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+Rustume
+Copyright (C) 2026 Turbo Coder
+
+This product is licensed under the GNU Affero General Public License v3.0 only
+(AGPL-3.0-only). See the LICENSE file for the full license text.
+
+Portions of this software are derived from Reactive Resume (MIT License).
+See THIRD_PARTY_NOTICES for required attribution.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A privacy-first, offline-first resume builder powered by Rust.
 <!-- Badges: Security & License -->
 <p align="center">
 <a href="https://github.com/lgtm-hq/Rustume/actions/workflows/scorecards.yml?query=branch%3Amain"><img src="https://github.com/lgtm-hq/Rustume/actions/workflows/scorecards.yml/badge.svg?branch=main" alt="OpenSSF Scorecard"></a>
-<a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>
+<a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License"></a>
 </p>
 
 <!-- Badges: Tech Stack -->
@@ -147,7 +147,8 @@ uv run lintro fmt        # Auto-fix formatting
 
 Rustume is heavily inspired by and builds upon the work of Reactive Resume by
 Amruth Pillai. The template designs in particular are adapted from Reactive
-Resume's originals.
+Resume's originals. See [THIRD_PARTY_NOTICES](THIRD_PARTY_NOTICES) for the
+required MIT attribution.
 
 <p>
 <a href="https://rxresu.me/"><img src="https://img.shields.io/badge/Inspired_by-Reactive_Resume-6c47ff?logo=github&logoColor=white" alt="Reactive Resume"></a>
@@ -163,4 +164,20 @@ Resume's originals.
 
 ## 📄 License
 
-MIT License - see [LICENSE](LICENSE) for details.
+Rustume is licensed under the [GNU Affero General Public License v3.0
+(AGPL-3.0-only)](LICENSE).
+
+**What this means in practice:**
+
+- **Self-hosting** for personal or internal use: fully permitted
+- **Offering Rustume as a network service**: you must share your modifications under AGPL
+- **CLI and library use locally**: no network interaction, so AGPL network provisions do not apply
+- **Template designs**: adapted from
+  [Reactive Resume](https://github.com/AmruthPillai/Reactive-Resume) (MIT); see
+  [THIRD_PARTY_NOTICES](THIRD_PARTY_NOTICES)
+
+Prior commits were released under MIT; AGPL applies from the relicense forward.
+See also [NOTICE](NOTICE).
+
+Rustume follows the same licensing approach as projects like Plausible, Cal.com,
+Signal, and Standard Notes.

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,37 @@
+Third-Party Notices
+===================
+
+Reactive Resume
+---------------
+
+Copyright (c) 2026 Amruth Pillai
+
+The following Rustume components are adapted from Reactive Resume
+(<https://github.com/AmruthPillai/Reactive-Resume>), which is licensed under
+the MIT License:
+
+- Typst resume templates: azurill, bronzor, chikorita, ditto, gengar, glalie,
+  kakuna, leafish, nosepass, onyx, pikachu, and rhyhorn (originally
+  `apps/artboard/src/templates/*.tsx` in Reactive Resume)
+- Template theme colors in `crates/render/src/typst_engine/engine.rs`
+  (originally `libs/utils/src/namespaces/template.ts` in Reactive Resume)
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -4,7 +4,7 @@ Third-Party Notices
 Reactive Resume
 ---------------
 
-Copyright (c) 2026 Amruth Pillai
+Copyright (c) 2021 Amruth Pillai
 
 The following Rustume components are adapted from Reactive Resume
 (<https://github.com/AmruthPillai/Reactive-Resume>), which is licensed under

--- a/apps/site/.gitignore
+++ b/apps/site/.gitignore
@@ -3,3 +3,4 @@ dist/
 .astro/
 public/assets/css/
 public/assets/rustume.png
+public/legal/

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "private": true,
-  "license": "MIT",
+  "license": "AGPL-3.0-only",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/apps/site/scripts/copy-assets.mjs
+++ b/apps/site/scripts/copy-assets.mjs
@@ -25,6 +25,18 @@ if (existsSync(favicon)) {
   console.log("Copied favicon.svg");
 }
 
+const legalDir = join(publicDir, "legal");
+mkdirSync(legalDir, { recursive: true });
+for (const name of ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES"]) {
+  const src = join(repoRoot, name);
+  if (existsSync(src)) {
+    cpSync(src, join(legalDir, name));
+    console.log(`Copied ${name}`);
+  } else {
+    throw new Error(`Missing required legal file: ${name}`);
+  }
+}
+
 const turboCssRoot = join(
   siteRoot,
   "node_modules",

--- a/apps/site/src/components/Footer.astro
+++ b/apps/site/src/components/Footer.astro
@@ -26,7 +26,9 @@ const year = new Date().getFullYear();
         <a href="https://github.com/lgtm-hq/Rustume/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">Contributing</a>
       </div>
     </div>
-    <p class="footer-bottom">MIT &copy; {year} Rustume</p>
+    <p class="footer-bottom">
+      <a href={`${base}license/`}>AGPL-3.0</a> &copy; {year} Rustume
+    </p>
   </div>
 </footer>
 

--- a/apps/site/src/data/faq.ts
+++ b/apps/site/src/data/faq.ts
@@ -175,6 +175,14 @@ export const FAQ_ITEMS: FaqItem[] = [
     learnMore: "docs/getting-started/import-formats/",
   },
   {
+    id: "license-agpl",
+    category: "privacy",
+    question: "Why is Rustume licensed under AGPL-3.0?",
+    answer:
+      "AGPL keeps Rustume Cloud transparent: self-hosting and local CLI use are unrestricted, but offering Rustume as a network service requires sharing modifications under the same license. Template designs adapted from Reactive Resume remain MIT-attributed in THIRD_PARTY_NOTICES.",
+    learnMore: "license/",
+  },
+  {
     id: "api-keys-scope",
     category: "data",
     question: "What can API keys do?",

--- a/apps/site/src/data/site-links.test.ts
+++ b/apps/site/src/data/site-links.test.ts
@@ -5,6 +5,9 @@ describe("site-links", () => {
   it("exposes internal doc paths under docs/", () => {
     expect(docs.quickstart).toMatch(/^docs\//);
     expect(docs.cloudOverview).toMatch(/^docs\//);
+  });
+
+  it("exposes non-doc internal paths like license", () => {
     expect(docs.license).toBe("license/");
   });
 

--- a/apps/site/src/data/site-links.test.ts
+++ b/apps/site/src/data/site-links.test.ts
@@ -5,6 +5,7 @@ describe("site-links", () => {
   it("exposes internal doc paths under docs/", () => {
     expect(docs.quickstart).toMatch(/^docs\//);
     expect(docs.cloudOverview).toMatch(/^docs\//);
+    expect(docs.license).toBe("license/");
   });
 
   it("exposes home and external link metadata", () => {

--- a/apps/site/src/data/site-links.ts
+++ b/apps/site/src/data/site-links.ts
@@ -14,6 +14,7 @@ export const docs = {
   cloudPublicPages: "docs/cloud/public-pages/",
   pricingPlans: "docs/pricing/plans/",
   faq: "faq/",
+  license: "license/",
   importFormats: "docs/getting-started/import-formats/",
   cliUsage: "docs/cli/usage/",
   apiKeys: "docs/api/api-keys/",

--- a/apps/site/src/pages/license/index.astro
+++ b/apps/site/src/pages/license/index.astro
@@ -1,0 +1,99 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PageHeader from '../../components/ui/PageHeader.astro';
+import Callout from '../../components/ui/Callout.astro';
+import Section from '../../components/ui/Section.astro';
+import DocsResources from '../../components/docs/DocsResources.astro';
+import { docHref, docs, external } from '../../data/site-links';
+
+const base = import.meta.env.BASE_URL;
+const legal = (name: string) => `${base}legal/${name}`;
+const licenseResources = [
+  { label: 'Full AGPL-3.0 text', href: legal('LICENSE') },
+  { label: 'NOTICE', href: legal('NOTICE') },
+  { label: 'Third-party notices', href: legal('THIRD_PARTY_NOTICES') },
+  { label: 'FAQ', href: docHref(base, docs.faq) },
+  { label: 'Contributing guide', href: `${external.github.href}/blob/main/CONTRIBUTING.md` },
+];
+---
+
+<BaseLayout
+  title="License"
+  description="Rustume is licensed under AGPL-3.0-only. Self-hosting and local CLI use are unrestricted; network services must share modifications."
+>
+  <div class="container content license-page">
+    <PageHeader
+      kicker="Legal"
+      title="License"
+      description="Rustume is licensed under the GNU Affero General Public License v3.0 only (AGPL-3.0-only)."
+    />
+
+    <Callout title="What this means in practice" variant="info" class="callout-banner">
+      <ul>
+        <li>
+          <strong>Self-hosting</strong> for personal or internal use is fully permitted.
+        </li>
+        <li>
+          <strong>Rustume Cloud</strong> and other hosted offerings may charge for operation;
+          AGPL does not restrict paid hosting of unmodified software.
+        </li>
+        <li>
+          <strong>Offering Rustume as a network service</strong> after modifying the software
+          requires sharing those modifications under AGPL.
+        </li>
+        <li>
+          <strong>CLI and library use locally</strong> does not trigger AGPL network provisions.
+        </li>
+      </ul>
+    </Callout>
+
+    <Section>
+      <h2>Template attribution</h2>
+      <p>
+        Resume template designs are adapted from{' '}
+        <a href={external.reactiveResume.href} target="_blank" rel="noopener noreferrer">
+          Reactive Resume
+        </a>{' '}
+        (MIT). See{' '}
+        <a href={legal('THIRD_PARTY_NOTICES')}>THIRD_PARTY_NOTICES</a> for the required copyright
+        and permission notice.
+      </p>
+    </Section>
+
+    <Section>
+      <h2>Prior licensing</h2>
+      <p>
+        Earlier commits were released under MIT. AGPL-3.0-only applies from the relicense forward.
+      </p>
+    </Section>
+
+    <Section>
+      <h2>Full license texts</h2>
+      <ul>
+        <li><a href={legal('LICENSE')}>LICENSE</a> — GNU AGPL-3.0</li>
+        <li><a href={legal('NOTICE')}>NOTICE</a> — Rustume copyright header</li>
+        <li>
+          <a href={legal('THIRD_PARTY_NOTICES')}>THIRD_PARTY_NOTICES</a> — Reactive Resume MIT
+          attribution
+        </li>
+      </ul>
+    </Section>
+
+    <DocsResources resources={licenseResources} />
+  </div>
+</BaseLayout>
+
+<style>
+  .license-page {
+    max-width: 48rem;
+  }
+
+  .callout-banner ul {
+    margin: 0;
+    padding-left: 1.25rem;
+  }
+
+  .callout-banner li + li {
+    margin-top: 0.5rem;
+  }
+</style>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,7 @@
   "name": "@rustume/web",
   "version": "0.1.0",
   "type": "module",
+  "license": "AGPL-3.0-only",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -34,7 +34,7 @@ impl Modify for CookieAuthAddon {
         title = "Rustume API",
         version = env!("CARGO_PKG_VERSION"),
         description = "REST API for resume parsing, rendering, validation, and Rustume Cloud storage.\n\n## Features\n\n- **Parse**: Import resumes from JSON Resume, LinkedIn exports, or Reactive Resume v3\n- **Render**: Generate PDF or PNG previews of resumes\n- **Validate**: Check resume data against the schema\n- **Templates**: List available resume templates with theme colors\n- **Cloud** (when enabled): WorkOS auth and authenticated resume CRUD",
-        license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
+        license(name = "AGPL-3.0-only", url = "https://www.gnu.org/licenses/agpl-3.0.en.html"),
         contact(name = "Rustume", url = "https://github.com/lgtm-hq/Rustume")
     ),
     servers(

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -138,6 +138,9 @@ COPY --from=web-builder /app/apps/web/dist /app/web
 COPY --from=builder /usr/share/fonts/liberation /usr/share/fonts/truetype/liberation
 COPY --from=builder /usr/share/fonts/dejavu /usr/share/fonts/truetype/dejavu
 
+# License texts (AGPL distribution compliance for self-hosted images)
+COPY LICENSE NOTICE THIRD_PARTY_NOTICES /app/legal/
+
 # Environment variables
 ENV RUST_LOG=info
 ENV PORT=3000

--- a/docker/Dockerfile.railway
+++ b/docker/Dockerfile.railway
@@ -112,6 +112,9 @@ COPY --from=web-builder /app/apps/web/dist /app/web
 COPY --from=builder /usr/share/fonts/liberation /usr/share/fonts/truetype/liberation
 COPY --from=builder /usr/share/fonts/dejavu /usr/share/fonts/truetype/dejavu
 
+# License texts (AGPL distribution compliance for self-hosted images)
+COPY LICENSE NOTICE THIRD_PARTY_NOTICES /app/legal/
+
 ENV RUST_LOG=info
 ENV PORT=3000
 ENV RUSTUME_STATIC_DIR=/app/web

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Linting configuration for Rustume"
 requires-python = ">=3.11"
 readme = "README.md"
-license = { text = "MIT" }
+license = "AGPL-3.0-only"
 
 # No Python dependencies - this is just for lintro tooling
 dependencies = []

--- a/scripts/ci/check-vuln-suppressions.sh
+++ b/scripts/ci/check-vuln-suppressions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 #
 # check-vuln-suppressions.sh — Detect stale or expired vulnerability
 # suppressions in .osv-scanner.toml and open a cleanup PR removing them.

--- a/scripts/ci/ci-log.sh
+++ b/scripts/ci/ci-log.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # ci-log.sh

--- a/scripts/ci/ci-pr-comment.sh
+++ b/scripts/ci/ci-pr-comment.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # Show help if requested

--- a/scripts/ci/classify-suppressions.py
+++ b/scripts/ci/classify-suppressions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 """Classify vulnerability suppressions as active, stale, or expired.
 
 Standalone version — does not depend on the lintro Python package.

--- a/scripts/ci/docker/smoke-test.sh
+++ b/scripts/ci/docker/smoke-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # Functional smoke test for Rustume container images.
@@ -81,6 +82,17 @@ until curl -sf --max-time "$CURL_TIMEOUT" "http://127.0.0.1:${PORT}/health" >/de
 	fi
 	sleep 1
 done
+
+echo "Checking bundled license texts"
+legal_staging="$(mktemp -d)"
+for legal_file in LICENSE NOTICE THIRD_PARTY_NOTICES; do
+	if ! docker cp "${CONTAINER_NAME}:/app/legal/${legal_file}" "${legal_staging}/${legal_file}" 2>/dev/null; then
+		echo "Missing /app/legal/${legal_file}" >&2
+		rm -rf "$legal_staging"
+		exit 1
+	fi
+done
+rm -rf "$legal_staging"
 
 echo "Checking web UI"
 if ! curl -sf --max-time "$CURL_TIMEOUT" "http://127.0.0.1:${PORT}/" | grep -qi "rustume"; then

--- a/scripts/ci/fail-audit.sh
+++ b/scripts/ci/fail-audit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 # Fail the CI job when the security audit found vulnerabilities or errors.
 set -euo pipefail
 

--- a/scripts/ci/fail-on-lint.sh
+++ b/scripts/ci/fail-on-lint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # fail-on-lint.sh

--- a/scripts/ci/format-security-comment.py
+++ b/scripts/ci/format-security-comment.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
 """Format lintro osv-scanner JSON output as a markdown PR comment body.
 
 Adapted from py-lintro's format-security-comment.py to parse lintro's

--- a/scripts/ci/lintro/run-lintro-docker.sh
+++ b/scripts/ci/lintro/run-lintro-docker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # run-lintro-docker.sh

--- a/scripts/ci/maintenance/auto-tag.sh
+++ b/scripts/ci/maintenance/auto-tag.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # auto-tag.sh

--- a/scripts/ci/maintenance/ghcr-prune-tags.sh
+++ b/scripts/ci/maintenance/ghcr-prune-tags.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # Prune aged tagged GHCR versions while preserving release tags.

--- a/scripts/ci/maintenance/ghcr-prune-untagged.sh
+++ b/scripts/ci/maintenance/ghcr-prune-untagged.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # ghcr-prune-untagged.sh

--- a/scripts/ci/maintenance/guard-release-commit.sh
+++ b/scripts/ci/maintenance/guard-release-commit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # guard-release-commit.sh

--- a/scripts/ci/maintenance/update-cargo-version.sh
+++ b/scripts/ci/maintenance/update-cargo-version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # update-cargo-version.sh

--- a/scripts/ci/maintenance/validate-action-pinning.sh
+++ b/scripts/ci/maintenance/validate-action-pinning.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # validate-action-pinning.sh

--- a/scripts/ci/pull-lintro-image.sh
+++ b/scripts/ci/pull-lintro-image.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 # Pull the py-lintro Docker image and tag it for local use.
 set -euo pipefail
 

--- a/scripts/ci/release/build-binaries.sh
+++ b/scripts/ci/release/build-binaries.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # build-binaries.sh

--- a/scripts/ci/release/check-bump-needed.sh
+++ b/scripts/ci/release/check-bump-needed.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # check-bump-needed.sh

--- a/scripts/ci/release/enable-auto-merge.sh
+++ b/scripts/ci/release/enable-auto-merge.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # enable-auto-merge.sh

--- a/scripts/ci/release/package-unix.sh
+++ b/scripts/ci/release/package-unix.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # package-unix.sh
@@ -53,7 +54,7 @@ fi
 mkdir -p "$STAGING"
 cp "$CLI_BIN" "$STAGING/"
 cp "$SRV_BIN" "$STAGING/"
-cp README.md LICENSE "$STAGING/" 2>/dev/null || true
+cp README.md LICENSE NOTICE THIRD_PARTY_NOTICES "$STAGING/"
 tar czf "${STAGING}.tar.gz" "$STAGING"
 shasum -a 256 "${STAGING}.tar.gz" >"${STAGING}.tar.gz.sha256"
 rm -rf "$STAGING"

--- a/scripts/ci/release/verify-tag-version.sh
+++ b/scripts/ci/release/verify-tag-version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 # verify-tag-version.sh

--- a/scripts/ci/security-audit.sh
+++ b/scripts/ci/security-audit.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 # Run osv-scanner via lintro in Docker and generate a security PR comment.
 set -euo pipefail
 

--- a/scripts/ci/site/build.sh
+++ b/scripts/ci/site/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 # Build the Rustume documentation site for GitHub Pages.
 set -euo pipefail
 

--- a/scripts/ci/site/check.sh
+++ b/scripts/ci/site/check.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 # Type-check the documentation site with Astro check.
 set -euo pipefail
 

--- a/scripts/ci/site/fix-markdown-docs.py
+++ b/scripts/ci/site/fix-markdown-docs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
 """Fix markdownlint issues in Astro docs content."""
 
 from __future__ import annotations

--- a/scripts/ci/site/generate-template-thumbnails.sh
+++ b/scripts/ci/site/generate-template-thumbnails.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 # Generate PNG thumbnails for all resume templates in the docs site.
 set -euo pipefail
 

--- a/scripts/ci/site/prepare-lychee-action-args.sh
+++ b/scripts/ci/site/prepare-lychee-action-args.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Prepare lychee-action CLI args from lgtm-ci build-lychee-args output.
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 : "${RAW_ARGS:?RAW_ARGS is required}"

--- a/scripts/ci/site/preview-pages-local.sh
+++ b/scripts/ci/site/preview-pages-local.sh
@@ -72,6 +72,7 @@ fi
 if [[ "${INCLUDE_RUST}" == "1" ]]; then
 	echo "==> Running Rust coverage + HTML (workspace; may take several minutes)"
 	rustup toolchain install stable --profile minimal 2>/dev/null || true
+	rustup component add llvm-tools-preview --toolchain stable
 	CARGO_LLVM_COV_VERSION="${CARGO_LLVM_COV_VERSION:-0.8.6}"
 	installed_llvm_cov_version=""
 	if llvm_cov_version_out="$(rustup run stable cargo llvm-cov --version 2>/dev/null)"; then

--- a/scripts/ci/site/preview-pages-local.sh
+++ b/scripts/ci/site/preview-pages-local.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 # Build the docs site and optionally merge local coverage HTML for a Pages-like preview.
 set -euo pipefail
 

--- a/scripts/ci/site/preview-serve.sh
+++ b/scripts/ci/site/preview-serve.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 # Serve apps/site/dist with the same ASTRO_BASE used at build time (GitHub Pages subpath).
 set -euo pipefail
 

--- a/scripts/ci/site/test-all.sh
+++ b/scripts/ci/site/test-all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run Vitest and site script pytest for the documentation site.
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"

--- a/scripts/ci/site/test-python.sh
+++ b/scripts/ci/site/test-python.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run pytest for site-related maintenance scripts.
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"

--- a/scripts/ci/site/test.sh
+++ b/scripts/ci/site/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run Vitest with coverage for the documentation site.
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"

--- a/scripts/ci/testing/rust/setup-rust-nextest.sh
+++ b/scripts/ci/testing/rust/setup-rust-nextest.sh
@@ -15,7 +15,7 @@ _install_cargo_crate() {
 	local version="$2"
 
 	if command -v "$crate" >/dev/null 2>&1; then
-		if "$crate" --version 2>/dev/null | grep -qE "^${crate} ${version}(\$| )"; then
+		if "$crate" --version 2>/dev/null | grep -qF "${crate} ${version}"; then
 			return 0
 		fi
 		echo "Found ${crate} but not pinned ${version}; reinstalling..."

--- a/scripts/ci/testing/rust/setup-rust-nextest.sh
+++ b/scripts/ci/testing/rust/setup-rust-nextest.sh
@@ -25,6 +25,7 @@ _install_cargo_crate() {
 	if command -v cargo-binstall >/dev/null 2>&1; then
 		cargo binstall "$crate" \
 			--version "$version" \
+			--force \
 			--no-confirm ||
 			cargo install "$crate" \
 				--locked \

--- a/scripts/ci/testing/rust/setup-rust-nextest.sh
+++ b/scripts/ci/testing/rust/setup-rust-nextest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 # Purpose: Install cargo-nextest and optional cargo-llvm-cov for Rust CI.
 # Workaround: pass --force on cargo install when reinstalling a pinned version
 # (lgtm-ci v0.33.0 setup-rust-nextest.sh omits --force; see CI run 27070245152).

--- a/scripts/ci/testing/rust/setup-rust-nextest.sh
+++ b/scripts/ci/testing/rust/setup-rust-nextest.sh
@@ -15,7 +15,7 @@ _install_cargo_crate() {
 	local version="$2"
 
 	if command -v "$crate" >/dev/null 2>&1; then
-		if "$crate" --version 2>/dev/null | grep -qF "${crate} ${version}"; then
+		if "$crate" --version 2>/dev/null | grep -qxF "${crate} ${version}"; then
 			return 0
 		fi
 		echo "Found ${crate} but not pinned ${version}; reinstalling..."

--- a/scripts/utils/install-osv-scanner.sh
+++ b/scripts/utils/install-osv-scanner.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: AGPL-3.0-only
 #
 # install-osv-scanner.sh — Download and verify osv-scanner binary.
 #

--- a/scripts/utils/utils.sh
+++ b/scripts/utils/utils.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
 
 # Shared utilities for workflow scripts
 # This file contains common functions and variables used across multiple scripts


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(license): relicense from MIT to AGPL-3.0 before public launch
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Relicense Rustume from MIT to AGPL-3.0-only before Rustume Cloud public launch.
This keeps self-hosting and local CLI use unrestricted while requiring network-service
forks to share modifications. Reactive Resume MIT attribution is preserved for adapted
template designs.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro tst`; pre-existing sqlfluff migration warnings on main)

## Closes

- Closes #249

## Details

### License files and metadata
- Replace `LICENSE` with full GNU AGPL-3.0 text
- Add `NOTICE` and `THIRD_PARTY_NOTICES` (Reactive Resume MIT attribution)
- Update `Cargo.toml`, `pyproject.toml`, npm `package.json`, and OpenAPI license fields

### Documentation
- Expand README license section and AGPL FAQ
- Add docs site `/license/` page with links to full legal texts
- Update CONTRIBUTING contributor license terms and site footer

### Distribution compliance
- Bundle legal files in release tarballs and Docker runtime images (`/app/legal/`)
- Assert legal files in container smoke tests
- Copy legal texts into site build via `copy-assets.mjs`

### CI hygiene
- Align SPDX headers to `AGPL-3.0-only` across workflows and scripts
- Document `INSTALL_COVERAGE_TOOLS` contract in coverage workflow
- Harden pinned crate version checks in `setup-rust-nextest.sh`

### Review follow-ups
- Greptile: coverage env contract documented; grep fixed-string version check applied
- CodeRabbit: site-links test split, `cargo binstall --force`, local preview llvm-tools install

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Relicense project from MIT to AGPL-3.0-only before public launch
> - Replaces the MIT `LICENSE` file with the full AGPL-3.0 text and adds `NOTICE` and `THIRD_PARTY_NOTICES` files for attribution.
> - Updates all SPDX license headers across workflow files, scripts, and package manifests (`Cargo.toml`, `pyproject.toml`, `apps/site/package.json`, `apps/web/package.json`).
> - Adds a dedicated `/license/` page to the marketing site with links to the bundled legal files, and updates the footer and FAQ to reference AGPL-3.0.
> - Bundles `LICENSE`, `NOTICE`, and `THIRD_PARTY_NOTICES` into Docker images under `/app/legal/` and into release tarballs; build and smoke-test scripts now fail if any of these files are absent.
> - Risk: the license change is a breaking contractual change for any downstream consumers or forks that relied on the permissive MIT terms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f41b88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched project license from MIT to AGPL-3.0-only across codebase and manifests.
  * Ensure license/legal files are packaged into builds and container images.

* **Documentation**
  * Added a dedicated License page, updated README and CONTRIBUTING with AGPL details.
  * Added NOTICE and THIRD_PARTY_NOTICES for attribution.
  * Updated site footer and FAQ with licensing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR relicenses Rustume from MIT to AGPL-3.0-only ahead of the Rustume Cloud public launch, updating every SPDX header, package manifest, and distribution artifact (Docker images, release tarballs, and the docs site) to carry the new license texts.

- Adds `NOTICE` and `THIRD_PARTY_NOTICES` files, bundles all three legal files into Docker images at `/app/legal/`, release tarballs, and `public/legal/` in the site build, and adds CI smoke-test assertions that verify their presence in the container image.
- Adds a `/license/` page to the docs site with an AGPL FAQ entry, updates the footer badge, and expands the README and CONTRIBUTING license sections.
- Hardens the `cargo-nextest`/`cargo-llvm-cov` version check in `setup-rust-nextest.sh` from a regex to `grep -qxF` (exact-line, fixed-string match) and adds `--force` to `cargo binstall` to prevent stale cached binaries.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the MIT attribution block in THIRD_PARTY_NOTICES.

The THIRD_PARTY_NOTICES file omits the Reactive Resume copyright line from inside the MIT license block — the copyright appears 12 lines above the 'Permission is hereby granted' text, separated by descriptive prose. This means anyone who copies just the MIT License section misses the required copyright holder attribution, undermining the purpose of the file. All other changes (SPDX header updates, Docker legal-file bundling, smoke-test assertions, site license page, release tarball hardening, and the nextest version-check fix) are correct and low-risk.

THIRD_PARTY_NOTICES — the MIT license block needs the copyright line inserted directly between 'MIT License' and 'Permission is hereby granted'.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| THIRD_PARTY_NOTICES | New MIT attribution file; copyright year corrected to 2021, but the copyright line is outside the MIT license block, which may undermine redistribution compliance. |
| scripts/ci/testing/rust/setup-rust-nextest.sh | Version-check regex replaced with `grep -qxF` (exact-line fixed-string) and `--force` added to `cargo binstall`; both are correct hardening fixes. |
| scripts/ci/docker/smoke-test.sh | Adds post-health-check assertion that copies all three legal files out of the container; cleanup is handled correctly on all exit paths. |
| scripts/ci/release/package-unix.sh | Removed `|| true` fallback so release packaging hard-fails when any legal file is absent; intentional and correct. |
| apps/site/scripts/copy-assets.mjs | Adds loop to copy LICENSE/NOTICE/THIRD_PARTY_NOTICES from repo root into `public/legal/`; throws on missing file; `repoRoot` path is correctly computed. |
| docker/Dockerfile | Copies three legal files into `/app/legal/` in the final image layer; straightforward AGPL distribution compliance addition. |
| apps/site/src/pages/license/index.astro | New license page referencing `external.reactiveResume` (defined in site-links.ts) and legal file paths populated by copy-assets.mjs; all references resolve correctly. |
| LICENSE | Replaced MIT text with canonical AGPL-3.0 boilerplate; no modifications to the license text itself. |
| NOTICE | Short AGPL copyright header for Rustume itself; copyright year 2026 matches the current year of relicensing. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Source checkout] --> B[copy-assets.mjs]
    B -->|copies legal files| C[public/legal/]
    B -->|missing file| X1[throw Error - build fails]

    A --> D[Docker build]
    D -->|COPY legal files| E[app/legal/ in image]

    A --> F[package-unix.sh]
    F -->|cp legal files| G[release tarball staging]
    F -->|missing file| X2[CI fails - no tarball]

    E --> H[smoke-test.sh]
    H -->|docker cp each file| I{file present?}
    I -->|yes| J[smoke test passes]
    I -->|no| X3[exit 1 - CI fails]

    C --> K[license page on docs site]
    K --> L[Links to public/legal/ files]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ATHIRD_PARTY_NOTICES%3A19-21%0AThe%20MIT%20license%20block%20is%20missing%20the%20copyright%20line%20between%20%60MIT%20License%60%20and%20%60Permission%20is%20hereby%20granted%60.%20The%20copyright%20notice%20currently%20sits%2012%20lines%20above%20the%20license%20text%2C%20separated%20by%20descriptive%20prose%20about%20which%20components%20were%20adapted.%20MIT's%20own%20boilerplate%20says%20%22The%20above%20copyright%20notice%20and%20this%20permission%20notice%20shall%20be%20included%20in%20all%20copies%22%20%E2%80%94%20%60the%20above%20copyright%20notice%60%20is%20most%20naturally%20read%20as%20the%20line%20immediately%20preceding%20%60Permission%20is%20hereby%20granted%60.%20Someone%20who%20copies%20just%20the%20MIT%20License%20block%20starting%20at%20line%2019%20would%20omit%20the%20copyright%20holder%20entirely%2C%20which%20is%20exactly%20what%20this%20attribution%20is%20trying%20to%20prevent.%0A%0A%60%60%60suggestion%0AMIT%20License%0A%0ACopyright%20%28c%29%202021%20Amruth%20Pillai%0A%0APermission%20is%20hereby%20granted%2C%20free%20of%20charge%2C%20to%20any%20person%20obtaining%20a%20copy%0A%60%60%60%0A%0A&pr=277&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ATHIRD_PARTY_NOTICES%3A19-21%0AThe%20MIT%20license%20block%20is%20missing%20the%20copyright%20line%20between%20%60MIT%20License%60%20and%20%60Permission%20is%20hereby%20granted%60.%20The%20copyright%20notice%20currently%20sits%2012%20lines%20above%20the%20license%20text%2C%20separated%20by%20descriptive%20prose%20about%20which%20components%20were%20adapted.%20MIT's%20own%20boilerplate%20says%20%22The%20above%20copyright%20notice%20and%20this%20permission%20notice%20shall%20be%20included%20in%20all%20copies%22%20%E2%80%94%20%60the%20above%20copyright%20notice%60%20is%20most%20naturally%20read%20as%20the%20line%20immediately%20preceding%20%60Permission%20is%20hereby%20granted%60.%20Someone%20who%20copies%20just%20the%20MIT%20License%20block%20starting%20at%20line%2019%20would%20omit%20the%20copyright%20holder%20entirely%2C%20which%20is%20exactly%20what%20this%20attribution%20is%20trying%20to%20prevent.%0A%0A%60%60%60suggestion%0AMIT%20License%0A%0ACopyright%20%28c%29%202021%20Amruth%20Pillai%0A%0APermission%20is%20hereby%20granted%2C%20free%20of%20charge%2C%20to%20any%20person%20obtaining%20a%20copy%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=277&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22chore%2F249-relicense-mit-to-agpl-3-before-public-launch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F249-relicense-mit-to-agpl-3-before-public-launch%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ATHIRD_PARTY_NOTICES%3A19-21%0AThe%20MIT%20license%20block%20is%20missing%20the%20copyright%20line%20between%20%60MIT%20License%60%20and%20%60Permission%20is%20hereby%20granted%60.%20The%20copyright%20notice%20currently%20sits%2012%20lines%20above%20the%20license%20text%2C%20separated%20by%20descriptive%20prose%20about%20which%20components%20were%20adapted.%20MIT's%20own%20boilerplate%20says%20%22The%20above%20copyright%20notice%20and%20this%20permission%20notice%20shall%20be%20included%20in%20all%20copies%22%20%E2%80%94%20%60the%20above%20copyright%20notice%60%20is%20most%20naturally%20read%20as%20the%20line%20immediately%20preceding%20%60Permission%20is%20hereby%20granted%60.%20Someone%20who%20copies%20just%20the%20MIT%20License%20block%20starting%20at%20line%2019%20would%20omit%20the%20copyright%20holder%20entirely%2C%20which%20is%20exactly%20what%20this%20attribution%20is%20trying%20to%20prevent.%0A%0A%60%60%60suggestion%0AMIT%20License%0A%0ACopyright%20%28c%29%202021%20Amruth%20Pillai%0A%0APermission%20is%20hereby%20granted%2C%20free%20of%20charge%2C%20to%20any%20person%20obtaining%20a%20copy%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=277&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(license): correct Reactive Resume MI..."](https://github.com/lgtm-hq/rustume/commit/5f41b88c4458e73461d41e33263b36a7a14825fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36059787)</sub>

<!-- /greptile_comment -->