### PR TITLE
feat(cloud): require authentication on hosted Rustume Cloud

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { onCleanup, onMount, createSignal, Show, type ParentComponent } from "solid-js";
 import { AppShell } from "./components/layout/AppShell";
 import { CloudImportPrompt } from "./components/Auth/CloudImportPrompt";
+import { RequireAuthGuard } from "./components/Auth/RequireAuthGuard";
 import { Button, ToastRegion } from "./components/ui";
 import { authStore } from "./stores/auth";
 import { handleAuthQueryParams } from "./lib/authFeedback";
@@ -60,7 +61,9 @@ const App: ParentComponent = (props) => {
           </div>
         </div>
       </Show>
-      <AppShell>{props.children}</AppShell>
+      <RequireAuthGuard>
+        <AppShell>{props.children}</AppShell>
+      </RequireAuthGuard>
       <CloudImportPrompt />
       <ToastRegion />
     </div>

--- a/apps/web/src/api/__tests__/auth.test.ts
+++ b/apps/web/src/api/__tests__/auth.test.ts
@@ -100,4 +100,14 @@ describe("probeAuth", () => {
       requireAuth: true,
     });
   });
+
+  it("rejects invalid authenticated /auth/me payloads", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => null,
+    });
+
+    await expect(probeAuth()).rejects.toThrow(/invalid \/auth\/me response/i);
+  });
 });

--- a/apps/web/src/api/__tests__/auth.test.ts
+++ b/apps/web/src/api/__tests__/auth.test.ts
@@ -57,6 +57,27 @@ describe("probeAuth", () => {
         first_name: "Grace",
         last_name: "Hopper",
       },
+      requireAuth: false,
+    });
+  });
+
+  it("maps require_auth from authenticated /auth/me", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "user-1",
+        plan: "free",
+        require_auth: true,
+      }),
+    });
+
+    const result = await probeAuth();
+
+    expect(result).toEqual({
+      mode: "cloud",
+      user: { id: "user-1", plan: "free" },
+      requireAuth: true,
     });
   });
 
@@ -67,8 +88,16 @@ describe("probeAuth", () => {
   });
 
   it("returns signed-out cloud mode on 401", async () => {
-    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "Not authenticated", require_auth: true }),
+    });
 
-    await expect(probeAuth()).resolves.toEqual({ mode: "cloud", user: null });
+    await expect(probeAuth()).resolves.toEqual({
+      mode: "cloud",
+      user: null,
+      requireAuth: true,
+    });
   });
 });

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -18,6 +18,34 @@ function parseRequireAuth(payload: unknown): boolean {
   return (payload as { require_auth?: boolean }).require_auth === true;
 }
 
+function parseAuthUserPayload(payload: unknown): { user: AuthUser; requireAuth: boolean } {
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("Auth probe failed: invalid /auth/me response");
+  }
+
+  const record = payload as Record<string, unknown>;
+  const id = record.id;
+  const plan = record.plan;
+
+  if (typeof id !== "string" || typeof plan !== "string") {
+    throw new Error("Auth probe failed: invalid /auth/me response");
+  }
+
+  const user: AuthUser = { id, plan };
+
+  if (typeof record.email === "string") {
+    user.email = record.email;
+  }
+  if (typeof record.first_name === "string") {
+    user.first_name = record.first_name;
+  }
+  if (typeof record.last_name === "string") {
+    user.last_name = record.last_name;
+  }
+
+  return { user, requireAuth: record.require_auth === true };
+}
+
 /** Build a display label from profile fields, falling back to email or a generic label. */
 export function userDisplayName(
   user: Pick<AuthUser, "email" | "first_name" | "last_name">,
@@ -49,12 +77,12 @@ export async function probeAuth(): Promise<AuthProbeResult> {
     throw new Error(`Auth probe failed (${response.status})`);
   }
 
-  const payload = (await response.json()) as AuthUser & { require_auth?: boolean };
-  const { require_auth: requireAuthRaw, ...user } = payload;
+  const payload = await response.json();
+  const { user, requireAuth } = parseAuthUserPayload(payload);
   return {
     mode: "cloud",
-    user: user as AuthUser,
-    requireAuth: requireAuthRaw === true,
+    user,
+    requireAuth,
   };
 }
 

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -6,7 +6,17 @@ export interface AuthUser {
   last_name?: string;
 }
 
-export type AuthProbeResult = { mode: "self-hosted" } | { mode: "cloud"; user: AuthUser | null };
+export type AuthProbeResult =
+  | { mode: "self-hosted" }
+  | { mode: "cloud"; user: AuthUser | null; requireAuth: boolean };
+
+function parseRequireAuth(payload: unknown): boolean {
+  if (typeof payload !== "object" || payload === null) {
+    return false;
+  }
+
+  return (payload as { require_auth?: boolean }).require_auth === true;
+}
 
 /** Build a display label from profile fields, falling back to email or a generic label. */
 export function userDisplayName(
@@ -31,15 +41,21 @@ export async function probeAuth(): Promise<AuthProbeResult> {
   }
 
   if (response.status === 401) {
-    return { mode: "cloud", user: null };
+    const payload = await response.json().catch(() => ({}));
+    return { mode: "cloud", user: null, requireAuth: parseRequireAuth(payload) };
   }
 
   if (!response.ok) {
     throw new Error(`Auth probe failed (${response.status})`);
   }
 
-  const user = (await response.json()) as AuthUser;
-  return { mode: "cloud", user };
+  const payload = (await response.json()) as AuthUser & { require_auth?: boolean };
+  const { require_auth: requireAuthRaw, ...user } = payload;
+  return {
+    mode: "cloud",
+    user: user as AuthUser,
+    requireAuth: requireAuthRaw === true,
+  };
 }
 
 export function login(): void {

--- a/apps/web/src/components/Auth/AuthMenu.tsx
+++ b/apps/web/src/components/Auth/AuthMenu.tsx
@@ -14,6 +14,8 @@ export function AuthMenu() {
     signIn();
   };
 
+  const showSignedOutSignIn = () => state.cloudEnabled && !state.requireAuth && !state.user;
+
   return (
     <Show
       when={!state.loading}
@@ -23,9 +25,11 @@ export function AuthMenu() {
         <Show
           when={state.user}
           fallback={
-            <Button variant="secondary" size="sm" onClick={handleSignIn} loading={signingIn()}>
-              Sign in to Cloud
-            </Button>
+            <Show when={showSignedOutSignIn()}>
+              <Button variant="secondary" size="sm" onClick={handleSignIn} loading={signingIn()}>
+                Sign in to Cloud
+              </Button>
+            </Show>
           }
         >
           {(user) => (

--- a/apps/web/src/components/Auth/RequireAuthGuard.tsx
+++ b/apps/web/src/components/Auth/RequireAuthGuard.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from "@solidjs/router";
-import { createEffect, type ParentComponent } from "solid-js";
+import { createEffect, Show, type ParentComponent } from "solid-js";
 import { authStore } from "../../stores/auth";
+import { Spinner } from "../ui";
 
 const AUTH_PATH_PREFIX = "/auth/";
 
@@ -9,7 +10,7 @@ function isProtectedPath(pathname: string): boolean {
     return false;
   }
 
-  if (pathname === "/account") {
+  if (pathname === "/account" || pathname.startsWith("/account/")) {
     return false;
   }
 
@@ -38,5 +39,9 @@ export const RequireAuthGuard: ParentComponent = (props) => {
     navigate("/auth/login", { replace: true });
   });
 
-  return props.children;
+  return (
+    <Show when={!state.loading} fallback={<Spinner class="w-6 h-6 text-accent mx-auto mt-24" />}>
+      {props.children}
+    </Show>
+  );
 };

--- a/apps/web/src/components/Auth/RequireAuthGuard.tsx
+++ b/apps/web/src/components/Auth/RequireAuthGuard.tsx
@@ -23,16 +23,15 @@ export const RequireAuthGuard: ParentComponent = (props) => {
   const location = useLocation();
   const { state } = authStore;
 
+  const shouldBlock = () =>
+    !state.loading &&
+    state.cloudEnabled &&
+    state.requireAuth &&
+    !state.user &&
+    isProtectedPath(location.pathname);
+
   createEffect(() => {
-    if (state.loading) {
-      return;
-    }
-
-    if (!state.cloudEnabled || !state.requireAuth || state.user) {
-      return;
-    }
-
-    if (!isProtectedPath(location.pathname)) {
+    if (!shouldBlock()) {
       return;
     }
 
@@ -40,7 +39,12 @@ export const RequireAuthGuard: ParentComponent = (props) => {
   });
 
   return (
-    <Show when={!state.loading} fallback={<Spinner class="w-6 h-6 text-accent mx-auto mt-24" />}>
+    <Show
+      when={!state.loading && !shouldBlock()}
+      fallback={
+        <Spinner class="w-6 h-6 text-accent mx-auto mt-24" ariaLabel="Loading authentication" />
+      }
+    >
       {props.children}
     </Show>
   );

--- a/apps/web/src/components/Auth/RequireAuthGuard.tsx
+++ b/apps/web/src/components/Auth/RequireAuthGuard.tsx
@@ -1,0 +1,42 @@
+import { useLocation, useNavigate } from "@solidjs/router";
+import { createEffect, type ParentComponent } from "solid-js";
+import { authStore } from "../../stores/auth";
+
+const AUTH_PATH_PREFIX = "/auth/";
+
+function isProtectedPath(pathname: string): boolean {
+  if (pathname.startsWith(AUTH_PATH_PREFIX)) {
+    return false;
+  }
+
+  if (pathname === "/account") {
+    return false;
+  }
+
+  return true;
+}
+
+/** Redirect signed-out users to login when hosted require-auth mode is active. */
+export const RequireAuthGuard: ParentComponent = (props) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { state } = authStore;
+
+  createEffect(() => {
+    if (state.loading) {
+      return;
+    }
+
+    if (!state.cloudEnabled || !state.requireAuth || state.user) {
+      return;
+    }
+
+    if (!isProtectedPath(location.pathname)) {
+      return;
+    }
+
+    navigate("/auth/login", { replace: true });
+  });
+
+  return props.children;
+};

--- a/apps/web/src/components/Auth/__tests__/RequireAuthGuard.test.tsx
+++ b/apps/web/src/components/Auth/__tests__/RequireAuthGuard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@solidjs/testing-library";
 import { Route, Router } from "@solidjs/router";
 import { RequireAuthGuard } from "../RequireAuthGuard";
 
-const { mockAuthState, navigateMock } = vi.hoisted(() => ({
+const { mockAuthState, navigateMock, useLocationMock } = vi.hoisted(() => ({
   mockAuthState: {
     loading: false,
     cloudEnabled: true,
@@ -11,6 +11,13 @@ const { mockAuthState, navigateMock } = vi.hoisted(() => ({
     user: null as { id: string; plan: string } | null,
   },
   navigateMock: vi.fn(),
+  useLocationMock: vi.fn(() => ({
+    pathname: "/edit/resume-1",
+    search: "",
+    hash: "",
+    state: null,
+    query: {},
+  })),
 }));
 
 vi.mock("../../../stores/auth", () => ({
@@ -26,17 +33,19 @@ vi.mock("@solidjs/router", async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => navigateMock,
-    useLocation: () => ({
-      pathname: "/edit/resume-1",
-      search: "",
-      hash: "",
-      state: null,
-      query: {},
-    }),
+    useLocation: () => useLocationMock(),
   };
 });
 
-function renderGuard() {
+function renderGuard(pathname = "/edit/resume-1") {
+  useLocationMock.mockReturnValue({
+    pathname,
+    search: "",
+    hash: "",
+    state: null,
+    query: {},
+  });
+
   return render(() => (
     <Router>
       <Route
@@ -53,6 +62,7 @@ function renderGuard() {
 
 describe("RequireAuthGuard", () => {
   it("redirects signed-out users to login when require-auth mode is active", () => {
+    navigateMock.mockClear();
     mockAuthState.loading = false;
     mockAuthState.cloudEnabled = true;
     mockAuthState.requireAuth = true;
@@ -72,6 +82,67 @@ describe("RequireAuthGuard", () => {
     navigateMock.mockClear();
 
     renderGuard();
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect in self-hosted mode", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = false;
+    mockAuthState.requireAuth = false;
+    mockAuthState.user = null;
+    navigateMock.mockClear();
+
+    renderGuard();
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect when the user is signed in", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = true;
+    mockAuthState.user = { id: "user-1", plan: "free" };
+    navigateMock.mockClear();
+
+    renderGuard();
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("defers navigation while auth is loading", () => {
+    mockAuthState.loading = true;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = true;
+    mockAuthState.user = null;
+    navigateMock.mockClear();
+
+    renderGuard();
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
+  });
+
+  it("does not redirect on auth callback paths", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = true;
+    mockAuthState.user = null;
+    navigateMock.mockClear();
+
+    renderGuard("/auth/callback");
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect on account sub-routes", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = true;
+    mockAuthState.user = null;
+    navigateMock.mockClear();
+
+    renderGuard("/account/settings");
 
     expect(navigateMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/components/Auth/__tests__/RequireAuthGuard.test.tsx
+++ b/apps/web/src/components/Auth/__tests__/RequireAuthGuard.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { Route, Router } from "@solidjs/router";
+import { RequireAuthGuard } from "../RequireAuthGuard";
+
+const { mockAuthState, navigateMock } = vi.hoisted(() => ({
+  mockAuthState: {
+    loading: false,
+    cloudEnabled: true,
+    requireAuth: true,
+    user: null as { id: string; plan: string } | null,
+  },
+  navigateMock: vi.fn(),
+}));
+
+vi.mock("../../../stores/auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+  },
+}));
+
+vi.mock("@solidjs/router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solidjs/router")>();
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useLocation: () => ({
+      pathname: "/edit/resume-1",
+      search: "",
+      hash: "",
+      state: null,
+      query: {},
+    }),
+  };
+});
+
+function renderGuard() {
+  return render(() => (
+    <Router>
+      <Route
+        path="*"
+        component={() => (
+          <RequireAuthGuard>
+            <div data-testid="protected-content">Protected</div>
+          </RequireAuthGuard>
+        )}
+      />
+    </Router>
+  ));
+}
+
+describe("RequireAuthGuard", () => {
+  it("redirects signed-out users to login when require-auth mode is active", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = true;
+    mockAuthState.user = null;
+
+    renderGuard();
+
+    expect(navigateMock).toHaveBeenCalledWith("/auth/login", { replace: true });
+    expect(screen.getByTestId("protected-content")).toBeInTheDocument();
+  });
+
+  it("does not redirect when require-auth mode is disabled", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = false;
+    mockAuthState.user = null;
+    navigateMock.mockClear();
+
+    renderGuard();
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/Auth/__tests__/RequireAuthGuard.test.tsx
+++ b/apps/web/src/components/Auth/__tests__/RequireAuthGuard.test.tsx
@@ -71,6 +71,19 @@ describe("RequireAuthGuard", () => {
     renderGuard();
 
     expect(navigateMock).toHaveBeenCalledWith("/auth/login", { replace: true });
+    expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
+  });
+
+  it("shows protected content when the user is signed in", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = true;
+    mockAuthState.user = { id: "user-1", plan: "free" };
+    navigateMock.mockClear();
+
+    renderGuard();
+
+    expect(navigateMock).not.toHaveBeenCalled();
     expect(screen.getByTestId("protected-content")).toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -87,18 +87,21 @@ export default function Account() {
                     Sign in to Rustume Cloud
                   </h1>
                   <p class="text-stone text-sm max-w-md mx-auto mb-6">
-                    Sync resumes across devices with your Rustume Cloud account. Your local copies
-                    stay on this device until you choose to import them.
+                    {state.requireAuth
+                      ? "Sign in is required to use Rustume Cloud on this deployment."
+                      : "Sync resumes across devices with your Rustume Cloud account. Your local copies stay on this device until you choose to import them."}
                   </p>
                   <Button onClick={handleSignIn} loading={signingIn()}>
                     Sign in to Cloud
                   </Button>
-                  <p class="mt-4 text-xs text-stone">
-                    Prefer local-only?{" "}
-                    <A href="/" class="text-accent hover:underline">
-                      Continue without signing in
-                    </A>
-                  </p>
+                  <Show when={!state.requireAuth}>
+                    <p class="mt-4 text-xs text-stone">
+                      Prefer local-only?{" "}
+                      <A href="/" class="text-accent hover:underline">
+                        Continue without signing in
+                      </A>
+                    </p>
+                  </Show>
                 </div>
               }
             >

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -43,7 +43,8 @@ export default function Home() {
   const [renameValue, setRenameValue] = createSignal("");
   const [signingIn, setSigningIn] = createSignal(false);
 
-  const showCloudSignInCta = () => authState.cloudEnabled && !authState.loading && !authState.user;
+  const showCloudSignInCta = () =>
+    authState.cloudEnabled && !authState.requireAuth && !authState.loading && !authState.user;
 
   const handleCloudSignIn = () => {
     setSigningIn(true);

--- a/apps/web/src/pages/__tests__/Account.test.tsx
+++ b/apps/web/src/pages/__tests__/Account.test.tsx
@@ -7,6 +7,7 @@ const { mockAuthState, signInMock, signOutMock } = vi.hoisted(() => ({
   mockAuthState: {
     loading: false,
     cloudEnabled: true,
+    requireAuth: false,
     user: null as {
       id: string;
       plan: string;

--- a/apps/web/src/pages/__tests__/Account.test.tsx
+++ b/apps/web/src/pages/__tests__/Account.test.tsx
@@ -59,12 +59,28 @@ describe("Account page", () => {
   it("shows a sign-in CTA when cloud is enabled and the user is signed out", () => {
     mockAuthState.loading = false;
     mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = false;
     mockAuthState.user = null;
 
     renderAccount();
 
     expect(screen.getByText("Sign in to Rustume Cloud")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Sign in to Cloud" })).toBeInTheDocument();
+    expect(screen.getByText(/Continue without signing in/i)).toBeInTheDocument();
+  });
+
+  it("shows required-auth copy and hides local-only link when require-auth mode is active", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = true;
+    mockAuthState.user = null;
+
+    renderAccount();
+
+    expect(
+      screen.getByText(/Sign in is required to use Rustume Cloud on this deployment/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Continue without signing in/i)).not.toBeInTheDocument();
   });
 
   it("shows profile details when signed in", () => {

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -7,6 +7,7 @@ const { mockAuthState, signInMock } = vi.hoisted(() => ({
   mockAuthState: {
     loading: false,
     cloudEnabled: false,
+    requireAuth: false,
     user: null as { id: string; plan: string } | null,
   },
   signInMock: vi.fn(),
@@ -48,12 +49,24 @@ describe("Home cloud sign-in CTA", () => {
   it("shows the cloud banner when cloud is enabled and the user is signed out", () => {
     mockAuthState.loading = false;
     mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = false;
     mockAuthState.user = null;
 
     renderHome();
 
     expect(screen.getByTestId("home-cloud-sign-in")).toBeInTheDocument();
     expect(screen.getByText(/Working locally on this device/i)).toBeInTheDocument();
+  });
+
+  it("hides the cloud banner when hosted require-auth mode is active", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = true;
+    mockAuthState.user = null;
+
+    renderHome();
+
+    expect(screen.queryByTestId("home-cloud-sign-in")).not.toBeInTheDocument();
   });
 
   it("hides the cloud banner when the user is signed in", () => {

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -12,6 +12,7 @@ import {
 interface AuthState {
   loading: boolean;
   cloudEnabled: boolean;
+  requireAuth: boolean;
   user: AuthUser | null;
 }
 
@@ -19,16 +20,22 @@ function createAuthStore() {
   const [state, setState] = createStore<AuthState>({
     loading: true,
     cloudEnabled: false,
+    requireAuth: false,
     user: null,
   });
 
   function applyProbe(result: AuthProbeResult) {
     if (result.mode === "self-hosted") {
-      setState({ cloudEnabled: false, user: null, loading: false });
+      setState({ cloudEnabled: false, requireAuth: false, user: null, loading: false });
       return;
     }
 
-    setState({ cloudEnabled: true, user: result.user, loading: false });
+    setState({
+      cloudEnabled: true,
+      requireAuth: result.requireAuth,
+      user: result.user,
+      loading: false,
+    });
   }
 
   async function refresh() {
@@ -37,7 +44,7 @@ function createAuthStore() {
       applyProbe(await probeAuth());
     } catch (error) {
       console.error("Failed to probe auth:", error);
-      setState({ cloudEnabled: false, user: null, loading: false });
+      setState({ cloudEnabled: false, requireAuth: false, user: null, loading: false });
     }
   }
 

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -17,6 +17,7 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::config::MAX_BODY_SIZE;
+use crate::middleware::auth::require_auth_when_enabled;
 use crate::middleware::security::security_headers;
 use crate::observability::apply_sentry_layers;
 use crate::openapi::ApiDoc;
@@ -41,16 +42,23 @@ pub fn create_router_with_static_dir(dir: PathBuf) -> Router {
 pub fn create_router_with_state(state: AppState) -> Router {
     let cors = build_cors_layer();
 
-    let mut router = Router::new()
-        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
-        .route("/health", get(health))
-        .route("/metrics", get(metrics))
+    let billable_routes = Router::new()
         .route("/api/templates", get(list_templates))
         .route("/api/templates/{id}/thumbnail", get(template_thumbnail))
         .route("/api/parse", post(parse))
         .route("/api/render/pdf", post(render_pdf))
         .route("/api/render/preview", post(render_preview))
-        .route("/api/validate", post(validate));
+        .route("/api/validate", post(validate))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_auth_when_enabled,
+        ));
+
+    let mut router = Router::new()
+        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        .route("/health", get(health))
+        .route("/metrics", get(metrics))
+        .merge(billable_routes);
 
     if state.cloud.is_some() {
         router = router

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -111,6 +111,17 @@ pub fn cloud_enabled() -> bool {
             .is_some_and(|url| !url.trim().is_empty())
 }
 
+/// Returns `true` when hosted Rustume Cloud should reject anonymous billable API use.
+///
+/// Only meaningful when [`cloud_enabled`] is also true.
+pub fn require_auth_enabled() -> bool {
+    require_auth_from_env(cloud_enabled(), std::env::var("RUSTUME_REQUIRE_AUTH").ok())
+}
+
+fn require_auth_from_env(cloud: bool, value: Option<String>) -> bool {
+    cloud && matches!(value.as_deref().map(str::trim), Some("true" | "1"))
+}
+
 /// Shared cloud services (database, auth providers).
 #[derive(Clone)]
 pub struct CloudState {
@@ -147,4 +158,18 @@ pub async fn init_cloud(config: CloudConfig) -> anyhow::Result<Arc<CloudState>> 
         sessions,
         workos_redirect_uri,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_auth_from_env_requires_cloud_and_truthy_flag() {
+        assert!(!require_auth_from_env(false, Some("true".to_string())));
+        assert!(!require_auth_from_env(true, None));
+        assert!(!require_auth_from_env(true, Some("false".to_string())));
+        assert!(require_auth_from_env(true, Some("true".to_string())));
+        assert!(require_auth_from_env(true, Some("1".to_string())));
+    }
 }

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -221,6 +221,8 @@ impl AuthUserResponse {
     }
 }
 
+/// NOTE: `require_auth` is always `false` here. Prefer [`AuthUserResponse::from_user`] when the
+/// hosted require-auth flag must be propagated to the client.
 impl From<User> for AuthUserResponse {
     fn from(user: User) -> Self {
         Self::from_user(user, false)

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -221,14 +221,6 @@ impl AuthUserResponse {
     }
 }
 
-/// NOTE: `require_auth` is always `false` here. Prefer [`AuthUserResponse::from_user`] when the
-/// hosted require-auth flag must be propagated to the client.
-impl From<User> for AuthUserResponse {
-    fn from(user: User) -> Self {
-        Self::from_user(user, false)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -273,7 +265,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let json = serde_json::to_value(AuthUserResponse::from(user)).unwrap();
+        let json = serde_json::to_value(AuthUserResponse::from_user(user, false)).unwrap();
 
         assert!(json.get("email").is_none());
         assert!(json.get("first_name").is_none());

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -196,17 +196,34 @@ pub struct AuthUserResponse {
     /// Family name from WorkOS, when available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_name: Option<String>,
+    /// Whether billable routes require sign-in on this deployment.
+    pub require_auth: bool,
 }
 
-impl From<User> for AuthUserResponse {
-    fn from(user: User) -> Self {
+/// Signed-out probe payload returned by `GET /auth/me` with HTTP 401.
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+pub struct AuthMeUnauthorizedResponse {
+    pub error: String,
+    pub require_auth: bool,
+}
+
+impl AuthUserResponse {
+    /// Build a profile response with the hosted require-auth flag.
+    pub fn from_user(user: User, require_auth: bool) -> Self {
         Self {
             id: user.id,
             plan: user.plan,
             email: user.email,
             first_name: user.first_name,
             last_name: user.last_name,
+            require_auth,
         }
+    }
+}
+
+impl From<User> for AuthUserResponse {
+    fn from(user: User) -> Self {
+        Self::from_user(user, false)
     }
 }
 
@@ -229,7 +246,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let response = AuthUserResponse::from(user);
+        let response = AuthUserResponse::from_user(user, true);
         let json = serde_json::to_value(&response).unwrap();
 
         assert_eq!(json["id"], Uuid::nil().to_string());
@@ -237,6 +254,7 @@ mod tests {
         assert_eq!(json["email"], "dev@example.com");
         assert_eq!(json["first_name"], "Ada");
         assert_eq!(json["last_name"], "Lovelace");
+        assert_eq!(json["require_auth"], true);
     }
 
     #[test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -667,7 +667,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -617,4 +617,133 @@ mod tests {
             "strict-origin-when-cross-origin"
         );
     }
+
+    fn test_cloud_state() -> std::sync::Arc<cloud::CloudState> {
+        use auth::{session::SessionService, workos::WorkOsClient};
+        use sqlx::postgres::PgPoolOptions;
+
+        let pool = PgPoolOptions::new()
+            .connect_lazy("postgres://localhost/rustume_test")
+            .expect("lazy pool");
+        std::sync::Arc::new(cloud::CloudState {
+            db: pool.clone(),
+            workos: WorkOsClient::new("client_test".to_string(), "api_key_test".to_string()),
+            sessions: SessionService::new(
+                pool,
+                "test-session-secret-at-least-32-chars".to_string(),
+                false,
+            ),
+            workos_redirect_uri: "http://localhost/auth/callback".to_string(),
+        })
+    }
+
+    fn sample_render_pdf_request() -> RenderPdfRequest {
+        RenderPdfRequest {
+            resume: serde_json::to_value(ResumeData::default()).unwrap(),
+            template: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_render_pdf_anonymous_ok_when_require_auth_disabled() {
+        let state = state::AppState::with_require_auth(
+            std::sync::Arc::new(routes::static_dir()),
+            Some(test_cloud_state()),
+            false,
+        );
+        let app = create_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/render/pdf")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&sample_render_pdf_request()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_render_pdf_anonymous_401_when_require_auth_enabled() {
+        let state = state::AppState::with_require_auth(
+            std::sync::Arc::new(routes::static_dir()),
+            Some(test_cloud_state()),
+            true,
+        );
+        let app = create_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/render/pdf")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&sample_render_pdf_request()).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_templates_anonymous_401_when_require_auth_enabled() {
+        let state = state::AppState::with_require_auth(
+            std::sync::Arc::new(routes::static_dir()),
+            Some(test_cloud_state()),
+            true,
+        );
+        let app = create_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/templates")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_auth_me_includes_require_auth_when_signed_out() {
+        let state = state::AppState::with_require_auth(
+            std::sync::Arc::new(routes::static_dir()),
+            Some(test_cloud_state()),
+            true,
+        );
+        let app = create_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/auth/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let payload: db::AuthMeUnauthorizedResponse = serde_json::from_slice(&body).unwrap();
+        assert!(payload.require_auth);
+        assert_eq!(payload.error, "Not authenticated");
+    }
 }

--- a/crates/server/src/middleware/auth.rs
+++ b/crates/server/src/middleware/auth.rs
@@ -1,6 +1,11 @@
 //! Session cookie authentication extractor for cloud routes.
 
-use axum::{extract::FromRequestParts, http::request::Parts};
+use axum::{
+    extract::{FromRequestParts, Request, State},
+    http::request::Parts,
+    middleware::Next,
+    response::Response,
+};
 use axum_extra::extract::CookieJar;
 use tracing::error;
 
@@ -45,4 +50,19 @@ impl FromRequestParts<AppState> for AuthUser {
 
 fn unauthorized(message: &str) -> ApiError {
     ApiError::unauthorized(message)
+}
+
+/// Require a session on billable routes when hosted require-auth mode is enabled.
+pub async fn require_auth_when_enabled(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    if !state.require_auth {
+        return Ok(next.run(request).await);
+    }
+
+    let (mut parts, body) = request.into_parts();
+    AuthUser::from_request_parts(&mut parts, &state).await?;
+    Ok(next.run(Request::from_parts(parts, body)).await)
 }

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -5,9 +5,9 @@ use utoipa::Modify;
 use utoipa::OpenApi;
 
 use crate::db::{
-    AuthUserResponse, CreateResumeRequest, ImportFailure, ImportResumeItem, ImportResumesRequest,
-    ImportResumesResponse, PaginatedResumeSummaries, ResumeListQuery, ResumeRow, ResumeSummary,
-    UpdateResumeRequest,
+    AuthMeUnauthorizedResponse, AuthUserResponse, CreateResumeRequest, ImportFailure,
+    ImportResumeItem, ImportResumesRequest, ImportResumesResponse, PaginatedResumeSummaries,
+    ResumeListQuery, ResumeRow, ResumeSummary, UpdateResumeRequest,
 };
 use crate::dto::{
     ParseFormat, ParseRequest, RenderPdfRequest, RenderPreviewRequest, TemplateInfo, ThemeInfo,
@@ -68,6 +68,7 @@ impl Modify for CookieAuthAddon {
             ThemeInfo,
             ValidationResponse,
             AuthUserResponse,
+            AuthMeUnauthorizedResponse,
             ResumeSummary,
             PaginatedResumeSummaries,
             ResumeListQuery,

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -13,9 +13,8 @@ use uuid::Uuid;
 
 use crate::auth::session::SESSION_COOKIE;
 use crate::auth::workos::upsert_user;
-use crate::db::AuthUserResponse;
+use crate::db::{AuthMeUnauthorizedResponse, AuthUserResponse};
 use crate::error::ApiError;
-use crate::middleware::auth::AuthUser;
 use crate::state::AppState;
 
 const OAUTH_STATE_COOKIE: &str = "rustume_oauth_state";
@@ -163,13 +162,37 @@ pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> Result<Res
     tag = "Auth",
     responses(
         (status = 200, description = "Authenticated user", body = AuthUserResponse),
-        (status = 401, description = "Not authenticated", body = ApiError),
+        (status = 401, description = "Not authenticated", body = AuthMeUnauthorizedResponse),
         (status = 404, description = "Cloud auth not enabled", body = ApiError),
     ),
     security(("cookieAuth" = []))
 )]
-pub async fn me(AuthUser(user): AuthUser) -> Json<AuthUserResponse> {
-    Json(user.into())
+pub async fn me(State(state): State<AppState>, jar: CookieJar) -> Result<Response, ApiError> {
+    let cloud = state.cloud()?;
+    let require_auth = state.require_auth;
+
+    if let Some(cookie) = jar.get(SESSION_COOKIE) {
+        if let Some(user) = cloud
+            .sessions
+            .user_for_token(cookie.value())
+            .await
+            .map_err(|err| {
+                error!("session lookup failed: {err}");
+                ApiError::internal("internal server error")
+            })?
+        {
+            return Ok(Json(AuthUserResponse::from_user(user, require_auth)).into_response());
+        }
+    }
+
+    Ok((
+        StatusCode::UNAUTHORIZED,
+        Json(AuthMeUnauthorizedResponse {
+            error: "Not authenticated".to_string(),
+            require_auth,
+        }),
+    )
+        .into_response())
 }
 
 fn oauth_error_redirect(code: &'static str) -> Response {

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -11,6 +11,8 @@ pub struct AppState {
     pub static_dir: Arc<PathBuf>,
     pub cloud: Option<Arc<CloudState>>,
     pub renderer: Arc<TypstRenderer>,
+    /// When true, billable API routes require a valid session (hosted Rustume Cloud).
+    pub require_auth: bool,
 }
 
 impl AppState {
@@ -20,6 +22,22 @@ impl AppState {
             static_dir,
             cloud,
             renderer: Arc::new(TypstRenderer::new()),
+            require_auth: crate::cloud::require_auth_enabled(),
+        }
+    }
+
+    /// Build application state with an explicit require-auth flag (tests).
+    #[cfg(test)]
+    pub fn with_require_auth(
+        static_dir: Arc<PathBuf>,
+        cloud: Option<Arc<CloudState>>,
+        require_auth: bool,
+    ) -> Self {
+        Self {
+            static_dir,
+            cloud,
+            renderer: Arc::new(TypstRenderer::new()),
+            require_auth,
         }
     }
 

--- a/docs/operations/rustume-cloud-deploy.md
+++ b/docs/operations/rustume-cloud-deploy.md
@@ -194,7 +194,9 @@ Update on the `responsible-celebration` service:
 When `RUSTUME_REQUIRE_AUTH=true` and cloud mode is enabled, billable API routes
 (`/api/render/*`, `/api/parse`, `/api/validate`, `/api/templates*`) require a session cookie.
 The web app redirects signed-out users to `/auth/login`. Self-hosted deployments leave this
-unset so local IndexedDB use and optional anonymous API access continue to work.
+unset so local IndexedDB use and optional anonymous API access continue to work. The `/auth/me`
+endpoint returns HTTP 200 or 401 with a `require_auth` boolean so the frontend can discover the
+requirement before sign-in.
 
 Redeploy after changing env vars so the process picks up the new origin and callback.
 
@@ -210,10 +212,13 @@ that URL.
 ### Post-cutover verification
 
 1. `GET https://app.rustume.com/health` returns **200**.
-2. Anonymous requests to billable APIs return **401** when `RUSTUME_REQUIRE_AUTH=true`.
-3. WorkOS AuthKit sign-in completes on `app.rustume.com` (callback hits the new redirect URI).
-4. Docs site loads at `https://rustume.com` with valid HTTPS.
-5. GitHub **Deploy - GitHub Pages** workflow reports success against the custom domain URL.
+2. `GET https://app.rustume.com/auth/me` without session cookies returns **401** with
+   `require_auth: true` in the response body.
+3. Anonymous requests (no session cookie) to billable APIs return **401** when
+   `RUSTUME_REQUIRE_AUTH=true`.
+4. WorkOS AuthKit sign-in completes on `app.rustume.com` (callback hits the new redirect URI).
+5. Docs site loads at `https://rustume.com` with valid HTTPS.
+6. GitHub **Deploy - GitHub Pages** workflow reports success against the custom domain URL.
 
 ### Railway default domain
 

--- a/docs/operations/rustume-cloud-deploy.md
+++ b/docs/operations/rustume-cloud-deploy.md
@@ -86,6 +86,9 @@ Project: `rustume-cloud` (service historically named `responsible-celebration`).
    deploy workflow is the single deploy authority.
 7. Keep runtime variables unchanged (`RUSTUME_CLOUD`, `DATABASE_URL`, WorkOS, `SESSION_SECRET`,
    `CORS_ORIGIN`, observability secrets, etc.).
+8. Set **`RUSTUME_REQUIRE_AUTH=true`** on the hosted Railway service only (`app.rustume.com`).
+   Do **not** set this on local docker-compose or self-hosted examples — optional anonymous
+   use remains available when the flag is unset.
 
 ### Post-merge CI validation
 
@@ -186,6 +189,12 @@ Update on the `responsible-celebration` service:
 | --- | --- |
 | `CORS_ORIGIN` | `https://app.rustume.com` |
 | `WORKOS_REDIRECT_URI` | `https://app.rustume.com/auth/callback` |
+| `RUSTUME_REQUIRE_AUTH` | `true` (hosted production only) |
+
+When `RUSTUME_REQUIRE_AUTH=true` and cloud mode is enabled, billable API routes
+(`/api/render/*`, `/api/parse`, `/api/validate`, `/api/templates*`) require a session cookie.
+The web app redirects signed-out users to `/auth/login`. Self-hosted deployments leave this
+unset so local IndexedDB use and optional anonymous API access continue to work.
 
 Redeploy after changing env vars so the process picks up the new origin and callback.
 
@@ -201,9 +210,10 @@ that URL.
 ### Post-cutover verification
 
 1. `GET https://app.rustume.com/health` returns **200**.
-2. WorkOS AuthKit sign-in completes on `app.rustume.com` (callback hits the new redirect URI).
-3. Docs site loads at `https://rustume.com` with valid HTTPS.
-4. GitHub **Deploy - GitHub Pages** workflow reports success against the custom domain URL.
+2. Anonymous requests to billable APIs return **401** when `RUSTUME_REQUIRE_AUTH=true`.
+3. WorkOS AuthKit sign-in completes on `app.rustume.com` (callback hits the new redirect URI).
+4. Docs site loads at `https://rustume.com` with valid HTTPS.
+5. GitHub **Deploy - GitHub Pages** workflow reports success against the custom domain URL.
 
 ### Railway default domain
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(cloud): require authentication on hosted Rustume Cloud
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Hosted Rustume Cloud (`app.rustume.com`) now requires sign-in before anonymous users can call billable APIs or use protected app routes. Self-hosted and local deployments remain unchanged when `RUSTUME_REQUIRE_AUTH` is unset.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #310
- Relates to #253
- Relates to #259

## Details

### Server
- Add `RUSTUME_REQUIRE_AUTH` parsing via `require_auth_enabled()` in `cloud.rs` (only active with cloud mode).
- Protect billable routes (`/api/render/*`, `/api/parse`, `/api/validate`, `/api/templates*`) with `require_auth_when_enabled` middleware.
- Extend `GET /auth/me` to return `require_auth` on both 200 and 401 responses.

### Web
- Probe and store `requireAuth` from `/auth/me`.
- Add `RequireAuthGuard` to redirect signed-out users to `/auth/login` on protected routes (except `/auth/*` and `/account*`).
- Hide duplicate home/header sign-in CTAs when the login wall is active; keep account page as the signed-out landing.

### Ops
- Document setting `RUSTUME_REQUIRE_AUTH=true` on Railway production only in `docs/operations/rustume-cloud-deploy.md`.

### Testing
- Rust integration tests for anonymous 401 vs 200 on render/templates and `/auth/me` payload.
- Vitest coverage for auth probe, route guard, and CTA collapse behavior.
- `uv run lintro chk` and `uv run lintro tst` pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosted deployments can enforce mandatory authentication via configuration.
  * Added a client-side route guard that redirects unauthenticated users to the login page.
  * Cloud sign-in CTAs/prompts and messaging now adapt when authentication is required.
  * Billable API endpoints now enforce authentication when enabled.
* **Bug Fixes**
  * Auth status probing and signed-out responses now indicate whether auth is required.
* **Documentation**
  * Updated the Rustume Cloud deployment guide and verification checklist for the new require-auth behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR gates all billable API routes and the full web UI behind an opt-in authentication wall (`RUSTUME_REQUIRE_AUTH=true`) that only activates on the hosted deployment. Self-hosted instances are unaffected.

- **Server**: Adds `require_auth_enabled()` in `cloud.rs`, wires a `require_auth_when_enabled` layer-middleware onto the billable router, and rewrites `GET /auth/me` to return a structured `AuthMeUnauthorizedResponse` (with `require_auth: bool`) on 401 rather than a generic `ApiError`.
- **Web**: Extends the auth probe to extract `requireAuth` from both 200 and 401 `/auth/me` responses, adds a `RequireAuthGuard` that spins while auth loads and redirects unauthenticated users away from protected paths, and collapses sign-in CTAs on the home/header when the login wall is active.
- **Tests**: Adds Rust integration tests for anonymous 401 / 200 on render and templates routes and for the `/auth/me` payload shape, plus Vitest coverage for the probe mapping, guard redirect/pass-through, and CTA collapse behaviour.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the two blocking issues flagged in the previous review round are both correctly resolved, and the new auth gate enforces access at the server layer independently of the client-side guard.

The `From<User>` impl that silently hard-coded `require_auth: false` is gone, replaced by the explicit `from_user(user, require_auth)` constructor used in every call site. The `RequireAuthGuard` `Show` condition now gates on `!shouldBlock()` as well as `!state.loading`, so the spinner is held while a redirect is in flight and no protected content flashes before navigation. The middleware correctly short-circuits to `next` when the flag is off, making self-hosted deployments unaffected. Integration tests cover the 401/200 split on billable routes and the `/auth/me` payload shape. The only observation is a design note about not caching the resolved user in request extensions, which has no effect on current handlers.

No files require special attention. The middleware and route handler changes are the most security-relevant and both look correct.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/middleware/auth.rs | Adds `require_auth_when_enabled` middleware that short-circuits to `next` when the flag is off; when enabled, uses the existing `AuthUser` extractor for auth, then reconstructs the request and forwards the body unchanged. |
| crates/server/src/routes/auth.rs | Rewrites `GET /auth/me` to return a structured `AuthMeUnauthorizedResponse` on 401 (with `require_auth`) instead of a generic `ApiError`; 200 path now calls `from_user(user, require_auth)` with the correct flag. |
| crates/server/src/db/models.rs | Removes the `From<User> for AuthUserResponse` blanket impl (which would have silently set `require_auth: false`) and replaces it with an explicit `from_user(user, require_auth)` constructor; adds `AuthMeUnauthorizedResponse` for the 401 payload. |
| apps/web/src/components/Auth/RequireAuthGuard.tsx | New guard wraps the AppShell; uses `shouldBlock()` in both `createEffect` (redirect) and `Show` condition (`!state.loading && !shouldBlock()`) so the spinner is held until navigation completes — no flash of protected content. |
| apps/web/src/api/auth.ts | Extends `probeAuth` to extract `requireAuth` from both 200 (`parseAuthUserPayload`) and 401 (`parseRequireAuth`) responses; adds strict runtime validation with informative throws on malformed payloads. |
| crates/server/src/app.rs | Extracts billable routes into a dedicated sub-router and applies `require_auth_when_enabled` as a `route_layer`; health/metrics/swagger remain unprotected. |
| crates/server/src/lib.rs | Adds integration tests validating 401 on render/templates when `require_auth=true`, 200 when disabled, and that `/auth/me` 401 body contains `require_auth: true` and the correct error string. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant RequireAuthGuard
    participant AuthStore
    participant Server as Server (/auth/me)
    participant BillableAPI as Server (billable routes)

    Browser->>AuthStore: app mount → refresh()
    AuthStore->>Server: GET /auth/me
    alt Cloud + require_auth enabled, no session
        Server-->>AuthStore: "401 { require_auth: true }"
        AuthStore-->>RequireAuthGuard: "loading=false, requireAuth=true, user=null"
        RequireAuthGuard->>Browser: "navigate("/auth/login", {replace:true})"
        Note over RequireAuthGuard: Show spinner until navigation completes
    else Cloud + require_auth enabled, valid session
        Server-->>AuthStore: "200 { id, plan, require_auth: true }"
        AuthStore-->>RequireAuthGuard: "loading=false, requireAuth=true, user={...}"
        RequireAuthGuard->>Browser: render children (AppShell)
        Browser->>BillableAPI: POST /api/render/pdf (with session cookie)
        Note over BillableAPI: require_auth_when_enabled middleware
        BillableAPI-->>Browser: 200 OK
    else Cloud + require_auth disabled (self-hosted)
        Server-->>AuthStore: 404 → mode: self-hosted
        AuthStore-->>RequireAuthGuard: "loading=false, cloudEnabled=false"
        RequireAuthGuard->>Browser: render children (no gate)
        Browser->>BillableAPI: POST /api/render/pdf (anonymous)
        BillableAPI-->>Browser: 200 OK (middleware is no-op)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant RequireAuthGuard
    participant AuthStore
    participant Server as Server (/auth/me)
    participant BillableAPI as Server (billable routes)

    Browser->>AuthStore: app mount → refresh()
    AuthStore->>Server: GET /auth/me
    alt Cloud + require_auth enabled, no session
        Server-->>AuthStore: "401 { require_auth: true }"
        AuthStore-->>RequireAuthGuard: "loading=false, requireAuth=true, user=null"
        RequireAuthGuard->>Browser: "navigate("/auth/login", {replace:true})"
        Note over RequireAuthGuard: Show spinner until navigation completes
    else Cloud + require_auth enabled, valid session
        Server-->>AuthStore: "200 { id, plan, require_auth: true }"
        AuthStore-->>RequireAuthGuard: "loading=false, requireAuth=true, user={...}"
        RequireAuthGuard->>Browser: render children (AppShell)
        Browser->>BillableAPI: POST /api/render/pdf (with session cookie)
        Note over BillableAPI: require_auth_when_enabled middleware
        BillableAPI-->>Browser: 200 OK
    else Cloud + require_auth disabled (self-hosted)
        Server-->>AuthStore: 404 → mode: self-hosted
        AuthStore-->>RequireAuthGuard: "loading=false, cloudEnabled=false"
        RequireAuthGuard->>Browser: render children (no gate)
        Browser->>BillableAPI: POST /api/render/pdf (anonymous)
        BillableAPI-->>Browser: 200 OK (middleware is no-op)
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): validate auth probe payload an..."](https://github.com/lgtm-hq/rustume/commit/ad82ce33df73410e18cda460e888021a6789c56e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38425812)</sub>

<!-- /greptile_comment -->