### PR TITLE
fix(ci): resolve shell test flake and kcov include-path error

### DIFF
--- a/tests/bats/unit/railway/test_create_github_deployment.bats
+++ b/tests/bats/unit/railway/test_create_github_deployment.bats
@@ -21,6 +21,7 @@ teardown() {
 @test "create-github-deployment: writes deployment id to GITHUB_OUTPUT" {
 	mock_command_script "gh" '
 if [[ "$1" == "api" ]]; then
+  cat >/dev/null
   echo "424242"
   exit 0
 fi


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): resolve shell test flake and kcov include-path error
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Fixes two issues that left `Test - Railway Shell Scripts` failing on `main` after #302 merged:

1. **Broken pipe flake** — The mock `gh` script in `test_create_github_deployment.bats` now drains stdin (`cat >/dev/null`) before responding. `create-github-deployment.sh` pipes jq output into `gh api --input -`, so the mock must consume stdin to avoid a timing-sensitive broken pipe under kcov.
2. **kcov include-path error** — Added `scripts/ci/lib/.gitkeep` because the reusable shell test workflow hardcodes `scripts/ci/lib` as the kcov include path (no `kcov-include-path` input is available in `reusable-test-shell.yml` v0.45.1).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`scripts/ci/railway/test.sh` and `uv run lintro chk`)

## Closes

- Closes #305

## Details

### Testing strategy

- `scripts/ci/railway/test.sh` — 19/19 pass locally
- `uv run lintro chk` — zero lint issues

### AI review notes

- **Greptile**: Safe to merge (4/5 confidence); findings are pre-existing P2 items in `deploy-ghcr.sh` from #302, out of scope for this fix.
- **CodeRabbit**: Suggested additional test coverage and validation improvements across #302 files; deferred to follow-up issues since this PR is scoped to the CI failures in #305.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mock configuration for GitHub deployment test to properly handle standard input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two CI failures introduced by #302: a timing-sensitive broken-pipe flake in the bats mock for `gh api`, and a missing directory that kcov requires as a hardcoded include path.

- **Broken-pipe fix**: The mock `gh api` handler in `test_create_github_deployment.bats` now calls `cat >/dev/null` to drain `jq`'s piped stdin before echoing the response, preventing SIGPIPE from propagating through the `set -euo pipefail` pipeline under kcov instrumentation.
- **kcov include-path fix**: `scripts/ci/lib/.gitkeep` is added so git tracks the directory that `reusable-test-shell.yml` v0.45.1 unconditionally passes to kcov's `--include-path` option.
</details>

<h3>Confidence Score: 5/5</h3>

Both changes are safe to merge — one is a trivial empty placeholder file, the other is a one-line stdin-drain addition to a test mock with no production-code impact.

The mock fix is mechanically correct: `cat >/dev/null` fully drains jq's pipe before the mock exits, matching exactly how the real `gh api --input -` would consume its stdin. The `.gitkeep` file is a no-op at runtime and only exists to satisfy kcov's directory check. Neither change touches production paths or alters observable script behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/.gitkeep | Empty placeholder file added to ensure scripts/ci/lib/ is tracked by git, satisfying the hardcoded kcov include-path in reusable-test-shell.yml v0.45.1. |
| tests/bats/unit/railway/test_create_github_deployment.bats | Adds `cat >/dev/null` to the mock `gh api` branch so stdin is fully drained before the mock exits, eliminating a timing-sensitive broken-pipe failure when jq pipes into the mock under kcov. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant jq
    participant gh as mock gh (fixed)
    participant script as create-github-deployment.sh

    script->>jq: "jq -nc '{ref, environment, ...}'"
    jq-->>gh: JSON payload (via stdin pipe)
    Note over gh: cat >/dev/null — drain stdin<br/>prevents broken pipe under kcov
    gh-->>script: echo "424242" (mocked .id)
    script->>script: "echo "id=424242" >> $GITHUB_OUTPUT"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant jq
    participant gh as mock gh (fixed)
    participant script as create-github-deployment.sh

    script->>jq: "jq -nc '{ref, environment, ...}'"
    jq-->>gh: JSON payload (via stdin pipe)
    Note over gh: cat >/dev/null — drain stdin<br/>prevents broken pipe under kcov
    gh-->>script: echo "424242" (mocked .id)
    script->>script: "echo "id=424242" >> $GITHUB_OUTPUT"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): add scripts/ci/lib for kcov inc..."](https://github.com/lgtm-hq/rustume/commit/0ce2e34c7047805f98d2ec24538e9edbdf28f3c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38350622)</sub>

<!-- /greptile_comment -->