### PR TITLE
feat(web): polish Rustume Cloud login and account UX

### DIFF
--- a/apps/web/src/components/Auth/AuthMenu.tsx
+++ b/apps/web/src/components/Auth/AuthMenu.tsx
@@ -26,8 +26,14 @@ export function AuthMenu() {
           when={state.user}
           fallback={
             <Show when={showSignedOutSignIn()}>
-              <Button variant="secondary" size="sm" onClick={handleSignIn} loading={signingIn()}>
-                Sign in to Cloud
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleSignIn}
+                loading={signingIn()}
+                title="Sign in to sync resumes across devices with Rustume Cloud"
+              >
+                Sign in to sync
               </Button>
             </Show>
           }

--- a/apps/web/src/components/Auth/RequireAuthGuard.tsx
+++ b/apps/web/src/components/Auth/RequireAuthGuard.tsx
@@ -1,5 +1,6 @@
-import { useLocation, useNavigate } from "@solidjs/router";
-import { createEffect, Show, type ParentComponent } from "solid-js";
+import { useLocation } from "@solidjs/router";
+import { Show, type ParentComponent } from "solid-js";
+import Unauthorized from "../../pages/Unauthorized";
 import { authStore } from "../../stores/auth";
 import { Spinner } from "../ui";
 
@@ -17,9 +18,8 @@ function isProtectedPath(pathname: string): boolean {
   return true;
 }
 
-/** Redirect signed-out users to login when hosted require-auth mode is active. */
+/** Block protected routes with a sign-in page when hosted require-auth mode is active. */
 export const RequireAuthGuard: ParentComponent = (props) => {
-  const navigate = useNavigate();
   const location = useLocation();
   const { state } = authStore;
 
@@ -30,22 +30,18 @@ export const RequireAuthGuard: ParentComponent = (props) => {
     !state.user &&
     isProtectedPath(location.pathname);
 
-  createEffect(() => {
-    if (!shouldBlock()) {
-      return;
-    }
-
-    navigate("/auth/login", { replace: true });
-  });
-
   return (
     <Show
-      when={!state.loading && !shouldBlock()}
+      when={!state.loading}
       fallback={
-        <Spinner class="w-6 h-6 text-accent mx-auto mt-24" ariaLabel="Loading authentication" />
+        <div class="flex min-h-[calc(100vh-3.5rem)] items-center justify-center">
+          <Spinner class="h-6 w-6 text-accent" ariaLabel="Loading authentication" />
+        </div>
       }
     >
-      {props.children}
+      <Show when={!shouldBlock()} fallback={<Unauthorized />}>
+        {props.children}
+      </Show>
     </Show>
   );
 };

--- a/apps/web/src/components/Auth/__tests__/RequireAuthGuard.test.tsx
+++ b/apps/web/src/components/Auth/__tests__/RequireAuthGuard.test.tsx
@@ -3,14 +3,13 @@ import { render, screen } from "@solidjs/testing-library";
 import { Route, Router } from "@solidjs/router";
 import { RequireAuthGuard } from "../RequireAuthGuard";
 
-const { mockAuthState, navigateMock, useLocationMock } = vi.hoisted(() => ({
+const { mockAuthState, useLocationMock } = vi.hoisted(() => ({
   mockAuthState: {
     loading: false,
     cloudEnabled: true,
     requireAuth: true,
     user: null as { id: string; plan: string } | null,
   },
-  navigateMock: vi.fn(),
   useLocationMock: vi.fn(() => ({
     pathname: "/edit/resume-1",
     search: "",
@@ -25,6 +24,7 @@ vi.mock("../../../stores/auth", () => ({
     get state() {
       return mockAuthState;
     },
+    signIn: vi.fn(),
   },
 }));
 
@@ -32,7 +32,6 @@ vi.mock("@solidjs/router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@solidjs/router")>();
   return {
     ...actual,
-    useNavigate: () => navigateMock,
     useLocation: () => useLocationMock(),
   };
 });
@@ -61,8 +60,7 @@ function renderGuard(pathname = "/edit/resume-1") {
 }
 
 describe("RequireAuthGuard", () => {
-  it("redirects signed-out users to login when require-auth mode is active", () => {
-    navigateMock.mockClear();
+  it("shows the unauthorized page when require-auth mode blocks access", () => {
     mockAuthState.loading = false;
     mockAuthState.cloudEnabled = true;
     mockAuthState.requireAuth = true;
@@ -70,7 +68,7 @@ describe("RequireAuthGuard", () => {
 
     renderGuard();
 
-    expect(navigateMock).toHaveBeenCalledWith("/auth/login", { replace: true });
+    expect(screen.getByTestId("unauthorized-page")).toBeInTheDocument();
     expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
   });
 
@@ -79,84 +77,67 @@ describe("RequireAuthGuard", () => {
     mockAuthState.cloudEnabled = true;
     mockAuthState.requireAuth = true;
     mockAuthState.user = { id: "user-1", plan: "free" };
-    navigateMock.mockClear();
 
     renderGuard();
 
-    expect(navigateMock).not.toHaveBeenCalled();
     expect(screen.getByTestId("protected-content")).toBeInTheDocument();
+    expect(screen.queryByTestId("unauthorized-page")).not.toBeInTheDocument();
   });
 
-  it("does not redirect when require-auth mode is disabled", () => {
+  it("does not block when require-auth mode is disabled", () => {
     mockAuthState.loading = false;
     mockAuthState.cloudEnabled = true;
     mockAuthState.requireAuth = false;
     mockAuthState.user = null;
-    navigateMock.mockClear();
 
     renderGuard();
 
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("protected-content")).toBeInTheDocument();
   });
 
-  it("does not redirect in self-hosted mode", () => {
+  it("does not block in self-hosted mode", () => {
     mockAuthState.loading = false;
     mockAuthState.cloudEnabled = false;
     mockAuthState.requireAuth = false;
     mockAuthState.user = null;
-    navigateMock.mockClear();
 
     renderGuard();
 
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("protected-content")).toBeInTheDocument();
   });
 
-  it("does not redirect when the user is signed in", () => {
-    mockAuthState.loading = false;
-    mockAuthState.cloudEnabled = true;
-    mockAuthState.requireAuth = true;
-    mockAuthState.user = { id: "user-1", plan: "free" };
-    navigateMock.mockClear();
-
-    renderGuard();
-
-    expect(navigateMock).not.toHaveBeenCalled();
-  });
-
-  it("defers navigation while auth is loading", () => {
+  it("shows a loading state while auth is loading", () => {
     mockAuthState.loading = true;
     mockAuthState.cloudEnabled = true;
     mockAuthState.requireAuth = true;
     mockAuthState.user = null;
-    navigateMock.mockClear();
 
     renderGuard();
 
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Loading authentication")).toBeInTheDocument();
     expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("unauthorized-page")).not.toBeInTheDocument();
   });
 
-  it("does not redirect on auth callback paths", () => {
+  it("does not block auth callback paths", () => {
     mockAuthState.loading = false;
     mockAuthState.cloudEnabled = true;
     mockAuthState.requireAuth = true;
     mockAuthState.user = null;
-    navigateMock.mockClear();
 
     renderGuard("/auth/callback");
 
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("protected-content")).toBeInTheDocument();
   });
 
-  it("does not redirect on account sub-routes", () => {
+  it("does not block account sub-routes", () => {
     mockAuthState.loading = false;
     mockAuthState.cloudEnabled = true;
     mockAuthState.requireAuth = true;
     mockAuthState.user = null;
-    navigateMock.mockClear();
 
     renderGuard("/account/settings");
 
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("protected-content")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/errors/StatusPage.tsx
+++ b/apps/web/src/components/errors/StatusPage.tsx
@@ -1,0 +1,115 @@
+import { A } from "@solidjs/router";
+import { Show, type JSX } from "solid-js";
+import { Button } from "../ui";
+
+export interface StatusPageAction {
+  label: string;
+  onClick?: () => void;
+  href?: string;
+  loading?: boolean;
+  variant?: "primary" | "secondary";
+}
+
+export interface StatusPageProps {
+  /** HTTP-style status code shown in the hero. */
+  statusCode: string;
+  /** Short page title. */
+  title: string;
+  /** Supporting copy beneath the title. */
+  description: string;
+  /** Primary call to action. */
+  primaryAction: StatusPageAction;
+  /** Optional secondary action rendered as a text link. */
+  secondaryAction?: StatusPageAction;
+  /** Optional decorative icon rendered above the title. */
+  icon?: JSX.Element;
+  /** Optional test id for the page root. */
+  testId?: string;
+}
+
+/** Shared layout for application error and auth-required pages. */
+export function StatusPage(props: StatusPageProps) {
+  return (
+    <div
+      class="relative flex min-h-[calc(100vh-3.5rem)] items-center justify-center overflow-hidden px-4 py-16"
+      data-testid={props.testId}
+    >
+      <div
+        class="pointer-events-none absolute inset-0 flex items-center justify-center select-none"
+        aria-hidden="true"
+      >
+        <span class="font-display text-[10rem] font-bold leading-none text-ink/[0.04] md:text-[14rem]">
+          {props.statusCode}
+        </span>
+      </div>
+
+      <section
+        class="relative z-10 w-full max-w-xl animate-slide-up text-center"
+        aria-labelledby="status-page-title"
+      >
+        <Show when={props.icon}>
+          <div class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl border border-border bg-surface shadow-soft">
+            {props.icon}
+          </div>
+        </Show>
+
+        <p class="font-mono text-xs uppercase tracking-[0.3em] text-stone">{props.statusCode}</p>
+        <h1
+          id="status-page-title"
+          class="mt-3 font-display text-3xl font-semibold text-ink md:text-4xl"
+        >
+          {props.title}
+        </h1>
+        <p class="mx-auto mt-4 max-w-md text-base leading-7 text-stone">{props.description}</p>
+
+        <div class="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <Show
+            when={props.primaryAction.href}
+            fallback={
+              <Button
+                size="lg"
+                variant={props.primaryAction.variant === "secondary" ? "secondary" : undefined}
+                onClick={() => props.primaryAction.onClick?.()}
+                loading={props.primaryAction.loading}
+              >
+                {props.primaryAction.label}
+              </Button>
+            }
+          >
+            {(href) => (
+              <A
+                href={href()}
+                class="inline-flex items-center justify-center rounded-lg bg-ink px-6 py-3 text-base font-medium text-paper shadow-soft transition-all hover:bg-ink/90"
+              >
+                {props.primaryAction.label}
+              </A>
+            )}
+          </Show>
+
+          <Show when={props.secondaryAction}>
+            {(action) => (
+              <Show
+                when={action().href}
+                fallback={
+                  <button
+                    type="button"
+                    class="text-sm font-medium text-accent hover:underline"
+                    onClick={() => action().onClick?.()}
+                  >
+                    {action().label}
+                  </button>
+                }
+              >
+                {(href) => (
+                  <A href={href()} class="text-sm font-medium text-accent hover:underline">
+                    {action().label}
+                  </A>
+                )}
+              </Show>
+            )}
+          </Show>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/errors/StatusPage.tsx
+++ b/apps/web/src/components/errors/StatusPage.tsx
@@ -25,10 +25,14 @@ export interface StatusPageProps {
   icon?: JSX.Element;
   /** Optional test id for the page root. */
   testId?: string;
+  /** Heading id for aria-labelledby; override when multiple instances may mount. */
+  titleId?: string;
 }
 
 /** Shared layout for application error and auth-required pages. */
 export function StatusPage(props: StatusPageProps) {
+  const titleId = () => props.titleId ?? "status-page-title";
+
   return (
     <div
       class="relative flex min-h-[calc(100vh-3.5rem)] items-center justify-center overflow-hidden px-4 py-16"
@@ -45,7 +49,7 @@ export function StatusPage(props: StatusPageProps) {
 
       <section
         class="relative z-10 w-full max-w-xl animate-slide-up text-center"
-        aria-labelledby="status-page-title"
+        aria-labelledby={titleId()}
       >
         <Show when={props.icon}>
           <div class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl border border-border bg-surface shadow-soft">
@@ -54,10 +58,7 @@ export function StatusPage(props: StatusPageProps) {
         </Show>
 
         <p class="font-mono text-xs uppercase tracking-[0.3em] text-stone">{props.statusCode}</p>
-        <h1
-          id="status-page-title"
-          class="mt-3 font-display text-3xl font-semibold text-ink md:text-4xl"
-        >
+        <h1 id={titleId()} class="mt-3 font-display text-3xl font-semibold text-ink md:text-4xl">
           {props.title}
         </h1>
         <p class="mx-auto mt-4 max-w-md text-base leading-7 text-stone">{props.description}</p>

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -92,7 +92,7 @@ export default function Account() {
                       : "Sync resumes across devices with your Rustume Cloud account. Your local copies stay on this device until you choose to import them."}
                   </p>
                   <Button onClick={handleSignIn} loading={signingIn()}>
-                    Sign in to Cloud
+                    Sign in to sync
                   </Button>
                   <Show when={!state.requireAuth}>
                     <p class="mt-4 text-xs text-stone">

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -138,7 +138,7 @@ export default function Home() {
               loading={signingIn()}
               data-testid="home-cloud-sign-in"
             >
-              Sign in to Cloud
+              Sign in to sync
             </Button>
           </div>
         </div>

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -33,6 +33,7 @@ export default function NotFound() {
   return (
     <StatusPage
       testId="not-found-page"
+      titleId="not-found-page-title"
       statusCode="404"
       title="Page not found"
       description={`We couldn't find a page at ${pathLabel()}. Your resumes are still safe — head back home or open one from your list.`}

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -1,27 +1,50 @@
-import { useNavigate } from "@solidjs/router";
-import { Button } from "../components/ui";
+import { useLocation, useNavigate } from "@solidjs/router";
+import { StatusPage } from "../components/errors/StatusPage";
+
+function MissingPageIcon() {
+  return (
+    <svg
+      class="h-8 w-8 text-accent"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.75"
+        d="M8 4h8l3 4v11a1 1 0 01-1 1H6a1 1 0 01-1-1V5a1 1 0 011-1h2z"
+      />
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M9 12h6" />
+    </svg>
+  );
+}
 
 export default function NotFound() {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const pathLabel = () => {
+    const path = location.pathname;
+    return path.length > 48 ? `${path.slice(0, 45)}…` : path;
+  };
 
   return (
-    <main class="min-h-[calc(100vh-4rem)] bg-paper px-6 py-16 text-ink">
-      <section class="mx-auto flex max-w-3xl flex-col items-start gap-8 rounded-3xl border border-border/60 bg-surface/70 p-8 shadow-card md:p-12">
-        <div class="space-y-4">
-          <p class="font-mono text-sm uppercase tracking-[0.35em] text-stone">404</p>
-          <h1 class="font-display text-4xl font-semibold leading-tight md:text-5xl">
-            This page is off the page.
-          </h1>
-          <p class="max-w-2xl text-lg leading-8 text-stone">
-            The route you opened does not exist in Rustume. Your saved resumes are still available
-            from the home screen.
-          </p>
-        </div>
-
-        <Button size="lg" onClick={() => navigate("/", { replace: true })}>
-          Back to resumes
-        </Button>
-      </section>
-    </main>
+    <StatusPage
+      testId="not-found-page"
+      statusCode="404"
+      title="Page not found"
+      description={`We couldn't find a page at ${pathLabel()}. Your resumes are still safe — head back home or open one from your list.`}
+      icon={<MissingPageIcon />}
+      primaryAction={{
+        label: "Back to resumes",
+        onClick: () => navigate("/", { replace: true }),
+      }}
+      secondaryAction={{
+        label: "Open account",
+        href: "/account",
+      }}
+    />
   );
 }

--- a/apps/web/src/pages/Unauthorized.tsx
+++ b/apps/web/src/pages/Unauthorized.tsx
@@ -1,0 +1,52 @@
+import { createSignal } from "solid-js";
+import { StatusPage } from "../components/errors/StatusPage";
+import { authStore } from "../stores/auth";
+
+function LockIcon() {
+  return (
+    <svg
+      class="h-8 w-8 text-accent"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.75"
+        d="M16 11V8a4 4 0 10-8 0v3M6 11h12v9H6z"
+      />
+    </svg>
+  );
+}
+
+/** Shown when hosted Rustume Cloud requires sign-in before using the app. */
+export default function Unauthorized() {
+  const { signIn } = authStore;
+  const [signingIn, setSigningIn] = createSignal(false);
+
+  const handleSignIn = () => {
+    setSigningIn(true);
+    signIn();
+  };
+
+  return (
+    <StatusPage
+      testId="unauthorized-page"
+      statusCode="401"
+      title="Sign in required"
+      description="Rustume Cloud on this deployment requires an account. Sign in to open, edit, and sync your resumes across devices."
+      icon={<LockIcon />}
+      primaryAction={{
+        label: "Sign in to sync across devices",
+        onClick: handleSignIn,
+        loading: signingIn(),
+      }}
+      secondaryAction={{
+        label: "Learn about cloud accounts",
+        href: "/account",
+      }}
+    />
+  );
+}

--- a/apps/web/src/pages/Unauthorized.tsx
+++ b/apps/web/src/pages/Unauthorized.tsx
@@ -28,12 +28,17 @@ export default function Unauthorized() {
 
   const handleSignIn = () => {
     setSigningIn(true);
-    signIn();
+    try {
+      signIn();
+    } catch {
+      setSigningIn(false);
+    }
   };
 
   return (
     <StatusPage
       testId="unauthorized-page"
+      titleId="unauthorized-page-title"
       statusCode="401"
       title="Sign in required"
       description="Rustume Cloud on this deployment requires an account. Sign in to open, edit, and sync your resumes across devices."

--- a/apps/web/src/pages/__tests__/Account.test.tsx
+++ b/apps/web/src/pages/__tests__/Account.test.tsx
@@ -65,7 +65,7 @@ describe("Account page", () => {
     renderAccount();
 
     expect(screen.getByText("Sign in to Rustume Cloud")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Sign in to Cloud" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in to sync" })).toBeInTheDocument();
     expect(screen.getByText(/Continue without signing in/i)).toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/__tests__/NotFound.test.tsx
+++ b/apps/web/src/pages/__tests__/NotFound.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { Route, Router } from "@solidjs/router";
+import NotFound from "../NotFound";
+
+vi.mock("@solidjs/router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solidjs/router")>();
+  return {
+    ...actual,
+    useLocation: () => ({
+      pathname: "/missing-page",
+      search: "",
+      hash: "",
+      state: null,
+      query: {},
+    }),
+    useNavigate: () => vi.fn(),
+  };
+});
+
+describe("NotFound page", () => {
+  it("renders a helpful 404 message with navigation actions", () => {
+    render(() => (
+      <Router>
+        <Route path="*" component={NotFound} />
+      </Router>
+    ));
+
+    expect(screen.getByTestId("not-found-page")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Page not found" })).toBeInTheDocument();
+    expect(screen.getByText(/missing-page/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back to resumes" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open account" })).toHaveAttribute("href", "/account");
+  });
+});

--- a/apps/web/src/pages/__tests__/NotFound.test.tsx
+++ b/apps/web/src/pages/__tests__/NotFound.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { Route, Router } from "@solidjs/router";
 import NotFound from "../NotFound";
+
+const { navigateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+}));
 
 vi.mock("@solidjs/router", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@solidjs/router")>();
@@ -14,12 +18,14 @@ vi.mock("@solidjs/router", async (importOriginal) => {
       state: null,
       query: {},
     }),
-    useNavigate: () => vi.fn(),
+    useNavigate: () => navigateMock,
   };
 });
 
 describe("NotFound page", () => {
   it("renders a helpful 404 message with navigation actions", () => {
+    navigateMock.mockClear();
+
     render(() => (
       <Router>
         <Route path="*" component={NotFound} />
@@ -31,5 +37,18 @@ describe("NotFound page", () => {
     expect(screen.getByText(/missing-page/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Back to resumes" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open account" })).toHaveAttribute("href", "/account");
+  });
+
+  it("navigates home when the primary action is clicked", () => {
+    navigateMock.mockClear();
+
+    render(() => (
+      <Router>
+        <Route path="*" component={NotFound} />
+      </Router>
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to resumes" }));
+    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
   });
 });

--- a/apps/web/src/pages/__tests__/Unauthorized.test.tsx
+++ b/apps/web/src/pages/__tests__/Unauthorized.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { Route, Router } from "@solidjs/router";
+import Unauthorized from "../Unauthorized";
+
+const { signInMock } = vi.hoisted(() => ({
+  signInMock: vi.fn(),
+}));
+
+vi.mock("../../stores/auth", () => ({
+  authStore: {
+    signIn: signInMock,
+  },
+}));
+
+describe("Unauthorized page", () => {
+  it("renders sign-in guidance and actions", () => {
+    signInMock.mockClear();
+
+    render(() => (
+      <Router>
+        <Route path="*" component={Unauthorized} />
+      </Router>
+    ));
+
+    expect(screen.getByTestId("unauthorized-page")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Sign in required" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sign in to sync across devices" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Learn about cloud accounts" })).toHaveAttribute(
+      "href",
+      "/account",
+    );
+  });
+
+  it("starts sign-in when the primary action is clicked", () => {
+    signInMock.mockClear();
+
+    render(() => (
+      <Router>
+        <Route path="*" component={Unauthorized} />
+      </Router>
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in to sync across devices" }));
+    expect(signInMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): polish Rustume Cloud login and account UX
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Completes the remaining #253 edge-case and error UX on top of the account menu,
profile fields, and `RequireAuthGuard` work already on main (#287, #311). Adds
polished 404/401 pages, in-app unauthorized handling, and clearer “sign in to
sync” copy so OAuth failures and protected routes feel first-class.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #253
- Relates to #243

## Details

### Changes made

- Add shared `StatusPage` layout (watermark code, icon, actions)
- Redesign `NotFound` with path context and recovery actions
- Add `Unauthorized` page for sign-in-required states
- Update `RequireAuthGuard` to render `Unauthorized` instead of redirecting to `/auth/login`
- Align copy to “Sign in to sync” in `AuthMenu`, `Home`, and `Account`
- Add/update tests: `NotFound`, `Unauthorized`, `RequireAuthGuard`

### Testing strategy

- `cd apps/web && bun run test` — 256 tests passing
- `uv run lintro fmt` / `uv run lintro chk` — zero issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Sign in required” unauthorized page for protected routes, displayed instead of redirecting.
  * Introduced a shared `StatusPage` component used to render standardized 404/401-style views.
* **Improvements**
  * Updated cloud sign-in wording from “Sign in to Cloud” to “Sign in to sync” across the app.
  * Updated the 404 page to use the shared layout and show route-aware details plus improved actions.
* **Tests**
  * Updated and added coverage for the new unauthorized/404 rendering and actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR completes the Rustume Cloud login and account UX polish by introducing a shared `StatusPage` layout, redesigning `NotFound` with path context, adding a new `Unauthorized` page, and switching `RequireAuthGuard` from a redirect-based block to an inline in-place render of `Unauthorized`. Copy is also aligned to "Sign in to sync" across `AuthMenu`, `Home`, and `Account`.

- **`RequireAuthGuard`** drops the `createEffect` + `navigate` pattern in favour of a nested `<Show>` that renders `<Unauthorized />` directly, keeping the URL stable while prompting sign-in.
- **`StatusPage`** is a new reusable layout component consumed by both `NotFound` and `Unauthorized`; both callers pass unique `titleId` props, addressing the duplicate-`id` concern from prior review threads.
- Tests are added for all three new/changed components.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — well-scoped UX improvements with good test coverage and no regressions in auth guard logic.

The `RequireAuthGuard` refactor is straightforward and the reactive conditions are correct. `StatusPage` is a clean presentational component. The two minor observations (dead try/catch in `Unauthorized.tsx` and silently dropped `loading`/`variant` props on link-rendered primary actions) don't affect runtime behavior for any current caller.

`StatusPage.tsx` — the `primaryAction.href` branch silently ignores `loading` and `variant`; worth a follow-up if future callers need a link-style primary action with loading state.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/errors/StatusPage.tsx | New shared layout component for status/error pages; `loading` and `variant` on `primaryAction` are silently dropped when `href` is set (no current callers affected, but latent interface inconsistency). |
| apps/web/src/pages/Unauthorized.tsx | New unauthorized page shown by RequireAuthGuard; contains a dead try/catch around the synchronous `signIn()` call that diverges from the established pattern. |
| apps/web/src/components/Auth/RequireAuthGuard.tsx | Cleanly replaces the navigate-on-effect pattern with inline `<Unauthorized />` rendering; loading/blocking logic is correct. |
| apps/web/src/pages/NotFound.tsx | Redesigned to use `StatusPage`; path label is truncated and rendered as a text node (no XSS risk). |
| apps/web/src/components/Auth/__tests__/RequireAuthGuard.test.tsx | Tests updated to reflect in-place `Unauthorized` rendering instead of redirect; covers loading, blocked, and bypass cases thoroughly. |
| apps/web/src/pages/__tests__/Unauthorized.test.tsx | New tests cover rendering and sign-in click; correctly mocks `authStore.signIn`. |
| apps/web/src/pages/__tests__/NotFound.test.tsx | New tests validate 404 rendering and navigation action; clean and complete. |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fpages%2FUnauthorized.tsx%3A29-36%0A%60signIn%60%20is%20the%20synchronous%20%60login%28%29%60%20function%20%28%60window.location.href%20%3D%20%22%2Fauth%2Flogin%22%60%29%2C%20which%20never%20throws.%20The%20%60catch%60%20block%20%E2%80%94%20including%20%60setSigningIn%28false%29%60%20%E2%80%94%20is%20unreachable%20dead%20code%20and%20diverges%20from%20the%20established%20pattern%20in%20%60AuthMenu.tsx%60%20and%20%60Account.tsx%60%2C%20both%20of%20which%20simply%20call%20%60setSigningIn%28true%29%3B%20signIn%28%29%3B%60%20without%20a%20try%2Fcatch.%0A%0A%60%60%60suggestion%0A%20%20const%20handleSignIn%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20setSigningIn%28true%29%3B%0A%20%20%20%20signIn%28%29%3B%0A%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fcomponents%2Ferrors%2FStatusPage.tsx%3A67-88%0A%60loading%60%20and%20%60variant%60%20on%20%60StatusPageAction%60%20are%20silently%20ignored%20when%20%60primaryAction.href%60%20is%20set%20%E2%80%94%20the%20branch%20renders%20a%20plain%20%60%3CA%3E%60%20link%20and%20never%20reads%20those%20props.%20Current%20callers%20%28%60NotFound%60%2C%20%60Unauthorized%60%29%20only%20put%20%60href%60%20on%20the%20secondary%20action%2C%20so%20nothing%20breaks%20today%2C%20but%20the%20interface%20implies%20all%20props%20work%20regardless%20of%20which%20rendering%20path%20is%20taken.%20Consider%20either%20rendering%20a%20%60Button%60%20with%20%60as%3D%7BA%7D%60%20%28if%20the%20UI%20component%20supports%20it%29%2C%20or%20documenting%20that%20%60loading%60%2F%60variant%60%20have%20no%20effect%20on%20link-rendered%20actions.%0A%0A&pr=320&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fpages%2FUnauthorized.tsx%3A29-36%0A%60signIn%60%20is%20the%20synchronous%20%60login%28%29%60%20function%20%28%60window.location.href%20%3D%20%22%2Fauth%2Flogin%22%60%29%2C%20which%20never%20throws.%20The%20%60catch%60%20block%20%E2%80%94%20including%20%60setSigningIn%28false%29%60%20%E2%80%94%20is%20unreachable%20dead%20code%20and%20diverges%20from%20the%20established%20pattern%20in%20%60AuthMenu.tsx%60%20and%20%60Account.tsx%60%2C%20both%20of%20which%20simply%20call%20%60setSigningIn%28true%29%3B%20signIn%28%29%3B%60%20without%20a%20try%2Fcatch.%0A%0A%60%60%60suggestion%0A%20%20const%20handleSignIn%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20setSigningIn%28true%29%3B%0A%20%20%20%20signIn%28%29%3B%0A%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fcomponents%2Ferrors%2FStatusPage.tsx%3A67-88%0A%60loading%60%20and%20%60variant%60%20on%20%60StatusPageAction%60%20are%20silently%20ignored%20when%20%60primaryAction.href%60%20is%20set%20%E2%80%94%20the%20branch%20renders%20a%20plain%20%60%3CA%3E%60%20link%20and%20never%20reads%20those%20props.%20Current%20callers%20%28%60NotFound%60%2C%20%60Unauthorized%60%29%20only%20put%20%60href%60%20on%20the%20secondary%20action%2C%20so%20nothing%20breaks%20today%2C%20but%20the%20interface%20implies%20all%20props%20work%20regardless%20of%20which%20rendering%20path%20is%20taken.%20Consider%20either%20rendering%20a%20%60Button%60%20with%20%60as%3D%7BA%7D%60%20%28if%20the%20UI%20component%20supports%20it%29%2C%20or%20documenting%20that%20%60loading%60%2F%60variant%60%20have%20no%20effect%20on%20link-rendered%20actions.%0A%0A&repo=lgtm-hq%2Frustume&pr=320&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22feat%2F253-cloud-login-account-ux%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F253-cloud-login-account-ux%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fpages%2FUnauthorized.tsx%3A29-36%0A%60signIn%60%20is%20the%20synchronous%20%60login%28%29%60%20function%20%28%60window.location.href%20%3D%20%22%2Fauth%2Flogin%22%60%29%2C%20which%20never%20throws.%20The%20%60catch%60%20block%20%E2%80%94%20including%20%60setSigningIn%28false%29%60%20%E2%80%94%20is%20unreachable%20dead%20code%20and%20diverges%20from%20the%20established%20pattern%20in%20%60AuthMenu.tsx%60%20and%20%60Account.tsx%60%2C%20both%20of%20which%20simply%20call%20%60setSigningIn%28true%29%3B%20signIn%28%29%3B%60%20without%20a%20try%2Fcatch.%0A%0A%60%60%60suggestion%0A%20%20const%20handleSignIn%20%3D%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20setSigningIn%28true%29%3B%0A%20%20%20%20signIn%28%29%3B%0A%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fcomponents%2Ferrors%2FStatusPage.tsx%3A67-88%0A%60loading%60%20and%20%60variant%60%20on%20%60StatusPageAction%60%20are%20silently%20ignored%20when%20%60primaryAction.href%60%20is%20set%20%E2%80%94%20the%20branch%20renders%20a%20plain%20%60%3CA%3E%60%20link%20and%20never%20reads%20those%20props.%20Current%20callers%20%28%60NotFound%60%2C%20%60Unauthorized%60%29%20only%20put%20%60href%60%20on%20the%20secondary%20action%2C%20so%20nothing%20breaks%20today%2C%20but%20the%20interface%20implies%20all%20props%20work%20regardless%20of%20which%20rendering%20path%20is%20taken.%20Consider%20either%20rendering%20a%20%60Button%60%20with%20%60as%3D%7BA%7D%60%20%28if%20the%20UI%20component%20supports%20it%29%2C%20or%20documenting%20that%20%60loading%60%2F%60variant%60%20have%20no%20effect%20on%20link-rendered%20actions.%0A%0A&repo=lgtm-hq%2Frustume&pr=320&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(web): harden StatusPage a11y and err..."](https://github.com/lgtm-hq/rustume/commit/834299b803ae63e878f744480e4181b46393c100) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38652656)</sub>

<!-- /greptile_comment -->