### PR TITLE
fix(ci): trigger release PR for web and site app changes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,7 +44,8 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 ## Release
 
 - **semantic-release.yml** — Opens version bump PR via `reusable-release-version-pr`
-  (dual `workflow_run` + `push` triggers for non-Rust commits)
+  (`workflow_run` after Rust Build, Coverage Reports, or Site Quality on `main`;
+  `push` fallback for docs-only commits)
 - **auto-tag-on-main.yml** — Creates tags when `Cargo.toml` version changes on `main`
   via `reusable-release-auto-tag` (`version-source: cargo`, `create-release: false`)
 - **publish-release-on-tag.yml** — GitHub Release on tag push (inline;

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,7 +45,8 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 
 - **semantic-release.yml** — Opens version bump PR via `reusable-release-version-pr`
   (`workflow_run` after Rust Build, Coverage Reports, or Site Quality on `main`;
-  `push` fallback for docs-only commits)
+  `push` fallback for config/scripting/tooling changes that skip all three app-CI
+  workflows)
 - **auto-tag-on-main.yml** — Creates tags when `Cargo.toml` version changes on `main`
   via `reusable-release-auto-tag` (`version-source: cargo`, `create-release: false`)
 - **publish-release-on-tag.yml** — GitHub Release on tag push (inline;

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -7,7 +7,7 @@ name: Release - Automated PR Creation
 # - Rust Build (workspace) — backend / workspace Rust changes
 # - Coverage Reports — web app and Rust test coverage changes
 # - Quality - Documentation Site — apps/site documentation site changes
-# - push (paths below) — docs/scripts-only commits that skip app CI workflows
+# - push (paths below) — commits that skip Rust Build, Coverage, and Site Quality
 
 "on":
   # Gate releases on CI passing: trigger after app or Rust CI workflows complete.
@@ -18,12 +18,11 @@ name: Release - Automated PR Creation
       - Quality - Documentation Site
     branches: [main]
     types: [completed]
-  # For commits that don't touch app source (docs, scripts, Docker, etc.)
-  # the test suite never runs, so fall back to a direct push trigger.
+  # Fallback when no app CI workflow runs (e.g. Docker-only or hygiene workflow edits).
+  # Omit docs/** — Quality - Documentation Site workflow_run covers that path set.
   push:
     branches: [main]
     paths:
-      - "docs/**"
       - "scripts/**"
       - "docker/**"
       - "**.md"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -2,15 +2,23 @@
 ---
 name: Release - Automated PR Creation
 # Computes next semantic version using conventional commits and opens release PR.
+#
+# Trigger matrix (after CI succeeds on main):
+# - Rust Build (workspace) — backend / workspace Rust changes
+# - Coverage Reports — web app and Rust test coverage changes
+# - Quality - Documentation Site — apps/site documentation site changes
+# - push (paths below) — docs/scripts-only commits that skip app CI workflows
 
 "on":
-  # Gate releases on CI passing: only trigger after the Rust build workflow
-  # completes on main. The job condition below rejects failed runs.
+  # Gate releases on CI passing: trigger after app or Rust CI workflows complete.
   workflow_run:
-    workflows: ["Rust Build (workspace)"]
+    workflows:
+      - Rust Build (workspace)
+      - Coverage Reports
+      - Quality - Documentation Site
     branches: [main]
     types: [completed]
-  # For commits that don't touch Rust source (docs, scripts, Docker, etc.)
+  # For commits that don't touch app source (docs, scripts, Docker, etc.)
   # the test suite never runs, so fall back to a direct push trigger.
   push:
     branches: [main]

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -7,7 +7,8 @@ name: Release - Automated PR Creation
 # - Rust Build (workspace) — backend / workspace Rust changes
 # - Coverage Reports — web app and Rust test coverage changes
 # - Quality - Documentation Site — apps/site documentation site changes
-# - push (paths below) — commits that skip Rust Build, Coverage, and Site Quality
+# - push (paths below) — config/scripting/tooling changes that skip all three app-CI
+#   workflows (scripts, docker, markdown, renovate, .github, Makefile)
 
 "on":
   # Gate releases on CI passing: trigger after app or Rust CI workflows complete.
@@ -18,8 +19,8 @@ name: Release - Automated PR Creation
       - Quality - Documentation Site
     branches: [main]
     types: [completed]
-  # Fallback when no app CI workflow runs (e.g. Docker-only or hygiene workflow edits).
-  # Omit docs/** — Quality - Documentation Site workflow_run covers that path set.
+  # Fallback for config/scripting/tooling changes that skip Rust Build, Coverage, and
+  # Site Quality. Omit docs/** — Site Quality workflow_run covers that path set.
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): trigger release PR for web and site app changes
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Extends `semantic-release.yml` so release PR creation runs after CI workflows that already gate frontend and docs-site merges — not only Rust Build. Web-only merges like #320 (`feat(web)`) were shipping without a version bump because neither `workflow_run` nor `push` paths matched `apps/web/**`.

Also removes `docs/**` from the push fallback to avoid duplicate release runs when Site Quality already triggers via `workflow_run`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #321
- Relates to #320

## Details

**`workflow_run` triggers added:**
- Coverage Reports — covers `apps/web/**` TypeScript changes
- Quality - Documentation Site — covers `apps/site/**` changes
- Rust Build (workspace) — unchanged for backend/Rust

**Push fallback** retained for paths that skip all three workflows (`scripts/**`, `docker/**`, `**.md`, `renovate.json`, `.github/**`, `Makefile`). `docs/**` removed because Site Quality `workflow_run` already covers it.

`concurrency: release-pr-${{ github.ref }}` dedupes when multiple workflows complete for the same merge.

After merge, consider a one-time `workflow_dispatch` on Release to backfill the missed minor bump for #320 (`feat(web)` at `daec673`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a gap where merges touching only `apps/web/**` or `apps/site/**` bypassed the semantic-release workflow entirely, as neither the existing `workflow_run` (Rust Build only) nor the push paths matched those directories. The fix adds Coverage Reports and Quality - Documentation Site to the `workflow_run` list, and removes the now-redundant `docs/**` push path.

- **Trigger gap closed**: web and site commits now reliably chain into the release-PR workflow via the relevant CI workflow completing, mirroring the existing Rust Build chain.
- **`docs/**` push path removed**: intended to eliminate the double-trigger introduced by adding Quality - Documentation Site to `workflow_run`, though `**.md` in the retained push paths still overlaps with markdown files under `docs/`, `apps/web/`, and `apps/site/`.
- **Concurrency group**: `cancel-in-progress: true` is already present and acts as the deduplication mechanism for concurrent workflow_run completions, but this setting contradicts the repo's documented standard that release workflows should not cancel in-progress runs on `main`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core trigger-gap fix is correct and the worst-case runtime behavior (double-triggering) is already handled by the concurrency group.

The change correctly closes the release-PR gap for web and site commits. No logic path is broken: the job condition already filters out failed workflow_run conclusions, and the concurrency group prevents duplicate release PRs from landing.

.github/workflows/semantic-release.yml — the push-paths glob and the concurrency cancel behavior are worth a second look before triggering at higher volume.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/semantic-release.yml | Expands workflow_run triggers to include Coverage Reports and Quality - Documentation Site, and removes docs/** from the push fallback. Core fix is correct, but the **.md glob still double-fires for markdown in docs/ and apps/web/, and cancel-in-progress: true conflicts with the repo's documented standard for release workflows. |
| .github/workflows/README.md | Docs-only update: trigger matrix description updated to reflect the new three-workflow_run + push-fallback design. |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fsemantic-release.yml%3A29%0A**%60**.md%60%20overlap%20reintroduces%20the%20duplicate%20trigger%20the%20%60docs%2F**%60%20removal%20was%20meant%20to%20prevent**%0A%0AThe%20PR%20removes%20%60docs%2F**%60%20from%20push%20paths%20to%20avoid%20firing%20semantic-release%20twice%20%28once%20via%20push%2C%20once%20via%20the%20new%20Quality%20-%20Documentation%20Site%20%60workflow_run%60%29.%20However%2C%20%60**.md%60%20still%20matches%20every%20markdown%20file%2C%20including%20%60docs%2Ffoo.md%60%2C%20%60apps%2Fsite%2FREADME.md%60%2C%20and%20%60apps%2Fweb%2FCHANGELOG.md%60.%20Any%20commit%20touching%20a%20markdown%20file%20under%20those%20directories%20will%20now%20trigger%20semantic-release%20from%20both%20paths%20simultaneously%20%E2%80%94%20exactly%20the%20duplication%20the%20removal%20was%20trying%20to%20eliminate.%20%60cancel-in-progress%3A%20true%60%20dedups%20the%20runs%2C%20but%20it%20means%20a%20live%20release-PR%20job%20can%20be%20killed%20mid-flight%20and%20restarted.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fsemantic-release.yml%3A41-43%0A**%60cancel-in-progress%3A%20true%60%20contradicts%20the%20repo's%20own%20standard%20for%20release%20workflows**%0A%0A%60README.md%60%20%28Concurrency%20section%29%20states%3A%20%22Deploy%20and%20release%20workflows%20do%20not%20cancel%20in-progress%20runs%20on%20%60main%60.%22%20This%20workflow%20has%20%60cancel-in-progress%3A%20true%60%2C%20and%20the%20PR%20description%20explicitly%20relies%20on%20that%20setting%20to%20deduplicate%20the%20now-higher%20number%20of%20concurrent%20workflow_run%20triggers.%20Using%20%60cancel-in-progress%3A%20true%60%20on%20a%20release-PR-creation%20job%20means%20a%20mid-flight%20run%20can%20be%20killed%20when%20a%20second%20trigger%20fires%20within%20seconds%20of%20the%20first%20%E2%80%94%20which%20is%20now%20the%20normal%20case%20for%20any%20Rust%20commit%20that%20triggers%20both%20Rust%20Build%20and%20Coverage%20Reports.%0A%0A&pr=322&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fsemantic-release.yml%3A29%0A**%60**.md%60%20overlap%20reintroduces%20the%20duplicate%20trigger%20the%20%60docs%2F**%60%20removal%20was%20meant%20to%20prevent**%0A%0AThe%20PR%20removes%20%60docs%2F**%60%20from%20push%20paths%20to%20avoid%20firing%20semantic-release%20twice%20%28once%20via%20push%2C%20once%20via%20the%20new%20Quality%20-%20Documentation%20Site%20%60workflow_run%60%29.%20However%2C%20%60**.md%60%20still%20matches%20every%20markdown%20file%2C%20including%20%60docs%2Ffoo.md%60%2C%20%60apps%2Fsite%2FREADME.md%60%2C%20and%20%60apps%2Fweb%2FCHANGELOG.md%60.%20Any%20commit%20touching%20a%20markdown%20file%20under%20those%20directories%20will%20now%20trigger%20semantic-release%20from%20both%20paths%20simultaneously%20%E2%80%94%20exactly%20the%20duplication%20the%20removal%20was%20trying%20to%20eliminate.%20%60cancel-in-progress%3A%20true%60%20dedups%20the%20runs%2C%20but%20it%20means%20a%20live%20release-PR%20job%20can%20be%20killed%20mid-flight%20and%20restarted.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fsemantic-release.yml%3A41-43%0A**%60cancel-in-progress%3A%20true%60%20contradicts%20the%20repo's%20own%20standard%20for%20release%20workflows**%0A%0A%60README.md%60%20%28Concurrency%20section%29%20states%3A%20%22Deploy%20and%20release%20workflows%20do%20not%20cancel%20in-progress%20runs%20on%20%60main%60.%22%20This%20workflow%20has%20%60cancel-in-progress%3A%20true%60%2C%20and%20the%20PR%20description%20explicitly%20relies%20on%20that%20setting%20to%20deduplicate%20the%20now-higher%20number%20of%20concurrent%20workflow_run%20triggers.%20Using%20%60cancel-in-progress%3A%20true%60%20on%20a%20release-PR-creation%20job%20means%20a%20mid-flight%20run%20can%20be%20killed%20when%20a%20second%20trigger%20fires%20within%20seconds%20of%20the%20first%20%E2%80%94%20which%20is%20now%20the%20normal%20case%20for%20any%20Rust%20commit%20that%20triggers%20both%20Rust%20Build%20and%20Coverage%20Reports.%0A%0A&repo=lgtm-hq%2Frustume&pr=322&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F321-trigger-release-pr-for-web-and-site-app-changes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F321-trigger-release-pr-for-web-and-site-app-changes%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fsemantic-release.yml%3A29%0A**%60**.md%60%20overlap%20reintroduces%20the%20duplicate%20trigger%20the%20%60docs%2F**%60%20removal%20was%20meant%20to%20prevent**%0A%0AThe%20PR%20removes%20%60docs%2F**%60%20from%20push%20paths%20to%20avoid%20firing%20semantic-release%20twice%20%28once%20via%20push%2C%20once%20via%20the%20new%20Quality%20-%20Documentation%20Site%20%60workflow_run%60%29.%20However%2C%20%60**.md%60%20still%20matches%20every%20markdown%20file%2C%20including%20%60docs%2Ffoo.md%60%2C%20%60apps%2Fsite%2FREADME.md%60%2C%20and%20%60apps%2Fweb%2FCHANGELOG.md%60.%20Any%20commit%20touching%20a%20markdown%20file%20under%20those%20directories%20will%20now%20trigger%20semantic-release%20from%20both%20paths%20simultaneously%20%E2%80%94%20exactly%20the%20duplication%20the%20removal%20was%20trying%20to%20eliminate.%20%60cancel-in-progress%3A%20true%60%20dedups%20the%20runs%2C%20but%20it%20means%20a%20live%20release-PR%20job%20can%20be%20killed%20mid-flight%20and%20restarted.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fsemantic-release.yml%3A41-43%0A**%60cancel-in-progress%3A%20true%60%20contradicts%20the%20repo's%20own%20standard%20for%20release%20workflows**%0A%0A%60README.md%60%20%28Concurrency%20section%29%20states%3A%20%22Deploy%20and%20release%20workflows%20do%20not%20cancel%20in-progress%20runs%20on%20%60main%60.%22%20This%20workflow%20has%20%60cancel-in-progress%3A%20true%60%2C%20and%20the%20PR%20description%20explicitly%20relies%20on%20that%20setting%20to%20deduplicate%20the%20now-higher%20number%20of%20concurrent%20workflow_run%20triggers.%20Using%20%60cancel-in-progress%3A%20true%60%20on%20a%20release-PR-creation%20job%20means%20a%20mid-flight%20run%20can%20be%20killed%20when%20a%20second%20trigger%20fires%20within%20seconds%20of%20the%20first%20%E2%80%94%20which%20is%20now%20the%20normal%20case%20for%20any%20Rust%20commit%20that%20triggers%20both%20Rust%20Build%20and%20Coverage%20Reports.%0A%0A&repo=lgtm-hq%2Frustume&pr=322&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs(ci): align release push fallback de..."](https://github.com/lgtm-hq/rustume/commit/77938100e750f697a1fb7517dcadcbe031f7fe63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38662600)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow triggers to improve the reliability and consistency of the automated release process across multiple CI/CD scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->