### PR TITLE
feat: add cloud login and account UX (Phase 1 MVP)

### DIFF
--- a/apps/site/src/content/docs/cloud/auth.md
+++ b/apps/site/src/content/docs/cloud/auth.md
@@ -22,15 +22,35 @@ The `rustume_session` cookie is signed, `HttpOnly`, and `SameSite=Lax`. It is ma
 the configured redirect URL uses HTTPS. OAuth state is kept in a short-lived cookie and checked
 during callback.
 
-## Account data boundary
+## Account data stored by Rustume
 
-Rustume records an opaque `workos_id` for identity linkage rather than persisting WorkOS profile
-details such as email, name, avatar, or OAuth tokens as separate account fields. Hosted billing
-metadata identifies service access; it does not decide whether product functionality is exposed.
+WorkOS AuthKit requires an email address for every user and may receive first/last name from the
+identity provider (Google, GitHub, SAML SSO, etc.). Rustume syncs these fields into its own database
+on each sign-in so the account UI can greet the user by name.
 
-Resume data is different from identity metadata: a saved document can contain contact and employment
-information. Read [Cloud Storage](/docs/cloud/storage/) and [Encryption](/docs/cloud/encryption/)
-before operating a connected deployment.
+| Field | Source | Stored in Rustume DB | Shown in UI |
+| --- | --- | --- | --- |
+| `workos_id` | WorkOS | Yes | No |
+| `email` | WorkOS | Yes | Yes |
+| `first_name` | WorkOS / IdP | Yes (when available) | Yes |
+| `last_name` | WorkOS / IdP | Yes (when available) | Yes |
+| `plan` | Paddle / internal | Yes | Yes |
+
+**WorkOS itself also retains these fields** in its User Management dashboard. Deployment operators
+with WorkOS dashboard access can view and manage user profiles there.
+
+### What is _not_ stored as account data
+
+OAuth tokens, passwords, and WorkOS session metadata are never persisted by Rustume. The session
+cookie references an opaque server-side session ID — not identity claims.
+
+## Resume data boundary
+
+Resume data is separate from account identity: a saved document can contain contact and employment
+information authored by the user. Read [Cloud Storage](/docs/cloud/storage/) and
+[Encryption](/docs/cloud/encryption/) before operating a connected deployment.
+
+End-to-end encryption of resume content is planned for a future release.
 
 ## Operator configuration
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,7 +28,9 @@ const App: ParentComponent = (props) => {
     handleAuthQueryParams();
     const onPageShow = (event: PageTransitionEvent) => {
       if (event.persisted) {
-        void authStore.refresh();
+        authStore.refresh().catch((err: unknown) => {
+          console.error("Failed to refresh auth on page restore:", err);
+        });
       }
     };
     window.addEventListener("pageshow", onPageShow);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { AppShell } from "./components/layout/AppShell";
 import { CloudImportPrompt } from "./components/Auth/CloudImportPrompt";
 import { Button, ToastRegion } from "./components/ui";
 import { authStore } from "./stores/auth";
+import { handleAuthQueryParams } from "./lib/authFeedback";
 import { initWasm } from "./wasm";
 
 const WASM_NOTICE_KEY = "wasmNoticeDismissed";
@@ -19,7 +20,8 @@ const App: ParentComponent = (props) => {
   };
 
   onMount(async () => {
-    void authStore.refresh();
+    await authStore.refresh();
+    handleAuthQueryParams();
     const onPageShow = (event: PageTransitionEvent) => {
       if (event.persisted) {
         void authStore.refresh();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -20,7 +20,11 @@ const App: ParentComponent = (props) => {
   };
 
   onMount(async () => {
-    await authStore.refresh();
+    try {
+      await authStore.refresh();
+    } catch (error) {
+      console.error("Failed to refresh auth state:", error);
+    }
     handleAuthQueryParams();
     const onPageShow = (event: PageTransitionEvent) => {
       if (event.persisted) {

--- a/apps/web/src/api/__tests__/auth.test.ts
+++ b/apps/web/src/api/__tests__/auth.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { probeAuth, userDisplayName } from "../auth";
+
+describe("userDisplayName", () => {
+  it("prefers first and last name when both are present", () => {
+    expect(
+      userDisplayName({
+        first_name: "Ada",
+        last_name: "Lovelace",
+        email: "ada@example.com",
+      }),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("falls back to email when names are missing", () => {
+    expect(userDisplayName({ email: "dev@example.com" })).toBe("dev@example.com");
+  });
+
+  it("returns a generic label when profile fields are empty", () => {
+    expect(userDisplayName({})).toBe("Account");
+  });
+});
+
+describe("probeAuth", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+  });
+
+  it("maps extended profile fields from /auth/me", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "user-1",
+        plan: "free",
+        email: "dev@example.com",
+        first_name: "Grace",
+        last_name: "Hopper",
+      }),
+    });
+
+    const result = await probeAuth();
+
+    expect(result).toEqual({
+      mode: "cloud",
+      user: {
+        id: "user-1",
+        plan: "free",
+        email: "dev@example.com",
+        first_name: "Grace",
+        last_name: "Hopper",
+      },
+    });
+  });
+
+  it("returns self-hosted mode when cloud auth is disabled", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+
+    await expect(probeAuth()).resolves.toEqual({ mode: "self-hosted" });
+  });
+
+  it("returns signed-out cloud mode on 401", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+
+    await expect(probeAuth()).resolves.toEqual({ mode: "cloud", user: null });
+  });
+});

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,9 +1,26 @@
 export interface AuthUser {
   id: string;
   plan: string;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
 }
 
 export type AuthProbeResult = { mode: "self-hosted" } | { mode: "cloud"; user: AuthUser | null };
+
+/** Build a display label from profile fields, falling back to email or a generic label. */
+export function userDisplayName(
+  user: Pick<AuthUser, "email" | "first_name" | "last_name">,
+): string {
+  const parts = [user.first_name, user.last_name].filter(Boolean);
+  if (parts.length > 0) {
+    return parts.join(" ");
+  }
+  if (user.email) {
+    return user.email;
+  }
+  return "Account";
+}
 
 /** Detect cloud mode and current session via `/auth/me`. */
 export async function probeAuth(): Promise<AuthProbeResult> {

--- a/apps/web/src/components/Auth/AuthMenu.tsx
+++ b/apps/web/src/components/Auth/AuthMenu.tsx
@@ -23,13 +23,7 @@ export function AuthMenu() {
         <Show
           when={state.user}
           fallback={
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleSignIn}
-              loading={signingIn()}
-              disabled={signingIn()}
-            >
+            <Button variant="secondary" size="sm" onClick={handleSignIn} loading={signingIn()}>
               Sign in to Cloud
             </Button>
           }

--- a/apps/web/src/components/Auth/AuthMenu.tsx
+++ b/apps/web/src/components/Auth/AuthMenu.tsx
@@ -1,9 +1,18 @@
-import { Show } from "solid-js";
-import { Button, Spinner } from "../ui";
+import { DropdownMenu } from "@kobalte/core/dropdown-menu";
+import { useNavigate } from "@solidjs/router";
+import { createSignal, Show } from "solid-js";
 import { authStore } from "../../stores/auth";
+import { Button, Spinner } from "../ui";
 
 export function AuthMenu() {
-  const { state, signIn, signOut } = authStore;
+  const navigate = useNavigate();
+  const { state, signIn, signOut, displayName } = authStore;
+  const [signingIn, setSigningIn] = createSignal(false);
+
+  const handleSignIn = () => {
+    setSigningIn(true);
+    signIn();
+  };
 
   return (
     <Show
@@ -14,18 +23,75 @@ export function AuthMenu() {
         <Show
           when={state.user}
           fallback={
-            <Button variant="secondary" size="sm" onClick={signIn}>
-              Sign in
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleSignIn}
+              loading={signingIn()}
+              disabled={signingIn()}
+            >
+              Sign in to Cloud
             </Button>
           }
         >
-          {(_user) => (
-            <div class="flex items-center gap-3">
-              <span class="hidden sm:inline text-xs font-mono text-stone">Signed in</span>
-              <Button variant="ghost" size="sm" onClick={signOut}>
-                Sign out
-              </Button>
-            </div>
+          {(user) => (
+            <DropdownMenu>
+              <DropdownMenu.Trigger
+                class="flex items-center gap-2 max-w-[12rem] px-2.5 py-1.5 rounded-lg
+                  hover:bg-surface transition-colors text-sm text-ink focus-visible:outline-none
+                  focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+                aria-label="Account menu"
+              >
+                <div
+                  class="w-7 h-7 rounded-full bg-accent/10 text-accent flex items-center
+                    justify-center flex-shrink-0 font-mono text-xs font-semibold uppercase"
+                  aria-hidden="true"
+                >
+                  {(displayName(user()) || "A").slice(0, 1)}
+                </div>
+                <span class="hidden sm:block truncate text-left font-medium">
+                  {displayName(user())}
+                </span>
+                <svg
+                  class="w-4 h-4 text-stone flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content class="z-50 min-w-[220px] rounded-lg border border-border bg-paper shadow-soft p-1">
+                  <div class="px-3 py-2 border-b border-border mb-1">
+                    <p class="text-sm font-medium text-ink truncate">{displayName(user())}</p>
+                    <Show when={user().email}>
+                      {(email) => <p class="text-xs text-stone truncate mt-0.5">{email()}</p>}
+                    </Show>
+                  </div>
+                  <DropdownMenu.Item
+                    class="px-3 py-2 text-sm rounded-md cursor-pointer outline-none
+                      hover:bg-surface focus:bg-surface data-[highlighted]:bg-surface"
+                    onSelect={() => navigate("/account")}
+                  >
+                    Account
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    class="px-3 py-2 text-sm rounded-md cursor-pointer outline-none text-red-600
+                      hover:bg-red-50 focus:bg-red-50 data-[highlighted]:bg-red-50"
+                    onSelect={() => void signOut()}
+                  >
+                    Sign out
+                  </DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu>
           )}
         </Show>
       </Show>

--- a/apps/web/src/components/Auth/AuthMenu.tsx
+++ b/apps/web/src/components/Auth/AuthMenu.tsx
@@ -11,7 +11,11 @@ export function AuthMenu() {
 
   const handleSignIn = () => {
     setSigningIn(true);
-    signIn();
+    try {
+      signIn();
+    } catch {
+      setSigningIn(false);
+    }
   };
 
   return (

--- a/apps/web/src/components/Auth/AuthMenu.tsx
+++ b/apps/web/src/components/Auth/AuthMenu.tsx
@@ -11,11 +11,7 @@ export function AuthMenu() {
 
   const handleSignIn = () => {
     setSigningIn(true);
-    try {
-      signIn();
-    } catch {
-      setSigningIn(false);
-    }
+    signIn();
   };
 
   return (

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -6,6 +6,7 @@ import "./index.css";
 
 const Home = lazy(() => import("./pages/Home"));
 const Editor = lazy(() => import("./pages/Editor"));
+const Account = lazy(() => import("./pages/Account"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const root = document.getElementById("root");
@@ -18,6 +19,7 @@ render(
   () => (
     <Router root={App}>
       <Route path="/" component={Home} />
+      <Route path="/account" component={Account} />
       <Route path="/edit/:id" component={Editor} />
       <Route path="*404" component={NotFound} />
     </Router>

--- a/apps/web/src/lib/__tests__/authFeedback.test.ts
+++ b/apps/web/src/lib/__tests__/authFeedback.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { authErrorMessage, handleAuthQueryParams } from "../../lib/authFeedback";
+
+const { toastMock } = vi.hoisted(() => ({
+  toastMock: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../components/ui", () => ({
+  toast: toastMock,
+}));
+
+describe("handleAuthQueryParams", () => {
+  beforeEach(() => {
+    toastMock.success.mockReset();
+    toastMock.error.mockReset();
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("shows a success toast and removes signed_in from the URL", () => {
+    window.history.replaceState({}, "", "/?signed_in=1");
+
+    handleAuthQueryParams();
+
+    expect(toastMock.success).toHaveBeenCalledWith("You're signed in to Rustume Cloud.");
+    expect(window.location.pathname).toBe("/");
+    expect(window.location.search).toBe("");
+  });
+
+  it("maps auth_error codes to user-facing toasts", () => {
+    window.history.replaceState({}, "", "/?auth_error=invalid_state");
+
+    handleAuthQueryParams();
+
+    expect(toastMock.error).toHaveBeenCalledWith("Sign-in was interrupted. Please try again.");
+    expect(window.location.search).toBe("");
+  });
+
+  it("uses a safe fallback message for unknown auth_error codes", () => {
+    window.history.replaceState({}, "", "/?auth_error=workos_raw_failure");
+
+    handleAuthQueryParams();
+
+    expect(toastMock.error).toHaveBeenCalledWith("Sign-in failed. Please try again.");
+  });
+});
+
+describe("authErrorMessage", () => {
+  it("returns known OAuth error copy", () => {
+    expect(authErrorMessage("authentication_failed")).toBe(
+      "We couldn't sign you in. Please try again.",
+    );
+  });
+});

--- a/apps/web/src/lib/__tests__/authFeedback.test.ts
+++ b/apps/web/src/lib/__tests__/authFeedback.test.ts
@@ -48,6 +48,16 @@ describe("handleAuthQueryParams", () => {
     handleAuthQueryParams();
 
     expect(toastMock.error).toHaveBeenCalledWith("Sign-in failed. Please try again.");
+    expect(window.location.search).toBe("");
+  });
+
+  it("preserves unrelated query parameters when removing auth params", () => {
+    window.history.replaceState({}, "", "/?foo=bar&signed_in=1");
+
+    handleAuthQueryParams();
+
+    expect(toastMock.success).toHaveBeenCalledWith("You're signed in to Rustume Cloud.");
+    expect(window.location.search).toBe("?foo=bar");
   });
 });
 

--- a/apps/web/src/lib/authFeedback.ts
+++ b/apps/web/src/lib/authFeedback.ts
@@ -1,0 +1,38 @@
+import { toast } from "../components/ui";
+
+const AUTH_ERROR_MESSAGES: Record<string, string> = {
+  invalid_state: "Sign-in was interrupted. Please try again.",
+  authentication_failed: "We couldn't sign you in. Please try again.",
+  server_error: "Something went wrong on our end. Please try again later.",
+};
+
+/** Show one-time auth toasts from OAuth redirect query params and clean the URL. */
+export function handleAuthQueryParams(): void {
+  const params = new URLSearchParams(window.location.search);
+  const signedIn = params.get("signed_in");
+  const authError = params.get("auth_error");
+
+  if (!signedIn && !authError) {
+    return;
+  }
+
+  params.delete("signed_in");
+  params.delete("auth_error");
+  const remaining = params.toString();
+  const nextUrl = remaining ? `${window.location.pathname}?${remaining}` : window.location.pathname;
+  window.history.replaceState({}, "", nextUrl);
+
+  if (signedIn === "1") {
+    toast.success("You're signed in to Rustume Cloud.");
+    return;
+  }
+
+  if (authError) {
+    const message = AUTH_ERROR_MESSAGES[authError] ?? "Sign-in failed. Please try again.";
+    toast.error(message);
+  }
+}
+
+export function authErrorMessage(code: string): string {
+  return AUTH_ERROR_MESSAGES[code] ?? "Sign-in failed. Please try again.";
+}

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -54,7 +54,11 @@ export default function Account() {
 
   const handleSignIn = () => {
     setSigningIn(true);
-    signIn();
+    try {
+      signIn();
+    } catch {
+      setSigningIn(false);
+    }
   };
 
   return (

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -1,0 +1,168 @@
+import { Show, createSignal } from "solid-js";
+import { A, useNavigate } from "@solidjs/router";
+import { authStore } from "../stores/auth";
+import { Button, Spinner, toast } from "../components/ui";
+
+function ProfileAvatar(props: { label: string }) {
+  return (
+    <div
+      class="w-16 h-16 rounded-2xl bg-accent/10 text-accent flex items-center justify-center
+        font-display text-2xl font-semibold uppercase"
+      aria-hidden="true"
+    >
+      {props.label.slice(0, 1)}
+    </div>
+  );
+}
+
+function ComingSoonRow(props: { title: string; description: string }) {
+  return (
+    <div class="flex items-start justify-between gap-4 py-4 border-b border-border last:border-b-0">
+      <div>
+        <h3 class="font-medium text-ink">{props.title}</h3>
+        <p class="text-sm text-stone mt-1">{props.description}</p>
+      </div>
+      <span
+        class="inline-flex items-center rounded-full bg-surface px-2.5 py-1 text-xs font-mono
+          text-stone border border-border flex-shrink-0"
+      >
+        Coming soon
+      </span>
+    </div>
+  );
+}
+
+export default function Account() {
+  const { state, signIn, signOut, displayName } = authStore;
+  const navigate = useNavigate();
+  const [signingOut, setSigningOut] = createSignal(false);
+  const [signingIn, setSigningIn] = createSignal(false);
+
+  const handleSignOut = async () => {
+    setSigningOut(true);
+    try {
+      await signOut();
+      toast.success("Signed out");
+      navigate("/");
+    } catch (error) {
+      console.error("Sign out failed:", error);
+      toast.error("Failed to sign out. Please try again.");
+    } finally {
+      setSigningOut(false);
+    }
+  };
+
+  const handleSignIn = () => {
+    setSigningIn(true);
+    signIn();
+  };
+
+  return (
+    <div class="min-h-[calc(100vh-3.5rem)] bg-paper">
+      <div class="max-w-2xl mx-auto px-4 py-12">
+        <Show
+          when={!state.loading}
+          fallback={
+            <div class="flex justify-center py-16">
+              <Spinner class="w-6 h-6 text-accent" />
+            </div>
+          }
+        >
+          <Show
+            when={state.cloudEnabled}
+            fallback={
+              <div class="text-center py-16">
+                <h1 class="font-display text-2xl font-semibold text-ink mb-3">Account</h1>
+                <p class="text-stone">
+                  Cloud accounts are only available on Rustume Cloud deployments.
+                </p>
+              </div>
+            }
+          >
+            <Show
+              when={state.user}
+              fallback={
+                <div class="text-center py-16 border border-border rounded-2xl bg-surface/40 px-6">
+                  <h1 class="font-display text-2xl font-semibold text-ink mb-3">
+                    Sign in to Rustume Cloud
+                  </h1>
+                  <p class="text-stone text-sm max-w-md mx-auto mb-6">
+                    Sync resumes across devices with your Rustume Cloud account. Your local copies
+                    stay on this device until you choose to import them.
+                  </p>
+                  <Button onClick={handleSignIn} loading={signingIn()} disabled={signingIn()}>
+                    Sign in to Cloud
+                  </Button>
+                  <p class="mt-4 text-xs text-stone">
+                    Prefer local-only?{" "}
+                    <A href="/" class="text-accent hover:underline">
+                      Continue without signing in
+                    </A>
+                  </p>
+                </div>
+              }
+            >
+              {(user) => (
+                <div class="space-y-8">
+                  <div>
+                    <h1 class="font-display text-3xl font-semibold text-ink mb-2">Account</h1>
+                    <p class="text-stone text-sm">
+                      Manage your Rustume Cloud profile and sync settings.
+                    </p>
+                  </div>
+
+                  <section class="rounded-2xl border border-border bg-paper p-6 shadow-card">
+                    <div class="flex items-center gap-4">
+                      <ProfileAvatar label={displayName(user())} />
+                      <div class="min-w-0">
+                        <h2 class="font-display text-xl font-semibold text-ink truncate">
+                          {displayName(user())}
+                        </h2>
+                        <Show when={user().email}>
+                          {(email) => <p class="text-sm text-stone truncate mt-1">{email()}</p>}
+                        </Show>
+                        <p class="text-xs font-mono text-stone mt-2 uppercase tracking-wide">
+                          Plan: {user().plan}
+                        </p>
+                      </div>
+                    </div>
+                  </section>
+
+                  <section class="rounded-2xl border border-border bg-paper p-6 shadow-card">
+                    <h2 class="font-display text-lg font-semibold text-ink mb-2">Cloud sync</h2>
+                    <p class="text-sm text-stone">
+                      Resumes saved to your Rustume Cloud account are available on any signed-in
+                      device. Edits sync automatically while you're online.
+                    </p>
+                  </section>
+
+                  <section class="rounded-2xl border border-border bg-paper px-6 py-2 shadow-card">
+                    <ComingSoonRow
+                      title="Billing"
+                      description="Manage your subscription and payment details."
+                    />
+                    <ComingSoonRow
+                      title="End-to-end encryption"
+                      description="Optional client-side encryption for resume content."
+                    />
+                  </section>
+
+                  <div class="flex justify-end">
+                    <Button
+                      variant="secondary"
+                      onClick={() => void handleSignOut()}
+                      loading={signingOut()}
+                      disabled={signingOut()}
+                    >
+                      Sign out
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </Show>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -136,6 +136,25 @@ export default function Account() {
                     </p>
                   </section>
 
+                  <section class="rounded-2xl border border-border bg-paper p-6 shadow-card">
+                    <h2 class="font-display text-lg font-semibold text-ink mb-2">
+                      Privacy and data
+                    </h2>
+                    <p class="text-sm text-stone">
+                      Rustume Cloud uses{" "}
+                      <a
+                        href="https://workos.com/docs/user-management/authkit"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-accent hover:underline"
+                      >
+                        WorkOS AuthKit
+                      </a>{" "}
+                      for authentication. Your email and name are stored by both WorkOS and Rustume
+                      to identify your account.
+                    </p>
+                  </section>
+
                   <section class="rounded-2xl border border-border bg-paper px-6 py-2 shadow-card">
                     <ComingSoonRow
                       title="Billing"

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -64,7 +64,7 @@ export default function Account() {
           when={!state.loading}
           fallback={
             <div class="flex justify-center py-16">
-              <Spinner class="w-6 h-6 text-accent" />
+              <Spinner class="w-6 h-6 text-accent" ariaLabel="Loading account information" />
             </div>
           }
         >
@@ -90,7 +90,7 @@ export default function Account() {
                     Sync resumes across devices with your Rustume Cloud account. Your local copies
                     stay on this device until you choose to import them.
                   </p>
-                  <Button onClick={handleSignIn} loading={signingIn()} disabled={signingIn()}>
+                  <Button onClick={handleSignIn} loading={signingIn()}>
                     Sign in to Cloud
                   </Button>
                   <p class="mt-4 text-xs text-stone">
@@ -152,7 +152,6 @@ export default function Account() {
                       variant="secondary"
                       onClick={() => void handleSignOut()}
                       loading={signingOut()}
-                      disabled={signingOut()}
                     >
                       Sign out
                     </Button>

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -54,11 +54,7 @@ export default function Account() {
 
   const handleSignIn = () => {
     setSigningIn(true);
-    try {
-      signIn();
-    } catch {
-      setSigningIn(false);
-    }
+    signIn();
   };
 
   return (

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -47,7 +47,11 @@ export default function Home() {
 
   const handleCloudSignIn = () => {
     setSigningIn(true);
-    signIn();
+    try {
+      signIn();
+    } catch {
+      setSigningIn(false);
+    }
   };
 
   const handleNew = () => {

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { For, Show, createSignal } from "solid-js";
 import { A, useNavigate } from "@solidjs/router";
 import { Button, Spinner, toast } from "../components/ui";
 import { useResumeList } from "../stores/persistence";
+import { authStore } from "../stores/auth";
 import { generateId } from "../wasm/types";
 
 /** Format a Date as a human-readable relative or absolute string. */
@@ -33,12 +34,21 @@ function formatUpdatedAt(date: Date): string {
 
 export default function Home() {
   const navigate = useNavigate();
+  const { state: authState, signIn } = authStore;
   const { resumes, loading, deleteResume, duplicateResume, renameResume, refresh } =
     useResumeList();
   const [deletingId, setDeletingId] = createSignal<string | null>(null);
   const [duplicatingId, setDuplicatingId] = createSignal<string | null>(null);
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [renameValue, setRenameValue] = createSignal("");
+  const [signingIn, setSigningIn] = createSignal(false);
+
+  const showCloudSignInCta = () => authState.cloudEnabled && !authState.loading && !authState.user;
+
+  const handleCloudSignIn = () => {
+    setSigningIn(true);
+    signIn();
+  };
 
   const handleNew = () => {
     const id = generateId();
@@ -109,6 +119,31 @@ export default function Home() {
 
   return (
     <div class="min-h-[calc(100vh-3.5rem)] bg-paper">
+      <Show when={showCloudSignInCta()}>
+        <div class="border-b border-border bg-surface/60">
+          <div class="max-w-4xl mx-auto px-4 py-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+              <p class="text-sm font-medium text-ink">Working locally on this device</p>
+              <p class="text-sm text-stone mt-1">
+                Sign in to Rustume Cloud to sync resumes across devices. Local copies stay here
+                until you import them.
+              </p>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              class="flex-shrink-0"
+              onClick={handleCloudSignIn}
+              loading={signingIn()}
+              disabled={signingIn()}
+              data-testid="home-cloud-sign-in"
+            >
+              Sign in to Cloud
+            </Button>
+          </div>
+        </div>
+      </Show>
+
       {/* Hero Section */}
       <div class="py-16 px-4">
         <div class="max-w-4xl mx-auto text-center">

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -135,7 +135,6 @@ export default function Home() {
               class="flex-shrink-0"
               onClick={handleCloudSignIn}
               loading={signingIn()}
-              disabled={signingIn()}
               data-testid="home-cloud-sign-in"
             >
               Sign in to Cloud

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -47,11 +47,7 @@ export default function Home() {
 
   const handleCloudSignIn = () => {
     setSigningIn(true);
-    try {
-      signIn();
-    } catch {
-      setSigningIn(false);
-    }
+    signIn();
   };
 
   const handleNew = () => {

--- a/apps/web/src/pages/__tests__/Account.test.tsx
+++ b/apps/web/src/pages/__tests__/Account.test.tsx
@@ -82,6 +82,10 @@ describe("Account page", () => {
     expect(screen.getByText("dev@example.com")).toBeInTheDocument();
     expect(screen.getByText("Plan: free")).toBeInTheDocument();
     expect(screen.getByText(/Resumes saved to your Rustume Cloud account/i)).toBeInTheDocument();
+    expect(screen.getByText(/WorkOS AuthKit/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/email and name are stored by both WorkOS and Rustume/i),
+    ).toBeInTheDocument();
     expect(screen.getByText("Billing")).toBeInTheDocument();
     expect(screen.getByText("End-to-end encryption")).toBeInTheDocument();
     expect(screen.getAllByText("Coming soon").length).toBeGreaterThan(0);

--- a/apps/web/src/pages/__tests__/Account.test.tsx
+++ b/apps/web/src/pages/__tests__/Account.test.tsx
@@ -26,6 +26,7 @@ vi.mock("../../stores/auth", () => ({
     },
     signIn: signInMock,
     signOut: signOutMock,
+    // Mirrors userDisplayName — vi.mock hoisting prevents importing the real function.
     displayName: (user: { email?: string; first_name?: string; last_name?: string }) => {
       const parts = [user.first_name, user.last_name].filter(Boolean);
       if (parts.length > 0) return parts.join(" ");

--- a/apps/web/src/pages/__tests__/Account.test.tsx
+++ b/apps/web/src/pages/__tests__/Account.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { Route, Router } from "@solidjs/router";
+import Account from "../Account";
+
+const { mockAuthState, signInMock, signOutMock } = vi.hoisted(() => ({
+  mockAuthState: {
+    loading: false,
+    cloudEnabled: true,
+    user: null as {
+      id: string;
+      plan: string;
+      email?: string;
+      first_name?: string;
+      last_name?: string;
+    } | null,
+  },
+  signInMock: vi.fn(),
+  signOutMock: vi.fn(),
+}));
+
+vi.mock("../../stores/auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+    signIn: signInMock,
+    signOut: signOutMock,
+    displayName: (user: { email?: string; first_name?: string; last_name?: string }) => {
+      const parts = [user.first_name, user.last_name].filter(Boolean);
+      if (parts.length > 0) return parts.join(" ");
+      return user.email ?? "Account";
+    },
+  },
+}));
+
+vi.mock("../../components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../components/ui")>();
+  return {
+    ...actual,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+function renderAccount() {
+  return render(() => (
+    <Router>
+      <Route path="/" component={Account} />
+    </Router>
+  ));
+}
+
+describe("Account page", () => {
+  it("shows a sign-in CTA when cloud is enabled and the user is signed out", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = null;
+
+    renderAccount();
+
+    expect(screen.getByText("Sign in to Rustume Cloud")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in to Cloud" })).toBeInTheDocument();
+  });
+
+  it("shows profile details when signed in", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = {
+      id: "user-1",
+      plan: "free",
+      email: "dev@example.com",
+      first_name: "Ada",
+      last_name: "Lovelace",
+    };
+
+    renderAccount();
+
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("dev@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Plan: free")).toBeInTheDocument();
+    expect(screen.getByText(/Resumes saved to your Rustume Cloud account/i)).toBeInTheDocument();
+    expect(screen.getByText("Billing")).toBeInTheDocument();
+    expect(screen.getByText("End-to-end encryption")).toBeInTheDocument();
+    expect(screen.getAllByText("Coming soon").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { Route, Router } from "@solidjs/router";
+import Home from "../Home";
+
+const { mockAuthState, signInMock } = vi.hoisted(() => ({
+  mockAuthState: {
+    loading: false,
+    cloudEnabled: false,
+    user: null as { id: string; plan: string } | null,
+  },
+  signInMock: vi.fn(),
+}));
+
+vi.mock("../../stores/auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+    signIn: signInMock,
+  },
+}));
+
+vi.mock("../../stores/persistence", () => ({
+  useResumeList: () => ({
+    resumes: () => [],
+    loading: () => false,
+    deleteResume: vi.fn(),
+    duplicateResume: vi.fn(),
+    renameResume: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("../../wasm/types", () => ({
+  generateId: () => "resume-test-id",
+}));
+
+function renderHome() {
+  return render(() => (
+    <Router>
+      <Route path="/" component={Home} />
+    </Router>
+  ));
+}
+
+describe("Home cloud sign-in CTA", () => {
+  it("shows the cloud banner when cloud is enabled and the user is signed out", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = null;
+
+    renderHome();
+
+    expect(screen.getByTestId("home-cloud-sign-in")).toBeInTheDocument();
+    expect(screen.getByText(/Working locally on this device/i)).toBeInTheDocument();
+  });
+
+  it("hides the cloud banner when the user is signed in", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = { id: "user-1", plan: "free" };
+
+    renderHome();
+
+    expect(screen.queryByTestId("home-cloud-sign-in")).not.toBeInTheDocument();
+  });
+
+  it("hides the cloud banner in self-hosted mode", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = false;
+    mockAuthState.user = null;
+
+    renderHome();
+
+    expect(screen.queryByTestId("home-cloud-sign-in")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -62,7 +62,6 @@ function createAuthStore() {
     signIn: login,
     signOut,
     displayName,
-    userDisplayName,
   };
 }
 

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -50,7 +50,7 @@ function createAuthStore() {
     }
   }
 
-  function displayName(user: AuthUser = state.user!): string {
+  function displayName(user: AuthUser): string {
     return userDisplayName(user);
   }
 

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -1,6 +1,13 @@
 import { createRoot } from "solid-js";
 import { createStore } from "solid-js/store";
-import { type AuthProbeResult, type AuthUser, login, logout, probeAuth } from "../api/auth";
+import {
+  type AuthProbeResult,
+  type AuthUser,
+  login,
+  logout,
+  probeAuth,
+  userDisplayName,
+} from "../api/auth";
 
 interface AuthState {
   loading: boolean;
@@ -43,6 +50,10 @@ function createAuthStore() {
     }
   }
 
+  function displayName(user: AuthUser = state.user!): string {
+    return userDisplayName(user);
+  }
+
   return {
     get state() {
       return state;
@@ -50,6 +61,8 @@ function createAuthStore() {
     refresh,
     signIn: login,
     signOut,
+    displayName,
+    userDisplayName,
   };
 }
 

--- a/crates/server/src/auth/session.rs
+++ b/crates/server/src/auth/session.rs
@@ -73,7 +73,16 @@ impl SessionService {
 
         let row = sqlx::query_as::<_, User>(
             r#"
-            SELECT u.id, u.workos_id, u.plan, u.paddle_customer_id, u.created_at, u.updated_at
+            SELECT
+                u.id,
+                u.workos_id,
+                u.plan,
+                u.paddle_customer_id,
+                u.email,
+                u.first_name,
+                u.last_name,
+                u.created_at,
+                u.updated_at
             FROM sessions s
             JOIN users u ON u.id = s.user_id
             WHERE s.id = $1 AND s.expires_at > now()

--- a/crates/server/src/auth/workos.rs
+++ b/crates/server/src/auth/workos.rs
@@ -102,18 +102,12 @@ struct AuthenticateResponse {
 }
 
 /// Normalized WorkOS user returned after code exchange.
-///
-/// We only use `id` to link the auth session; personal fields are deserialized
-/// by serde but immediately discarded — never stored.
 #[derive(Debug, Clone, Deserialize)]
 pub struct WorkOsUser {
     pub id: String,
-    #[allow(dead_code)]
-    email: String,
-    #[allow(dead_code)]
-    first_name: Option<String>,
-    #[allow(dead_code)]
-    last_name: Option<String>,
+    pub email: String,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
 }
 
 /// Errors returned when communicating with WorkOS.
@@ -126,22 +120,36 @@ pub enum WorkOsAuthError {
 }
 
 /// Insert or update a user row from a WorkOS profile.
-///
-/// Privacy: we only persist the opaque `workos_id` — no email, name, or other PII.
 pub async fn upsert_user(
     pool: &sqlx::PgPool,
     workos_user: &WorkOsUser,
 ) -> Result<User, sqlx::Error> {
     sqlx::query_as::<_, User>(
         r#"
-        INSERT INTO users (workos_id, plan)
-        VALUES ($1, 'free')
+        INSERT INTO users (workos_id, plan, email, first_name, last_name)
+        VALUES ($1, 'free', $2, $3, $4)
         ON CONFLICT (workos_id) DO UPDATE
-        SET updated_at = now()
-        RETURNING id, workos_id, plan, paddle_customer_id, created_at, updated_at
+        SET
+            email = EXCLUDED.email,
+            first_name = EXCLUDED.first_name,
+            last_name = EXCLUDED.last_name,
+            updated_at = now()
+        RETURNING
+            id,
+            workos_id,
+            plan,
+            paddle_customer_id,
+            email,
+            first_name,
+            last_name,
+            created_at,
+            updated_at
         "#,
     )
     .bind(&workos_user.id)
+    .bind(&workos_user.email)
+    .bind(&workos_user.first_name)
+    .bind(&workos_user.last_name)
     .fetch_one(pool)
     .await
 }

--- a/crates/server/src/db/migrations/003_user_profile.sql
+++ b/crates/server/src/db/migrations/003_user_profile.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users
+ADD COLUMN email TEXT,
+ADD COLUMN first_name TEXT,
+ADD COLUMN last_name TEXT;

--- a/crates/server/src/db/migrations/003_user_profile.sql
+++ b/crates/server/src/db/migrations/003_user_profile.sql
@@ -1,3 +1,4 @@
+-- Profile fields are populated from WorkOS on the user's next sign-in.
 ALTER TABLE users
 ADD COLUMN email TEXT,
 ADD COLUMN first_name TEXT,

--- a/crates/server/src/db/migrations/004_unique_email.sql
+++ b/crates/server/src/db/migrations/004_unique_email.sql
@@ -1,0 +1,5 @@
+-- Enforce email uniqueness at the database level.
+-- WorkOS guarantees one email per user but a DB-side guard prevents
+-- duplicates if the upsert path ever changes. The index also speeds
+-- up any future lookup-by-email queries.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_unique ON users (email);

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -65,9 +65,9 @@ pub struct ImportResumesResponse {
 
 /// Authenticated user record stored in PostgreSQL.
 ///
-/// Privacy: account identity metadata is minimized — we store no email or name.
-/// The only link to the authentication provider is the opaque `workos_id`.
-/// Resume documents (stored separately) may contain sensitive personal data.
+/// Profile fields (`email`, `first_name`, `last_name`) are synced from WorkOS on
+/// sign-in for display in the account UI. Resume documents (stored separately) may
+/// contain sensitive personal data.
 #[derive(Debug, Clone, FromRow, Serialize)]
 pub struct User {
     /// Primary key.
@@ -79,6 +79,12 @@ pub struct User {
     pub plan: String,
     /// Paddle customer ID, set after first paid subscription.
     pub paddle_customer_id: Option<String>,
+    /// WorkOS account email, when available.
+    pub email: Option<String>,
+    /// WorkOS given name, when available.
+    pub first_name: Option<String>,
+    /// WorkOS family name, when available.
+    pub last_name: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -171,7 +177,7 @@ pub struct ImportResumesRequest {
 
 /// Authenticated user profile returned by `GET /auth/me`.
 ///
-/// Privacy: returns only account ID and hosted-service subscription status.
+/// Returns account identity and display-friendly profile fields from WorkOS.
 /// Resume content is not included and may contain personal data when fetched separately.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct AuthUserResponse {
@@ -179,6 +185,15 @@ pub struct AuthUserResponse {
     pub id: Uuid,
     /// Hosted-service subscription status for billing — not feature entitlements.
     pub plan: String,
+    /// Account email from WorkOS, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    /// Given name from WorkOS, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_name: Option<String>,
+    /// Family name from WorkOS, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_name: Option<String>,
 }
 
 impl From<User> for AuthUserResponse {
@@ -186,6 +201,60 @@ impl From<User> for AuthUserResponse {
         Self {
             id: user.id,
             plan: user.plan,
+            email: user.email,
+            first_name: user.first_name,
+            last_name: user.last_name,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    #[test]
+    fn auth_user_response_includes_profile_fields() {
+        let user = User {
+            id: Uuid::nil(),
+            workos_id: "user_01".to_string(),
+            plan: "free".to_string(),
+            paddle_customer_id: None,
+            email: Some("dev@example.com".to_string()),
+            first_name: Some("Ada".to_string()),
+            last_name: Some("Lovelace".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let response = AuthUserResponse::from(user);
+        let json = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(json["id"], Uuid::nil().to_string());
+        assert_eq!(json["plan"], "free");
+        assert_eq!(json["email"], "dev@example.com");
+        assert_eq!(json["first_name"], "Ada");
+        assert_eq!(json["last_name"], "Lovelace");
+    }
+
+    #[test]
+    fn auth_user_response_omits_empty_profile_fields() {
+        let user = User {
+            id: Uuid::nil(),
+            workos_id: "user_01".to_string(),
+            plan: "free".to_string(),
+            paddle_customer_id: None,
+            email: None,
+            first_name: None,
+            last_name: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let json = serde_json::to_value(AuthUserResponse::from(user)).unwrap();
+
+        assert!(json.get("email").is_none());
+        assert!(json.get("first_name").is_none());
+        assert!(json.get("last_name").is_none());
     }
 }

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -65,25 +65,27 @@ pub struct ImportResumesResponse {
 
 /// Authenticated user record stored in PostgreSQL.
 ///
-/// Profile fields (`email`, `first_name`, `last_name`) are synced from WorkOS on
-/// sign-in for display in the account UI. Resume documents (stored separately) may
-/// contain sensitive personal data.
+/// Profile fields (`email`, `first_name`, `last_name`) are synced from WorkOS
+/// on each sign-in. WorkOS requires an email for every user and may receive
+/// name fields from the identity provider (Google, GitHub, SSO, etc.).
+/// Rustume stores these so the account UI can greet the user by name.
+///
+/// Resume documents (stored separately) may contain additional personal data.
 #[derive(Debug, Clone, FromRow, Serialize)]
 pub struct User {
     /// Primary key.
     pub id: Uuid,
-    /// WorkOS user identifier (`user_…`) — opaque, non-personal.
+    /// WorkOS user identifier (`user_…`).
     pub workos_id: String,
     /// Hosted-service subscription status for billing (`free`, `pro`, `team`).
-    /// Tracks Paddle subscription — not feature entitlements.
     pub plan: String,
     /// Paddle customer ID, set after first paid subscription.
     pub paddle_customer_id: Option<String>,
-    /// WorkOS account email, when available.
+    /// Account email synced from WorkOS on sign-in.
     pub email: Option<String>,
-    /// WorkOS given name, when available.
+    /// Given name synced from WorkOS on sign-in, when available.
     pub first_name: Option<String>,
-    /// WorkOS family name, when available.
+    /// Family name synced from WorkOS on sign-in, when available.
     pub last_name: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -177,13 +179,13 @@ pub struct ImportResumesRequest {
 
 /// Authenticated user profile returned by `GET /auth/me`.
 ///
-/// Returns account identity and display-friendly profile fields from WorkOS.
-/// Resume content is not included and may contain personal data when fetched separately.
+/// Includes account identity and display-friendly profile fields synced from
+/// WorkOS. Resume content is not included.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct AuthUserResponse {
     #[schema(value_type = String, format = "uuid")]
     pub id: Uuid,
-    /// Hosted-service subscription status for billing — not feature entitlements.
+    /// Hosted-service subscription status for billing.
     pub plan: String,
     /// Account email from WorkOS, when available.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -24,8 +24,9 @@ const OAUTH_STATE_TTL_MINUTES: i64 = 10;
 /// OAuth query parameters returned by WorkOS on `/auth/callback`.
 #[derive(Debug, Deserialize)]
 pub struct CallbackQuery {
-    code: String,
+    code: Option<String>,
     state: Option<String>,
+    error: Option<String>,
 }
 
 /// Redirect the browser to WorkOS AuthKit for sign-in.
@@ -46,19 +47,51 @@ pub async fn login(State(state): State<AppState>) -> Result<Response, ApiError> 
 pub async fn callback(
     State(state): State<AppState>,
     jar: CookieJar,
-    Query(query): Query<CallbackQuery>,
+    query: Result<Query<CallbackQuery>, axum::extract::rejection::QueryRejection>,
     headers: HeaderMap,
 ) -> Response {
-    match callback_inner(state, jar, query, headers).await {
+    let query = match query {
+        Ok(Query(query)) => query,
+        Err(rejection) => {
+            error!("OAuth callback query rejected: {rejection}");
+            return oauth_error_redirect("authentication_failed");
+        }
+    };
+
+    if let Some(code) = oauth_callback_error_code(&query) {
+        if query.error.is_some() {
+            error!("WorkOS OAuth callback returned error");
+        }
+        return oauth_error_redirect(code);
+    }
+
+    let code = query
+        .code
+        .as_deref()
+        .expect("callback validated before inner handler");
+
+    match callback_inner(state, jar, code, query.state.as_deref(), headers).await {
         Ok(response) => response,
         Err(code) => oauth_error_redirect(code),
+    }
+}
+
+fn oauth_callback_error_code(query: &CallbackQuery) -> Option<&'static str> {
+    if query.error.is_some() {
+        return Some("authentication_failed");
+    }
+
+    match query.code.as_deref() {
+        Some(code) if !code.is_empty() => None,
+        _ => Some("authentication_failed"),
     }
 }
 
 async fn callback_inner(
     state: AppState,
     jar: CookieJar,
-    query: CallbackQuery,
+    code: &str,
+    oauth_state: Option<&str>,
     headers: HeaderMap,
 ) -> Result<Response, &'static str> {
     let cloud = state.cloud().map_err(|err| {
@@ -67,7 +100,7 @@ async fn callback_inner(
     })?;
 
     let stored_state = jar.get(OAUTH_STATE_COOKIE).map(|cookie| cookie.value());
-    match (stored_state, query.state.as_deref()) {
+    match (stored_state, oauth_state) {
         (Some(stored), Some(provided)) if stored == provided => {}
         _ => return Err("invalid_state"),
     }
@@ -79,7 +112,7 @@ async fn callback_inner(
 
     let workos_user = cloud
         .workos
-        .authenticate_with_code(&query.code, ip, user_agent)
+        .authenticate_with_code(code, ip, user_agent)
         .await
         .map_err(|err| {
             error!("WorkOS authentication failed: {err}");
@@ -211,5 +244,44 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("/?auth_error=invalid_state")
         );
+    }
+
+    #[test]
+    fn oauth_callback_error_code_when_workos_returns_error() {
+        let query = CallbackQuery {
+            code: None,
+            state: Some("state".to_string()),
+            error: Some("access_denied".to_string()),
+        };
+
+        assert_eq!(
+            oauth_callback_error_code(&query),
+            Some("authentication_failed")
+        );
+    }
+
+    #[test]
+    fn oauth_callback_error_code_when_code_is_missing() {
+        let query = CallbackQuery {
+            code: None,
+            state: Some("state".to_string()),
+            error: None,
+        };
+
+        assert_eq!(
+            oauth_callback_error_code(&query),
+            Some("authentication_failed")
+        );
+    }
+
+    #[test]
+    fn oauth_callback_error_code_none_when_code_present() {
+        let query = CallbackQuery {
+            code: Some("auth_code".to_string()),
+            state: Some("state".to_string()),
+            error: None,
+        };
+
+        assert_eq!(oauth_callback_error_code(&query), None);
     }
 }

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -61,7 +61,10 @@ async fn callback_inner(
     query: CallbackQuery,
     headers: HeaderMap,
 ) -> Result<Response, &'static str> {
-    let cloud = state.cloud().map_err(|_| "server_error")?;
+    let cloud = state.cloud().map_err(|err| {
+        error!("cloud configuration unavailable: {:?}", err);
+        "server_error"
+    })?;
 
     let stored_state = jar.get(OAUTH_STATE_COOKIE).map(|cookie| cookie.value());
     match (stored_state, query.state.as_deref()) {

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -61,14 +61,15 @@ pub async fn callback(
     if let Some(code) = oauth_callback_error_code(&query) {
         if query.error.is_some() {
             error!("WorkOS OAuth callback returned error");
+        } else {
+            error!("OAuth callback missing authorization code");
         }
         return oauth_error_redirect(code);
     }
 
-    let code = query
-        .code
-        .as_deref()
-        .expect("callback validated before inner handler");
+    let Some(code) = query.code.as_deref() else {
+        return oauth_error_redirect("authentication_failed");
+    };
 
     match callback_inner(state, jar, code, query.state.as_deref(), headers).await {
         Ok(response) => response,

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -48,13 +48,25 @@ pub async fn callback(
     jar: CookieJar,
     Query(query): Query<CallbackQuery>,
     headers: HeaderMap,
-) -> Result<Response, ApiError> {
-    let cloud = state.cloud()?;
+) -> Response {
+    match callback_inner(state, jar, query, headers).await {
+        Ok(response) => response,
+        Err(code) => oauth_error_redirect(code),
+    }
+}
+
+async fn callback_inner(
+    state: AppState,
+    jar: CookieJar,
+    query: CallbackQuery,
+    headers: HeaderMap,
+) -> Result<Response, &'static str> {
+    let cloud = state.cloud().map_err(|_| "server_error")?;
 
     let stored_state = jar.get(OAUTH_STATE_COOKIE).map(|cookie| cookie.value());
     match (stored_state, query.state.as_deref()) {
         (Some(stored), Some(provided)) if stored == provided => {}
-        _ => return Err(ApiError::unauthorized("Invalid OAuth state")),
+        _ => return Err("invalid_state"),
     }
 
     let ip = trusted_client_ip(&headers);
@@ -68,25 +80,26 @@ pub async fn callback(
         .await
         .map_err(|err| {
             error!("WorkOS authentication failed: {err}");
-            ApiError::new("Authentication failed")
+            "authentication_failed"
         })?;
 
     let user = upsert_user(&cloud.db, &workos_user).await.map_err(|err| {
         error!("user upsert failed: {err}");
-        ApiError::internal("internal server error")
+        "server_error"
     })?;
 
     let (_session, cookie) = cloud.sessions.create(user.id).await.map_err(|err| {
         error!("session creation failed: {err}");
-        ApiError::internal("internal server error")
+        "server_error"
     })?;
 
-    let mut response = Redirect::to("/").into_response();
-    append_set_cookie(&mut response, cookie)?;
+    let mut response = Redirect::to("/?signed_in=1").into_response();
+    append_set_cookie(&mut response, cookie).map_err(|_| "server_error")?;
     append_set_cookie(
         &mut response,
         clear_oauth_state_cookie(&cloud.workos_redirect_uri),
-    )?;
+    )
+    .map_err(|_| "server_error")?;
     Ok(response)
 }
 
@@ -120,6 +133,16 @@ pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> Result<Res
 )]
 pub async fn me(AuthUser(user): AuthUser) -> Json<AuthUserResponse> {
     Json(user.into())
+}
+
+fn oauth_error_redirect(code: &'static str) -> Response {
+    let path = match code {
+        "invalid_state" => "/?auth_error=invalid_state",
+        "authentication_failed" => "/?auth_error=authentication_failed",
+        "server_error" => "/?auth_error=server_error",
+        _ => "/?auth_error=server_error",
+    };
+    Redirect::to(path).into_response()
 }
 
 fn trusted_client_ip(headers: &HeaderMap) -> Option<&str> {
@@ -168,4 +191,22 @@ fn append_set_cookie(response: &mut Response, cookie: Cookie<'static>) -> Result
         .headers_mut()
         .append(header::SET_COOKIE, header_value);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oauth_error_redirect_uses_safe_query_code() {
+        let response = oauth_error_redirect("invalid_state");
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::LOCATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("/?auth_error=invalid_state")
+        );
+    }
 }


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat: add cloud login and account UX (Phase 1 MVP)
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Polish Rustume Cloud sign-in and account UX on top of the existing WorkOS AuthKit redirect flow (Phase 1 MVP). OAuth is unchanged — no custom login form.

- Extend `GET /auth/me` with display-friendly WorkOS profile fields (email, name)
- Replace header "Signed in" text with an account dropdown and `/account` page
- Add signed-out home CTA explaining local-only vs cloud sync
- Show one-time post-login and OAuth error toasts via safe query params
- Persist profile fields on sign-in via migration `003_user_profile.sql`

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`cargo test -p rustume-server`, `bun run test:coverage`, `uv run lintro fmt`; `lintro chk` passes for changed tools — pre-existing osv-scanner warnings in `apps/site/bun.lock`)

## Related Issues

<!-- No linked issue in branch name -->

## Details

### Server
- Migration adds nullable `email`, `first_name`, `last_name` on `users` (populated on next sign-in)
- WorkOS upsert syncs profile fields; session lookup returns them
- OAuth success redirects to `/?signed_in=1`; failures redirect to `/?auth_error=<code>`

### Web
- `AuthMenu` account dropdown, `/account` page with profile + "Coming soon" billing/encryption rows
- Home banner when cloud enabled and signed out
- `handleAuthQueryParams()` runs after auth refresh for welcome/error toasts without blocking `CloudImportPrompt`

### Testing
- Vitest: auth API, auth feedback, Account page, Home CTA
- Server unit tests: `AuthUserResponse` serialization, OAuth error redirect

### Manual test plan
- [ ] Sign in on staging → welcome toast on home
- [ ] Account menu shows email/name → `/account`
- [ ] Sign out from menu or account page
- [ ] Signed-out home CTA → sign in
- [ ] OAuth failure shows safe error toast (no raw WorkOS message)

### Follow-ups (not in scope)
- Post-login return-to-origin redirect (e.g. from `/account`) — deferred to a later phase

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cloud login and account UX with OAuth callback, user profile storage, and account page
> - OAuth callback route now redirects to the app with `?signed_in=1` on success or `?auth_error=…` on failure; a new `handleAuthQueryParams` helper surfaces these as toasts and cleans the URL.
> - User profile fields (`email`, `first_name`, `last_name`) are now persisted via two new DB migrations and synced from WorkOS on sign-in; `GET /auth/me` serializes these fields when present.
> - A new `/account` page displays the signed-in user's profile, plan, sync/privacy info, and a sign-out action with toast feedback and redirect.
> - `AuthMenu` replaces its sign-in/sign-out buttons with a dropdown showing an avatar, display name, and navigation to the account page.
> - The Home page shows a sign-in banner when cloud is enabled and the user is signed out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90bb751.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Account page with user profile details, cloud status, and “Coming soon” billing/privacy rows.
  * Persists and displays WorkOS profile fields (name/email) and uses them for user display.
  * Added “Sign in to Cloud” call-to-action on the Home page and a dropdown account menu with sign-out.
* **Bug Fixes**
  * Improved OAuth redirect handling with consistent success/error toasts and cleaned-up URL parameters.
  * Added error handling/logging around auth refresh during initial load and page restores.
* **Tests**
  * Expanded authentication, Home, and Account test coverage (including new helper behavior and profile serialization).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds cloud sign-in and account UX on top of the existing WorkOS AuthKit flow: user profile fields (`email`, `first_name`, `last_name`) are now persisted via two new migrations and synced from WorkOS on each sign-in, `GET /auth/me` surfaces them, and the OAuth callback redirects with safe `?signed_in=1` / `?auth_error=<code>` params that the front-end converts to toasts.

- New DB migrations 003 (nullable profile columns) + 004 (unique index on `email`) and server-side `upsert_user` update to sync fields on sign-in.
- New `AuthMenu` dropdown, `/account` page, signed-out Home CTA, and `handleAuthQueryParams` helper wired into `App.onMount` after `authStore.refresh()`.
- Comprehensive Vitest and Rust unit-test coverage for new paths.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the OAuth callback error paths are correct and no user-controlled data escapes into redirects, logs, or the DOM.

The auth flow changes are well-structured: error codes are static string literals never derived from user input, the unique-email concern from migration 003 is closed by migration 004, and handleAuthQueryParams maps raw query values through a fixed lookup table before displaying them. The minor nits in the callback handler do not affect runtime correctness.

crates/server/src/routes/auth.rs — unreachable guard and incomplete log line noted above.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/routes/auth.rs | OAuth callback refactored to redirect with ?signed_in=1 or ?auth_error=<code> instead of returning API errors; contains unreachable guard after oauth_callback_error_code check and silently drops query.error value from logs |
| crates/server/src/db/migrations/003_user_profile.sql | Adds nullable email, first_name, last_name columns; unique constraint addressed in migration 004 |
| crates/server/src/db/migrations/004_unique_email.sql | Adds unique index on email; correctly allows multiple NULLs via PostgreSQL partial-NULL semantics for existing users |
| crates/server/src/auth/workos.rs | Exposes email/first_name/last_name on WorkOsUser and syncs them via upsert ON CONFLICT; straightforward and correct |
| crates/server/src/db/models.rs | Adds optional profile fields to User and AuthUserResponse; serde skip_serializing_if correctly omits None fields from JSON |
| apps/web/src/lib/authFeedback.ts | New helper that reads signed_in/auth_error query params, fires toasts with safe mapped messages, and cleans the URL; auth_error value is never rendered directly |
| apps/web/src/pages/Account.tsx | New Account page with profile display, cloud sync info, coming-soon placeholders, and sign-out flow with toast + navigate |
| apps/web/src/components/Auth/AuthMenu.tsx | Replaces flat sign-in/sign-out buttons with a Kobalte DropdownMenu; avatar initial, display name, and email shown in trigger/header |
| apps/web/src/stores/auth.ts | Adds displayName wrapper around userDisplayName and exposes it from the store |
| apps/web/src/App.tsx | authStore.refresh() now awaited with error handling before handleAuthQueryParams() so toasts fire after the auth state is known |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant App as App (SolidJS)
    participant Server as Axum Server
    participant WorkOS

    Browser->>Server: GET /auth/login
    Server-->>Browser: 307 to WorkOS AuthKit plus state cookie
    Browser->>WorkOS: OAuth authorization
    WorkOS-->>Browser: "redirect /auth/callback?code=...&state=..."

    alt Success
        Browser->>Server: "GET /auth/callback?code=...&state=..."
        Server->>WorkOS: authenticate_with_code(code)
        WorkOS-->>Server: WorkOsUser with id, email, first_name, last_name
        Server->>Server: upsert_user syncs profile fields
        Server->>Server: sessions.create()
        Server-->>Browser: "303 to /?signed_in=1 plus session cookie"
        Browser->>App: mount and hydrate
        App->>Server: GET /auth/me
        Server-->>App: id, plan, email, first_name, last_name
        App->>App: authStore.refresh()
        App->>App: handleAuthQueryParams fires toast.success
    else OAuth Error or Missing Code
        WorkOS-->>Browser: "redirect /auth/callback?error=..."
        Browser->>Server: "GET /auth/callback?error=..."
        Server-->>Browser: "303 to /?auth_error=authentication_failed"
        Browser->>App: mount and hydrate
        App->>App: handleAuthQueryParams fires toast.error
    else Invalid State
        Browser->>Server: "GET /auth/callback?code=...&state=BAD"
        Server-->>Browser: "303 to /?auth_error=invalid_state"
        Browser->>App: handleAuthQueryParams fires toast.error
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fserver%2Fsrc%2Froutes%2Fauth.rs%3A70-72%0AUnreachable%20guard%20after%20%60oauth_callback_error_code%60.%20That%20helper%20returns%20%60None%60%20only%20when%20%60query.code%60%20is%20%60Some%60%20and%20non-empty%2C%20so%20the%20%60else%60%20branch%20here%20can%20never%20execute.%20Dead%20code%20that%20could%20mislead%20future%20readers%20into%20thinking%20a%20missing-code%20path%20is%20possible%20at%20this%20point.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20SAFETY%3A%20oauth_callback_error_code%20above%20returns%20None%20only%20when%0A%20%20%20%20%2F%2F%20query.code%20is%20Some%20and%20non-empty%2C%20so%20unwrap%20here%20is%20infallible.%0A%20%20%20%20let%20code%20%3D%20query.code.as_deref%28%29.unwrap_or_default%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fserver%2Fsrc%2Froutes%2Fauth.rs%3A62-64%0AThe%20WorkOS%20error%20code%20carried%20in%20%60query.error%60%20is%20silently%20dropped%20from%20the%20log.%20Knowing%20whether%20WorkOS%20sent%20%60access_denied%60%2C%20%60account_deactivated%60%2C%20or%20something%20else%20is%20useful%20for%20debugging%20and%20monitoring%20OAuth%20failure%20rates%2C%20and%20the%20value%20is%20only%20logged%20server-side%20%28it%20is%20never%20surfaced%20to%20the%20client%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20Some%28ref%20err%29%20%3D%20query.error%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20error!%28%22WorkOS%20OAuth%20callback%20returned%20error%3A%20%7Berr%7D%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fserver%2Fsrc%2Froutes%2Fauth.rs%3A52-78%0A**OAuth%20state%20cookie%20not%20cleared%20on%20error%20paths.**%20%60clear_oauth_state_cookie%60%20is%20only%20called%20inside%20%60callback_inner%60%20on%20the%20success%20path.%20When%20an%20error%20is%20detected%20early%20%28query%20parse%20failure%2C%20missing%20code%2C%20WorkOS%20error%20param%29%20the%20state%20cookie%20is%20left%20in%20the%20browser%20until%20its%2010-minute%20TTL%20expires.%20In%20practice%20this%20is%20benign%20%E2%80%94%20the%20cookie%20is%20%60HttpOnly%60%2F%60SameSite%3DLax%60%20and%20the%20state%20is%20single-use%20%E2%80%94%20but%20a%20second%20sign-in%20attempt%20within%20those%2010%20minutes%20will%20hit%20a%20fresh%20state%20cookie%20that%20overwrites%20it%20rather%20than%20a%20cleanly%20cleared%20one.%20Consider%20building%20the%20%60clear_oauth_state_cookie%60%20response%20header%20into%20%60oauth_error_redirect%60%20%28requires%20passing%20%60redirect_uri%60%20into%20it%29%20so%20every%20error%20path%20cleans%20up%20consistently.%0A%0A&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fserver%2Fsrc%2Froutes%2Fauth.rs%3A70-72%0AUnreachable%20guard%20after%20%60oauth_callback_error_code%60.%20That%20helper%20returns%20%60None%60%20only%20when%20%60query.code%60%20is%20%60Some%60%20and%20non-empty%2C%20so%20the%20%60else%60%20branch%20here%20can%20never%20execute.%20Dead%20code%20that%20could%20mislead%20future%20readers%20into%20thinking%20a%20missing-code%20path%20is%20possible%20at%20this%20point.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20SAFETY%3A%20oauth_callback_error_code%20above%20returns%20None%20only%20when%0A%20%20%20%20%2F%2F%20query.code%20is%20Some%20and%20non-empty%2C%20so%20unwrap%20here%20is%20infallible.%0A%20%20%20%20let%20code%20%3D%20query.code.as_deref%28%29.unwrap_or_default%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fserver%2Fsrc%2Froutes%2Fauth.rs%3A62-64%0AThe%20WorkOS%20error%20code%20carried%20in%20%60query.error%60%20is%20silently%20dropped%20from%20the%20log.%20Knowing%20whether%20WorkOS%20sent%20%60access_denied%60%2C%20%60account_deactivated%60%2C%20or%20something%20else%20is%20useful%20for%20debugging%20and%20monitoring%20OAuth%20failure%20rates%2C%20and%20the%20value%20is%20only%20logged%20server-side%20%28it%20is%20never%20surfaced%20to%20the%20client%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20Some%28ref%20err%29%20%3D%20query.error%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20error!%28%22WorkOS%20OAuth%20callback%20returned%20error%3A%20%7Berr%7D%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fserver%2Fsrc%2Froutes%2Fauth.rs%3A52-78%0A**OAuth%20state%20cookie%20not%20cleared%20on%20error%20paths.**%20%60clear_oauth_state_cookie%60%20is%20only%20called%20inside%20%60callback_inner%60%20on%20the%20success%20path.%20When%20an%20error%20is%20detected%20early%20%28query%20parse%20failure%2C%20missing%20code%2C%20WorkOS%20error%20param%29%20the%20state%20cookie%20is%20left%20in%20the%20browser%20until%20its%2010-minute%20TTL%20expires.%20In%20practice%20this%20is%20benign%20%E2%80%94%20the%20cookie%20is%20%60HttpOnly%60%2F%60SameSite%3DLax%60%20and%20the%20state%20is%20single-use%20%E2%80%94%20but%20a%20second%20sign-in%20attempt%20within%20those%2010%20minutes%20will%20hit%20a%20fresh%20state%20cookie%20that%20overwrites%20it%20rather%20than%20a%20cleanly%20cleared%20one.%20Consider%20building%20the%20%60clear_oauth_state_cookie%60%20response%20header%20into%20%60oauth_error_redirect%60%20%28requires%20passing%20%60redirect_uri%60%20into%20it%29%20so%20every%20error%20path%20cleans%20up%20consistently.%0A%0A&repo=lgtm-hq%2Frustume&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22feat%2Fcloud-login-account-ux%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcloud-login-account-ux%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fserver%2Fsrc%2Froutes%2Fauth.rs%3A70-72%0AUnreachable%20guard%20after%20%60oauth_callback_error_code%60.%20That%20helper%20returns%20%60None%60%20only%20when%20%60query.code%60%20is%20%60Some%60%20and%20non-empty%2C%20so%20the%20%60else%60%20branch%20here%20can%20never%20execute.%20Dead%20code%20that%20could%20mislead%20future%20readers%20into%20thinking%20a%20missing-code%20path%20is%20possible%20at%20this%20point.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20SAFETY%3A%20oauth_callback_error_code%20above%20returns%20None%20only%20when%0A%20%20%20%20%2F%2F%20query.code%20is%20Some%20and%20non-empty%2C%20so%20unwrap%20here%20is%20infallible.%0A%20%20%20%20let%20code%20%3D%20query.code.as_deref%28%29.unwrap_or_default%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fserver%2Fsrc%2Froutes%2Fauth.rs%3A62-64%0AThe%20WorkOS%20error%20code%20carried%20in%20%60query.error%60%20is%20silently%20dropped%20from%20the%20log.%20Knowing%20whether%20WorkOS%20sent%20%60access_denied%60%2C%20%60account_deactivated%60%2C%20or%20something%20else%20is%20useful%20for%20debugging%20and%20monitoring%20OAuth%20failure%20rates%2C%20and%20the%20value%20is%20only%20logged%20server-side%20%28it%20is%20never%20surfaced%20to%20the%20client%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20let%20Some%28ref%20err%29%20%3D%20query.error%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20error!%28%22WorkOS%20OAuth%20callback%20returned%20error%3A%20%7Berr%7D%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fserver%2Fsrc%2Froutes%2Fauth.rs%3A52-78%0A**OAuth%20state%20cookie%20not%20cleared%20on%20error%20paths.**%20%60clear_oauth_state_cookie%60%20is%20only%20called%20inside%20%60callback_inner%60%20on%20the%20success%20path.%20When%20an%20error%20is%20detected%20early%20%28query%20parse%20failure%2C%20missing%20code%2C%20WorkOS%20error%20param%29%20the%20state%20cookie%20is%20left%20in%20the%20browser%20until%20its%2010-minute%20TTL%20expires.%20In%20practice%20this%20is%20benign%20%E2%80%94%20the%20cookie%20is%20%60HttpOnly%60%2F%60SameSite%3DLax%60%20and%20the%20state%20is%20single-use%20%E2%80%94%20but%20a%20second%20sign-in%20attempt%20within%20those%2010%20minutes%20will%20hit%20a%20fresh%20state%20cookie%20that%20overwrites%20it%20rather%20than%20a%20cleanly%20cleared%20one.%20Consider%20building%20the%20%60clear_oauth_state_cookie%60%20response%20header%20into%20%60oauth_error_redirect%60%20%28requires%20passing%20%60redirect_uri%60%20into%20it%29%20so%20every%20error%20path%20cleans%20up%20consistently.%0A%0A&repo=lgtm-hq%2Frustume&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["fix: address CI review findings for clou..."](https://github.com/lgtm-hq/rustume/commit/7c25b2645e8055f412777c4894e0310f7eb5cd9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37384145)</sub>

<!-- /greptile_comment -->