### PR TITLE
fix(ci): grant release auto-tag caller permissions

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -31,4 +31,6 @@ jobs:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
     permissions:
+      actions: read
       contents: write
+      issues: write

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -30,7 +30,9 @@ jobs:
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+    # Caller must grant permissions required by reusable-release-auto-tag, including
+    # its report-release-failure follow-up job (lgtm-ci workflow-contract).
     permissions:
-      actions: read
-      contents: write
-      issues: write
+      actions: read # report-release-failure reads workflow/job metadata
+      contents: write # create and push version tags
+      issues: write # report-release-failure opens deduplicated failure issues


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): grant release auto-tag caller permissions
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds `actions: read` and `issues: write` to the reusable call job in `Release - Auto Tag`. Since the lgtm-ci migration (#281), this workflow has failed at startup because the pinned `reusable-release-auto-tag` includes a `report-release-failure` follow-up job that requires those permissions on the caller (lgtm-ci workflow contract, lgtm-ci #312). Without them, no tag is created — `v0.19.0` was never tagged when `Cargo.toml` was bumped.

`issues: write` is required for GitHub to validate the reusable workflow call, not for tag creation itself; it matches lgtm-ci's reference caller and Rustume's `semantic-release.yml` pattern.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (workflow-only change; no test updates needed)
- [ ] Docs updated if user-facing
- [x] Local CI passed (`cargo test --workspace`, web vitest, `uv run lintro chk`)

## Closes

- Closes #312

## Details

**Post-merge recovery (manual on `main`):**

1. Backfill missing `v0.19.0` tag (at commit `681fc82` or trigger auto-tag via `Cargo.toml` push)
2. Re-run **Release - Automated PR Creation** → expect `chore(release): version 0.20.0` for commits since `v0.19.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release automation workflow’s permissions and documentation to improve reliability and consistency of automated release tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Grants two additional GitHub Actions permissions (`actions: read`, `issues: write`) at the `auto-tag` job level to satisfy the caller contract required by the pinned `reusable-release-auto-tag` workflow in lgtm-ci, specifically its `report-release-failure` follow-up job that was causing workflow startup failures since the lgtm-ci migration.

- The top-level `permissions: {}` remains unchanged, preserving default-deny; only the `auto-tag` job's block is widened.
- Each new permission is narrowly scoped and inline-documented with its purpose (metadata reads and deduplicated failure issues respectively).
- The reusable workflow is pinned to a full commit SHA (`96a42109…`), so the expanded permissions are granted to a known, audited ref.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-justified permissions expansion confined to a single job in a pinned reusable workflow call.

The only modification is adding `actions: read` and `issues: write` to the `auto-tag` job's permissions block. The top-level `permissions: {}` still enforces default-deny for everything else, each new permission is narrowly scoped and purposeful, and the reusable workflow is pinned to a full commit SHA rather than a mutable tag, ensuring the expanded permissions are granted to a known, audited version of the workflow.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-tag-on-main.yml | Adds `actions: read` and `issues: write` to the job-level permissions block, alongside the existing `contents: write`, to satisfy the reusable workflow contract for `report-release-failure`. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Caller as auto-tag job<br/>(auto-tag-on-main.yml)
    participant Reusable as reusable-release-auto-tag<br/>(lgtm-ci @ SHA 96a421)
    participant RRF as report-release-failure<br/>(follow-up job)

    GH->>Caller: push to main (Cargo.toml changed)
    Note over Caller: permissions:<br/>actions: read<br/>contents: write ✅ (was present)<br/>issues: write ✅ (new)
    Caller->>Reusable: "call reusable workflow<br/>+ secrets: RELEASE_APP_ID, RELEASE_APP_PRIVATE_KEY"
    Reusable->>Reusable: detect version bump → create tag
    alt tag creation fails
        Reusable->>RRF: trigger report-release-failure
        RRF->>GH: read workflow/job metadata (actions: read)
        RRF->>GH: open/update failure issue (issues: write)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Caller as auto-tag job<br/>(auto-tag-on-main.yml)
    participant Reusable as reusable-release-auto-tag<br/>(lgtm-ci @ SHA 96a421)
    participant RRF as report-release-failure<br/>(follow-up job)

    GH->>Caller: push to main (Cargo.toml changed)
    Note over Caller: permissions:<br/>actions: read<br/>contents: write ✅ (was present)<br/>issues: write ✅ (new)
    Caller->>Reusable: "call reusable workflow<br/>+ secrets: RELEASE_APP_ID, RELEASE_APP_PRIVATE_KEY"
    Reusable->>Reusable: detect version bump → create tag
    alt tag creation fails
        Reusable->>RRF: trigger report-release-failure
        RRF->>GH: read workflow/job metadata (actions: read)
        RRF->>GH: open/update failure issue (issues: write)
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(ci): document auto-tag caller permi..."](https://github.com/lgtm-hq/rustume/commit/f0b3d0b4f061c60d164e6af0201a989f0e36dba6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38478958)</sub>

<!-- /greptile_comment -->