### PR TITLE
feat(infra): transactional email service for account lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,10 @@ WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 # Session signing secret (generate: openssl rand -hex 32)
 SESSION_SECRET=
 
-# Transactional email (Resend)
+# Transactional email (Resend) — set both to enable account lifecycle mail
 RESEND_API_KEY=
-EMAIL_FROM=noreply@rustume.com
+# EMAIL_FROM=noreply@rustume.com
+EMAIL_FROM=
 
 # Prometheus scrape auth (Authorization: Bearer <METRICS_TOKEN>)
 METRICS_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,9 @@ WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 SESSION_SECRET=
 
 # Transactional email (Resend) — set both to enable account lifecycle mail
-RESEND_API_KEY=
-# EMAIL_FROM=noreply@rustume.com
 EMAIL_FROM=
+# RESEND_API_KEY=re_...
+RESEND_API_KEY=
 
 # Prometheus scrape auth (Authorization: Bearer <METRICS_TOKEN>)
 METRICS_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 # Session signing secret (generate: openssl rand -hex 32)
 SESSION_SECRET=
 
+# Transactional email (Resend)
+RESEND_API_KEY=
+EMAIL_FROM=noreply@rustume.com
+
 # Prometheus scrape auth (Authorization: Bearer <METRICS_TOKEN>)
 METRICS_TOKEN=
 

--- a/apps/site/src/content/docs/deployment/env-reference.md
+++ b/apps/site/src/content/docs/deployment/env-reference.md
@@ -40,7 +40,7 @@ enabled, these identity and persistence settings are required:
 | `WORKOS_API_KEY` | Server-side WorkOS API key |
 | `WORKOS_REDIRECT_URI` | Registered OAuth callback URL |
 | `SESSION_SECRET` | Session signing secret, at least 32 characters |
-| `RESEND_API_KEY` | Resend API key for transactional account lifecycle email |
+| `RESEND_API_KEY` | Resend API key; required together with `EMAIL_FROM` to enable transactional email |
 | `EMAIL_FROM` | Sender address for outbound mail (for example `noreply@rustume.com`) |
 
 Set `TRUSTED_PROXY=true` only when the server is behind a trusted proxy and may rely on

--- a/apps/site/src/content/docs/deployment/env-reference.md
+++ b/apps/site/src/content/docs/deployment/env-reference.md
@@ -40,6 +40,8 @@ enabled, these identity and persistence settings are required:
 | `WORKOS_API_KEY` | Server-side WorkOS API key |
 | `WORKOS_REDIRECT_URI` | Registered OAuth callback URL |
 | `SESSION_SECRET` | Session signing secret, at least 32 characters |
+| `RESEND_API_KEY` | Resend API key for transactional account lifecycle email |
+| `EMAIL_FROM` | Sender address for outbound mail (for example `noreply@rustume.com`) |
 
 Set `TRUSTED_PROXY=true` only when the server is behind a trusted proxy and may rely on
 `X-Forwarded-For` when calling WorkOS.
@@ -54,6 +56,8 @@ export WORKOS_CLIENT_ID=client_...
 export WORKOS_API_KEY=sk_...
 export WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 export SESSION_SECRET="$(openssl rand -hex 32)"
+export RESEND_API_KEY=re_...
+export EMAIL_FROM=noreply@rustume.com
 export METRICS_TOKEN="$(openssl rand -hex 32)"
 export CORS_ORIGIN=http://localhost:5173
 cargo run -p rustume-server

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -4,7 +4,7 @@ use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::auth::session::SessionService;
 use crate::auth::workos::WorkOsClient;
@@ -117,8 +117,14 @@ fn required_non_empty_env(key: &str) -> anyhow::Result<String> {
 
 fn optional_non_empty_env(key: &str) -> anyhow::Result<Option<String>> {
     match std::env::var(key) {
-        Ok(value) if value.trim().is_empty() => Ok(None),
-        Ok(value) => Ok(Some(value)),
+        Ok(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.to_string()))
+            }
+        }
         Err(_) => Ok(None),
     }
 }
@@ -199,7 +205,7 @@ pub async fn init_cloud(config: CloudConfig) -> anyhow::Result<Arc<CloudState>> 
             Some(service)
         }
         None => {
-            warn!(
+            info!(
                 "Transactional email disabled: set RESEND_API_KEY and EMAIL_FROM to enable \
                  account lifecycle notifications"
             );

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -127,8 +127,8 @@ fn optional_non_empty_env(key: &str) -> anyhow::Result<Option<String>> {
             }
         }
         Err(VarError::NotPresent) => Ok(None),
-        Err(VarError::NotUnicode(os_string)) => Err(anyhow::anyhow!(
-            "environment variable {key} contains invalid unicode: {os_string:?}"
+        Err(VarError::NotUnicode(_os_string)) => Err(anyhow::anyhow!(
+            "environment variable {key} contains invalid unicode"
         )),
     }
 }

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -8,6 +8,7 @@ use tracing::info;
 
 use crate::auth::session::SessionService;
 use crate::auth::workos::WorkOsClient;
+use crate::email::EmailService;
 
 /// Cloud-specific configuration loaded from environment variables.
 #[derive(Clone)]
@@ -26,6 +27,10 @@ pub struct CloudConfig {
     pub db_max_connections: u32,
     /// Pool acquire timeout in seconds (`DB_ACQUIRE_TIMEOUT_SECS`, default 5).
     pub db_acquire_timeout_secs: u64,
+    /// Resend API key for transactional email (`RESEND_API_KEY`).
+    pub resend_api_key: String,
+    /// Sender address for outbound mail (`EMAIL_FROM`).
+    pub email_from: String,
 }
 
 impl CloudConfig {
@@ -46,6 +51,8 @@ impl CloudConfig {
             session_secret,
             db_max_connections: optional_env_u32("DB_MAX_CONNECTIONS", 10)?,
             db_acquire_timeout_secs: optional_env_u64("DB_ACQUIRE_TIMEOUT_SECS", 5)?,
+            resend_api_key: required_non_empty_env("RESEND_API_KEY")?,
+            email_from: required_non_empty_env("EMAIL_FROM")?,
         })
     }
 }
@@ -60,6 +67,8 @@ impl std::fmt::Debug for CloudConfig {
             .field("session_secret", &"<redacted>")
             .field("db_max_connections", &self.db_max_connections)
             .field("db_acquire_timeout_secs", &self.db_acquire_timeout_secs)
+            .field("resend_api_key", &"<redacted>")
+            .field("email_from", &self.email_from)
             .finish()
     }
 }
@@ -133,6 +142,8 @@ pub struct CloudState {
     pub sessions: SessionService,
     /// OAuth redirect URI validated at startup.
     pub workos_redirect_uri: String,
+    /// Transactional email delivery for account lifecycle events.
+    pub email: EmailService,
 }
 
 /// Connect to PostgreSQL, run migrations, and wire cloud auth services.
@@ -151,12 +162,14 @@ pub async fn init_cloud(config: CloudConfig) -> anyhow::Result<Arc<CloudState>> 
     let cookie_secure = config.workos_redirect_uri.starts_with("https://");
     let sessions = SessionService::new(db.clone(), config.session_secret, cookie_secure);
     let workos_redirect_uri = config.workos_redirect_uri;
+    let email = EmailService::new(config.resend_api_key, config.email_from);
 
     Ok(Arc::new(CloudState {
         db,
         workos,
         sessions,
         workos_redirect_uri,
+        email,
     }))
 }
 

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -134,7 +134,13 @@ fn validate_email_from(value: &str) -> anyhow::Result<()> {
     let Some((local, domain)) = trimmed.split_once('@') else {
         anyhow::bail!("EMAIL_FROM must be a valid email address");
     };
-    if local.is_empty() || domain.is_empty() || !domain.contains('.') {
+    if local.is_empty()
+        || domain.is_empty()
+        || domain.contains('@')
+        || domain.starts_with('.')
+        || domain.ends_with('.')
+        || !domain.contains('.')
+    {
         anyhow::bail!("EMAIL_FROM must be a valid email address");
     }
     Ok(())

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -2,6 +2,7 @@
 
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
+use std::env::VarError;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::info;
@@ -125,7 +126,10 @@ fn optional_non_empty_env(key: &str) -> anyhow::Result<Option<String>> {
                 Ok(Some(trimmed.to_string()))
             }
         }
-        Err(_) => Ok(None),
+        Err(VarError::NotPresent) => Ok(None),
+        Err(VarError::NotUnicode(os_string)) => Err(anyhow::anyhow!(
+            "environment variable {key} contains invalid unicode: {os_string:?}"
+        )),
     }
 }
 

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -4,7 +4,7 @@ use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::auth::session::SessionService;
 use crate::auth::workos::WorkOsClient;
@@ -27,10 +27,10 @@ pub struct CloudConfig {
     pub db_max_connections: u32,
     /// Pool acquire timeout in seconds (`DB_ACQUIRE_TIMEOUT_SECS`, default 5).
     pub db_acquire_timeout_secs: u64,
-    /// Resend API key for transactional email (`RESEND_API_KEY`).
-    pub resend_api_key: String,
-    /// Sender address for outbound mail (`EMAIL_FROM`).
-    pub email_from: String,
+    /// Resend API key when transactional email is enabled (`RESEND_API_KEY`).
+    pub resend_api_key: Option<String>,
+    /// Sender address when transactional email is enabled (`EMAIL_FROM`).
+    pub email_from: Option<String>,
 }
 
 impl CloudConfig {
@@ -51,8 +51,8 @@ impl CloudConfig {
             session_secret,
             db_max_connections: optional_env_u32("DB_MAX_CONNECTIONS", 10)?,
             db_acquire_timeout_secs: optional_env_u64("DB_ACQUIRE_TIMEOUT_SECS", 5)?,
-            resend_api_key: required_non_empty_env("RESEND_API_KEY")?,
-            email_from: required_non_empty_env("EMAIL_FROM")?,
+            resend_api_key: optional_non_empty_env("RESEND_API_KEY")?,
+            email_from: optional_non_empty_env("EMAIL_FROM")?,
         })
     }
 }
@@ -67,7 +67,10 @@ impl std::fmt::Debug for CloudConfig {
             .field("session_secret", &"<redacted>")
             .field("db_max_connections", &self.db_max_connections)
             .field("db_acquire_timeout_secs", &self.db_acquire_timeout_secs)
-            .field("resend_api_key", &"<redacted>")
+            .field(
+                "resend_api_key",
+                &self.resend_api_key.as_ref().map(|_| "<redacted>"),
+            )
             .field("email_from", &self.email_from)
             .finish()
     }
@@ -112,6 +115,38 @@ fn required_non_empty_env(key: &str) -> anyhow::Result<String> {
     Ok(value)
 }
 
+fn optional_non_empty_env(key: &str) -> anyhow::Result<Option<String>> {
+    match std::env::var(key) {
+        Ok(value) if value.trim().is_empty() => Ok(None),
+        Ok(value) => Ok(Some(value)),
+        Err(_) => Ok(None),
+    }
+}
+
+fn validate_email_from(value: &str) -> anyhow::Result<()> {
+    let trimmed = value.trim();
+    let Some((local, domain)) = trimmed.split_once('@') else {
+        anyhow::bail!("EMAIL_FROM must be a valid email address");
+    };
+    if local.is_empty() || domain.is_empty() || !domain.contains('.') {
+        anyhow::bail!("EMAIL_FROM must be a valid email address");
+    }
+    Ok(())
+}
+
+fn email_service_from_config(config: &CloudConfig) -> anyhow::Result<Option<EmailService>> {
+    match (&config.resend_api_key, &config.email_from) {
+        (Some(api_key), Some(from)) => {
+            validate_email_from(from)?;
+            Ok(Some(EmailService::new(api_key.clone(), from.clone())))
+        }
+        (None, None) => Ok(None),
+        _ => anyhow::bail!(
+            "RESEND_API_KEY and EMAIL_FROM must both be set to enable transactional email"
+        ),
+    }
+}
+
 /// Returns `true` when `RUSTUME_CLOUD` is enabled and `DATABASE_URL` is set.
 pub fn cloud_enabled() -> bool {
     matches!(std::env::var("RUSTUME_CLOUD").as_deref(), Ok("true" | "1"))
@@ -143,7 +178,7 @@ pub struct CloudState {
     /// OAuth redirect URI validated at startup.
     pub workos_redirect_uri: String,
     /// Transactional email delivery for account lifecycle events.
-    pub email: EmailService,
+    pub email: Option<EmailService>,
 }
 
 /// Connect to PostgreSQL, run migrations, and wire cloud auth services.
@@ -158,11 +193,24 @@ pub async fn init_cloud(config: CloudConfig) -> anyhow::Result<Arc<CloudState>> 
 
     info!("PostgreSQL migrations applied");
 
+    let email = match email_service_from_config(&config)? {
+        Some(service) => {
+            info!("Transactional email enabled");
+            Some(service)
+        }
+        None => {
+            warn!(
+                "Transactional email disabled: set RESEND_API_KEY and EMAIL_FROM to enable \
+                 account lifecycle notifications"
+            );
+            None
+        }
+    };
+
     let workos = WorkOsClient::new(config.workos_client_id, config.workos_api_key);
     let cookie_secure = config.workos_redirect_uri.starts_with("https://");
     let sessions = SessionService::new(db.clone(), config.session_secret, cookie_secure);
     let workos_redirect_uri = config.workos_redirect_uri;
-    let email = EmailService::new(config.resend_api_key, config.email_from);
 
     Ok(Arc::new(CloudState {
         db,
@@ -184,5 +232,23 @@ mod tests {
         assert!(!require_auth_from_env(true, Some("false".to_string())));
         assert!(require_auth_from_env(true, Some("true".to_string())));
         assert!(require_auth_from_env(true, Some("1".to_string())));
+    }
+
+    #[test]
+    fn email_service_from_config_requires_both_vars() {
+        let config = CloudConfig {
+            database_url: "postgres://localhost/rustume".to_string(),
+            workos_client_id: "client".to_string(),
+            workos_api_key: "key".to_string(),
+            workos_redirect_uri: "http://localhost/auth/callback".to_string(),
+            session_secret: "test-session-secret-at-least-32-chars".to_string(),
+            db_max_connections: 10,
+            db_acquire_timeout_secs: 5,
+            resend_api_key: Some("re_test".to_string()),
+            email_from: None,
+        };
+
+        let err = email_service_from_config(&config).expect_err("partial config");
+        assert!(err.to_string().contains("RESEND_API_KEY and EMAIL_FROM"));
     }
 }

--- a/crates/server/src/email.rs
+++ b/crates/server/src/email.rs
@@ -1,0 +1,209 @@
+//! Transactional email delivery via the Resend API.
+
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use serde::Serialize;
+use tracing::warn;
+
+const RESEND_API_BASE: &str = "https://api.resend.com";
+
+/// HTTP client for Resend transactional email.
+#[derive(Clone)]
+pub struct EmailService {
+    http: Client,
+    api_key: String,
+    from: String,
+}
+
+impl EmailService {
+    /// Create a client with the given Resend credentials and sender address.
+    pub fn new(api_key: String, from: String) -> Self {
+        Self {
+            http: Client::new(),
+            api_key,
+            from,
+        }
+    }
+
+    /// Sender address used for outbound mail.
+    pub fn from_address(&self) -> &str {
+        &self.from
+    }
+
+    /// Notify the user that subscription cancellation started a grace period.
+    pub async fn send_cancellation_warning(
+        &self,
+        to: &str,
+        days_remaining: u32,
+    ) -> Result<(), EmailError> {
+        let subject = "Your Rustume Cloud subscription has been canceled";
+        let text = format!(
+            "Your Rustume Cloud subscription has been canceled.\n\n\
+             You can continue using Rustume Cloud for {days_remaining} more day(s). \
+             Export your resumes before access ends.\n\n\
+             To reactivate, sign in at https://app.rustume.com and update billing."
+        );
+        let html = format!(
+            "<p>Your Rustume Cloud subscription has been canceled.</p>\
+             <p>You can continue using Rustume Cloud for <strong>{days_remaining}</strong> \
+             more day(s). Export your resumes before access ends.</p>\
+             <p>To reactivate, sign in at \
+             <a href=\"https://app.rustume.com\">app.rustume.com</a> and update billing.</p>"
+        );
+        self.send(to, subject, &text, &html).await
+    }
+
+    /// Warn the user that account data will be deleted on a specific date.
+    pub async fn send_deletion_warning(
+        &self,
+        to: &str,
+        deletion_date: DateTime<Utc>,
+    ) -> Result<(), EmailError> {
+        let formatted = deletion_date.format("%Y-%m-%d %H:%M UTC");
+        let subject = "Your Rustume Cloud account will be deleted soon";
+        let text = format!(
+            "Your Rustume Cloud account and stored resumes are scheduled for deletion on \
+             {formatted}.\n\n\
+             Sign in at https://app.rustume.com to export your data or reactivate your \
+             subscription before that date."
+        );
+        let html = format!(
+            "<p>Your Rustume Cloud account and stored resumes are scheduled for deletion on \
+             <strong>{formatted}</strong>.</p>\
+             <p>Sign in at <a href=\"https://app.rustume.com\">app.rustume.com</a> to export \
+             your data or reactivate your subscription before that date.</p>"
+        );
+        self.send(to, subject, &text, &html).await
+    }
+
+    /// Confirm that account deletion completed.
+    pub async fn send_deletion_confirmation(&self, to: &str) -> Result<(), EmailError> {
+        let subject = "Your Rustume Cloud account has been deleted";
+        let text = "Your Rustume Cloud account and associated resume data have been deleted.\n\n\
+            If you did not request this, contact support@rustume.com immediately.";
+        let html = "<p>Your Rustume Cloud account and associated resume data have been \
+            deleted.</p><p>If you did not request this, contact \
+            <a href=\"mailto:support@rustume.com\">support@rustume.com</a> immediately.</p>";
+        self.send(to, subject, text, html).await
+    }
+
+    /// Notify the user that a payment failed and action is required.
+    pub async fn send_payment_failed(&self, to: &str) -> Result<(), EmailError> {
+        let subject = "Action required: Rustume Cloud payment failed";
+        let text = "We could not process your latest Rustume Cloud payment.\n\n\
+            Sign in at https://app.rustume.com to update your billing details and avoid \
+            service interruption.";
+        let html = "<p>We could not process your latest Rustume Cloud payment.</p>\
+            <p>Sign in at <a href=\"https://app.rustume.com\">app.rustume.com</a> to update \
+            your billing details and avoid service interruption.</p>";
+        self.send(to, subject, text, html).await
+    }
+
+    async fn send(
+        &self,
+        to: &str,
+        subject: &str,
+        text: &str,
+        html: &str,
+    ) -> Result<(), EmailError> {
+        let payload = ResendEmailRequest {
+            from: self.from.clone(),
+            to: vec![to.to_string()],
+            subject: subject.to_string(),
+            text: text.to_string(),
+            html: html.to_string(),
+        };
+
+        let response = self
+            .http
+            .post(format!("{RESEND_API_BASE}/emails"))
+            .bearer_auth(&self.api_key)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|err| EmailError::Transport(err.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|err| format!("failed to read response: {err}"));
+            let body = truncate_body(&body);
+            return Err(EmailError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ResendEmailRequest {
+    from: String,
+    to: Vec<String>,
+    subject: String,
+    text: String,
+    html: String,
+}
+
+/// Errors returned when communicating with Resend.
+#[derive(Debug, thiserror::Error)]
+pub enum EmailError {
+    #[error("Resend request failed: {0}")]
+    Transport(String),
+    #[error("Resend API error ({status}): {body}")]
+    Api { status: u16, body: String },
+}
+
+/// Log email delivery failures without failing the caller's primary action.
+pub fn log_send_failure(template: &str, recipient: &str, err: &EmailError) {
+    warn!(
+        template = template,
+        recipient = recipient,
+        error = %err,
+        "transactional email send failed"
+    );
+}
+
+fn truncate_body(body: &str) -> String {
+    if body.chars().count() > 200 {
+        let truncated: String = body.chars().take(200).collect();
+        format!("{truncated}… (truncated)")
+    } else {
+        body.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resend_payload_serializes_expected_fields() {
+        let payload = ResendEmailRequest {
+            from: "noreply@rustume.com".to_string(),
+            to: vec!["user@example.com".to_string()],
+            subject: "Test".to_string(),
+            text: "plain".to_string(),
+            html: "<p>html</p>".to_string(),
+        };
+
+        let json = serde_json::to_value(payload).expect("serialize");
+        assert_eq!(json["from"], "noreply@rustume.com");
+        assert_eq!(json["to"], serde_json::json!(["user@example.com"]));
+        assert_eq!(json["subject"], "Test");
+        assert_eq!(json["text"], "plain");
+        assert_eq!(json["html"], "<p>html</p>");
+    }
+
+    #[test]
+    fn truncate_body_limits_long_api_errors() {
+        let long = "x".repeat(250);
+        let truncated = truncate_body(&long);
+        assert!(truncated.chars().count() <= 220);
+        assert!(truncated.ends_with("… (truncated)"));
+    }
+}

--- a/crates/server/src/email.rs
+++ b/crates/server/src/email.rs
@@ -3,9 +3,11 @@
 use chrono::{DateTime, Utc};
 use reqwest::Client;
 use serde::Serialize;
+use std::time::Duration;
 use tracing::warn;
 
 const RESEND_API_BASE: &str = "https://api.resend.com";
+const RESEND_HTTP_TIMEOUT_SECS: u64 = 10;
 
 /// HTTP client for Resend transactional email.
 #[derive(Clone)]
@@ -15,11 +17,24 @@ pub struct EmailService {
     from: String,
 }
 
+impl std::fmt::Debug for EmailService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmailService")
+            .field("api_key", &"<redacted>")
+            .field("from", &self.from)
+            .finish_non_exhaustive()
+    }
+}
+
 impl EmailService {
     /// Create a client with the given Resend credentials and sender address.
     pub fn new(api_key: String, from: String) -> Self {
+        let http = Client::builder()
+            .timeout(Duration::from_secs(RESEND_HTTP_TIMEOUT_SECS))
+            .build()
+            .expect("reqwest client");
         Self {
-            http: Client::new(),
+            http,
             api_key,
             from,
         }
@@ -37,16 +52,17 @@ impl EmailService {
         days_remaining: u32,
     ) -> Result<(), EmailError> {
         let subject = "Your Rustume Cloud subscription has been canceled";
+        let days_label = if days_remaining == 1 { "day" } else { "days" };
         let text = format!(
             "Your Rustume Cloud subscription has been canceled.\n\n\
-             You can continue using Rustume Cloud for {days_remaining} more day(s). \
+             You can continue using Rustume Cloud for {days_remaining} more {days_label}. \
              Export your resumes before access ends.\n\n\
              To reactivate, sign in at https://app.rustume.com and update billing."
         );
         let html = format!(
             "<p>Your Rustume Cloud subscription has been canceled.</p>\
              <p>You can continue using Rustume Cloud for <strong>{days_remaining}</strong> \
-             more day(s). Export your resumes before access ends.</p>\
+             more {days_label}. Export your resumes before access ends.</p>\
              <p>To reactivate, sign in at \
              <a href=\"https://app.rustume.com\">app.rustume.com</a> and update billing.</p>"
         );
@@ -162,10 +178,23 @@ pub enum EmailError {
 pub fn log_send_failure(template: &str, recipient: &str, err: &EmailError) {
     warn!(
         template = template,
-        recipient = recipient,
+        recipient = %mask_recipient(recipient),
         error = %err,
         "transactional email send failed"
     );
+}
+
+fn mask_recipient(recipient: &str) -> String {
+    let Some((local, domain)) = recipient.split_once('@') else {
+        return "***".to_string();
+    };
+
+    let masked_local = match local.chars().next() {
+        Some(first) => format!("{first}*"),
+        None => "*".to_string(),
+    };
+
+    format!("{masked_local}@{domain}")
 }
 
 fn truncate_body(body: &str) -> String {
@@ -197,6 +226,11 @@ mod tests {
         assert_eq!(json["subject"], "Test");
         assert_eq!(json["text"], "plain");
         assert_eq!(json["html"], "<p>html</p>");
+    }
+
+    #[test]
+    fn mask_recipient_redacts_local_part() {
+        assert_eq!(mask_recipient("user@example.com"), "u*@example.com",);
     }
 
     #[test]

--- a/crates/server/src/email.rs
+++ b/crates/server/src/email.rs
@@ -176,12 +176,25 @@ pub enum EmailError {
 
 /// Log email delivery failures without failing the caller's primary action.
 pub fn log_send_failure(template: &str, recipient: &str, err: &EmailError) {
-    warn!(
-        template = template,
-        recipient = %mask_recipient(recipient),
-        error = %err,
-        "transactional email send failed"
-    );
+    let masked_recipient = mask_recipient(recipient);
+    match err {
+        EmailError::Api { status, .. } => {
+            warn!(
+                template = template,
+                recipient = %masked_recipient,
+                status = status,
+                "transactional email send failed (Resend API error)"
+            );
+        }
+        EmailError::Transport(message) => {
+            warn!(
+                template = template,
+                recipient = %masked_recipient,
+                error = %message,
+                "transactional email send failed"
+            );
+        }
+    }
 }
 
 fn mask_recipient(recipient: &str) -> String {
@@ -190,8 +203,8 @@ fn mask_recipient(recipient: &str) -> String {
     };
 
     let masked_local = match local.chars().next() {
-        Some(first) => format!("{first}*"),
-        None => "*".to_string(),
+        Some(first) => format!("{first}***"),
+        None => "***".to_string(),
     };
 
     format!("{masked_local}@{domain}")
@@ -230,7 +243,8 @@ mod tests {
 
     #[test]
     fn mask_recipient_redacts_local_part() {
-        assert_eq!(mask_recipient("user@example.com"), "u*@example.com",);
+        assert_eq!(mask_recipient("user@example.com"), "u***@example.com");
+        assert_eq!(mask_recipient("a@example.com"), "a***@example.com");
     }
 
     #[test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -693,7 +693,10 @@ mod tests {
                 false,
             ),
             workos_redirect_uri: "http://localhost/auth/callback".to_string(),
-            email: EmailService::new("re_test_key".to_string(), "noreply@rustume.com".to_string()),
+            email: Some(EmailService::new(
+                "re_test_key".to_string(),
+                "noreply@rustume.com".to_string(),
+            )),
         })
     }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -30,6 +30,7 @@ pub mod cloud;
 pub mod config;
 pub mod db;
 pub mod dto;
+pub mod email;
 pub mod error;
 pub mod middleware;
 pub mod net;
@@ -677,6 +678,7 @@ mod tests {
 
     fn test_cloud_state() -> std::sync::Arc<cloud::CloudState> {
         use auth::{session::SessionService, workos::WorkOsClient};
+        use email::EmailService;
         use sqlx::postgres::PgPoolOptions;
 
         let pool = PgPoolOptions::new()
@@ -691,6 +693,7 @@ mod tests {
                 false,
             ),
             workos_redirect_uri: "http://localhost/auth/callback".to_string(),
+            email: EmailService::new("re_test_key".to_string(), "noreply@rustume.com".to_string()),
         })
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@
 #
 # Rustume Cloud local dev:
 #   cp .env.example .env   # required: POSTGRES_PASSWORD, DATABASE_URL,
-#                          # SESSION_SECRET (32+ chars), WORKOS_CLIENT_ID, WORKOS_API_KEY
+#                          # SESSION_SECRET (32+ chars), WORKOS_CLIENT_ID, WORKOS_API_KEY,
+#                          # RESEND_API_KEY, EMAIL_FROM
 #   docker compose --profile cloud up
 ---
 services:
@@ -28,6 +29,8 @@ services:
       WORKOS_API_KEY: ${WORKOS_API_KEY:-}
       WORKOS_REDIRECT_URI: ${WORKOS_REDIRECT_URI:-http://localhost:3000/auth/callback}
       SESSION_SECRET: ${SESSION_SECRET:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      EMAIL_FROM: ${EMAIL_FROM:-noreply@rustume.com}
     restart: unless-stopped
     depends_on:
       postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@
 #
 # Rustume Cloud local dev:
 #   cp .env.example .env   # required: POSTGRES_PASSWORD, DATABASE_URL,
-#                          # SESSION_SECRET (32+ chars), WORKOS_CLIENT_ID, WORKOS_API_KEY,
-#                          # RESEND_API_KEY, EMAIL_FROM
+#                          # SESSION_SECRET (32+ chars), WORKOS_CLIENT_ID, WORKOS_API_KEY
+#                          # optional: RESEND_API_KEY + EMAIL_FROM (transactional email)
 #   docker compose --profile cloud up
 ---
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       WORKOS_REDIRECT_URI: ${WORKOS_REDIRECT_URI:-http://localhost:3000/auth/callback}
       SESSION_SECRET: ${SESSION_SECRET:-}
       RESEND_API_KEY: ${RESEND_API_KEY:-}
-      EMAIL_FROM: ${EMAIL_FROM:-noreply@rustume.com}
+      EMAIL_FROM: ${EMAIL_FROM:-}
     restart: unless-stopped
     depends_on:
       postgres:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -17,6 +17,10 @@ WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 # Session signing (generate: openssl rand -base64 32)
 SESSION_SECRET=
 
+# Transactional email (Resend)
+RESEND_API_KEY=
+EMAIL_FROM=noreply@rustume.com
+
 # Optional observability
 SENTRY_DSN=
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -18,9 +18,9 @@ WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 SESSION_SECRET=
 
 # Transactional email (Resend) — set both to enable account lifecycle mail
-RESEND_API_KEY=
-# EMAIL_FROM=noreply@rustume.com
 EMAIL_FROM=
+# RESEND_API_KEY=re_...
+RESEND_API_KEY=
 
 # Optional observability
 SENTRY_DSN=

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -17,9 +17,10 @@ WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 # Session signing (generate: openssl rand -base64 32)
 SESSION_SECRET=
 
-# Transactional email (Resend)
+# Transactional email (Resend) — set both to enable account lifecycle mail
 RESEND_API_KEY=
-EMAIL_FROM=noreply@rustume.com
+# EMAIL_FROM=noreply@rustume.com
+EMAIL_FROM=
 
 # Optional observability
 SENTRY_DSN=


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(infra): transactional email service for account lifecycle
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds Resend-backed transactional email infrastructure for Rustume Cloud account lifecycle events. `EmailService` lives on `CloudState` with templates for cancellation warnings, deletion warnings/confirmations, and payment failures. Email is enabled only when both `RESEND_API_KEY` and `EMAIL_FROM` are set, so existing deployments keep starting until operators add the new vars.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #258
- Relates to #255
- Relates to #256

## Details

**New module:** `crates/server/src/email.rs` — Resend HTTP client (10s timeout), lifecycle send helpers, masked failure logging.

**Cloud wiring:** `CloudConfig` reads optional `RESEND_API_KEY` / `EMAIL_FROM`; `init_cloud` enables email when both are present and validates sender format.

**Docs/env:** `.env.example`, `docker-compose.yml`, `docker/.env.example`, and deployment env reference updated.

**Tests:** Resend payload serialization, error truncation, recipient masking, partial-config guard.

Greptile + CodeRabbit review findings addressed (optional startup, HTTP timeout, PII-safe logs, pluralization).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transactional email support (Resend) for cancellation warnings, deletion warnings, deletion confirmations, and payment-failure alerts.
  * Transactional email is enabled only when both `EMAIL_FROM` and `RESEND_API_KEY` are set; delivery problems are logged without interrupting the main flow.

* **Documentation**
  * Expanded the environment variable reference and local “connected mode” example to include `EMAIL_FROM` and `RESEND_API_KEY`.
  * Updated `.env.example` files and Docker Compose configuration with matching placeholders/defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a Resend-backed transactional email service (`EmailService`) wired onto `CloudState` for account lifecycle events (cancellation warnings, deletion warnings/confirmations, payment failures). Email is intentionally optional — startup proceeds normally when neither env var is set — and delivery failures are logged without interrupting the primary caller.

- **`crates/server/src/email.rs`**: New module with an HTTP client (10 s timeout), four send helpers, PII-safe `log_send_failure`, and error truncation; all user-controlled data interpolated into HTML templates is non-string types (u32, DateTime), so no XSS paths exist.
- **`crates/server/src/cloud.rs`**: `CloudConfig` gains optional `resend_api_key` / `email_from` fields; `email_service_from_config` enforces "both or neither" at startup and validates the sender address format.
- **Config files** (`.env.example`, `docker-compose.yml`, `docker/.env.example`): Both email vars now default to empty strings, resolving the partial-config startup failure flagged in earlier review rounds.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive, email is optional at startup, and previous review findings have all been addressed.

The partial-config startup failure (both env files now default to empty), the noisy warn! on disabled email (now info!), and the mask_recipient edge case for short handles are all addressed from prior rounds. HTML templates interpolate only numeric and date types — no XSS paths. The API key is redacted in Debug output and never appears in error messages. The "both or neither" config guard is covered by a unit test. No new defects introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/email.rs | New email module: HTTP client with timeout, four lifecycle send helpers, PII-safe logging, and truncated error bodies. No user-controlled data is interpolated into HTML; all template variables are numeric or date types. |
| crates/server/src/cloud.rs | Adds optional email fields to CloudConfig, optional_non_empty_env helper, a basic email-address validator, and email_service_from_config with strict "both or neither" enforcement; wired into init_cloud with info-level logging. |
| docker-compose.yml | Both RESEND_API_KEY and EMAIL_FROM now default to empty strings, ensuring the "both unset → email disabled" path is taken and startup succeeds without explicit configuration. |
| .env.example | Both email vars left blank with a commented example; consistent with docker-compose defaults and the "both or neither" startup guard. |
| docker/.env.example | Mirrors root .env.example pattern: both vars blank, with commented placeholder. |
| apps/site/src/content/docs/deployment/env-reference.md | Docs table and connected-mode example updated to document the two optional email vars; example values are placeholders only. |
| crates/server/src/lib.rs | Adds pub mod email declaration and wires a test EmailService into test_cloud_state; no functional changes to routing or handlers. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Init as init_cloud()
    participant Cfg as email_service_from_config()
    participant ES as EmailService
    participant Resend as Resend API

    Init->>Cfg: "&CloudConfig (resend_api_key, email_from)"
    alt Both set
        Cfg->>Cfg: validate_email_from(from)
        Cfg-->>Init: Some(EmailService)
        Init->>ES: store on CloudState
    else Neither set
        Cfg-->>Init: None (email disabled)
    else One set
        Cfg-->>Init: Err (bail!)
    end

    Note over Init,ES: At runtime (lifecycle events)

    ES->>Resend: POST /emails (bearer_auth)
    alt 2xx
        Resend-->>ES: Ok(())
    else non-2xx
        Resend-->>ES: body (truncated to 200 chars)
        ES-->>ES: "EmailError::Api { status, body }"
        ES->>ES: log_send_failure() — warn! status only, masked recipient
    else transport error
        ES-->>ES: EmailError::Transport(msg)
        ES->>ES: log_send_failure() — warn! error msg, masked recipient
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Init as init_cloud()
    participant Cfg as email_service_from_config()
    participant ES as EmailService
    participant Resend as Resend API

    Init->>Cfg: "&CloudConfig (resend_api_key, email_from)"
    alt Both set
        Cfg->>Cfg: validate_email_from(from)
        Cfg-->>Init: Some(EmailService)
        Init->>ES: store on CloudState
    else Neither set
        Cfg-->>Init: None (email disabled)
    else One set
        Cfg-->>Init: Err (bail!)
    end

    Note over Init,ES: At runtime (lifecycle events)

    ES->>Resend: POST /emails (bearer_auth)
    alt 2xx
        Resend-->>ES: Ok(())
    else non-2xx
        Resend-->>ES: body (truncated to 200 chars)
        ES-->>ES: "EmailError::Api { status, body }"
        ES->>ES: log_send_failure() — warn! status only, masked recipient
    else transport error
        ES-->>ES: EmailError::Transport(msg)
        ES->>ES: log_send_failure() — warn! error msg, masked recipient
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(infra): omit invalid unicode bytes f..."](https://github.com/lgtm-hq/rustume/commit/e379d5e17f9f30fa3e429b913dd5768f68b11a29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38698542)</sub>

<!-- /greptile_comment -->