### PR TITLE
fix(server): optimistic concurrency control on resume updates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, coverage, release automation,
 and publishing. Most workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`ba485556d3d4605b825347c2fe431ad4395b1c63` (**v0.44.1** release commit; not the annotated
+`96a42109637efd4c019d176e0902e3be23295716` (**v0.45.1** release commit; not the annotated
 tag object SHA). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
@@ -17,7 +17,7 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 
 - **test-rust.yml** — Rust workspace compile check via `reusable-test-rust-build`
   (ruleset gate: `rust-build / 🔨 Build Check`)
-- **coverage.yml** — Single-runtime coverage (lgtm-ci v0.44.1
+- **coverage.yml** — Single-runtime coverage (lgtm-ci v0.45.1
   compat/coverage contract): `rust-coverage` and `web-coverage` each use
   `coverage: true` and `publish-test-summary: true`; uploads Pages coverage
   HTML artifacts and distinct PR coverage comments (suite name in heading)
@@ -70,9 +70,9 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 Use the **release commit SHA**, not the annotated tag object SHA:
 
 ```yaml
-uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
 with:
-  tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1 release commit
+  tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1 release commit
 ```
 
 Sparse `lgtm-hq` tooling checkouts may use `actions/checkout` when `ref:` is quoted and

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -18,9 +18,9 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: "🏷️ Create Release Tag"
       version-source: cargo
       create-release: false

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -43,14 +43,14 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           egress-policy: audit
 
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -41,12 +41,12 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read # checkout repository sources for lintro analysis
       packages: read # pull the pinned lintro image from GHCR
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: "🛠️ Lintro Code Quality & Analysis"
       lintro-tool-options: clippy:timeout=300
       timeout-minutes: 30
@@ -64,14 +64,14 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read # read quality job outputs and artifacts
       pull-requests: write # post or update the quality summary comment
     with:
       exit-code: >-
         ${{ needs.quality.outputs.exit-code != '' && needs.quality.outputs.exit-code || '1' }}
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: "🛠️ Lintro Code Quality & Analysis PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,9 +23,9 @@ concurrency:
 jobs:
   analyze:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: "🔬 CodeQL Analysis"
       languages: actions,rust
       language-build-modes: '{"rust":"none","actions":"none"}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,12 +24,12 @@ permissions:
 jobs:
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: "🦀 Rust Coverage"
       coverage: true
       upload-pages-coverage-html: true
@@ -41,12 +41,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,11 +15,11 @@ concurrency:
 jobs:
   review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       job-name: "🔍 Dependency Review"
       fail-on-severity: high
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,7 +32,7 @@ jobs:
       actions: read
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -42,7 +42,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -33,7 +33,7 @@ jobs:
   docker:
     name: 🐳 Docker Build & Publish
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       packages: write
@@ -41,7 +41,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -40,7 +40,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       packages: write
@@ -48,7 +48,7 @@ jobs:
       package-name: rustume
       min-age-days: ${{ inputs.min_age_days || 7 }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: audit
       runner-image: ubuntu-24.04
     secrets:
@@ -68,13 +68,13 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           egress-policy: audit
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -13,11 +13,11 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       job-name: "👤 Auto Assign PR Author"
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,12 +12,12 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       job-name: "🏷️ Auto Label PR"
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -41,7 +41,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -85,7 +85,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -105,7 +105,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -45,7 +45,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       job-name: "🛡️ Scorecard Analysis"
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -22,12 +22,12 @@ concurrency:
 jobs:
   security-audit:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       packages: read
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: "Scan dependencies"
       runner-image: ubuntu-24.04
       # yamllint disable-line rule:line-length
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+          ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
           sparse-checkout: |
             .github/actions/harden-runner
             .github/actions/resolve-egress-allowlist
@@ -83,12 +83,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs: security-audit
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       pull-requests: write
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: "💬 Post PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -16,10 +16,10 @@ concurrency:
 jobs:
   check:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       job-name: "📝 Validate PR Title"
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       comment-marker: "<!-- semantic-pr-title -->"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -42,12 +42,12 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       ecosystems: rust
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -31,12 +31,12 @@ concurrency:
 jobs:
   site-quality:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       pull-requests: write # required: reusable declares this on internal publish job
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: Build and check documentation site
       test-job-name: Test documentation site
       node-version: '22'

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -28,10 +28,10 @@ jobs:
     # ruleset check name stays rust-build / 🔨 Build Check — an extra nesting
     # hop would prefix build / and break required-status matching.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       job-name: "🔨 Build Check"
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       draft-pr-skip: true
       egress-policy: block
       egress-preset: quality

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -16,9 +16,9 @@ concurrency:
 jobs:
   check-pinning:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       fail-on-error: true

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -19,10 +19,10 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@ba485556d3d4605b825347c2fe431ad4395b1c63 # v0.44.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       job-name: "🔍 Check Vulnerability Suppressions"
-      tooling-ref: 'ba485556d3d4605b825347c2fe431ad4395b1c63' # v0.44.1
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/apps/web/src/api/__tests__/resumes.test.ts
+++ b/apps/web/src/api/__tests__/resumes.test.ts
@@ -6,6 +6,8 @@ import {
   getCloudResume,
   importResumes,
   listCloudResumes,
+  parseApiErrorBody,
+  ResumeVersionConflictError,
   updateCloudResume,
   upsertCloudResume,
 } from "../resumes";
@@ -94,6 +96,44 @@ describe("upsertCloudResume", () => {
     await expect(upsertCloudResume("abc", testResume("Test"), "Test")).rejects.toBeInstanceOf(
       ApiError,
     );
+  });
+
+  it("passes version through to update requests", async () => {
+    const resumeData = testResume("Test");
+    const row = mockRow({ id: "abc", version: 4 });
+    const mockFetch = vi.fn().mockResolvedValue(jsonFetch(row));
+    globalThis.fetch = mockFetch;
+
+    const result = await upsertCloudResume("abc", resumeData, "Test", 3);
+
+    expect(result).toEqual(row);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/resumes/abc",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ title: "Test", data: resumeData, version: 3 }),
+      }),
+    );
+  });
+
+  it("propagates ResumeVersionConflictError without retrying create", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            error: "Resume was modified by another session",
+            current_version: 5,
+          }),
+        ),
+    });
+
+    await expect(upsertCloudResume("abc", testResume("Test"), "Test", 3)).rejects.toBeInstanceOf(
+      ResumeVersionConflictError,
+    );
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
   it("retries update when create returns 409 after a 404 update", async () => {
@@ -221,6 +261,41 @@ describe("resume API helpers", () => {
     );
   });
 
+  it("updateCloudResume sends version when provided", async () => {
+    const resumeData = createDefaultResume();
+    const mockFetch = vi.fn().mockResolvedValue(jsonFetch(mockRow({ version: 4 })));
+    globalThis.fetch = mockFetch;
+
+    await updateCloudResume("abc", { data: resumeData, version: 3 });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/resumes/abc",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ data: resumeData, version: 3 }),
+      }),
+    );
+  });
+
+  it("updateCloudResume throws ResumeVersionConflictError on version mismatch", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            error: "Resume was modified by another session",
+            current_version: 5,
+          }),
+        ),
+    });
+
+    await expect(
+      updateCloudResume("abc", { data: createDefaultResume(), version: 3 }),
+    ).rejects.toBeInstanceOf(ResumeVersionConflictError);
+  });
+
   it("importResumes posts the import payload", async () => {
     const payload: ImportResumeItem[] = [{ title: "One", data: createDefaultResume() }];
     const mockFetch = vi
@@ -280,5 +355,25 @@ describe("resume API helpers", () => {
         body: JSON.stringify({ resumes: payload.slice(100) }),
       }),
     );
+  });
+});
+
+describe("parseApiErrorBody", () => {
+  it("parses version conflict payloads", () => {
+    expect(
+      parseApiErrorBody(
+        JSON.stringify({
+          error: "Resume was modified by another session",
+          current_version: 5,
+        }),
+      ),
+    ).toEqual({
+      error: "Resume was modified by another session",
+      current_version: 5,
+    });
+  });
+
+  it("returns null for non-json bodies", () => {
+    expect(parseApiErrorBody("plain text")).toBeNull();
   });
 });

--- a/apps/web/src/api/__tests__/resumes.test.ts
+++ b/apps/web/src/api/__tests__/resumes.test.ts
@@ -277,6 +277,19 @@ describe("resume API helpers", () => {
     );
   });
 
+  it("rethrows generic 409 ApiError when current_version is absent", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+      text: () => Promise.resolve("A resume with this ID already exists"),
+    });
+
+    await expect(
+      updateCloudResume("abc", { data: createDefaultResume(), version: 3 }),
+    ).rejects.toBeInstanceOf(ApiError);
+  });
+
   it("updateCloudResume throws ResumeVersionConflictError on version mismatch", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/apps/web/src/api/resumes.ts
+++ b/apps/web/src/api/resumes.ts
@@ -83,7 +83,7 @@ export function parseApiErrorBody(message: string): ApiErrorBody | null {
   }
 }
 
-function throwIfVersionConflict(error: ApiError): never {
+function upgradeOrRethrow409(error: ApiError): never {
   if (error.status !== 409) {
     throw error;
   }
@@ -142,7 +142,7 @@ export async function updateCloudResume(
     return await put<CloudResumeRow>(`/resumes/${id}`, payload);
   } catch (error: unknown) {
     if (error instanceof ApiError) {
-      throwIfVersionConflict(error);
+      upgradeOrRethrow409(error);
     }
     throw error;
   }

--- a/apps/web/src/api/resumes.ts
+++ b/apps/web/src/api/resumes.ts
@@ -49,6 +49,51 @@ export interface CreateResumePayload {
 export interface UpdateResumePayload {
   title?: string;
   data?: ResumeData;
+  version?: number;
+}
+
+export interface ApiErrorBody {
+  error: string;
+  current_version?: number;
+}
+
+/** Thrown when a resume update fails due to optimistic concurrency control. */
+export class ResumeVersionConflictError extends Error {
+  constructor(
+    message: string,
+    public currentVersion: number,
+  ) {
+    super(message);
+    this.name = "ResumeVersionConflictError";
+  }
+}
+
+export function parseApiErrorBody(message: string): ApiErrorBody | null {
+  try {
+    const parsed: unknown = JSON.parse(message);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const body = parsed as Record<string, unknown>;
+    if (typeof body.error !== "string") return null;
+    return {
+      error: body.error,
+      current_version: typeof body.current_version === "number" ? body.current_version : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function throwIfVersionConflict(error: ApiError): never {
+  if (error.status !== 409) {
+    throw error;
+  }
+
+  const body = parseApiErrorBody(error.message);
+  if (body?.current_version !== undefined) {
+    throw new ResumeVersionConflictError(body.error, body.current_version);
+  }
+
+  throw error;
 }
 
 export async function listCloudResumesPage(
@@ -93,7 +138,14 @@ export async function updateCloudResume(
   id: string,
   payload: UpdateResumePayload,
 ): Promise<CloudResumeRow> {
-  return put<CloudResumeRow>(`/resumes/${id}`, payload);
+  try {
+    return await put<CloudResumeRow>(`/resumes/${id}`, payload);
+  } catch (error: unknown) {
+    if (error instanceof ApiError) {
+      throwIfVersionConflict(error);
+    }
+    throw error;
+  }
 }
 
 export async function deleteCloudResume(id: string): Promise<void> {
@@ -139,14 +191,22 @@ export async function upsertCloudResume(
   id: string,
   data: ResumeData,
   title?: string,
+  version?: number,
 ): Promise<CloudResumeRow> {
-  const payload = { title, data };
+  const payload: UpdateResumePayload = { title, data };
+  if (version !== undefined) {
+    payload.version = version;
+  }
+
   try {
     return await updateCloudResume(id, payload);
   } catch (error: unknown) {
+    if (error instanceof ResumeVersionConflictError) {
+      throw error;
+    }
     if (error instanceof ApiError && error.status === 404) {
       try {
-        return await createCloudResume({ id, ...payload });
+        return await createCloudResume({ id, title, data });
       } catch (createError: unknown) {
         if (createError instanceof ApiError && createError.status === 409) {
           return updateCloudResume(id, payload);

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -89,10 +89,13 @@ const ToastContent: Component<ToastContentProps> = (props) => {
           {props.action && (
             <button
               type="button"
-              class="mt-2 text-sm font-medium text-[var(--turbo-brand-primary)] hover:underline"
-              onClick={() => {
-                props.action?.onClick();
-                ToastPrimitive.toaster.dismiss(props.toastId);
+              class="mt-2 text-sm font-medium text-[var(--turbo-brand-primary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--turbo-brand-primary)]"
+              onClick={async () => {
+                try {
+                  await Promise.resolve(props.action?.onClick());
+                } finally {
+                  ToastPrimitive.toaster.dismiss(props.toastId);
+                }
               }}
             >
               {props.action.label}

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -39,12 +39,18 @@ const DEFAULT_DURATION: Record<ToastVariant, number> = {
   info: 4000,
 };
 
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 interface ToastContentProps {
   toastId: number;
   variant: ToastVariant;
   title?: string;
   description: string;
   duration: number;
+  action?: ToastAction;
 }
 
 const ToastContent: Component<ToastContentProps> = (props) => {
@@ -80,6 +86,18 @@ const ToastContent: Component<ToastContentProps> = (props) => {
           <ToastPrimitive.Description class="text-sm text-stone">
             {props.description}
           </ToastPrimitive.Description>
+          {props.action && (
+            <button
+              type="button"
+              class="mt-2 text-sm font-medium text-[var(--turbo-brand-primary)] hover:underline"
+              onClick={() => {
+                props.action?.onClick();
+                ToastPrimitive.toaster.dismiss(props.toastId);
+              }}
+            >
+              {props.action.label}
+            </button>
+          )}
         </div>
 
         <ToastPrimitive.CloseButton
@@ -126,6 +144,7 @@ interface ShowOptions {
   description: string;
   title?: string;
   duration?: number;
+  action?: ToastAction;
 }
 
 function show(options: ShowOptions) {
@@ -137,15 +156,18 @@ function show(options: ShowOptions) {
       title={options.title}
       description={options.description}
       duration={duration}
+      action={options.action}
     />
   ));
 }
 
 export const toast = {
-  success: (description: string, title?: string) =>
-    show({ variant: "success", description, title }),
-  error: (description: string, title?: string) => show({ variant: "error", description, title }),
-  warning: (description: string, title?: string) =>
-    show({ variant: "warning", description, title }),
-  info: (description: string, title?: string) => show({ variant: "info", description, title }),
+  success: (description: string, title?: string, action?: ToastAction) =>
+    show({ variant: "success", description, title, action }),
+  error: (description: string, title?: string, action?: ToastAction) =>
+    show({ variant: "error", description, title, action }),
+  warning: (description: string, title?: string, action?: ToastAction) =>
+    show({ variant: "warning", description, title, action }),
+  info: (description: string, title?: string, action?: ToastAction) =>
+    show({ variant: "info", description, title, action }),
 };

--- a/apps/web/src/stores/__tests__/cloudStorage.test.ts
+++ b/apps/web/src/stores/__tests__/cloudStorage.test.ts
@@ -42,11 +42,14 @@ vi.mock("../../api/resumes", async (importOriginal) => {
 
 import {
   clearCloudResumeVersion,
+  clearCloudWriteBlock,
   cloudResumeExists,
+  CloudWriteBlockedError,
   createCloudResumeWithId,
   duplicateCloudResume,
   getCloudResumeVersion,
   isCloudAuthenticated,
+  isCloudWriteBlocked,
   listCloudResumeSummaries,
   loadCloudResume,
   removeCloudResume,
@@ -161,6 +164,7 @@ describe("saveCloudResume", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearCloudResumeVersion("abc");
+    clearCloudWriteBlock("abc");
   });
 
   it("upserts with the provided title", async () => {
@@ -206,7 +210,7 @@ describe("saveCloudResume", () => {
     expect(getCloudResumeVersion("abc")).toBe(5);
   });
 
-  it("propagates version conflict errors", async () => {
+  it("propagates version conflict errors without updating cached version", async () => {
     const data = testResume("Conflict");
     setCloudResumeVersion("abc", 2);
     resumeApiMocks.upsertCloudResume.mockRejectedValue(
@@ -215,6 +219,20 @@ describe("saveCloudResume", () => {
 
     await expect(saveCloudResume("abc", data)).rejects.toBeInstanceOf(ResumeVersionConflictError);
     expect(getCloudResumeVersion("abc")).toBe(2);
+    expect(isCloudWriteBlocked("abc")).toBe(true);
+  });
+
+  it("blocks subsequent writes after a version conflict until reload", async () => {
+    const data = testResume("Blocked");
+    setCloudResumeVersion("abc", 2);
+    resumeApiMocks.upsertCloudResume.mockRejectedValue(
+      new ResumeVersionConflictError("Resume was modified by another session", 5),
+    );
+
+    await expect(saveCloudResume("abc", data)).rejects.toBeInstanceOf(ResumeVersionConflictError);
+
+    await expect(saveCloudResume("abc", data)).rejects.toBeInstanceOf(CloudWriteBlockedError);
+    expect(resumeApiMocks.upsertCloudResume).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/stores/__tests__/cloudStorage.test.ts
+++ b/apps/web/src/stores/__tests__/cloudStorage.test.ts
@@ -1,5 +1,6 @@
 import { ApiError } from "../../api/client";
 import type { CloudResumeRow, CloudResumeSummary } from "../../api/resumes";
+import { ResumeVersionConflictError } from "../../api/resumes";
 import { createDefaultResume } from "../../wasm/defaults";
 import type { ResumeData } from "../../wasm/types";
 import { ResumeCorruptedError, ResumeNotFoundError } from "../resume";
@@ -206,7 +207,6 @@ describe("saveCloudResume", () => {
   });
 
   it("propagates version conflict errors", async () => {
-    const { ResumeVersionConflictError } = await import("../../api/resumes");
     const data = testResume("Conflict");
     setCloudResumeVersion("abc", 2);
     resumeApiMocks.upsertCloudResume.mockRejectedValue(
@@ -214,6 +214,7 @@ describe("saveCloudResume", () => {
     );
 
     await expect(saveCloudResume("abc", data)).rejects.toBeInstanceOf(ResumeVersionConflictError);
+    expect(getCloudResumeVersion("abc")).toBe(2);
   });
 });
 

--- a/apps/web/src/stores/__tests__/cloudStorage.test.ts
+++ b/apps/web/src/stores/__tests__/cloudStorage.test.ts
@@ -31,18 +31,27 @@ vi.mock("../auth", () => ({
   },
 }));
 
-vi.mock("../../api/resumes", () => resumeApiMocks);
+vi.mock("../../api/resumes", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/resumes")>();
+  return {
+    ...actual,
+    ...resumeApiMocks,
+  };
+});
 
 import {
+  clearCloudResumeVersion,
   cloudResumeExists,
   createCloudResumeWithId,
   duplicateCloudResume,
+  getCloudResumeVersion,
   isCloudAuthenticated,
   listCloudResumeSummaries,
   loadCloudResume,
   removeCloudResume,
   renameCloudResume,
   saveCloudResume,
+  setCloudResumeVersion,
 } from "../cloudStorage";
 
 function testResume(name: string): ResumeData {
@@ -118,13 +127,14 @@ describe("loadCloudResume", () => {
   });
 
   it("returns validated resume data from the cloud row", async () => {
-    const row = mockRow({ id: "abc", data: testResume("Loaded Name") });
+    const row = mockRow({ id: "abc", data: testResume("Loaded Name"), version: 7 });
     resumeApiMocks.getCloudResume.mockResolvedValue(row);
 
     const data = await loadCloudResume("abc");
 
     expect(resumeApiMocks.getCloudResume).toHaveBeenCalledWith("abc");
     expect(data.basics.name).toBe("Loaded Name");
+    expect(getCloudResumeVersion("abc")).toBe(7);
   });
 
   it("maps 404 ApiError to ResumeNotFoundError", async () => {
@@ -149,24 +159,61 @@ describe("loadCloudResume", () => {
 describe("saveCloudResume", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearCloudResumeVersion("abc");
   });
 
   it("upserts with the provided title", async () => {
     const data = testResume("Save Me");
-    resumeApiMocks.upsertCloudResume.mockResolvedValue(mockRow({ title: "Custom Title" }));
+    resumeApiMocks.upsertCloudResume.mockResolvedValue(
+      mockRow({ title: "Custom Title", version: 2 }),
+    );
 
     await saveCloudResume("abc", data, "Custom Title");
 
-    expect(resumeApiMocks.upsertCloudResume).toHaveBeenCalledWith("abc", data, "Custom Title");
+    expect(resumeApiMocks.upsertCloudResume).toHaveBeenCalledWith(
+      "abc",
+      data,
+      "Custom Title",
+      undefined,
+    );
+    expect(getCloudResumeVersion("abc")).toBe(2);
   });
 
   it("derives title from resume data when title is omitted", async () => {
     const data = testResume("Derived Name");
-    resumeApiMocks.upsertCloudResume.mockResolvedValue(mockRow());
+    resumeApiMocks.upsertCloudResume.mockResolvedValue(mockRow({ version: 3 }));
 
     await saveCloudResume("abc", data);
 
-    expect(resumeApiMocks.upsertCloudResume).toHaveBeenCalledWith("abc", data, "Derived Name");
+    expect(resumeApiMocks.upsertCloudResume).toHaveBeenCalledWith(
+      "abc",
+      data,
+      "Derived Name",
+      undefined,
+    );
+    expect(getCloudResumeVersion("abc")).toBe(3);
+  });
+
+  it("sends tracked version on save", async () => {
+    const data = testResume("Versioned");
+    setCloudResumeVersion("abc", 4);
+    resumeApiMocks.upsertCloudResume.mockResolvedValue(mockRow({ version: 5 }));
+
+    await saveCloudResume("abc", data, "Versioned");
+
+    expect(resumeApiMocks.upsertCloudResume).toHaveBeenCalledWith("abc", data, "Versioned", 4);
+    expect(getCloudResumeVersion("abc")).toBe(5);
+  });
+
+  it("propagates version conflict errors", async () => {
+    const { ResumeVersionConflictError } = await import("../../api/resumes");
+    const data = testResume("Conflict");
+    setCloudResumeVersion("abc", 2);
+    resumeApiMocks.upsertCloudResume.mockRejectedValue(
+      new ResumeVersionConflictError("Resume was modified by another session", 5),
+    );
+
+    await expect(saveCloudResume("abc", data)).rejects.toBeInstanceOf(ResumeVersionConflictError);
   });
 });
 
@@ -222,13 +269,16 @@ describe("renameCloudResume", () => {
   });
 
   it("updates title without sending resume data", async () => {
-    resumeApiMocks.updateCloudResume.mockResolvedValue(mockRow({ title: "New Title" }));
+    setCloudResumeVersion("abc", 2);
+    resumeApiMocks.updateCloudResume.mockResolvedValue(mockRow({ title: "New Title", version: 3 }));
 
     await renameCloudResume("abc", "New Title");
 
     expect(resumeApiMocks.updateCloudResume).toHaveBeenCalledWith("abc", {
       title: "New Title",
+      version: 2,
     });
+    expect(getCloudResumeVersion("abc")).toBe(3);
   });
 });
 

--- a/apps/web/src/stores/__tests__/persistence-rename-cloud.test.ts
+++ b/apps/web/src/stores/__tests__/persistence-rename-cloud.test.ts
@@ -1,0 +1,144 @@
+import { createRoot } from "solid-js";
+import type { CloudResumeRow } from "../../api/resumes";
+import { createDefaultResume } from "../../wasm/defaults";
+import type { ResumeData } from "../../wasm/types";
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear() {
+      store = {};
+    },
+    getItem(key: string) {
+      return key in store ? store[key] : null;
+    },
+    key(index: number) {
+      const keys = Object.keys(store);
+      return keys[index] ?? null;
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+  };
+}
+
+const mockStorage = createMockStorage();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: mockStorage,
+  writable: true,
+  configurable: true,
+});
+
+const { mockAuthState, resumeApiMocks, toastMocks } = vi.hoisted(() => ({
+  mockAuthState: {
+    loading: false,
+    cloudEnabled: true,
+    user: { id: "user-1", plan: "free" },
+  },
+  resumeApiMocks: {
+    listCloudResumes: vi.fn(),
+    getCloudResume: vi.fn(),
+    createCloudResume: vi.fn(),
+    updateCloudResume: vi.fn(),
+    deleteCloudResume: vi.fn(),
+    upsertCloudResume: vi.fn(),
+  },
+  toastMocks: {
+    error: vi.fn(),
+    warning: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("../auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+  },
+}));
+
+vi.mock("../../api/resumes", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/resumes")>();
+  return {
+    ...actual,
+    ...resumeApiMocks,
+  };
+});
+
+vi.mock("../../wasm", () => ({
+  listResumes: vi.fn().mockRejectedValue(new Error("WASM not ready")),
+  deleteResume: vi.fn().mockRejectedValue(new Error("WASM not ready")),
+  getResume: vi.fn().mockRejectedValue(new Error("WASM not ready")),
+  saveResume: vi.fn().mockRejectedValue(new Error("WASM not ready")),
+  resumeExists: vi.fn().mockResolvedValue(false),
+  isWasmReady: () => false,
+}));
+
+vi.mock("../../components/ui", () => ({
+  toast: toastMocks,
+}));
+
+import * as cloudStorage from "../cloudStorage";
+import { useResumeList } from "../persistence";
+
+function testResume(name: string): ResumeData {
+  const resume = createDefaultResume();
+  resume.basics.name = name;
+  return resume;
+}
+
+function mockRow(overrides: Partial<CloudResumeRow> = {}): CloudResumeRow {
+  return {
+    id: "resume-1",
+    title: "My Resume",
+    updated_at: "2026-01-01T00:00:00Z",
+    user_id: "user-1",
+    data: testResume("Jane Doe"),
+    is_public: false,
+    public_slug: null,
+    version: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("persistence store - cloud renameResume", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStorage.clear();
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = { id: "user-1", plan: "free" };
+    resumeApiMocks.listCloudResumes.mockResolvedValue([]);
+    resumeApiMocks.getCloudResume.mockResolvedValue(mockRow({ id: "resume-1" }));
+  });
+
+  it("does not show generic error toast when cloud writes are blocked", async () => {
+    vi.spyOn(cloudStorage, "renameCloudResume").mockRejectedValueOnce(
+      new cloudStorage.CloudWriteBlockedError("resume-1"),
+    );
+
+    await createRoot(async (dispose) => {
+      try {
+        const store = useResumeList();
+
+        await expect(store.renameResume("resume-1", "New Title")).rejects.toBeInstanceOf(
+          cloudStorage.CloudWriteBlockedError,
+        );
+
+        expect(toastMocks.error).not.toHaveBeenCalledWith("Failed to rename resume");
+      } finally {
+        dispose();
+      }
+    });
+  });
+});

--- a/apps/web/src/stores/cloudStorage.ts
+++ b/apps/web/src/stores/cloudStorage.ts
@@ -17,6 +17,15 @@ import type { ResumeData } from "../wasm/types";
 import { ResumeNotFoundError } from "./resume";
 
 const resumeVersions = new Map<string, number>();
+const blockedCloudWrites = new Set<string>();
+
+/** Thrown when cloud writes are blocked until the resume is reloaded. */
+export class CloudWriteBlockedError extends Error {
+  constructor(public readonly resumeId: string) {
+    super(`Cloud writes blocked for resume ${resumeId} until reload`);
+    this.name = "CloudWriteBlockedError";
+  }
+}
 
 /** True when cloud mode is enabled and the user has an active session. */
 export function isCloudAuthenticated(): boolean {
@@ -36,16 +45,45 @@ export function clearCloudResumeVersion(id: string): void {
   resumeVersions.delete(id);
 }
 
+export function isCloudWriteBlocked(id: string): boolean {
+  return blockedCloudWrites.has(id);
+}
+
+export function blockCloudWritesUntilReload(id: string): void {
+  blockedCloudWrites.add(id);
+}
+
+export function clearCloudWriteBlock(id: string): void {
+  blockedCloudWrites.delete(id);
+}
+
 export function isResumeVersionConflictError(error: unknown): error is ResumeVersionConflictError {
   return error instanceof ResumeVersionConflictError;
 }
 
-export function showResumeVersionConflictToast(id: string, currentVersion: number): void {
-  setCloudResumeVersion(id, currentVersion);
+export function isCloudWriteBlockedError(error: unknown): error is CloudWriteBlockedError {
+  return error instanceof CloudWriteBlockedError;
+}
+
+export function showResumeVersionConflictToast(id: string): void {
+  blockCloudWritesUntilReload(id);
   toast.warning("Resume was updated elsewhere. Reload to see latest changes.", "Conflict", {
     label: "Reload",
     onClick: () => window.location.reload(),
   });
+}
+
+function assertCloudWriteAllowed(id: string): void {
+  if (isCloudWriteBlocked(id)) {
+    throw new CloudWriteBlockedError(id);
+  }
+}
+
+function handleVersionConflict(id: string, error: unknown): never {
+  if (error instanceof ResumeVersionConflictError) {
+    blockCloudWritesUntilReload(id);
+  }
+  throw error;
 }
 
 export async function listCloudResumeSummaries(): Promise<CloudResumeSummary[]> {
@@ -55,6 +93,7 @@ export async function listCloudResumeSummaries(): Promise<CloudResumeSummary[]> 
 export async function loadCloudResume(id: string): Promise<ResumeData> {
   try {
     const row = await getCloudResume(id);
+    clearCloudWriteBlock(id);
     setCloudResumeVersion(id, row.version);
     return validateResumeData(row.data, id);
   } catch (error: unknown) {
@@ -66,9 +105,14 @@ export async function loadCloudResume(id: string): Promise<ResumeData> {
 }
 
 export async function saveCloudResume(id: string, data: ResumeData, title?: string): Promise<void> {
+  assertCloudWriteAllowed(id);
   const resolvedTitle = title ?? deriveTitleFromResume(data);
-  const row = await upsertCloudResume(id, data, resolvedTitle, getCloudResumeVersion(id));
-  setCloudResumeVersion(id, row.version);
+  try {
+    const row = await upsertCloudResume(id, data, resolvedTitle, getCloudResumeVersion(id));
+    setCloudResumeVersion(id, row.version);
+  } catch (error: unknown) {
+    handleVersionConflict(id, error);
+  }
 }
 
 export async function createCloudResumeWithId(
@@ -81,20 +125,27 @@ export async function createCloudResumeWithId(
     title: title ?? deriveTitleFromResume(data),
     data,
   });
+  clearCloudWriteBlock(id);
   setCloudResumeVersion(id, row.version);
 }
 
 export async function removeCloudResume(id: string): Promise<void> {
   await deleteCloudResume(id);
   clearCloudResumeVersion(id);
+  clearCloudWriteBlock(id);
 }
 
 export async function renameCloudResume(id: string, title: string): Promise<void> {
-  const row = await updateCloudResume(id, {
-    title,
-    version: getCloudResumeVersion(id),
-  });
-  setCloudResumeVersion(id, row.version);
+  assertCloudWriteAllowed(id);
+  try {
+    const row = await updateCloudResume(id, {
+      title,
+      version: getCloudResumeVersion(id),
+    });
+    setCloudResumeVersion(id, row.version);
+  } catch (error: unknown) {
+    handleVersionConflict(id, error);
+  }
 }
 
 export async function duplicateCloudResume(
@@ -104,12 +155,14 @@ export async function duplicateCloudResume(
   title: string,
 ): Promise<void> {
   const row = await createCloudResume({ id: newId, title, data });
+  clearCloudWriteBlock(newId);
   setCloudResumeVersion(newId, row.version);
 }
 
 export async function cloudResumeExists(id: string): Promise<boolean> {
   try {
     const row = await getCloudResume(id);
+    clearCloudWriteBlock(id);
     setCloudResumeVersion(id, row.version);
     return true;
   } catch (error: unknown) {

--- a/apps/web/src/stores/cloudStorage.ts
+++ b/apps/web/src/stores/cloudStorage.ts
@@ -3,21 +3,49 @@ import {
   deleteCloudResume,
   getCloudResume,
   listCloudResumes,
+  ResumeVersionConflictError,
   updateCloudResume,
   upsertCloudResume,
   type CloudResumeSummary,
 } from "../api/resumes";
 import { ApiError } from "../api/client";
+import { toast } from "../components/ui";
 import { authStore } from "./auth";
 import { deriveTitleFromResume } from "./persistence";
 import { validateResumeData } from "./resume";
 import type { ResumeData } from "../wasm/types";
 import { ResumeNotFoundError } from "./resume";
 
+const resumeVersions = new Map<string, number>();
+
 /** True when cloud mode is enabled and the user has an active session. */
 export function isCloudAuthenticated(): boolean {
   const { loading, cloudEnabled, user } = authStore.state;
   return !loading && cloudEnabled && user !== null;
+}
+
+export function getCloudResumeVersion(id: string): number | undefined {
+  return resumeVersions.get(id);
+}
+
+export function setCloudResumeVersion(id: string, version: number): void {
+  resumeVersions.set(id, version);
+}
+
+export function clearCloudResumeVersion(id: string): void {
+  resumeVersions.delete(id);
+}
+
+export function isResumeVersionConflictError(error: unknown): error is ResumeVersionConflictError {
+  return error instanceof ResumeVersionConflictError;
+}
+
+export function showResumeVersionConflictToast(id: string, currentVersion: number): void {
+  setCloudResumeVersion(id, currentVersion);
+  toast.warning("Resume was updated elsewhere. Reload to see latest changes.", "Conflict", {
+    label: "Reload",
+    onClick: () => window.location.reload(),
+  });
 }
 
 export async function listCloudResumeSummaries(): Promise<CloudResumeSummary[]> {
@@ -27,6 +55,7 @@ export async function listCloudResumeSummaries(): Promise<CloudResumeSummary[]> 
 export async function loadCloudResume(id: string): Promise<ResumeData> {
   try {
     const row = await getCloudResume(id);
+    setCloudResumeVersion(id, row.version);
     return validateResumeData(row.data, id);
   } catch (error: unknown) {
     if (error instanceof ApiError && error.status === 404) {
@@ -38,7 +67,8 @@ export async function loadCloudResume(id: string): Promise<ResumeData> {
 
 export async function saveCloudResume(id: string, data: ResumeData, title?: string): Promise<void> {
   const resolvedTitle = title ?? deriveTitleFromResume(data);
-  await upsertCloudResume(id, data, resolvedTitle);
+  const row = await upsertCloudResume(id, data, resolvedTitle, getCloudResumeVersion(id));
+  setCloudResumeVersion(id, row.version);
 }
 
 export async function createCloudResumeWithId(
@@ -46,19 +76,25 @@ export async function createCloudResumeWithId(
   data: ResumeData,
   title?: string,
 ): Promise<void> {
-  await createCloudResume({
+  const row = await createCloudResume({
     id,
     title: title ?? deriveTitleFromResume(data),
     data,
   });
+  setCloudResumeVersion(id, row.version);
 }
 
 export async function removeCloudResume(id: string): Promise<void> {
   await deleteCloudResume(id);
+  clearCloudResumeVersion(id);
 }
 
 export async function renameCloudResume(id: string, title: string): Promise<void> {
-  await updateCloudResume(id, { title });
+  const row = await updateCloudResume(id, {
+    title,
+    version: getCloudResumeVersion(id),
+  });
+  setCloudResumeVersion(id, row.version);
 }
 
 export async function duplicateCloudResume(
@@ -67,12 +103,14 @@ export async function duplicateCloudResume(
   data: ResumeData,
   title: string,
 ): Promise<void> {
-  await createCloudResume({ id: newId, title, data });
+  const row = await createCloudResume({ id: newId, title, data });
+  setCloudResumeVersion(newId, row.version);
 }
 
 export async function cloudResumeExists(id: string): Promise<boolean> {
   try {
-    await getCloudResume(id);
+    const row = await getCloudResume(id);
+    setCloudResumeVersion(id, row.version);
     return true;
   } catch (error: unknown) {
     if (error instanceof ApiError && error.status === 404) {

--- a/apps/web/src/stores/persistence.ts
+++ b/apps/web/src/stores/persistence.ts
@@ -14,6 +14,7 @@ import { ResumeNotFoundError, ResumeCorruptedError, validateResumeData } from ".
 import { authStore } from "./auth";
 import {
   isCloudAuthenticated,
+  isCloudWriteBlockedError,
   isResumeVersionConflictError,
   listCloudResumeSummaries,
   loadCloudResume,
@@ -468,7 +469,7 @@ export function useResumeList() {
         await refetch();
       } catch (e) {
         console.error("Failed to rename resume:", e);
-        if (!isResumeVersionConflictError(e)) {
+        if (!isResumeVersionConflictError(e) && !isCloudWriteBlockedError(e)) {
           toast.error("Failed to rename resume");
         }
         throw e;

--- a/apps/web/src/stores/persistence.ts
+++ b/apps/web/src/stores/persistence.ts
@@ -14,6 +14,7 @@ import { ResumeNotFoundError, ResumeCorruptedError, validateResumeData } from ".
 import { authStore } from "./auth";
 import {
   isCloudAuthenticated,
+  isResumeVersionConflictError,
   listCloudResumeSummaries,
   loadCloudResume,
   removeCloudResume,
@@ -21,6 +22,7 @@ import {
   duplicateCloudResume,
   cloudResumeExists,
   saveCloudResume,
+  showResumeVersionConflictToast,
 } from "./cloudStorage";
 
 export interface ResumeListItem {
@@ -263,7 +265,14 @@ async function getResume(id: string): Promise<ResumeData> {
 async function saveResume(id: string, data: ResumeData): Promise<void> {
   if (isCloudAuthenticated()) {
     const title = resolveResumeTitle(id, data);
-    await saveCloudResume(id, data, title);
+    try {
+      await saveCloudResume(id, data, title);
+    } catch (error: unknown) {
+      if (isResumeVersionConflictError(error)) {
+        showResumeVersionConflictToast(id, error.currentVersion);
+      }
+      throw error;
+    }
     maybeUpdateResumeMeta(id, title);
     return;
   }
@@ -442,7 +451,14 @@ export function useResumeList() {
         if (!(await resumeExists(id))) return;
 
         if (isCloudAuthenticated()) {
-          await renameCloudResume(id, trimmed);
+          try {
+            await renameCloudResume(id, trimmed);
+          } catch (error: unknown) {
+            if (isResumeVersionConflictError(error)) {
+              showResumeVersionConflictToast(id, error.currentVersion);
+            }
+            throw error;
+          }
           setResumeMeta(id, trimmed);
           await refetch();
           return;

--- a/apps/web/src/stores/persistence.ts
+++ b/apps/web/src/stores/persistence.ts
@@ -269,7 +269,7 @@ async function saveResume(id: string, data: ResumeData): Promise<void> {
       await saveCloudResume(id, data, title);
     } catch (error: unknown) {
       if (isResumeVersionConflictError(error)) {
-        showResumeVersionConflictToast(id, error.currentVersion);
+        showResumeVersionConflictToast(id);
       }
       throw error;
     }
@@ -455,7 +455,7 @@ export function useResumeList() {
             await renameCloudResume(id, trimmed);
           } catch (error: unknown) {
             if (isResumeVersionConflictError(error)) {
-              showResumeVersionConflictToast(id, error.currentVersion);
+              showResumeVersionConflictToast(id);
             }
             throw error;
           }

--- a/apps/web/src/stores/persistence.ts
+++ b/apps/web/src/stores/persistence.ts
@@ -468,7 +468,9 @@ export function useResumeList() {
         await refetch();
       } catch (e) {
         console.error("Failed to rename resume:", e);
-        toast.error("Failed to rename resume");
+        if (!isResumeVersionConflictError(e)) {
+          toast.error("Failed to rename resume");
+        }
         throw e;
       }
     },

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -9,7 +9,13 @@ import {
   getResume as getFromWasmStorage,
   isWasmReady,
 } from "../wasm";
-import { isCloudAuthenticated, loadCloudResume, saveCloudResume } from "./cloudStorage";
+import {
+  isCloudAuthenticated,
+  isResumeVersionConflictError,
+  loadCloudResume,
+  saveCloudResume,
+  showResumeVersionConflictToast,
+} from "./cloudStorage";
 
 /** Thrown when the requested resume does not exist in storage. */
 export class ResumeNotFoundError extends Error {
@@ -324,6 +330,12 @@ async function persistResume() {
       setStore("isSaving", false);
     });
   } catch (e) {
+    if (isResumeVersionConflictError(e) && store.id) {
+      showResumeVersionConflictToast(store.id, e.currentVersion);
+      setStore("error", e.message);
+      setStore("isSaving", false);
+      return;
+    }
     setStore("error", e instanceof Error ? e.message : "Failed to save");
     setStore("isSaving", false);
   }

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -11,6 +11,7 @@ import {
 } from "../wasm";
 import {
   isCloudAuthenticated,
+  isCloudWriteBlockedError,
   isResumeVersionConflictError,
   loadCloudResume,
   saveCloudResume,
@@ -331,8 +332,13 @@ async function persistResume() {
     });
   } catch (e) {
     if (isResumeVersionConflictError(e) && store.id) {
-      showResumeVersionConflictToast(store.id, e.currentVersion);
+      showResumeVersionConflictToast(store.id);
       setStore("error", e.message);
+      setStore("isSaving", false);
+      return;
+    }
+    if (isCloudWriteBlockedError(e)) {
+      setStore("error", "Reload required to sync latest changes");
       setStore("isSaving", false);
       return;
     }

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -149,6 +149,8 @@ pub struct UpdateResumeRequest {
     pub title: Option<String>,
     #[schema(value_type = Object)]
     pub data: Option<serde_json::Value>,
+    /// Expected resume version for optimistic concurrency control.
+    pub version: Option<i32>,
 }
 
 /// Single resume payload within an import batch.

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -50,6 +50,9 @@ pub struct ApiError {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = json!(["basics.email: invalid email format"]))]
     pub details: Option<Vec<String>>,
+    /// Current resource version returned on optimistic concurrency conflicts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_version: Option<i32>,
     /// Error kind for HTTP status mapping (not serialized)
     #[serde(skip)]
     pub kind: ApiErrorKind,
@@ -61,6 +64,7 @@ impl ApiError {
         Self {
             error: error.into(),
             details: None,
+            current_version: None,
             kind: ApiErrorKind::BadRequest,
         }
     }
@@ -70,6 +74,7 @@ impl ApiError {
         Self {
             error: error.into(),
             details: Some(details),
+            current_version: None,
             kind: ApiErrorKind::UnprocessableEntity,
         }
     }
@@ -79,6 +84,7 @@ impl ApiError {
         Self {
             error: error.into(),
             details: None,
+            current_version: None,
             kind: ApiErrorKind::NotFound,
         }
     }
@@ -88,6 +94,7 @@ impl ApiError {
         Self {
             error: error.into(),
             details: None,
+            current_version: None,
             kind: ApiErrorKind::InternalError,
         }
     }
@@ -97,6 +104,7 @@ impl ApiError {
         Self {
             error: error.into(),
             details: None,
+            current_version: None,
             kind: ApiErrorKind::Unauthorized,
         }
     }
@@ -106,6 +114,7 @@ impl ApiError {
         Self {
             error: error.into(),
             details: None,
+            current_version: None,
             kind: ApiErrorKind::Forbidden,
         }
     }
@@ -115,6 +124,17 @@ impl ApiError {
         Self {
             error: error.into(),
             details: None,
+            current_version: None,
+            kind: ApiErrorKind::Conflict,
+        }
+    }
+
+    /// Create a 409 Conflict error with the current resource version.
+    pub fn version_conflict(error: impl Into<String>, current_version: i32) -> Self {
+        Self {
+            error: error.into(),
+            details: None,
+            current_version: Some(current_version),
             kind: ApiErrorKind::Conflict,
         }
     }

--- a/crates/server/src/middleware/auth.rs
+++ b/crates/server/src/middleware/auth.rs
@@ -6,7 +6,7 @@ use tracing::error;
 
 use crate::auth::session::SESSION_COOKIE;
 use crate::db::User;
-use crate::error::{ApiError, ApiErrorKind};
+use crate::error::ApiError;
 use crate::state::AppState;
 
 /// Authenticated user extracted from a valid `rustume_session` cookie.
@@ -44,9 +44,5 @@ impl FromRequestParts<AppState> for AuthUser {
 }
 
 fn unauthorized(message: &str) -> ApiError {
-    ApiError {
-        error: message.to_string(),
-        details: None,
-        kind: ApiErrorKind::Unauthorized,
-    }
+    ApiError::unauthorized(message)
 }

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -144,6 +144,7 @@ pub async fn create_resume(
         (status = 200, description = "Resume updated", body = ResumeRow),
         (status = 401, description = "Not authenticated", body = ApiError),
         (status = 404, description = "Resume not found", body = ApiError),
+        (status = 409, description = "Resume version conflict", body = ApiError),
     ),
     security(("cookieAuth" = []))
 )]
@@ -161,44 +162,7 @@ pub async fn update_resume(
     let existing = fetch_owned_resume(&state, user.id, id).await?;
     let title = body.title.unwrap_or(existing.title);
 
-    let row = match body.data {
-        Some(data) => {
-            sqlx::query_as::<_, ResumeRow>(
-                r#"
-                UPDATE resumes
-                SET title = $1,
-                    data = $2,
-                    version = version + 1,
-                    updated_at = now()
-                WHERE id = $3 AND user_id = $4
-                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
-                "#,
-            )
-            .bind(&title)
-            .bind(data)
-            .bind(id)
-            .bind(user.id)
-            .fetch_one(&cloud.db)
-            .await
-        }
-        None => {
-            sqlx::query_as::<_, ResumeRow>(
-                r#"
-                UPDATE resumes
-                SET title = $1,
-                    updated_at = now()
-                WHERE id = $2 AND user_id = $3
-                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
-                "#,
-            )
-            .bind(&title)
-            .bind(id)
-            .bind(user.id)
-            .fetch_one(&cloud.db)
-            .await
-        }
-    }
-    .map_err(map_resume_db_error)?;
+    let row = apply_resume_update(&cloud.db, user.id, id, &title, body.data, body.version).await?;
 
     Ok(Json(row))
 }
@@ -338,6 +302,125 @@ fn map_resume_db_error(err: sqlx::Error) -> ApiError {
         }
     }
     internal_db_error(err)
+}
+
+async fn apply_resume_update(
+    db: &sqlx::PgPool,
+    user_id: Uuid,
+    resume_id: Uuid,
+    title: &str,
+    data: Option<serde_json::Value>,
+    expected_version: Option<i32>,
+) -> Result<ResumeRow, ApiError> {
+    let row = match (data, expected_version) {
+        (Some(data), Some(version)) => {
+            sqlx::query_as::<_, ResumeRow>(
+                r#"
+                UPDATE resumes
+                SET title = $1,
+                    data = $2,
+                    version = version + 1,
+                    updated_at = now()
+                WHERE id = $3 AND user_id = $4 AND version = $5
+                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+                "#,
+            )
+            .bind(title)
+            .bind(data)
+            .bind(resume_id)
+            .bind(user_id)
+            .bind(version)
+            .fetch_optional(db)
+            .await
+        }
+        (Some(data), None) => {
+            sqlx::query_as::<_, ResumeRow>(
+                r#"
+                UPDATE resumes
+                SET title = $1,
+                    data = $2,
+                    version = version + 1,
+                    updated_at = now()
+                WHERE id = $3 AND user_id = $4
+                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+                "#,
+            )
+            .bind(title)
+            .bind(data)
+            .bind(resume_id)
+            .bind(user_id)
+            .fetch_optional(db)
+            .await
+        }
+        (None, Some(version)) => {
+            sqlx::query_as::<_, ResumeRow>(
+                r#"
+                UPDATE resumes
+                SET title = $1,
+                    version = version + 1,
+                    updated_at = now()
+                WHERE id = $2 AND user_id = $3 AND version = $4
+                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+                "#,
+            )
+            .bind(title)
+            .bind(resume_id)
+            .bind(user_id)
+            .bind(version)
+            .fetch_optional(db)
+            .await
+        }
+        (None, None) => {
+            sqlx::query_as::<_, ResumeRow>(
+                r#"
+                UPDATE resumes
+                SET title = $1,
+                    updated_at = now()
+                WHERE id = $2 AND user_id = $3
+                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+                "#,
+            )
+            .bind(title)
+            .bind(resume_id)
+            .bind(user_id)
+            .fetch_optional(db)
+            .await
+        }
+    }
+    .map_err(map_resume_db_error)?;
+
+    match row {
+        Some(row) => Ok(row),
+        None => map_update_miss(db, user_id, resume_id, expected_version).await,
+    }
+}
+
+async fn map_update_miss(
+    db: &sqlx::PgPool,
+    user_id: Uuid,
+    resume_id: Uuid,
+    expected_version: Option<i32>,
+) -> Result<ResumeRow, ApiError> {
+    let current = sqlx::query_scalar::<_, i32>(
+        r#"
+        SELECT version
+        FROM resumes
+        WHERE id = $1 AND user_id = $2
+        "#,
+    )
+    .bind(resume_id)
+    .bind(user_id)
+    .fetch_optional(db)
+    .await
+    .map_err(internal_db_error)?;
+
+    match (current, expected_version) {
+        (Some(current_version), Some(_)) => Err(ApiError::version_conflict(
+            "Resume was modified by another session",
+            current_version,
+        )),
+        _ => Err(ApiError::not_found("Resume not found")),
+    }
 }
 
 async fn fetch_owned_resume(

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -375,6 +375,7 @@ async fn apply_resume_update(
                 r#"
                 UPDATE resumes
                 SET title = $1,
+                    version = version + 1,
                     updated_at = now()
                 WHERE id = $2 AND user_id = $3
                 RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(server): optimistic concurrency control on resume updates
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Add optimistic concurrency control to `PUT /api/resumes/{id}` so stale writes from
another tab or device are rejected instead of silently overwriting cloud resumes.
The web app tracks resume versions from GET responses, sends them on PUT, and shows a
conflict toast with a reload action when the server returns 409.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` and web tests with coverage)

## Closes

- Closes #257

## Details

**Server**
- `UpdateResumeRequest` accepts optional `version`
- Updates with a version guard return `409 Conflict` with `current_version` when the
  resume exists but the expected version is stale
- Omitting `version` preserves existing behavior for backward compatibility

**Web**
- Track per-resume versions in `cloudStorage.ts` from GET/PUT responses
- Send `version` on cloud saves and renames
- Parse version-conflict 409 responses into `ResumeVersionConflictError`
- Show a warning toast with a Reload action when a conflict is detected

**Testing**
- Vitest coverage for version payload propagation, conflict parsing, and cloud storage
  version caching

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optimistic concurrency control to resume update and rename operations
> - The server's `PUT /api/resumes/{id}` handler now accepts an optional `version` field and returns a 409 with `current_version` in the error body when the provided version doesn't match, instead of blindly overwriting.
> - The web client tracks resume versions in memory (loaded on fetch, updated on save/create) and sends the expected version with every update or rename via `upsertCloudResume` and `updateCloudResume`.
> - On a 409 version conflict, the client blocks further cloud writes for that resume and shows a toast with a "Reload" action; subsequent blocked writes throw `CloudWriteBlockedError` rather than retrying.
> - Toast notifications in the resume and persistence stores now distinguish version conflicts from generic errors, showing a conflict-specific message instead of a generic failure.
> - Risk: once a write block is set, all further saves and renames for that resume fail until the page is reloaded — there is no automatic recovery path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbf95a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimistic concurrency control to prevent conflicts during concurrent resume edits
  * Toast notifications now support action buttons for improved user interactions
  * Version conflicts display helpful warnings with a Reload option

* **Bug Fixes**
  * Enhanced error handling for concurrent resume modifications with clearer feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds optimistic concurrency control to `PUT /api/resumes/{id}`: the server accepts an optional `version` in the request body and returns 409 with `current_version` on a mismatch; the web client tracks per-resume versions, sends them on save/rename, converts 409 responses into `ResumeVersionConflictError`, and blocks further writes until the page is reloaded.

- **Server** (`routes/resumes.rs`, `error.rs`, `models.rs`): four-arm `apply_resume_update` handles all data/version combinations; `map_update_miss` SELECT-based disambiguation returns 409 vs 404 correctly.
- **Client API & stores** (`resumes.ts`, `cloudStorage.ts`, `persistence.ts`, `resume.ts`): `upgradeOrRethrow409` converts the right 409 shape; `saveCloudResume` / `renameCloudResume` both assert the write-block guard and propagate the typed errors; `persistResume` and `renameResume` each show the conflict toast exactly once.
- **Toast UI** (`Toast.tsx`): action-button support added so the conflict toast can offer an inline \"Reload\" button.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: `cloudResumeExists` inadvertently clears the post-conflict write block, allowing a rename to re-arm the version guard and unblock subsequent auto-saves.

`cloudResumeExists` calls `clearCloudWriteBlock(id)` and updates `resumeVersions[id]` to the server's current version. Because `renameResume` calls `resumeExists` → `cloudResumeExists` before entering `renameCloudResume`, the block is always lifted before `assertCloudWriteAllowed` runs. After the rename the block stays cleared and the locally-tracked version is current, so the next auto-save debounce sends a matching version and succeeds — silently overwriting the other session's changes that the conflict toast was meant to protect against.

apps/web/src/stores/cloudStorage.ts — specifically the `clearCloudWriteBlock` call inside `cloudResumeExists`

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/stores/cloudStorage.ts | Introduces version tracking and write-block state correctly in most paths, but `cloudResumeExists` clears the write block — which is called by `resumeExists` before `renameCloudResume`'s guard runs, bypassing the post-conflict protection. |
| crates/server/src/routes/resumes.rs | Four-arm match correctly handles all combinations of data/version presence; `map_update_miss` SELECT→409/404 disambiguation is accurate. A narrow TOCTOU window between the failed UPDATE and the diagnostic SELECT (noted in a prior review thread) remains. |
| apps/web/src/api/resumes.ts | `upgradeOrRethrow409` correctly upgrades 409-with-current_version to `ResumeVersionConflictError` and rethrows everything else; `upsertCloudResume` propagates the conflict before the 404-fallback-create path. |
| apps/web/src/stores/persistence.ts | Rename and save paths correctly guard the conflict/blocked-write toasts; `resumeExists` → `cloudResumeExists` call ordering inadvertently defeats the write block (see comment on cloudStorage.ts). |
| apps/web/src/stores/resume.ts | Auto-save path correctly handles `ResumeVersionConflictError` and `CloudWriteBlockedError` with distinct UI messages; conflict toast shown exactly once per trigger. |
| crates/server/src/error.rs | New `version_conflict` constructor correctly sets `current_version` and all existing constructors are updated to initialise the new field. |
| crates/server/src/db/models.rs | Adds optional `version: Option<i32>` to `UpdateResumeRequest`; backwards-compatible since the field is optional. |
| apps/web/src/components/ui/Toast.tsx | Adds an optional `ToastAction` to all four toast variants; action button dismisses the toast in a `finally` block so it closes regardless of callback outcome. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User (browser)
    participant PS as persistence.ts
    participant CS as cloudStorage.ts
    participant API as resumes.ts (API)
    participant SRV as Server

    U->>PS: edit resume (markDirty)
    PS->>CS: saveCloudResume(id, data, title)
    CS->>CS: assertCloudWriteAllowed(id)
    CS->>API: upsertCloudResume(id, data, title, version)
    API->>SRV: "PUT /api/resumes/{id} {data, version}"
    alt version matches
        SRV-->>API: "200 {row, version: N+1}"
        API-->>CS: CloudResumeRow
        CS->>CS: setCloudResumeVersion(id, N+1)
    else version mismatch
        SRV-->>API: "409 {current_version: M}"
        API->>API: upgradeOrRethrow409 → ResumeVersionConflictError(M)
        API-->>CS: throws ResumeVersionConflictError
        CS->>CS: blockCloudWritesUntilReload(id)
        CS-->>PS: throws ResumeVersionConflictError
        PS->>PS: showResumeVersionConflictToast(id)
    end

    U->>PS: rename resume
    PS->>CS: resumeExists(id) → cloudResumeExists(id)
    CS->>SRV: "GET /api/resumes/{id}"
    SRV-->>CS: "200 {version: M}"
    CS->>CS: clearCloudWriteBlock(id) ⚠️ unblocks!
    CS->>CS: setCloudResumeVersion(id, M)
    PS->>CS: renameCloudResume(id, title)
    CS->>CS: assertCloudWriteAllowed(id) passes (block was cleared)
    CS->>SRV: "PUT /api/resumes/{id} {title, version: M}"
    SRV-->>CS: "200 {version: M+1}"
    Note over CS,SRV: Block gone, version current → next auto-save overwrites silently
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/stores/cloudStorage.ts`, line 162-174 ([link](https://github.com/lgtm-hq/rustume/blob/bbf95a7436c844f0594533be1ba8af86c5075655/apps/web/src/stores/cloudStorage.ts#L162-L174)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `cloudResumeExists` clears the write block even though it never loads the resume data into the editing store. `renameResume` (in `persistence.ts`) calls `resumeExists` → `cloudResumeExists` before it calls `renameCloudResume`, so by the time `assertCloudWriteAllowed` runs inside `renameCloudResume` the block has already been lifted. After the rename, the block stays cleared and `resumeVersions[id]` is set to the server's current version, so the next auto-save debounce will send the correct version to the server and succeed — silently overwriting the other session's changes. Only `loadCloudResume` (which replaces the in-memory editing data with the server copy) should clear the block.

   

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fstores%2FcloudStorage.ts%0ALine%3A%20162-174%0A%0AComment%3A%0A%60cloudResumeExists%60%20clears%20the%20write%20block%20even%20though%20it%20never%20loads%20the%20resume%20data%20into%20the%20editing%20store.%20%60renameResume%60%20%28in%20%60persistence.ts%60%29%20calls%20%60resumeExists%60%20%E2%86%92%20%60cloudResumeExists%60%20before%20it%20calls%20%60renameCloudResume%60%2C%20so%20by%20the%20time%20%60assertCloudWriteAllowed%60%20runs%20inside%20%60renameCloudResume%60%20the%20block%20has%20already%20been%20lifted.%20After%20the%20rename%2C%20the%20block%20stays%20cleared%20and%20%60resumeVersions%5Bid%5D%60%20is%20set%20to%20the%20server's%20current%20version%2C%20so%20the%20next%20auto-save%20debounce%20will%20send%20the%20correct%20version%20to%20the%20server%20and%20succeed%20%E2%80%94%20silently%20overwriting%20the%20other%20session's%20changes.%20Only%20%60loadCloudResume%60%20%28which%20replaces%20the%20in-memory%20editing%20data%20with%20the%20server%20copy%29%20should%20clear%20the%20block.%0A%0A%60%60%60suggestion%0Aexport%20async%20function%20cloudResumeExists%28id%3A%20string%29%3A%20Promise%3Cboolean%3E%20%7B%0A%20%20try%20%7B%0A%20%20%20%20const%20row%20%3D%20await%20getCloudResume%28id%29%3B%0A%20%20%20%20setCloudResumeVersion%28id%2C%20row.version%29%3B%0A%20%20%20%20return%20true%3B%0A%20%20%7D%20catch%20%28error%3A%20unknown%29%20%7B%0A%20%20%20%20if%20%28error%20instanceof%20ApiError%20%26%26%20error.status%20%3D%3D%3D%20404%29%20%7B%0A%20%20%20%20%20%20return%20false%3B%0A%20%20%20%20%7D%0A%20%20%20%20throw%20error%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fstores%2FcloudStorage.ts%0ALine%3A%20162-174%0A%0AComment%3A%0A%60cloudResumeExists%60%20clears%20the%20write%20block%20even%20though%20it%20never%20loads%20the%20resume%20data%20into%20the%20editing%20store.%20%60renameResume%60%20%28in%20%60persistence.ts%60%29%20calls%20%60resumeExists%60%20%E2%86%92%20%60cloudResumeExists%60%20before%20it%20calls%20%60renameCloudResume%60%2C%20so%20by%20the%20time%20%60assertCloudWriteAllowed%60%20runs%20inside%20%60renameCloudResume%60%20the%20block%20has%20already%20been%20lifted.%20After%20the%20rename%2C%20the%20block%20stays%20cleared%20and%20%60resumeVersions%5Bid%5D%60%20is%20set%20to%20the%20server's%20current%20version%2C%20so%20the%20next%20auto-save%20debounce%20will%20send%20the%20correct%20version%20to%20the%20server%20and%20succeed%20%E2%80%94%20silently%20overwriting%20the%20other%20session's%20changes.%20Only%20%60loadCloudResume%60%20%28which%20replaces%20the%20in-memory%20editing%20data%20with%20the%20server%20copy%29%20should%20clear%20the%20block.%0A%0A%60%60%60suggestion%0Aexport%20async%20function%20cloudResumeExists%28id%3A%20string%29%3A%20Promise%3Cboolean%3E%20%7B%0A%20%20try%20%7B%0A%20%20%20%20const%20row%20%3D%20await%20getCloudResume%28id%29%3B%0A%20%20%20%20setCloudResumeVersion%28id%2C%20row.version%29%3B%0A%20%20%20%20return%20true%3B%0A%20%20%7D%20catch%20%28error%3A%20unknown%29%20%7B%0A%20%20%20%20if%20%28error%20instanceof%20ApiError%20%26%26%20error.status%20%3D%3D%3D%20404%29%20%7B%0A%20%20%20%20%20%20return%20false%3B%0A%20%20%20%20%7D%0A%20%20%20%20throw%20error%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F257-optimistic-concurrency-control-on-resume-updates%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F257-optimistic-concurrency-control-on-resume-updates%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fstores%2FcloudStorage.ts%0ALine%3A%20162-174%0A%0AComment%3A%0A%60cloudResumeExists%60%20clears%20the%20write%20block%20even%20though%20it%20never%20loads%20the%20resume%20data%20into%20the%20editing%20store.%20%60renameResume%60%20%28in%20%60persistence.ts%60%29%20calls%20%60resumeExists%60%20%E2%86%92%20%60cloudResumeExists%60%20before%20it%20calls%20%60renameCloudResume%60%2C%20so%20by%20the%20time%20%60assertCloudWriteAllowed%60%20runs%20inside%20%60renameCloudResume%60%20the%20block%20has%20already%20been%20lifted.%20After%20the%20rename%2C%20the%20block%20stays%20cleared%20and%20%60resumeVersions%5Bid%5D%60%20is%20set%20to%20the%20server's%20current%20version%2C%20so%20the%20next%20auto-save%20debounce%20will%20send%20the%20correct%20version%20to%20the%20server%20and%20succeed%20%E2%80%94%20silently%20overwriting%20the%20other%20session's%20changes.%20Only%20%60loadCloudResume%60%20%28which%20replaces%20the%20in-memory%20editing%20data%20with%20the%20server%20copy%29%20should%20clear%20the%20block.%0A%0A%60%60%60suggestion%0Aexport%20async%20function%20cloudResumeExists%28id%3A%20string%29%3A%20Promise%3Cboolean%3E%20%7B%0A%20%20try%20%7B%0A%20%20%20%20const%20row%20%3D%20await%20getCloudResume%28id%29%3B%0A%20%20%20%20setCloudResumeVersion%28id%2C%20row.version%29%3B%0A%20%20%20%20return%20true%3B%0A%20%20%7D%20catch%20%28error%3A%20unknown%29%20%7B%0A%20%20%20%20if%20%28error%20instanceof%20ApiError%20%26%26%20error.status%20%3D%3D%3D%20404%29%20%7B%0A%20%20%20%20%20%20return%20false%3B%0A%20%20%20%20%7D%0A%20%20%20%20throw%20error%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fstores%2FcloudStorage.ts%3A162-174%0A%60cloudResumeExists%60%20clears%20the%20write%20block%20even%20though%20it%20never%20loads%20the%20resume%20data%20into%20the%20editing%20store.%20%60renameResume%60%20%28in%20%60persistence.ts%60%29%20calls%20%60resumeExists%60%20%E2%86%92%20%60cloudResumeExists%60%20before%20it%20calls%20%60renameCloudResume%60%2C%20so%20by%20the%20time%20%60assertCloudWriteAllowed%60%20runs%20inside%20%60renameCloudResume%60%20the%20block%20has%20already%20been%20lifted.%20After%20the%20rename%2C%20the%20block%20stays%20cleared%20and%20%60resumeVersions%5Bid%5D%60%20is%20set%20to%20the%20server's%20current%20version%2C%20so%20the%20next%20auto-save%20debounce%20will%20send%20the%20correct%20version%20to%20the%20server%20and%20succeed%20%E2%80%94%20silently%20overwriting%20the%20other%20session's%20changes.%20Only%20%60loadCloudResume%60%20%28which%20replaces%20the%20in-memory%20editing%20data%20with%20the%20server%20copy%29%20should%20clear%20the%20block.%0A%0A%60%60%60suggestion%0Aexport%20async%20function%20cloudResumeExists%28id%3A%20string%29%3A%20Promise%3Cboolean%3E%20%7B%0A%20%20try%20%7B%0A%20%20%20%20const%20row%20%3D%20await%20getCloudResume%28id%29%3B%0A%20%20%20%20setCloudResumeVersion%28id%2C%20row.version%29%3B%0A%20%20%20%20return%20true%3B%0A%20%20%7D%20catch%20%28error%3A%20unknown%29%20%7B%0A%20%20%20%20if%20%28error%20instanceof%20ApiError%20%26%26%20error.status%20%3D%3D%3D%20404%29%20%7B%0A%20%20%20%20%20%20return%20false%3B%0A%20%20%20%20%7D%0A%20%20%20%20throw%20error%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fstores%2FcloudStorage.ts%3A162-174%0A%60cloudResumeExists%60%20clears%20the%20write%20block%20even%20though%20it%20never%20loads%20the%20resume%20data%20into%20the%20editing%20store.%20%60renameResume%60%20%28in%20%60persistence.ts%60%29%20calls%20%60resumeExists%60%20%E2%86%92%20%60cloudResumeExists%60%20before%20it%20calls%20%60renameCloudResume%60%2C%20so%20by%20the%20time%20%60assertCloudWriteAllowed%60%20runs%20inside%20%60renameCloudResume%60%20the%20block%20has%20already%20been%20lifted.%20After%20the%20rename%2C%20the%20block%20stays%20cleared%20and%20%60resumeVersions%5Bid%5D%60%20is%20set%20to%20the%20server's%20current%20version%2C%20so%20the%20next%20auto-save%20debounce%20will%20send%20the%20correct%20version%20to%20the%20server%20and%20succeed%20%E2%80%94%20silently%20overwriting%20the%20other%20session's%20changes.%20Only%20%60loadCloudResume%60%20%28which%20replaces%20the%20in-memory%20editing%20data%20with%20the%20server%20copy%29%20should%20clear%20the%20block.%0A%0A%60%60%60suggestion%0Aexport%20async%20function%20cloudResumeExists%28id%3A%20string%29%3A%20Promise%3Cboolean%3E%20%7B%0A%20%20try%20%7B%0A%20%20%20%20const%20row%20%3D%20await%20getCloudResume%28id%29%3B%0A%20%20%20%20setCloudResumeVersion%28id%2C%20row.version%29%3B%0A%20%20%20%20return%20true%3B%0A%20%20%7D%20catch%20%28error%3A%20unknown%29%20%7B%0A%20%20%20%20if%20%28error%20instanceof%20ApiError%20%26%26%20error.status%20%3D%3D%3D%20404%29%20%7B%0A%20%20%20%20%20%20return%20false%3B%0A%20%20%20%20%7D%0A%20%20%20%20throw%20error%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F257-optimistic-concurrency-control-on-resume-updates%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F257-optimistic-concurrency-control-on-resume-updates%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fstores%2FcloudStorage.ts%3A162-174%0A%60cloudResumeExists%60%20clears%20the%20write%20block%20even%20though%20it%20never%20loads%20the%20resume%20data%20into%20the%20editing%20store.%20%60renameResume%60%20%28in%20%60persistence.ts%60%29%20calls%20%60resumeExists%60%20%E2%86%92%20%60cloudResumeExists%60%20before%20it%20calls%20%60renameCloudResume%60%2C%20so%20by%20the%20time%20%60assertCloudWriteAllowed%60%20runs%20inside%20%60renameCloudResume%60%20the%20block%20has%20already%20been%20lifted.%20After%20the%20rename%2C%20the%20block%20stays%20cleared%20and%20%60resumeVersions%5Bid%5D%60%20is%20set%20to%20the%20server's%20current%20version%2C%20so%20the%20next%20auto-save%20debounce%20will%20send%20the%20correct%20version%20to%20the%20server%20and%20succeed%20%E2%80%94%20silently%20overwriting%20the%20other%20session's%20changes.%20Only%20%60loadCloudResume%60%20%28which%20replaces%20the%20in-memory%20editing%20data%20with%20the%20server%20copy%29%20should%20clear%20the%20block.%0A%0A%60%60%60suggestion%0Aexport%20async%20function%20cloudResumeExists%28id%3A%20string%29%3A%20Promise%3Cboolean%3E%20%7B%0A%20%20try%20%7B%0A%20%20%20%20const%20row%20%3D%20await%20getCloudResume%28id%29%3B%0A%20%20%20%20setCloudResumeVersion%28id%2C%20row.version%29%3B%0A%20%20%20%20return%20true%3B%0A%20%20%7D%20catch%20%28error%3A%20unknown%29%20%7B%0A%20%20%20%20if%20%28error%20instanceof%20ApiError%20%26%26%20error.status%20%3D%3D%3D%20404%29%20%7B%0A%20%20%20%20%20%20return%20false%3B%0A%20%20%20%20%7D%0A%20%20%20%20throw%20error%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["ci: bump lgtm-ci pins from v0.44.1 to v0..."](https://github.com/lgtm-hq/rustume/commit/bbf95a7436c844f0594533be1ba8af86c5075655) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37209166)</sub>

<!-- /greptile_comment -->