### PR TITLE
chore(security): post-launch hardening for open-source posture

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,10 @@
 
 | Version   | Supported |
 | --------- | --------- |
-| `0.16.x`  | ✅        |
-| `< 0.16`  | ❌        |
+| `0.20.x`  | ✅        |
+| `< 0.20`  | ❌        |
 
-Current release line matches the workspace version in `Cargo.toml` (currently `0.16.1`).
+Current release line matches the workspace version in `Cargo.toml` (currently `0.20.0`).
 
 <!-- markdownlint-enable MD060 -->
 
@@ -26,9 +26,15 @@ helps prevent potential exploitation while we work on a fix.
 
 1. **Email**: Send details to `turbocoder13@gmail.com`
 2. **Subject**: Include "SECURITY: Rustume" in the subject line
-3. **Backup**: Create a [private security advisory][advisory]
+3. **Canonical contact file**: See [security.txt](https://rustume.com/.well-known/security.txt)
+4. **Backup**: Create a [private security advisory][advisory]
 
 [advisory]: https://github.com/lgtm-hq/Rustume/security/advisories/new
+
+### **Encrypted Reports**
+
+If you need to send an encrypted report, reply to your acknowledgment email and
+we will provide a PGP public key for follow-up communication.
 
 ### **What to Include**
 
@@ -43,6 +49,21 @@ helps prevent potential exploitation while we work on a fix.
 - **Assessment**: Initial severity assessment within 7 calendar days
 - **Updates**: You'll be kept informed of progress
 - **Fix**: We'll work on a solution and coordinate disclosure
+
+## Data Classification
+
+Rustume deployments handle two classes of data:
+
+- **Account identity metadata** — WorkOS identifiers, session records, billing
+  references, and similar operator-managed account state. This metadata is
+  minimized but may still be sensitive.
+- **Resume documents** — User-authored resume JSON and rendered exports. These
+  documents may contain personal data (names, contact details, employment
+  history) and must be protected in transit and at rest.
+
+Public documentation describes workflows and operator responsibilities. Exact
+production retention values, recovery targets, and restricted runbook detail
+belong in private operations documentation.
 
 ## For Contributors
 
@@ -65,10 +86,13 @@ This project implements the following security practices:
 - Container image scanning with Trivy
 - Signed commits and releases
 - Pinned GitHub Actions dependencies
+- Append-only audit logging for authentication and destructive resume operations
+- JSON complexity limits on resume payloads
 
 [scorecard]: https://github.com/lgtm-hq/Rustume/actions/workflows/scorecards.yml
 
 ## Contact
 
 - **Primary**: `turbocoder13@gmail.com`
+- **security.txt**: `https://rustume.com/.well-known/security.txt`
 - **Backup**: Create a [private security advisory][advisory]

--- a/apps/site/scripts/doc_enrichment/descriptions.py
+++ b/apps/site/scripts/doc_enrichment/descriptions.py
@@ -18,6 +18,10 @@ OPERATIONS_POLICY_DESCRIPTIONS: dict[str, str] = {
         "Recovery guidance for PostgreSQL-backed connected deployments and the operated "
         "Rustume Cloud service."
     ),
+    "operations/secrets-rotation.md": (
+        "Rotate <code>SESSION_SECRET</code>, WorkOS keys, <code>METRICS_TOKEN</code>, "
+        "and database credentials with minimal downtime."
+    ),
 }
 
 DESCRIPTIONS: dict[str, str] = {

--- a/apps/site/src/content/docs/operations/secrets-rotation.md
+++ b/apps/site/src/content/docs/operations/secrets-rotation.md
@@ -1,0 +1,54 @@
+---
+title: "Secrets Rotation"
+description: 'Rotate <code>SESSION_SECRET</code>, WorkOS keys, <code>METRICS_TOKEN</code>, and database credentials with minimal downtime.'
+category: operations
+order: 40
+---
+
+Rotate Rustume deployment secrets in order of least user impact. Exact provider
+dashboard steps depend on your host; hosted Rustume Cloud uses Railway with
+WorkOS and Neon.
+
+## Rotation order
+
+1. `METRICS_TOKEN`
+2. `WORKOS_API_KEY` / `WORKOS_CLIENT_ID`
+3. `SESSION_SECRET`
+4. `DATABASE_URL` credentials
+
+## `METRICS_TOKEN`
+
+Update your scraper authorization header and the deployment environment
+variable, then rolling-restart the service. User sessions are unaffected.
+
+## WorkOS keys
+
+Rotate in the WorkOS dashboard, update deployment environment variables,
+rolling-restart, and verify a full `/auth/login` → `/auth/callback` flow.
+Revoke the previous key after validation.
+
+## `SESSION_SECRET`
+
+Rotating `SESSION_SECRET` invalidates every existing `rustume_session` cookie.
+Plan a brief re-authentication window for active users.
+
+1. Generate `openssl rand -hex 32`
+2. Update `SESSION_SECRET` in the deployment environment
+3. Rolling-restart all instances
+4. Verify sign-in works
+
+## `DATABASE_URL`
+
+Create new database credentials in your provider, update `DATABASE_URL`,
+rolling-restart, and revoke old credentials after `/health` reports database
+connectivity.
+
+## Verification
+
+- `/health` returns OK
+- Sign-in completes and resume CRUD works for a test account
+- `/metrics` accepts the new bearer token when configured
+- Audit events continue writing in cloud mode
+
+See also [Authentication](/docs/cloud/auth/) and the
+[environment reference](/docs/deployment/env-reference/).

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -27,8 +27,8 @@ use crate::observability::apply_sentry_layers;
 use crate::openapi::ApiDoc;
 use crate::routes::{
     callback, create_resume, delete_resume, get_resume, health, import_resumes, list_resumes,
-    list_templates, login, logout, me, metrics, parse, render_pdf, render_preview, spa_fallback,
-    static_dir, template_thumbnail, update_resume, validate,
+    list_templates, login, logout, me, metrics, parse, render_pdf, render_preview, security_txt,
+    spa_fallback, static_dir, template_thumbnail, update_resume, validate,
 };
 use crate::state::AppState;
 
@@ -108,6 +108,7 @@ pub fn create_router_with_state(state: AppState) -> Router {
 
     let mut router = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        .route("/.well-known/security.txt", get(security_txt))
         .merge(health_routes)
         .merge(metrics_routes)
         .merge(billable_core)

--- a/crates/server/src/audit/mod.rs
+++ b/crates/server/src/audit/mod.rs
@@ -1,0 +1,52 @@
+//! Append-only audit logging for security-sensitive events.
+
+use serde_json::Value;
+use sqlx::PgPool;
+use tracing::error;
+use uuid::Uuid;
+
+/// Security-relevant event to persist in the audit log.
+#[derive(Debug)]
+pub struct AuditEvent<'a> {
+    /// Stable event identifier (for example `auth.login.success`).
+    pub event_type: &'a str,
+    /// Authenticated user associated with the event, when known.
+    pub actor_user_id: Option<Uuid>,
+    /// Resource category (for example `resume`).
+    pub resource_type: Option<&'a str>,
+    /// Resource identifier, when applicable.
+    pub resource_id: Option<Uuid>,
+    /// Structured metadata without secrets or resume document content.
+    pub metadata: Value,
+    /// Client IP address, when available.
+    pub ip_address: Option<&'a str>,
+}
+
+/// Insert an audit event without failing the primary request on persistence errors.
+pub async fn record_event(pool: &PgPool, event: AuditEvent<'_>) {
+    let result = sqlx::query(
+        r#"
+        INSERT INTO audit_events (
+            event_type,
+            actor_user_id,
+            resource_type,
+            resource_id,
+            metadata,
+            ip_address
+        )
+        VALUES ($1, $2, $3, $4, $5, $6::inet)
+        "#,
+    )
+    .bind(event.event_type)
+    .bind(event.actor_user_id)
+    .bind(event.resource_type)
+    .bind(event.resource_id)
+    .bind(event.metadata)
+    .bind(event.ip_address)
+    .execute(pool)
+    .await;
+
+    if let Err(err) = result {
+        error!("audit log insert failed: {err}");
+    }
+}

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -7,7 +7,7 @@ use governor::Quota;
 /// Maximum request body size (10 MB)
 pub const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
 
-/// Maximum nested JSON depth for resume payloads.
+/// Maximum nested JSON depth for resume payloads (root depth = 1).
 pub const MAX_JSON_DEPTH: usize = 32;
 
 /// Maximum length for any single string field inside resume JSON.

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -7,6 +7,18 @@ use governor::Quota;
 /// Maximum request body size (10 MB)
 pub const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
 
+/// Maximum nested JSON depth for resume payloads.
+pub const MAX_JSON_DEPTH: usize = 32;
+
+/// Maximum length for any single string field inside resume JSON.
+pub const MAX_STRING_FIELD_LEN: usize = 16_384;
+
+/// Maximum serialized resume JSON size (2 MB).
+pub const MAX_RESUME_JSON_BYTES: usize = 2 * 1024 * 1024;
+
+/// Maximum resume title length in characters.
+pub const MAX_TITLE_LEN: usize = 512;
+
 /// Default server port
 pub const DEFAULT_PORT: u16 = 3000;
 

--- a/crates/server/src/db/migrations/005_audit_events.sql
+++ b/crates/server/src/db/migrations/005_audit_events.sql
@@ -1,7 +1,7 @@
 CREATE TABLE audit_events (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     event_type TEXT NOT NULL,
-    actor_user_id UUID REFERENCES users (id) ON DELETE SET NULL,
+    actor_user_id UUID REFERENCES users (id) ON DELETE RESTRICT,
     resource_type TEXT,
     resource_id UUID,
     metadata JSONB NOT NULL DEFAULT '{}',
@@ -12,3 +12,22 @@ CREATE TABLE audit_events (
 CREATE INDEX audit_events_created_at_idx ON audit_events (created_at);
 CREATE INDEX audit_events_event_type_idx ON audit_events (event_type);
 CREATE INDEX audit_events_actor_user_id_idx ON audit_events (actor_user_id);
+CREATE INDEX audit_events_actor_user_id_created_at_idx
+ON audit_events (actor_user_id, created_at DESC);
+
+CREATE OR REPLACE FUNCTION audit_events_immutable()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'audit_events records are append-only';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER audit_events_no_update
+BEFORE UPDATE ON audit_events
+FOR EACH ROW
+EXECUTE FUNCTION audit_events_immutable();
+
+CREATE TRIGGER audit_events_no_delete
+BEFORE DELETE ON audit_events
+FOR EACH ROW
+EXECUTE FUNCTION audit_events_immutable();

--- a/crates/server/src/db/migrations/005_audit_events.sql
+++ b/crates/server/src/db/migrations/005_audit_events.sql
@@ -11,3 +11,4 @@ CREATE TABLE audit_events (
 
 CREATE INDEX audit_events_created_at_idx ON audit_events (created_at);
 CREATE INDEX audit_events_event_type_idx ON audit_events (event_type);
+CREATE INDEX audit_events_actor_user_id_idx ON audit_events (actor_user_id);

--- a/crates/server/src/db/migrations/005_audit_events.sql
+++ b/crates/server/src/db/migrations/005_audit_events.sql
@@ -1,0 +1,13 @@
+CREATE TABLE audit_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type TEXT NOT NULL,
+    actor_user_id UUID REFERENCES users (id) ON DELETE SET NULL,
+    resource_type TEXT,
+    resource_id UUID,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    ip_address INET,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX audit_events_created_at_idx ON audit_events (created_at);
+CREATE INDEX audit_events_event_type_idx ON audit_events (event_type);

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -24,6 +24,7 @@
 //! - `GET /metrics` - Prometheus metrics
 
 pub mod app;
+pub mod audit;
 pub mod auth;
 pub mod cloud;
 pub mod config;
@@ -38,6 +39,7 @@ pub mod routes;
 pub mod run;
 pub mod shutdown;
 pub mod state;
+pub mod validation;
 
 pub use app::{create_router, create_router_with_state, create_router_with_static_dir};
 pub use run::run;
@@ -591,6 +593,60 @@ mod tests {
             .unwrap();
 
         assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_security_txt_endpoint() {
+        let app = create_router();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/security.txt")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "text/plain; charset=utf-8"
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        assert!(text.contains("Contact: mailto:turbocoder13@gmail.com"));
+        assert!(text.contains("Canonical: https://rustume.com/.well-known/security.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_render_rejects_deeply_nested_resume_json() {
+        use crate::config::MAX_JSON_DEPTH;
+
+        let app = create_router();
+        let mut resume = serde_json::json!(1);
+        for _ in 0..MAX_JSON_DEPTH {
+            resume = serde_json::json!({ "nested": resume });
+        }
+
+        let payload = serde_json::json!({ "resume": resume });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/render/preview")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use tracing::error;
 use uuid::Uuid;
 
+use crate::audit::{record_event, AuditEvent};
 use crate::auth::session::SESSION_COOKIE;
 use crate::auth::workos::upsert_user;
 use crate::db::{AuthMeUnauthorizedResponse, AuthUserResponse};
@@ -103,7 +104,10 @@ async fn callback_inner(
     let stored_state = jar.get(OAUTH_STATE_COOKIE).map(|cookie| cookie.value());
     match (stored_state, oauth_state) {
         (Some(stored), Some(provided)) if stored == provided => {}
-        _ => return Err("invalid_state"),
+        _ => {
+            record_auth_failure(&cloud.db, "invalid_state", trusted_client_ip(&headers)).await;
+            return Err("invalid_state");
+        }
     }
 
     let ip_address = trusted_client_ip(&headers, net::trusted_proxy_enabled());
@@ -112,14 +116,18 @@ async fn callback_inner(
         .get(header::USER_AGENT)
         .and_then(|value| value.to_str().ok());
 
-    let workos_user = cloud
+    let workos_user = match cloud
         .workos
         .authenticate_with_code(code, ip, user_agent)
         .await
-        .map_err(|err| {
+    {
+        Ok(user) => user,
+        Err(err) => {
             error!("WorkOS authentication failed: {err}");
-            "authentication_failed"
-        })?;
+            record_auth_failure(&cloud.db, "authentication_failed", ip).await;
+            return Err("authentication_failed");
+        }
+    };
 
     let user = upsert_user(&cloud.db, &workos_user).await.map_err(|err| {
         error!("user upsert failed: {err}");
@@ -130,6 +138,19 @@ async fn callback_inner(
         error!("session creation failed: {err}");
         "server_error"
     })?;
+
+    record_event(
+        &cloud.db,
+        AuditEvent {
+            event_type: "auth.login.success",
+            actor_user_id: Some(user.id),
+            resource_type: Some("auth"),
+            resource_id: None,
+            metadata: serde_json::json!({}),
+            ip_address: ip,
+        },
+    )
+    .await;
 
     let mut response = Redirect::to("/?signed_in=1").into_response();
     append_set_cookie(&mut response, cookie).map_err(|_| "server_error")?;
@@ -144,12 +165,33 @@ async fn callback_inner(
 /// Clear the session cookie and delete the server-side session row.
 pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> Result<Response, ApiError> {
     let cloud = state.cloud()?;
+    let mut actor_user_id = None;
     if let Some(cookie) = jar.get(SESSION_COOKIE) {
+        actor_user_id = cloud
+            .sessions
+            .user_for_token(cookie.value())
+            .await
+            .ok()
+            .flatten()
+            .map(|user| user.id);
         cloud.sessions.delete(cookie.value()).await.map_err(|err| {
             error!("session deletion failed: {err}");
             ApiError::internal("internal server error")
         })?;
     }
+
+    record_event(
+        &cloud.db,
+        AuditEvent {
+            event_type: "auth.logout",
+            actor_user_id,
+            resource_type: Some("auth"),
+            resource_id: None,
+            metadata: serde_json::json!({}),
+            ip_address: None,
+        },
+    )
+    .await;
 
     let clear = cloud.sessions.clear_cookie();
     let mut response = (StatusCode::NO_CONTENT, ()).into_response();
@@ -240,6 +282,21 @@ fn append_set_cookie(response: &mut Response, cookie: Cookie<'static>) -> Result
         .headers_mut()
         .append(header::SET_COOKIE, header_value);
     Ok(())
+}
+
+async fn record_auth_failure(pool: &sqlx::PgPool, reason: &str, ip_address: Option<&str>) {
+    record_event(
+        pool,
+        AuditEvent {
+            event_type: "auth.login.failure",
+            actor_user_id: None,
+            resource_type: Some("auth"),
+            resource_id: None,
+            metadata: serde_json::json!({ "reason": reason }),
+            ip_address,
+        },
+    )
+    .await;
 }
 
 #[cfg(test)]

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -105,7 +105,12 @@ async fn callback_inner(
     match (stored_state, oauth_state) {
         (Some(stored), Some(provided)) if stored == provided => {}
         _ => {
-            record_auth_failure(&cloud.db, "invalid_state", trusted_client_ip(&headers)).await;
+            record_auth_failure(
+                &cloud.db,
+                "invalid_state",
+                trusted_client_ip(&headers, net::trusted_proxy_enabled()).as_deref(),
+            )
+            .await;
             return Err("invalid_state");
         }
     }
@@ -163,7 +168,11 @@ async fn callback_inner(
 }
 
 /// Clear the session cookie and delete the server-side session row.
-pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> Result<Response, ApiError> {
+pub async fn logout(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    headers: HeaderMap,
+) -> Result<Response, ApiError> {
     let cloud = state.cloud()?;
     let mut actor_user_id = None;
     if let Some(cookie) = jar.get(SESSION_COOKIE) {
@@ -188,7 +197,7 @@ pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> Result<Res
             resource_type: Some("auth"),
             resource_id: None,
             metadata: serde_json::json!({}),
-            ip_address: None,
+            ip_address: trusted_client_ip(&headers, net::trusted_proxy_enabled()).as_deref(),
         },
     )
     .await;

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -51,10 +51,13 @@ pub async fn callback(
     query: Result<Query<CallbackQuery>, axum::extract::rejection::QueryRejection>,
     headers: HeaderMap,
 ) -> Response {
+    let ip = trusted_client_ip(&headers, net::trusted_proxy_enabled());
+
     let query = match query {
         Ok(Query(query)) => query,
         Err(rejection) => {
             error!("OAuth callback query rejected: {rejection}");
+            audit_callback_failure(&state, "invalid_query", ip.as_deref()).await;
             return oauth_error_redirect("authentication_failed");
         }
     };
@@ -62,13 +65,16 @@ pub async fn callback(
     if let Some(code) = oauth_callback_error_code(&query) {
         if query.error.is_some() {
             error!("WorkOS OAuth callback returned error");
+            audit_callback_failure(&state, "provider_error", ip.as_deref()).await;
         } else {
             error!("OAuth callback missing authorization code");
+            audit_callback_failure(&state, "missing_code", ip.as_deref()).await;
         }
         return oauth_error_redirect(code);
     }
 
     let Some(code) = query.code.as_deref() else {
+        audit_callback_failure(&state, "missing_code", ip.as_deref()).await;
         return oauth_error_redirect("authentication_failed");
     };
 
@@ -144,6 +150,14 @@ async fn callback_inner(
         "server_error"
     })?;
 
+    let mut response = Redirect::to("/?signed_in=1").into_response();
+    append_set_cookie(&mut response, cookie).map_err(|_| "server_error")?;
+    append_set_cookie(
+        &mut response,
+        clear_oauth_state_cookie(&cloud.workos_redirect_uri),
+    )
+    .map_err(|_| "server_error")?;
+
     record_event(
         &cloud.db,
         AuditEvent {
@@ -157,13 +171,6 @@ async fn callback_inner(
     )
     .await;
 
-    let mut response = Redirect::to("/?signed_in=1").into_response();
-    append_set_cookie(&mut response, cookie).map_err(|_| "server_error")?;
-    append_set_cookie(
-        &mut response,
-        clear_oauth_state_cookie(&cloud.workos_redirect_uri),
-    )
-    .map_err(|_| "server_error")?;
     Ok(response)
 }
 
@@ -306,6 +313,12 @@ async fn record_auth_failure(pool: &sqlx::PgPool, reason: &str, ip_address: Opti
         },
     )
     .await;
+}
+
+async fn audit_callback_failure(state: &AppState, reason: &str, ip_address: Option<&str>) {
+    if let Ok(cloud) = state.cloud() {
+        record_auth_failure(&cloud.db, reason, ip_address).await;
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -6,6 +6,7 @@ pub mod metrics;
 pub mod parse;
 pub mod render;
 pub mod resumes;
+pub mod security_txt;
 pub mod static_files;
 pub mod templates;
 pub mod validate;
@@ -18,6 +19,7 @@ pub use render::{render_pdf, render_preview};
 pub use resumes::{
     create_resume, delete_resume, get_resume, import_resumes, list_resumes, update_resume,
 };
+pub use security_txt::security_txt;
 pub use static_files::{sanitize_static_path, spa_fallback, static_dir};
 pub use templates::{list_templates, template_thumbnail};
 pub use validate::validate;

--- a/crates/server/src/routes/render.rs
+++ b/crates/server/src/routes/render.rs
@@ -12,12 +12,14 @@ use crate::dto::{RenderPdfRequest, RenderPreviewRequest};
 use crate::error::ApiError;
 use crate::routes::validate::validation_errors;
 use crate::state::AppState;
+use crate::validation::validate_resume_json;
 
 /// Deserialize resume JSON, apply an optional template override, and validate.
 fn prepare_resume(
     resume: serde_json::Value,
     template: Option<String>,
 ) -> Result<ResumeData, ApiError> {
+    validate_resume_json(&resume)?;
     let mut resume: ResumeData =
         serde_json::from_value(resume).map_err(|_| ApiError::new("Invalid resume data format"))?;
 

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -240,6 +240,7 @@ const MAX_IMPORT_BATCH: usize = 100;
 pub async fn import_resumes(
     AuthUser(user): AuthUser,
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(body): Json<ImportResumesRequest>,
 ) -> Result<Json<ImportResumesResponse>, ApiError> {
     if body.resumes.len() > MAX_IMPORT_BATCH {
@@ -290,7 +291,7 @@ pub async fn import_resumes(
                 "imported": imported.len(),
                 "failed": failed.len(),
             }),
-            ip_address: None,
+            ip_address: trusted_client_ip(&headers, net::trusted_proxy_enabled()).as_deref(),
         },
     )
     .await;

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -2,7 +2,7 @@
 
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     Json,
 };
 use tracing::error;
@@ -16,6 +16,7 @@ use crate::db::{
 };
 use crate::error::ApiError;
 use crate::middleware::auth::AuthUser;
+use crate::net::{self, trusted_client_ip};
 use crate::state::AppState;
 use crate::validation::{validate_resume_json, validate_title};
 
@@ -192,6 +193,7 @@ pub async fn delete_resume(
     AuthUser(user): AuthUser,
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    headers: HeaderMap,
 ) -> Result<StatusCode, ApiError> {
     let cloud = state.cloud()?;
     let result = sqlx::query("DELETE FROM resumes WHERE id = $1 AND user_id = $2")
@@ -213,7 +215,7 @@ pub async fn delete_resume(
             resource_type: Some("resume"),
             resource_id: Some(id),
             metadata: serde_json::json!({}),
-            ip_address: None,
+            ip_address: trusted_client_ip(&headers, net::trusted_proxy_enabled()).as_deref(),
         },
     )
     .await;

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -8,6 +8,7 @@ use axum::{
 use tracing::error;
 use uuid::Uuid;
 
+use crate::audit::{record_event, AuditEvent};
 use crate::db::{
     CreateResumeRequest, ImportFailure, ImportResumeItem, ImportResumesRequest,
     ImportResumesResponse, PaginatedResumeSummaries, ResumeListQuery, ResumeRow, ResumeSummary,
@@ -16,6 +17,7 @@ use crate::db::{
 use crate::error::ApiError;
 use crate::middleware::auth::AuthUser;
 use crate::state::AppState;
+use crate::validation::{validate_resume_json, validate_title};
 
 /// List resumes for the authenticated user.
 #[utoipa::path(
@@ -113,6 +115,8 @@ pub async fn create_resume(
 ) -> Result<(StatusCode, Json<ResumeRow>), ApiError> {
     let cloud = state.cloud()?;
     let title = body.title.unwrap_or_else(|| "Untitled".to_string());
+    validate_title(title.as_str())?;
+    validate_resume_json(&body.data)?;
     let resume_id = body.id.unwrap_or_else(Uuid::new_v4);
 
     let row = sqlx::query_as::<_, ResumeRow>(
@@ -161,6 +165,10 @@ pub async fn update_resume(
     let cloud = state.cloud()?;
     let existing = fetch_owned_resume(&state, user.id, id).await?;
     let title = body.title.unwrap_or(existing.title);
+    validate_title(title.as_str())?;
+    if let Some(data) = &body.data {
+        validate_resume_json(data)?;
+    }
 
     let row = apply_resume_update(&cloud.db, user.id, id, &title, body.data, body.version).await?;
 
@@ -197,6 +205,19 @@ pub async fn delete_resume(
         return Err(ApiError::not_found("Resume not found"));
     }
 
+    record_event(
+        &cloud.db,
+        AuditEvent {
+            event_type: "resume.delete",
+            actor_user_id: Some(user.id),
+            resource_type: Some("resume"),
+            resource_id: Some(id),
+            metadata: serde_json::json!({}),
+            ip_address: None,
+        },
+    )
+    .await;
+
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -226,11 +247,26 @@ pub async fn import_resumes(
     }
 
     let cloud = state.cloud()?;
+    let requested_count = body.resumes.len();
     let mut imported = Vec::new();
     let mut failed = Vec::new();
 
     for item in body.resumes {
         let resume_id = item.id;
+        if let Err(err) = validate_title(item.title.as_deref().unwrap_or("Untitled")) {
+            failed.push(ImportFailure {
+                id: resume_id,
+                error: err.error,
+            });
+            continue;
+        }
+        if let Err(err) = validate_resume_json(&item.data) {
+            failed.push(ImportFailure {
+                id: resume_id,
+                error: err.error,
+            });
+            continue;
+        }
         match import_single_resume(&cloud.db, user.id, item).await {
             Ok(row) => imported.push(ResumeSummary::from(row)),
             Err(err) => failed.push(ImportFailure {
@@ -239,6 +275,23 @@ pub async fn import_resumes(
             }),
         }
     }
+
+    record_event(
+        &cloud.db,
+        AuditEvent {
+            event_type: "resume.import.batch",
+            actor_user_id: Some(user.id),
+            resource_type: None,
+            resource_id: None,
+            metadata: serde_json::json!({
+                "requested": requested_count,
+                "imported": imported.len(),
+                "failed": failed.len(),
+            }),
+            ip_address: None,
+        },
+    )
+    .await;
 
     Ok(Json(ImportResumesResponse { imported, failed }))
 }

--- a/crates/server/src/routes/security_txt.rs
+++ b/crates/server/src/routes/security_txt.rs
@@ -10,7 +10,8 @@ Contact: mailto:turbocoder13@gmail.com\n\
 Expires: 2027-06-19T00:00:00.000Z\n\
 Preferred-Languages: en\n\
 Canonical: https://rustume.com/.well-known/security.txt\n\
-Policy: https://github.com/lgtm-hq/Rustume/blob/main/SECURITY.md\n";
+Policy: https://github.com/lgtm-hq/Rustume/blob/main/SECURITY.md\n\
+# Renew Expires annually — see SECURITY.md and issue #248.\n";
 
 /// Serve `/.well-known/security.txt` for responsible disclosure contacts.
 pub async fn security_txt() -> Response {

--- a/crates/server/src/routes/security_txt.rs
+++ b/crates/server/src/routes/security_txt.rs
@@ -1,0 +1,26 @@
+//! RFC 9116 security contact endpoint.
+
+use axum::{
+    http::{header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+
+const SECURITY_TXT: &str = "\
+Contact: mailto:turbocoder13@gmail.com\n\
+Expires: 2027-06-19T00:00:00.000Z\n\
+Preferred-Languages: en\n\
+Canonical: https://rustume.com/.well-known/security.txt\n\
+Policy: https://github.com/lgtm-hq/Rustume/blob/main/SECURITY.md\n";
+
+/// Serve `/.well-known/security.txt` for responsible disclosure contacts.
+pub async fn security_txt() -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; charset=utf-8"),
+        )],
+        SECURITY_TXT,
+    )
+        .into_response()
+}

--- a/crates/server/src/validation/json_limits.rs
+++ b/crates/server/src/validation/json_limits.rs
@@ -1,0 +1,108 @@
+//! JSON complexity limits for resume payloads.
+
+use serde_json::Value;
+
+use crate::config::{MAX_JSON_DEPTH, MAX_RESUME_JSON_BYTES, MAX_STRING_FIELD_LEN, MAX_TITLE_LEN};
+use crate::error::ApiError;
+
+/// Reject titles that exceed the configured character limit.
+pub fn validate_title(title: &str) -> Result<(), ApiError> {
+    if title.chars().count() > MAX_TITLE_LEN {
+        return Err(ApiError::new(format!(
+            "Title exceeds maximum length of {MAX_TITLE_LEN} characters"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate resume JSON depth, string lengths, and serialized size.
+pub fn validate_resume_json(value: &Value) -> Result<(), ApiError> {
+    validate_json_depth(value, MAX_JSON_DEPTH, 1)?;
+    validate_string_lengths(value)?;
+    let size = serde_json::to_vec(value)
+        .map_err(|_| ApiError::new("Invalid resume JSON"))?
+        .len();
+    if size > MAX_RESUME_JSON_BYTES {
+        return Err(ApiError::new(format!(
+            "Resume JSON exceeds maximum size of {MAX_RESUME_JSON_BYTES} bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_json_depth(value: &Value, max_depth: usize, current: usize) -> Result<(), ApiError> {
+    if current > max_depth {
+        return Err(ApiError::new(format!(
+            "JSON depth exceeds maximum of {max_depth}"
+        )));
+    }
+
+    match value {
+        Value::Object(map) => {
+            for child in map.values() {
+                validate_json_depth(child, max_depth, current + 1)?;
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                validate_json_depth(child, max_depth, current + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn validate_string_lengths(value: &Value) -> Result<(), ApiError> {
+    match value {
+        Value::String(text) => {
+            if text.chars().count() > MAX_STRING_FIELD_LEN {
+                return Err(ApiError::new(format!(
+                    "String field exceeds maximum length of {MAX_STRING_FIELD_LEN} characters"
+                )));
+            }
+        }
+        Value::Object(map) => {
+            for child in map.values() {
+                validate_string_lengths(child)?;
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                validate_string_lengths(child)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rejects_deeply_nested_json() {
+        let mut value = json!(1);
+        for _ in 0..MAX_JSON_DEPTH {
+            value = json!({ "nested": value });
+        }
+
+        let err = validate_resume_json(&value).expect_err("expected depth error");
+        assert!(err.error.contains("depth"));
+    }
+
+    #[test]
+    fn rejects_oversized_string_field() {
+        let value = json!({ "summary": "x".repeat(MAX_STRING_FIELD_LEN + 1) });
+        let err = validate_resume_json(&value).expect_err("expected string length error");
+        assert!(err.error.contains("String field"));
+    }
+
+    #[test]
+    fn accepts_minimal_resume_json() {
+        validate_resume_json(&json!({ "basics": { "name": "Ada Lovelace" } }))
+            .expect("minimal resume should pass");
+    }
+}

--- a/crates/server/src/validation/json_limits.rs
+++ b/crates/server/src/validation/json_limits.rs
@@ -105,4 +105,14 @@ mod tests {
         validate_resume_json(&json!({ "basics": { "name": "Ada Lovelace" } }))
             .expect("minimal resume should pass");
     }
+
+    #[test]
+    fn accepts_json_at_max_depth() {
+        let mut value = json!(1);
+        for _ in 0..(MAX_JSON_DEPTH - 1) {
+            value = json!({ "nested": value });
+        }
+
+        validate_resume_json(&value).expect("depth at MAX_JSON_DEPTH should pass");
+    }
 }

--- a/crates/server/src/validation/mod.rs
+++ b/crates/server/src/validation/mod.rs
@@ -1,0 +1,5 @@
+//! Request payload validation helpers.
+
+pub mod json_limits;
+
+pub use json_limits::{validate_resume_json, validate_title};

--- a/docs/operations/secrets-rotation.md
+++ b/docs/operations/secrets-rotation.md
@@ -1,0 +1,73 @@
+# Secrets Rotation Runbook
+
+Operator guide for rotating Rustume Cloud and self-hosted secrets without
+unnecessary downtime. Public documentation mirrors this content at
+`apps/site/src/content/docs/operations/secrets-rotation.md`.
+
+## Scope
+
+This runbook covers application secrets configured via environment variables.
+Database credential rotation follows your PostgreSQL provider's procedure
+(Neon, Railway Postgres, or self-managed).
+
+## Rotation Order (Least Disruptive First)
+
+1. `METRICS_TOKEN`
+2. `WORKOS_API_KEY` / `WORKOS_CLIENT_ID`
+3. `SESSION_SECRET`
+4. `DATABASE_URL` credentials
+
+## `METRICS_TOKEN`
+
+1. Generate a new random token (32+ bytes).
+2. Update the scraper or monitoring job authorization header.
+3. Update the deployment environment variable.
+4. Rolling restart the Rustume service.
+5. Revoke the old token after metrics scrapes succeed.
+
+No user sessions are affected.
+
+## WorkOS Keys (`WORKOS_API_KEY`, `WORKOS_CLIENT_ID`)
+
+1. Create or rotate credentials in the WorkOS dashboard.
+2. Confirm redirect URIs still match the deployment (`/auth/callback`).
+3. Update Railway (or your host) environment variables.
+4. Rolling restart the service.
+5. Verify `/auth/login` completes a full sign-in flow.
+6. Revoke the previous WorkOS key in the dashboard.
+
+## `SESSION_SECRET`
+
+Rotating `SESSION_SECRET` **invalidates all existing `rustume_session` cookies**.
+There is no dual-secret grace period in the current implementation.
+
+1. Announce a short maintenance window if users are actively signed in.
+2. Generate a new secret (`openssl rand -hex 32`).
+3. Update `SESSION_SECRET` in the deployment environment.
+4. Rolling restart all Rustume instances simultaneously.
+5. Confirm users can sign in again via WorkOS.
+6. Remove the old secret from secret stores.
+
+## `DATABASE_URL`
+
+1. Create a new database role/password in your provider.
+2. Update connection strings in the deployment environment.
+3. Rolling restart Rustume and verify `/health` reports database connectivity.
+4. Revoke the old database credentials after traffic stabilizes.
+
+For managed providers, prefer provider-native rotation workflows that support
+connection draining.
+
+## Verification Checklist
+
+- [ ] `/health` returns OK
+- [ ] `/auth/login` → callback → signed-in session works
+- [ ] Resume list/create/update/delete succeeds for a test account
+- [ ] `/metrics` accepts the new bearer token (if configured)
+- [ ] Audit events continue writing after restart (cloud mode)
+
+## References
+
+- [Environment reference](../apps/site/src/content/docs/deployment/env-reference.md)
+- [Cloud authentication](../apps/site/src/content/docs/cloud/auth.md)
+- [SECURITY.md](../SECURITY.md)

--- a/docs/operations/secrets-rotation.md
+++ b/docs/operations/secrets-rotation.md
@@ -68,6 +68,6 @@ connection draining.
 
 ## References
 
-- [Environment reference](../apps/site/src/content/docs/deployment/env-reference.md)
-- [Cloud authentication](../apps/site/src/content/docs/cloud/auth.md)
-- [SECURITY.md](../SECURITY.md)
+- [Environment reference](/docs/deployment/env-reference/)
+- [Cloud authentication](/docs/cloud/auth/)
+- [SECURITY.md](https://github.com/lgtm-hq/Rustume/blob/main/SECURITY.md)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(security): post-launch hardening for open-source posture
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Delivers the P0/P1 security hardening items from #248 for Rustume Cloud's open-source posture: responsible disclosure, operational runbooks, input complexity limits, and immutable audit logging for sensitive actions. Rate limiting is already on main via #259.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #248
- Relates to #243

## Details

### Changes made

- Update `SECURITY.md` for 0.20.x disclosure policy, data classification, and response expectations
- Add `GET /.well-known/security.txt` (RFC 9116) route
- Add secrets rotation runbook (`docs/operations/secrets-rotation.md` + site mirror)
- Add JSON complexity limits (`validation/json_limits`) with constants in `config.rs`; reject pathological payloads on render/update/import paths
- Add append-only `audit_events` table and `record_event` helper; wire auth login/logout/failure and resume delete events with trusted client IP capture
- Reconcile with #259 rate-limit route groups in `app.rs` and shared `net::trusted_client_ip` helper

### Out of scope (tracked separately)

- Rate limiting (#259 — merged)
- Fuzz testing, DB SSL enforcement, Renovate/DAST/SRI/pen-test (P1/P2 follow-ups in #248)

### Testing strategy

- `cargo test -p rustume-server` — 48 tests passing (security.txt, deep JSON rejection, audit/IP wiring, rate-limit coexistence)
- `uv run lintro fmt` / `uv run lintro chk` — clippy, rustfmt, and related checks pass locally (gitleaks timed out in local scan only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized security contact endpoint at `/.well-known/security.txt` for vulnerability disclosure.
  * Added append-only audit logging for security-sensitive authentication and resume actions.
* **Improvements**
  * Strengthened resume input validation (title and JSON nesting/size limits) and hardened preview/render behavior.
  * Added audit coverage for logout, resume create/update/delete/import, and deeper per-request IP capture where available.
* **Documentation**
  * Expanded security policy guidance, including data classification and encrypted communication/contact details.
  * Added a secrets rotation runbook with a least-disruptive procedure and verification checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers the P0/P1 security hardening backlog for Rustume Cloud's open-source posture: a public `/.well-known/security.txt` endpoint (RFC 9116), an append-only `audit_events` table with immutable-row triggers, IP-attributed audit events for all sensitive auth and resume operations, and recursive JSON complexity limits (depth, string length, serialized size) applied consistently across create/update/import/render paths.

- **Audit logging** — New `record_event` helper with fire-and-forget error handling writes `auth.login.success`, `auth.login.failure`, `auth.logout`, `resume.delete`, and `resume.import.batch` events; the migration uses `ON DELETE RESTRICT` on the `actor_user_id` FK to preserve immutability.
- **JSON validation** — `validate_resume_json` / `validate_title` are called at all entry points (`create_resume`, `update_resume`, `import_resumes`, `prepare_resume` for render paths); constants are centralized in `config.rs`.
- **Operational docs** — Secrets-rotation runbook added to both the repo (`docs/operations/`) and the public site mirror.
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; all audit wiring, validation guards, and the migration are self-contained and do not alter existing data paths.

The auth and resume mutations now have consistent IP-attributed audit coverage, the migration's immutable-row triggers and ON DELETE RESTRICT FK correctly enforce the append-only contract, and the JSON complexity validators are applied at every entry point with tests covering the boundary. The one noted item — the hardcoded Expires date in security_txt.rs — is a future operational concern, not a current defect.

crates/server/src/routes/security_txt.rs — the hardcoded Expires date will eventually require a code change and deployment to renew.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/routes/security_txt.rs | New RFC 9116 endpoint serving a hardcoded security.txt; the Expires date is baked in at compile-time and will need an annual code+deploy cycle to stay valid. |
| crates/server/src/audit/mod.rs | New append-only audit log helper; fire-and-forget design is intentional and well-documented. No issues found. |
| crates/server/src/db/migrations/005_audit_events.sql | Creates audit_events table with ON DELETE RESTRICT FK, immutable-row triggers for both UPDATE and DELETE, and appropriate composite indexes. |
| crates/server/src/validation/json_limits.rs | Recursive depth/string-length/byte-size validation for resume JSON; the accepts_json_at_max_depth test correctly documents that 31 object wrappers (leaf at depth 32) is the effective maximum. |
| crates/server/src/routes/auth.rs | Wires audit events for login success, login failure (provider error, invalid state, missing code), and logout; IP extraction is consistent across all call sites. |
| crates/server/src/routes/resumes.rs | Adds JSON/title validation on create, update, and import paths; records resume.delete and resume.import.batch audit events with IP capture via HeaderMap extractor. |
| crates/server/src/routes/render.rs | Calls validate_resume_json inside prepare_resume, covering both render_preview and render_pdf paths before any processing occurs. |
| crates/server/src/config.rs | Adds four new validation constants (MAX_JSON_DEPTH, MAX_STRING_FIELD_LEN, MAX_RESUME_JSON_BYTES, MAX_TITLE_LEN); values are reasonable and centrally defined. |
| crates/server/src/app.rs | Registers /.well-known/security.txt at the top-level router (unauthenticated), correctly outside all auth/rate-limit middleware groups. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant AuthRoute as auth.rs
    participant ResumeRoute as resumes.rs
    participant RenderRoute as render.rs
    participant Validation as json_limits.rs
    participant AuditLog as audit/mod.rs
    participant DB as PostgreSQL

    Client->>AuthRoute: GET /auth/callback
    AuthRoute->>AuthRoute: trusted_client_ip()
    alt OAuth state mismatch / auth failure
        AuthRoute->>AuditLog: record_event(auth.login.failure, reason, ip)
        AuditLog->>DB: INSERT audit_events
    else Success
        AuthRoute->>AuditLog: record_event(auth.login.success, user_id, ip)
        AuditLog->>DB: INSERT audit_events
    end

    Client->>AuthRoute: POST /auth/logout
    AuthRoute->>AuthRoute: sessions.user_for_token()
    AuthRoute->>AuditLog: record_event(auth.logout, actor_user_id?, ip)
    AuditLog->>DB: INSERT audit_events

    Client->>ResumeRoute: POST /api/resumes
    ResumeRoute->>Validation: validate_title() + validate_resume_json()
    alt Invalid payload
        Validation-->>Client: 400 Bad Request
    else Valid
        ResumeRoute->>DB: INSERT resumes
    end

    Client->>ResumeRoute: DELETE /api/resumes/:id
    ResumeRoute->>DB: DELETE FROM resumes
    ResumeRoute->>AuditLog: record_event(resume.delete, user_id, resume_id, ip)
    AuditLog->>DB: INSERT audit_events

    Client->>RenderRoute: POST /api/render/preview
    RenderRoute->>Validation: validate_resume_json()
    alt Depth / size exceeded
        Validation-->>Client: 400 Bad Request
    else Valid
        RenderRoute->>RenderRoute: prepare_resume() → render
        RenderRoute-->>Client: 200 HTML/PDF
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant AuthRoute as auth.rs
    participant ResumeRoute as resumes.rs
    participant RenderRoute as render.rs
    participant Validation as json_limits.rs
    participant AuditLog as audit/mod.rs
    participant DB as PostgreSQL

    Client->>AuthRoute: GET /auth/callback
    AuthRoute->>AuthRoute: trusted_client_ip()
    alt OAuth state mismatch / auth failure
        AuthRoute->>AuditLog: record_event(auth.login.failure, reason, ip)
        AuditLog->>DB: INSERT audit_events
    else Success
        AuthRoute->>AuditLog: record_event(auth.login.success, user_id, ip)
        AuditLog->>DB: INSERT audit_events
    end

    Client->>AuthRoute: POST /auth/logout
    AuthRoute->>AuthRoute: sessions.user_for_token()
    AuthRoute->>AuditLog: record_event(auth.logout, actor_user_id?, ip)
    AuditLog->>DB: INSERT audit_events

    Client->>ResumeRoute: POST /api/resumes
    ResumeRoute->>Validation: validate_title() + validate_resume_json()
    alt Invalid payload
        Validation-->>Client: 400 Bad Request
    else Valid
        ResumeRoute->>DB: INSERT resumes
    end

    Client->>ResumeRoute: DELETE /api/resumes/:id
    ResumeRoute->>DB: DELETE FROM resumes
    ResumeRoute->>AuditLog: record_event(resume.delete, user_id, resume_id, ip)
    AuditLog->>DB: INSERT audit_events

    Client->>RenderRoute: POST /api/render/preview
    RenderRoute->>Validation: validate_resume_json()
    alt Depth / size exceeded
        Validation-->>Client: 400 Bad Request
    else Valid
        RenderRoute->>RenderRoute: prepare_resume() → render
        RenderRoute-->>Client: 200 HTML/PDF
    end
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fserver%2Fsrc%2Froutes%2Fsecurity_txt.rs%3A10-14%0A**Hardcoded%20%60Expires%60%20date%20will%20silently%20go%20stale**%0A%0AThe%20%60Expires%60%20field%20is%20baked%20into%20a%20compile-time%20%60const%60%2C%20so%20updating%20it%20to%20the%20next%20annual%20date%20requires%20a%20code%20change%20and%20a%20full%20deployment.%20If%20that%20deploy%20is%20missed%2C%20any%20RFC-9116-compliant%20scanner%20or%20security%20researcher%20will%20reject%20the%20file%20as%20expired%20and%20may%20stop%20trying%20to%20report%20vulnerabilities.%20Additionally%2C%20the%20comment%20on%20line%2014%20%28%60%23%20Renew%20Expires%20annually%20%E2%80%94%20see%20SECURITY.md%20and%20issue%20%23248.%60%29%20is%20emitted%20verbatim%20in%20the%20public%20HTTP%20response%2C%20leaking%20the%20internal%20tracking%20issue%20number%20to%20any%20visitor%20or%20crawler.%0A%0A&pr=317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fserver%2Fsrc%2Froutes%2Fsecurity_txt.rs%3A10-14%0A**Hardcoded%20%60Expires%60%20date%20will%20silently%20go%20stale**%0A%0AThe%20%60Expires%60%20field%20is%20baked%20into%20a%20compile-time%20%60const%60%2C%20so%20updating%20it%20to%20the%20next%20annual%20date%20requires%20a%20code%20change%20and%20a%20full%20deployment.%20If%20that%20deploy%20is%20missed%2C%20any%20RFC-9116-compliant%20scanner%20or%20security%20researcher%20will%20reject%20the%20file%20as%20expired%20and%20may%20stop%20trying%20to%20report%20vulnerabilities.%20Additionally%2C%20the%20comment%20on%20line%2014%20%28%60%23%20Renew%20Expires%20annually%20%E2%80%94%20see%20SECURITY.md%20and%20issue%20%23248.%60%29%20is%20emitted%20verbatim%20in%20the%20public%20HTTP%20response%2C%20leaking%20the%20internal%20tracking%20issue%20number%20to%20any%20visitor%20or%20crawler.%0A%0A&repo=lgtm-hq%2Frustume&pr=317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22chore%2F248-post-launch-security-hardening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F248-post-launch-security-hardening%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fserver%2Fsrc%2Froutes%2Fsecurity_txt.rs%3A10-14%0A**Hardcoded%20%60Expires%60%20date%20will%20silently%20go%20stale**%0A%0AThe%20%60Expires%60%20field%20is%20baked%20into%20a%20compile-time%20%60const%60%2C%20so%20updating%20it%20to%20the%20next%20annual%20date%20requires%20a%20code%20change%20and%20a%20full%20deployment.%20If%20that%20deploy%20is%20missed%2C%20any%20RFC-9116-compliant%20scanner%20or%20security%20researcher%20will%20reject%20the%20file%20as%20expired%20and%20may%20stop%20trying%20to%20report%20vulnerabilities.%20Additionally%2C%20the%20comment%20on%20line%2014%20%28%60%23%20Renew%20Expires%20annually%20%E2%80%94%20see%20SECURITY.md%20and%20issue%20%23248.%60%29%20is%20emitted%20verbatim%20in%20the%20public%20HTTP%20response%2C%20leaking%20the%20internal%20tracking%20issue%20number%20to%20any%20visitor%20or%20crawler.%0A%0A&repo=lgtm-hq%2Frustume&pr=317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs: fix secrets rotation reference lin..."](https://github.com/lgtm-hq/rustume/commit/531bdf21618b3e214fffcc37831ce134604e98d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38620734)</sub>

<!-- /greptile_comment -->