### PR TITLE
test(ci): add BATS tests for Railway deploy scripts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,6 +25,8 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
   `reusable-publish-quality-summary`
 - **site-quality.yml** — Docs site build, link check, Astro check, Vitest + pytest via
   `reusable-site-quality`
+- **test-railway-shell.yml** — BATS tests for `scripts/ci/railway/` via
+  `reusable-test-shell`
 
 ## Deploy
 
@@ -106,5 +108,6 @@ in-progress runs on `main`.
 ## Local scripts
 
 Repo-local scripts under `scripts/ci/` remain for site build/test, release binary
-packaging, and GHCR tagged prune. Quality, security audit, release automation, and
-vulnerability suppression paths are handled by lgtm-ci reusables.
+packaging, Railway deploy automation tests, and GHCR tagged prune. Quality,
+security audit, release automation, and vulnerability suppression paths are
+handled by lgtm-ci reusables.

--- a/.github/workflows/deploy-railway-cloud.yml
+++ b/.github/workflows/deploy-railway-cloud.yml
@@ -55,8 +55,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
-            backboard.railway.com:443
+            github.com:443
             api.github.com:443
+            codeload.github.com:443
+            backboard.railway.com:443
 
       - name: Checkout
         # yamllint disable-line rule:line-length

--- a/.github/workflows/deploy-railway-cloud.yml
+++ b/.github/workflows/deploy-railway-cloud.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Update GitHub Deployment (failure)
         if: >-
-          failure() &&
+          (failure() || cancelled()) &&
           steps.deployment.outputs.id &&
           inputs.dry_run != true &&
           inputs.dry_run != 'true'

--- a/.github/workflows/test-railway-shell.yml
+++ b/.github/workflows/test-railway-shell.yml
@@ -35,7 +35,8 @@ jobs:
       job-name: Railway Shell Tests
       test-path: tests/bats/unit/railway
       coverage: true
-      coverage-threshold: 0 # kcov reports 0% for bash via BATS; non-zero fails CI until measurement fixed
+      # kcov reports 0% for bash via BATS; non-zero fails CI until measurement fixed
+      coverage-threshold: 0
       upload-coverage: false
       egress-policy: block
       egress-preset: github-tooling

--- a/.github/workflows/test-railway-shell.yml
+++ b/.github/workflows/test-railway-shell.yml
@@ -27,7 +27,7 @@ jobs:
   shell-tests:
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:

--- a/.github/workflows/test-railway-shell.yml
+++ b/.github/workflows/test-railway-shell.yml
@@ -35,7 +35,7 @@ jobs:
       job-name: Railway Shell Tests
       test-path: tests/bats/unit/railway
       coverage: true
-      coverage-threshold: 0
+      coverage-threshold: 0 # kcov reports 0% for bash via BATS; non-zero fails CI until measurement fixed
       upload-coverage: false
       egress-policy: block
       egress-preset: github-tooling

--- a/.github/workflows/test-railway-shell.yml
+++ b/.github/workflows/test-railway-shell.yml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Test - Railway Shell Scripts
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/railway/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-railway-shell.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/ci/railway/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-railway-shell.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-railway-shell-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell-tests:
+    permissions:
+      contents: read
+      pull-requests: write
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    with:
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      job-name: Railway Shell Tests
+      test-path: tests/bats/unit/railway
+      coverage: true
+      coverage-threshold: 0
+      upload-coverage: false
+      egress-policy: block
+      egress-preset: github-tooling
+      runner-image: ubuntu-24.04

--- a/docs/operations/rustume-cloud-deploy.md
+++ b/docs/operations/rustume-cloud-deploy.md
@@ -76,13 +76,30 @@ Project: `rustume-cloud` (service historically named `responsible-celebration`).
 3. Set image to `ghcr.io/lgtm-hq/rustume:main`.
 4. Under **Registry credentials**, add a GitHub PAT with `read:packages` if pulls fail.
    Railway accepts GHCR tokens per [private registry docs](https://docs.railway.com/builds/private-registries).
+   Use the `lgtm-hq/railway` machine account (or equivalent) username and store the PAT
+   **only in Railway** — never in GitHub Actions or the repository.
 5. Remove source-build settings:
-   - `RAILWAY_DOCKERFILE_PATH` (and any `Dockerfile.railway` reference)
+   - `RAILWAY_DOCKERFILE_PATH` (and any `Dockerfile.railway` reference) — delete from
+     the service if still present (dashboard or Terraform `environment_variables`)
    - GitHub repo / branch deploy hooks used only for source builds
 6. **Disconnect GitHub source:** Settings → Source → Disconnect GitHub repo. The
    deploy workflow is the single deploy authority.
 7. Keep runtime variables unchanged (`RUSTUME_CLOUD`, `DATABASE_URL`, WorkOS, `SESSION_SECRET`,
    `CORS_ORIGIN`, observability secrets, etc.).
+
+### Post-merge CI validation
+
+After merging the deploy egress fix and configuring registry credentials:
+
+1. **Actions → Deploy - Rustume Cloud (Railway) → Run workflow** on `main` with
+   `dry_run: true` (logs only; no deploy).
+2. Re-run with `dry_run: false` to deploy `:main` via GraphQL.
+3. Confirm a GitHub Deployment for environment `rustume-cloud` / `production` on the
+   commit with status `success`.
+4. Verify `GET /health` returns 200 on the Railway URL.
+
+The `workflow_run` chain (docker publish → deploy) fires only when
+`docker-build-publish.yml` completes on `main` with path-filtered changes.
 
 ### Terraform
 

--- a/scripts/ci/railway/deploy-ghcr.sh
+++ b/scripts/ci/railway/deploy-ghcr.sh
@@ -118,8 +118,8 @@ wait_for_new_deployment_id() {
 deploy_via_graphql() {
 	echo "Deploying ${SERVICE_ID} from ${IMAGE} via GraphQL API..."
 
-	register_timeout="${DEPLOY_ID_REGISTER_TIMEOUT:-60}"
-	register_interval="${DEPLOY_ID_REGISTER_INTERVAL:-2}"
+	local register_timeout="${DEPLOY_ID_REGISTER_TIMEOUT:-60}"
+	local register_interval="${DEPLOY_ID_REGISTER_INTERVAL:-2}"
 	validate_positive_int "DEPLOY_ID_REGISTER_TIMEOUT" "${register_timeout}"
 	validate_positive_int "DEPLOY_ID_REGISTER_INTERVAL" "${register_interval}"
 

--- a/scripts/ci/railway/deploy-ghcr.sh
+++ b/scripts/ci/railway/deploy-ghcr.sh
@@ -115,6 +115,11 @@ wait_for_new_deployment_id() {
 deploy_via_graphql() {
 	echo "Deploying ${SERVICE_ID} from ${IMAGE} via GraphQL API..."
 
+	register_timeout="${DEPLOY_ID_REGISTER_TIMEOUT:-60}"
+	register_interval="${DEPLOY_ID_REGISTER_INTERVAL:-2}"
+	validate_positive_int "DEPLOY_ID_REGISTER_TIMEOUT" "${register_timeout}"
+	validate_positive_int "DEPLOY_ID_REGISTER_INTERVAL" "${register_interval}"
+
 	previous_deployment_id="$(fetch_latest_deployment_id)"
 
 	# CAUTION: Railway's serviceInstanceUpdate resets numReplicas to 1 if omitted.

--- a/scripts/ci/railway/deploy-ghcr.sh
+++ b/scripts/ci/railway/deploy-ghcr.sh
@@ -99,7 +99,10 @@ wait_for_new_deployment_id() {
 	validate_positive_int "DEPLOY_ID_REGISTER_INTERVAL" "${register_interval}"
 
 	while ((elapsed < register_timeout)); do
-		deployment_id="$(fetch_latest_deployment_id)"
+		if ! deployment_id="$(fetch_latest_deployment_id)"; then
+			echo "Failed to query deployment status during polling." >&2
+			return 1
+		fi
 		if [[ -n "${deployment_id}" && "${deployment_id}" != "${previous_id}" ]]; then
 			printf '%s' "${deployment_id}"
 			return 0
@@ -120,7 +123,10 @@ deploy_via_graphql() {
 	validate_positive_int "DEPLOY_ID_REGISTER_TIMEOUT" "${register_timeout}"
 	validate_positive_int "DEPLOY_ID_REGISTER_INTERVAL" "${register_interval}"
 
-	previous_deployment_id="$(fetch_latest_deployment_id)"
+	previous_deployment_id="$(fetch_latest_deployment_id)" || {
+		echo "Failed to query latest deployment before deploy." >&2
+		exit 1
+	}
 
 	# CAUTION: Railway's serviceInstanceUpdate resets numReplicas to 1 if omitted.
 	# Current config: 1 replica. If scaling up, include numReplicas in the input.
@@ -160,7 +166,9 @@ deploy_via_graphql() {
 		exit 1
 	fi
 
-	deployment_id="$(wait_for_new_deployment_id "${previous_deployment_id}")"
+	if ! deployment_id="$(wait_for_new_deployment_id "${previous_deployment_id}")"; then
+		exit 1
+	fi
 
 	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 		echo "deployment_id=${deployment_id}" >>"${GITHUB_OUTPUT}"

--- a/scripts/ci/railway/test.sh
+++ b/scripts/ci/railway/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# Run BATS tests for Railway deploy scripts.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TEST_PATH="${ROOT}/tests/bats/unit/railway"
+
+if ! command -v bats >/dev/null 2>&1; then
+	echo "bats is required to run Railway shell tests" >&2
+	exit 1
+fi
+
+# Prevent accidental live Railway calls when developers have tokens exported locally.
+clear_railway_tokens() {
+	unset RAILWAY_TOKEN RAILWAY_API_TOKEN
+}
+clear_railway_tokens
+
+echo "Running Railway shell tests in ${TEST_PATH}"
+bats --recursive "${TEST_PATH}"

--- a/tests/bats/fixtures/railway/mock-curl-deploy.sh
+++ b/tests/bats/fixtures/railway/mock-curl-deploy.sh
@@ -25,6 +25,8 @@ if [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
 elif [[ "${payload}" == *"serviceInstanceDeployV2"* ]]; then
 	echo '{"data":{"serviceInstanceDeployV2":true}}'
 elif [[ "${payload}" == *"deployments"* ]]; then
+	# Call order in deploy_via_graphql(): 1=pre-deploy fetch, 2=update, 3=deploy,
+	# 4+=poll. count<=1 returns old-deploy; count>=2 returns new-deploy.
 	if [[ "${count}" -le 1 ]]; then
 		echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
 	else

--- a/tests/bats/fixtures/railway/mock-curl-deploy.sh
+++ b/tests/bats/fixtures/railway/mock-curl-deploy.sh
@@ -11,6 +11,11 @@ while (($# > 0)); do
 	fi
 done
 
+if [[ -z "${COUNTER_FILE:-}" ]]; then
+	echo "COUNTER_FILE must be set" >&2
+	exit 1
+fi
+
 count="$(cat "${COUNTER_FILE}")"
 count=$((count + 1))
 echo "${count}" >"${COUNTER_FILE}"

--- a/tests/bats/fixtures/railway/mock-curl-deploy.sh
+++ b/tests/bats/fixtures/railway/mock-curl-deploy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+payload=""
+while (($# > 0)); do
+	if [[ "$1" == "-d" && $# -ge 2 ]]; then
+		payload="$2"
+		shift 2
+	else
+		shift
+	fi
+done
+
+count="$(cat "${COUNTER_FILE}")"
+count=$((count + 1))
+echo "${count}" >"${COUNTER_FILE}"
+
+if [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
+	echo '{"data":{"serviceInstanceUpdate":true}}'
+elif [[ "${payload}" == *"serviceInstanceDeployV2"* ]]; then
+	echo '{"data":{"serviceInstanceDeployV2":true}}'
+elif [[ "${payload}" == *"deployments"* ]]; then
+	if [[ "${count}" -le 1 ]]; then
+		echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
+	else
+		echo '{"data":{"deployments":{"edges":[{"node":{"id":"new-deploy","status":"BUILDING"}}]}}}'
+	fi
+else
+	echo '{"errors":[{"message":"unexpected query"}]}' >&2
+	exit 1
+fi

--- a/tests/bats/helpers/common.bash
+++ b/tests/bats/helpers/common.bash
@@ -85,7 +85,9 @@ fi
 
 setup_temp_dir() {
 	if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
-		export BATS_TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/bats-test.XXXXXXXXXX")"
+		local tmpdir
+		tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/bats-test.XXXXXXXXXX")"
+		export BATS_TEST_TMPDIR="${tmpdir}"
 	fi
 }
 

--- a/tests/bats/helpers/common.bash
+++ b/tests/bats/helpers/common.bash
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Common utilities for Rustume BATS tests.
+
+HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${HELPERS_DIR}/../../.." && pwd)"
+export PROJECT_ROOT
+export RAILWAY_SCRIPTS_DIR="${PROJECT_ROOT}/scripts/ci/railway"
+
+_load_bats_library() {
+	local name="$1"
+	local paths=(
+		"${BATS_TEST_DIRNAME}/../../node_modules/bats-${name}/load.bash"
+		"/opt/homebrew/lib/bats-${name}/load.bash"
+		"/usr/local/lib/bats-${name}/load.bash"
+		"/usr/lib/bats-${name}/load.bash"
+	)
+
+	for path in "${paths[@]}"; do
+		if [[ -f "${path}" ]]; then
+			# shellcheck disable=SC1090
+			source "${path}"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+if ! _load_bats_library "support"; then
+	fail() {
+		echo "# $*" >&2
+		return 1
+	}
+fi
+
+if ! _load_bats_library "assert"; then
+	# status and output are set by BATS run()
+	# shellcheck disable=SC2154
+	assert_success() {
+		[[ "${status}" -eq 0 ]] || {
+			echo "# Expected success, got exit ${status}" >&2
+			echo "# Output: ${output}" >&2
+			return 1
+		}
+	}
+
+	# shellcheck disable=SC2154
+	assert_failure() {
+		[[ "${status}" -ne 0 ]] || {
+			echo "# Expected failure, got exit 0" >&2
+			echo "# Output: ${output}" >&2
+			return 1
+		}
+	}
+
+	# shellcheck disable=SC2154
+	assert_output() {
+		local expected
+		if [[ "$1" == "--partial" ]]; then
+			expected="$2"
+			[[ "${output}" == *"${expected}"* ]] || {
+				echo "# Expected output to contain: ${expected}" >&2
+				echo "# Actual output: ${output}" >&2
+				return 1
+			}
+		else
+			expected="$1"
+			[[ "${output}" == "${expected}" ]] || {
+				echo "# Expected output: ${expected}" >&2
+				echo "# Actual output: ${output}" >&2
+				return 1
+			}
+		fi
+	}
+
+	assert_equal() {
+		[[ "$1" == "$2" ]] || {
+			echo "# Expected: $1" >&2
+			echo "# Actual:   $2" >&2
+			return 1
+		}
+	}
+fi
+
+setup_temp_dir() {
+	BATS_TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/bats-test.XXXXXXXXXX")"
+	export BATS_TEST_TMPDIR
+}
+
+teardown_temp_dir() {
+	if [[ -n "${BATS_TEST_TMPDIR:-}" ]] && [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+		rm -rf "${BATS_TEST_TMPDIR}"
+	fi
+}
+
+get_github_output() {
+	local key="$1"
+	grep "^${key}=" "${GITHUB_OUTPUT}" | cut -d= -f2-
+}
+
+clear_railway_tokens() {
+	unset RAILWAY_TOKEN RAILWAY_API_TOKEN
+}

--- a/tests/bats/helpers/common.bash
+++ b/tests/bats/helpers/common.bash
@@ -84,8 +84,9 @@ if ! _load_bats_library "assert"; then
 fi
 
 setup_temp_dir() {
-	BATS_TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/bats-test.XXXXXXXXXX")"
-	export BATS_TEST_TMPDIR
+	if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+		export BATS_TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/bats-test.XXXXXXXXXX")"
+	fi
 }
 
 teardown_temp_dir() {
@@ -96,7 +97,7 @@ teardown_temp_dir() {
 
 get_github_output() {
 	local key="$1"
-	grep "^${key}=" "${GITHUB_OUTPUT}" | cut -d= -f2-
+	grep -m1 "^${key}=" "${GITHUB_OUTPUT}" | cut -d= -f2-
 }
 
 clear_railway_tokens() {

--- a/tests/bats/helpers/common.bash
+++ b/tests/bats/helpers/common.bash
@@ -86,7 +86,14 @@ fi
 setup_temp_dir() {
 	if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
 		local tmpdir
-		tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/bats-test.XXXXXXXXXX")"
+		if ! tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/bats-test.XXXXXXXXXX")"; then
+			echo "# Failed to create BATS temp directory" >&2
+			return 1
+		fi
+		if [[ -z "${tmpdir}" ]]; then
+			echo "# Failed to create BATS temp directory: empty path" >&2
+			return 1
+		fi
 		export BATS_TEST_TMPDIR="${tmpdir}"
 	fi
 }

--- a/tests/bats/helpers/mocks.bash
+++ b/tests/bats/helpers/mocks.bash
@@ -6,6 +6,11 @@ mock_command() {
 	local cmd_name="$1"
 	local output="${2:-}"
 	local exit_code="${3:-0}"
+
+	[[ -n "${BATS_TEST_TMPDIR:-}" ]] || {
+		echo "Error: BATS_TEST_TMPDIR not set" >&2
+		return 1
+	}
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
 
 	mkdir -p "${mock_bin}"
@@ -25,6 +30,11 @@ EOF
 mock_command_script() {
 	local cmd_name="$1"
 	local script_body="$2"
+
+	[[ -n "${BATS_TEST_TMPDIR:-}" ]] || {
+		echo "Error: BATS_TEST_TMPDIR not set" >&2
+		return 1
+	}
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
 
 	mkdir -p "${mock_bin}"

--- a/tests/bats/helpers/mocks.bash
+++ b/tests/bats/helpers/mocks.bash
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Command mocking helpers for Rustume BATS tests.
+
+mock_command() {
+	local cmd_name="$1"
+	local output="${2:-}"
+	local exit_code="${3:-0}"
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+
+	mkdir -p "${mock_bin}"
+
+	cat >"${mock_bin}/${cmd_name}" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' '${output//\'/\'\\\'\'}'
+exit ${exit_code}
+EOF
+	chmod +x "${mock_bin}/${cmd_name}"
+
+	if [[ ":${PATH}:" != *":${mock_bin}:"* ]]; then
+		export PATH="${mock_bin}:${PATH}"
+	fi
+}
+
+mock_command_script() {
+	local cmd_name="$1"
+	local script_body="$2"
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+
+	mkdir -p "${mock_bin}"
+
+	cat >"${mock_bin}/${cmd_name}" <<EOF
+#!/usr/bin/env bash
+${script_body}
+EOF
+	chmod +x "${mock_bin}/${cmd_name}"
+
+	if [[ ":${PATH}:" != *":${mock_bin}:"* ]]; then
+		export PATH="${mock_bin}:${PATH}"
+	fi
+}
+
+save_path() {
+	export _ORIGINAL_PATH="${PATH}"
+}
+
+restore_path() {
+	if [[ -n "${_ORIGINAL_PATH:-}" ]]; then
+		export PATH="${_ORIGINAL_PATH}"
+	fi
+}

--- a/tests/bats/unit/railway/test_create_github_deployment.bats
+++ b/tests/bats/unit/railway/test_create_github_deployment.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/railway/create-github-deployment.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	export GITHUB_REPOSITORY="lgtm-hq/Rustume"
+	touch "${GITHUB_OUTPUT}"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "create-github-deployment: writes deployment id to GITHUB_OUTPUT" {
+	mock_command_script "gh" '
+if [[ "$1" == "api" ]]; then
+  echo "424242"
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+'
+
+	run env \
+		DEPLOY_REF="abc123def456" \
+		bash "${RAILWAY_SCRIPTS_DIR}/create-github-deployment.sh"
+
+	assert_success
+	assert_equal "424242" "$(get_github_output id)"
+}
+
+@test "create-github-deployment: fails when DEPLOY_REF is missing" {
+	run bash "${RAILWAY_SCRIPTS_DIR}/create-github-deployment.sh"
+
+	assert_failure
+	assert_output --partial "DEPLOY_REF is required"
+}

--- a/tests/bats/unit/railway/test_deploy_ghcr.bats
+++ b/tests/bats/unit/railway/test_deploy_ghcr.bats
@@ -136,3 +136,89 @@ EOF
 	assert_failure
 	assert_output --partial "serviceInstanceDeployV2 failed"
 }
+
+@test "deploy-ghcr: graphql-only fails when pre-deploy deployment query returns errors" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+
+	cat >"${mock_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+payload=""
+while (($# > 0)); do
+	if [[ "$1" == "-d" && $# -ge 2 ]]; then
+		payload="$2"
+		shift 2
+	else
+		shift
+	fi
+done
+if [[ "${payload}" == *"deployments"* ]]; then
+	echo '{"errors":[{"message":"deployments query failed"}]}'
+else
+	echo '{"data":{}}'
+fi
+EOF
+	chmod +x "${mock_bin}/curl"
+
+	run bash -c "
+		PATH='${mock_bin}:'\"\${PATH}\" \
+		RAILWAY_TOKEN='test-token' \
+		bash '${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh' --graphql-only
+	"
+
+	assert_failure
+	assert_output --partial "Failed to query latest deployment before deploy"
+}
+
+@test "deploy-ghcr: graphql-only fails when polling deployment query returns errors" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	local counter_file="${BATS_TEST_TMPDIR}/curl_calls"
+	mkdir -p "${mock_bin}"
+	echo "0" >"${counter_file}"
+
+	cat >"${mock_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+payload=""
+while (($# > 0)); do
+	if [[ "$1" == "-d" && $# -ge 2 ]]; then
+		payload="$2"
+		shift 2
+	else
+		shift
+	fi
+done
+if [[ -z "${COUNTER_FILE:-}" ]]; then
+	echo "COUNTER_FILE must be set" >&2
+	exit 1
+fi
+count="$(cat "${COUNTER_FILE}")"
+count=$((count + 1))
+echo "${count}" >"${COUNTER_FILE}"
+if [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
+	echo '{"data":{"serviceInstanceUpdate":true}}'
+elif [[ "${payload}" == *"serviceInstanceDeployV2"* ]]; then
+	echo '{"data":{"serviceInstanceDeployV2":true}}'
+elif [[ "${payload}" == *"deployments"* ]]; then
+	if [[ "${count}" -le 1 ]]; then
+		echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
+	else
+		echo '{"errors":[{"message":"polling query failed"}]}'
+	fi
+else
+	echo '{"data":{}}'
+fi
+EOF
+	chmod +x "${mock_bin}/curl"
+
+	run bash -c "
+		PATH='${mock_bin}:'\"\${PATH}\" \
+		COUNTER_FILE='${counter_file}' \
+		RAILWAY_TOKEN='test-token' \
+		DEPLOY_ID_REGISTER_TIMEOUT='5' \
+		DEPLOY_ID_REGISTER_INTERVAL='1' \
+		bash '${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh' --graphql-only
+	"
+
+	assert_failure
+	assert_output --partial "Failed to query deployment status during polling"
+}

--- a/tests/bats/unit/railway/test_deploy_ghcr.bats
+++ b/tests/bats/unit/railway/test_deploy_ghcr.bats
@@ -99,3 +99,40 @@ EOF
 	assert_failure
 	assert_output --partial "serviceInstanceUpdate failed"
 }
+
+@test "deploy-ghcr: graphql-only fails when serviceInstanceDeployV2 returns errors" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+
+	cat >"${mock_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+payload=""
+while (($# > 0)); do
+	if [[ "$1" == "-d" && $# -ge 2 ]]; then
+		payload="$2"
+		shift 2
+	else
+		shift
+	fi
+done
+if [[ "${payload}" == *"deployments"* ]]; then
+	echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
+elif [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
+	echo '{"data":{"serviceInstanceUpdate":true}}'
+elif [[ "${payload}" == *"serviceInstanceDeployV2"* ]]; then
+	echo '{"errors":[{"message":"deploy failed"}]}'
+else
+	echo '{"data":{}}'
+fi
+EOF
+	chmod +x "${mock_bin}/curl"
+
+	run bash -c "
+		PATH='${mock_bin}:'\"\${PATH}\" \
+		RAILWAY_TOKEN='test-token' \
+		bash '${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh' --graphql-only
+	"
+
+	assert_failure
+	assert_output --partial "serviceInstanceDeployV2 failed"
+}

--- a/tests/bats/unit/railway/test_deploy_ghcr.bats
+++ b/tests/bats/unit/railway/test_deploy_ghcr.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/railway/deploy-ghcr.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+	clear_railway_tokens
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	touch "${GITHUB_OUTPUT}"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "deploy-ghcr: --help exits successfully" {
+	run bash "${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh" --help
+
+	assert_success
+	assert_output --partial "RAILWAY_TOKEN or RAILWAY_API_TOKEN"
+}
+
+@test "deploy-ghcr: fails when token is missing" {
+	run bash "${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh" --graphql-only
+
+	assert_failure
+	assert_output --partial "RAILWAY_TOKEN or RAILWAY_API_TOKEN is required"
+}
+
+@test "deploy-ghcr: rejects invalid DEPLOY_ID_REGISTER_INTERVAL" {
+	run env \
+		RAILWAY_TOKEN="test-token" \
+		DEPLOY_ID_REGISTER_INTERVAL="0" \
+		bash "${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh" --graphql-only
+
+	assert_failure
+	assert_output --partial "DEPLOY_ID_REGISTER_INTERVAL must be a positive integer"
+}
+
+@test "deploy-ghcr: graphql-only triggers deploy and writes deployment_id" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	local counter_file="${BATS_TEST_TMPDIR}/curl_calls"
+	mkdir -p "${mock_bin}"
+	echo "0" >"${counter_file}"
+	cp "${PROJECT_ROOT}/tests/bats/fixtures/railway/mock-curl-deploy.sh" "${mock_bin}/curl"
+	chmod +x "${mock_bin}/curl"
+
+	run bash -c "
+		PATH='${mock_bin}:'\"\${PATH}\" \
+		COUNTER_FILE='${counter_file}' \
+		RAILWAY_TOKEN='test-token' \
+		DEPLOY_ID_REGISTER_TIMEOUT='5' \
+		DEPLOY_ID_REGISTER_INTERVAL='1' \
+		GITHUB_OUTPUT='${GITHUB_OUTPUT}' \
+		bash '${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh' --graphql-only
+	"
+
+	assert_success
+	assert_output --partial "Railway deploy triggered"
+	assert_equal "new-deploy" "$(get_github_output deployment_id)"
+}
+
+@test "deploy-ghcr: graphql-only fails when serviceInstanceUpdate returns errors" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+
+	cat >"${mock_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+payload=""
+while (($# > 0)); do
+	if [[ "$1" == "-d" && $# -ge 2 ]]; then
+		payload="$2"
+		shift 2
+	else
+		shift
+	fi
+done
+if [[ "${payload}" == *"deployments"* ]]; then
+	echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
+elif [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
+	echo '{"errors":[{"message":"update failed"}]}'
+else
+	echo '{"data":{}}'
+fi
+EOF
+	chmod +x "${mock_bin}/curl"
+
+	run bash -c "
+		PATH='${mock_bin}:'\"\${PATH}\" \
+		RAILWAY_TOKEN='test-token' \
+		bash '${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh' --graphql-only
+	"
+
+	assert_failure
+	assert_output --partial "serviceInstanceUpdate failed"
+}

--- a/tests/bats/unit/railway/test_dry_run_deploy.bats
+++ b/tests/bats/unit/railway/test_dry_run_deploy.bats
@@ -6,6 +6,7 @@ load "../../helpers/common"
 
 setup() {
 	setup_temp_dir
+	clear_railway_tokens
 }
 
 teardown() {

--- a/tests/bats/unit/railway/test_dry_run_deploy.bats
+++ b/tests/bats/unit/railway/test_dry_run_deploy.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/railway/dry-run-deploy.sh
+
+load "../../helpers/common"
+
+setup() {
+	setup_temp_dir
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "dry-run-deploy: prints planned deploy details" {
+	run env \
+		RAILWAY_IMAGE="ghcr.io/lgtm-hq/rustume:main" \
+		RAILWAY_SERVICE_ID="service-123" \
+		RAILWAY_ENVIRONMENT_ID="env-456" \
+		RAILWAY_PROJECT_ID="project-789" \
+		bash "${RAILWAY_SCRIPTS_DIR}/dry-run-deploy.sh"
+
+	assert_success
+	assert_output --partial "DRY RUN"
+	assert_output --partial "ghcr.io/lgtm-hq/rustume:main"
+	assert_output --partial "service-123"
+}
+
+@test "dry-run-deploy: fails when RAILWAY_IMAGE is missing" {
+	run bash "${RAILWAY_SCRIPTS_DIR}/dry-run-deploy.sh"
+
+	assert_failure
+	assert_output --partial "RAILWAY_IMAGE is required"
+}

--- a/tests/bats/unit/railway/test_poll_deploy_status.bats
+++ b/tests/bats/unit/railway/test_poll_deploy_status.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/railway/poll-deploy-status.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+	clear_railway_tokens
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "poll-deploy-status: fails when token is missing" {
+	run bash "${RAILWAY_SCRIPTS_DIR}/poll-deploy-status.sh"
+
+	assert_failure
+	assert_output --partial "RAILWAY_TOKEN or RAILWAY_API_TOKEN is required"
+}
+
+@test "poll-deploy-status: rejects invalid DEPLOY_POLL_INTERVAL" {
+	run env \
+		RAILWAY_TOKEN="test-token" \
+		RAILWAY_DEPLOYMENT_ID="deploy-1" \
+		DEPLOY_POLL_INTERVAL="0" \
+		bash "${RAILWAY_SCRIPTS_DIR}/poll-deploy-status.sh"
+
+	assert_failure
+	assert_output --partial "DEPLOY_POLL_INTERVAL must be a positive integer"
+}
+
+@test "poll-deploy-status: exits 0 when deployment succeeds" {
+	mock_command_script "curl" '
+payload=""
+while (($# > 0)); do
+	if [[ "$1" == "-d" && $# -ge 2 ]]; then
+		payload="$2"
+		shift 2
+	else
+		shift
+	fi
+done
+echo "{\"data\":{\"deployment\":{\"status\":\"SUCCESS\"}}}"
+'
+
+	run env \
+		PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
+		RAILWAY_TOKEN="test-token" \
+		RAILWAY_DEPLOYMENT_ID="deploy-1" \
+		DEPLOY_POLL_TIMEOUT="30" \
+		DEPLOY_POLL_INTERVAL="1" \
+		bash "${RAILWAY_SCRIPTS_DIR}/poll-deploy-status.sh"
+
+	assert_success
+	assert_output --partial "Deployment succeeded"
+}
+
+@test "poll-deploy-status: exits 1 when deployment fails" {
+	mock_command_script "curl" '
+payload=""
+while (($# > 0)); do
+	if [[ "$1" == "-d" && $# -ge 2 ]]; then
+		payload="$2"
+		shift 2
+	else
+		shift
+	fi
+done
+echo "{\"data\":{\"deployment\":{\"status\":\"FAILED\"}}}"
+'
+
+	run env \
+		PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
+		RAILWAY_TOKEN="test-token" \
+		RAILWAY_DEPLOYMENT_ID="deploy-1" \
+		DEPLOY_POLL_TIMEOUT="30" \
+		DEPLOY_POLL_INTERVAL="1" \
+		bash "${RAILWAY_SCRIPTS_DIR}/poll-deploy-status.sh"
+
+	assert_failure
+	assert_output --partial "Deployment FAILED"
+}
+
+@test "poll-deploy-status: times out when status never completes" {
+	mock_command_script "curl" '
+payload=""
+while (($# > 0)); do
+	if [[ "$1" == "-d" && $# -ge 2 ]]; then
+		payload="$2"
+		shift 2
+	else
+		shift
+	fi
+done
+echo "{\"data\":{\"deployment\":{\"status\":\"BUILDING\"}}}"
+'
+
+	run env \
+		PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
+		RAILWAY_TOKEN="test-token" \
+		RAILWAY_DEPLOYMENT_ID="deploy-1" \
+		DEPLOY_POLL_TIMEOUT="2" \
+		DEPLOY_POLL_INTERVAL="1" \
+		bash "${RAILWAY_SCRIPTS_DIR}/poll-deploy-status.sh"
+
+	assert_failure
+	assert_output --partial "Timeout after 2s"
+}

--- a/tests/bats/unit/railway/test_poll_deploy_status.bats
+++ b/tests/bats/unit/railway/test_poll_deploy_status.bats
@@ -49,7 +49,6 @@ echo "{\"data\":{\"deployment\":{\"status\":\"SUCCESS\"}}}"
 '
 
 	run env \
-		PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
 		RAILWAY_TOKEN="test-token" \
 		RAILWAY_DEPLOYMENT_ID="deploy-1" \
 		DEPLOY_POLL_TIMEOUT="30" \
@@ -75,7 +74,6 @@ echo "{\"data\":{\"deployment\":{\"status\":\"FAILED\"}}}"
 '
 
 	run env \
-		PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
 		RAILWAY_TOKEN="test-token" \
 		RAILWAY_DEPLOYMENT_ID="deploy-1" \
 		DEPLOY_POLL_TIMEOUT="30" \
@@ -101,7 +99,6 @@ echo "{\"data\":{\"deployment\":{\"status\":\"BUILDING\"}}}"
 '
 
 	run env \
-		PATH="${BATS_TEST_TMPDIR}/bin:${PATH}" \
 		RAILWAY_TOKEN="test-token" \
 		RAILWAY_DEPLOYMENT_ID="deploy-1" \
 		DEPLOY_POLL_TIMEOUT="2" \

--- a/tests/bats/unit/railway/test_update_github_deployment_status.bats
+++ b/tests/bats/unit/railway/test_update_github_deployment_status.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/railway/update-github-deployment-status.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export GITHUB_REPOSITORY="lgtm-hq/Rustume"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "update-github-deployment-status: posts success status with environment URL" {
+	mock_command_script "gh" '
+if [[ "$1" == "api" ]]; then
+  echo "ok"
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+'
+
+	run env \
+		DEPLOY_ID="99" \
+		DEPLOY_STATE="success" \
+		DEPLOY_ENVIRONMENT_URL="https://app.rustume.com" \
+		DEPLOY_DESCRIPTION="Deployed to Railway" \
+		bash "${RAILWAY_SCRIPTS_DIR}/update-github-deployment-status.sh"
+
+	assert_success
+	assert_output --partial "ok"
+}
+
+@test "update-github-deployment-status: fails when DEPLOY_ID is missing" {
+	run env DEPLOY_STATE="failure" bash "${RAILWAY_SCRIPTS_DIR}/update-github-deployment-status.sh"
+
+	assert_failure
+	assert_output --partial "DEPLOY_ID is required"
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(ci): add BATS tests for Railway deploy scripts
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds BATS coverage and CI for the Railway deploy shell scripts merged in #301.
Also hardens deploy ID polling error handling and early validation of register
poll env vars.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`bash scripts/ci/railway/test.sh`; shellcheck/shfmt/actionlint clean on changed paths)

## Closes

- Relates to #299

## Details

### Changes

- **BATS tests** (`tests/bats/unit/railway/`) — 17 tests covering `deploy-ghcr.sh`,
  `poll-deploy-status.sh`, `dry-run-deploy.sh`, and GitHub Deployment helper scripts
  with mocked `curl`/`gh`
- **Local runner** — `scripts/ci/railway/test.sh` clears inherited `RAILWAY_*` tokens
- **CI workflow** — `.github/workflows/test-railway-shell.yml` via `reusable-test-shell`
- **Script hardening** — fail fast on deployment lookup errors during polling; validate
  `DEPLOY_ID_REGISTER_*` before GraphQL calls

### Test plan

- [x] `bash scripts/ci/railway/test.sh` — 17/17 pass
- [x] CodeRabbit + Greptile pre-push review (critical/major findings addressed)
- [ ] CI: `test-railway-shell.yml` passes on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated CI workflow to run Railway deployment BATS coverage on relevant changes.

* **Bug Fixes**
  * Improved Railway GraphQL deploy reliability with stricter validation and fail-fast behavior.
  * Updated Railway Cloud deploy handling so GitHub Deployment status is recorded on cancellations.
  * Expanded Harden Runner egress allowlist for additional GitHub endpoints.

* **Tests**
  * Added/extended BATS unit tests, fixtures, and shared helper utilities for Railway scripts.

* **Documentation**
  * Updated CI workflow documentation and enhanced Railway Cloud deployment instructions with post-merge validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds BATS test coverage for the Railway deploy shell scripts introduced in #301, wires up a CI workflow to run them, and hardens two failure paths in `deploy-ghcr.sh`: fail-fast when `fetch_latest_deployment_id` errors during polling, and early validation of `DEPLOY_ID_REGISTER_*` env vars before any GraphQL calls. A companion fix in the deploy workflow ensures cancelled runs also mark the GitHub Deployment as failed.

- **BATS tests** (`tests/bats/unit/railway/`) — 17 tests across 5 files covering the deploy, poll, dry-run, and GitHub Deployment helper scripts with counter-based `curl`/`gh` mocks; shared helpers in `tests/bats/helpers/` provide mock infrastructure and teardown utilities.
- **Script hardening** (`deploy-ghcr.sh`) — `wait_for_new_deployment_id` now returns 1 on `fetch_latest_deployment_id` failure (previously the error was swallowed); `deploy_via_graphql` validates TIMEOUT/INTERVAL env vars before making API calls and propagates wait errors with `exit 1`.
- **CI/workflow fixes** — new `test-railway-shell.yml` workflow; `deploy-railway-cloud.yml` adds missing egress entries (`github.com`, `codeload.github.com`) and extends the GitHub Deployment update step to fire on cancellation as well as failure.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive tests, infrastructure plumbing, and targeted hardening of existing error paths with no regressions in core deploy logic.

The new error-handling paths in deploy-ghcr.sh are exercised end-to-end by dedicated BATS tests (pre-deploy fetch error, polling error, both mutation errors, success path). The workflow changes are narrow (added egress entries, cancellation guard for deployment status). No existing behavior is altered except that failures during ID polling and cancellations now propagate correctly instead of being silently swallowed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/railway/deploy-ghcr.sh | Adds fail-fast error handling for polling and pre-deploy fetches, plus early DEPLOY_ID_REGISTER_* validation in deploy_via_graphql; local variable declarations and logic are correct. |
| tests/bats/unit/railway/test_deploy_ghcr.bats | Comprehensive tests covering all new error-handling paths (pre-deploy fetch error, polling error, mutation errors) alongside the success path; counter-based fixture reuse is correct. |
| tests/bats/fixtures/railway/mock-curl-deploy.sh | Counter-based curl fixture with call-order documentation comment added; routes payload by query type before consulting counter, so mutation calls don't shift the deployments-query boundary. |
| tests/bats/helpers/mocks.bash | New mock_command and mock_command_script helpers correctly deduplicate PATH prepend and write mock executables; save_path/restore_path allow per-test PATH isolation. |
| .github/workflows/test-railway-shell.yml | New workflow correctly pins the reusable action to a commit SHA, restricts permissions, uses concurrency cancellation, and documents why coverage-threshold is 0. |
| .github/workflows/deploy-railway-cloud.yml | Adds missing egress allowlist entries and extends the failure deployment-status update to also fire on cancellation; both changes are correct. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as deploy-railway-cloud.yml
    participant S as deploy-ghcr.sh
    participant R as Railway GraphQL API
    participant G as GitHub Deployments API

    W->>G: create-github-deployment.sh (DEPLOY_REF)
    G-->>W: deployment.id

    W->>S: --graphql-only
    S->>S: validate DEPLOY_ID_REGISTER_TIMEOUT/INTERVAL (early, before API calls)
    S->>R: fetch_latest_deployment_id (pre-deploy)
    alt fetch fails
        R-->>S: errors[]
        S-->>W: exit 1 "Failed to query latest deployment before deploy"
    end
    R-->>S: previous_deployment_id

    S->>R: serviceInstanceUpdate (set image)
    alt update fails
        R-->>S: errors[]
        S-->>W: exit 1 "serviceInstanceUpdate failed"
    end

    S->>R: serviceInstanceDeployV2 (trigger deploy)
    alt deploy fails
        R-->>S: errors[]
        S-->>W: exit 1 "serviceInstanceDeployV2 failed"
    end

    loop poll until new deployment_id or timeout
        S->>R: fetch_latest_deployment_id
        alt fetch fails
            R-->>S: errors[]
            S-->>W: exit 1 "Failed to query deployment status during polling"
        end
        R-->>S: deployment_id
    end

    S-->>W: deployment_id (GITHUB_OUTPUT)

    alt success()
        W->>G: "update-github-deployment-status.sh (state=success)"
    else failure() OR cancelled()
        W->>G: "update-github-deployment-status.sh (state=failure)"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as deploy-railway-cloud.yml
    participant S as deploy-ghcr.sh
    participant R as Railway GraphQL API
    participant G as GitHub Deployments API

    W->>G: create-github-deployment.sh (DEPLOY_REF)
    G-->>W: deployment.id

    W->>S: --graphql-only
    S->>S: validate DEPLOY_ID_REGISTER_TIMEOUT/INTERVAL (early, before API calls)
    S->>R: fetch_latest_deployment_id (pre-deploy)
    alt fetch fails
        R-->>S: errors[]
        S-->>W: exit 1 "Failed to query latest deployment before deploy"
    end
    R-->>S: previous_deployment_id

    S->>R: serviceInstanceUpdate (set image)
    alt update fails
        R-->>S: errors[]
        S-->>W: exit 1 "serviceInstanceUpdate failed"
    end

    S->>R: serviceInstanceDeployV2 (trigger deploy)
    alt deploy fails
        R-->>S: errors[]
        S-->>W: exit 1 "serviceInstanceDeployV2 failed"
    end

    loop poll until new deployment_id or timeout
        S->>R: fetch_latest_deployment_id
        alt fetch fails
            R-->>S: errors[]
            S-->>W: exit 1 "Failed to query deployment status during polling"
        end
        R-->>S: deployment_id
    end

    S-->>W: deployment_id (GITHUB_OUTPUT)

    alt success()
        W->>G: "update-github-deployment-status.sh (state=success)"
    else failure() OR cancelled()
        W->>G: "update-github-deployment-status.sh (state=failure)"
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): satisfy yamllint line-length on..."](https://github.com/lgtm-hq/rustume/commit/9a993ceb724024f37e564adc6bff5730aef70670) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37951306)</sub>

<!-- /greptile_comment -->