### PR TITLE
feat(cloud): account deletion with full data erasure

### DIFF
--- a/apps/web/src/api/__tests__/account.test.ts
+++ b/apps/web/src/api/__tests__/account.test.ts
@@ -29,7 +29,7 @@ describe("deleteAccount", () => {
       vi.fn().mockResolvedValue({
         ok: false,
         status: 400,
-        text: async () => "Type DELETE to confirm account deletion",
+        text: async () => JSON.stringify({ error: "Type DELETE to confirm account deletion" }),
       }),
     );
 

--- a/apps/web/src/api/__tests__/account.test.ts
+++ b/apps/web/src/api/__tests__/account.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { deleteAccount } from "../account";
+
+describe("deleteAccount", () => {
+  it("sends DELETE with confirmation body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        deleted: true,
+        message: "Account and all data permanently deleted.",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await deleteAccount("DELETE");
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/account", {
+      method: "DELETE",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ confirmation: "DELETE" }),
+    });
+    expect(result.deleted).toBe(true);
+  });
+
+  it("throws when the server rejects deletion", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => "Type DELETE to confirm account deletion",
+      }),
+    );
+
+    await expect(deleteAccount("delete")).rejects.toThrow(
+      "Type DELETE to confirm account deletion",
+    );
+  });
+});

--- a/apps/web/src/api/account.ts
+++ b/apps/web/src/api/account.ts
@@ -14,7 +14,16 @@ export async function deleteAccount(confirmation: string): Promise<DeleteAccount
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(text || `Account deletion failed (${response.status})`);
+    let message = text;
+    try {
+      const json = JSON.parse(text) as { error?: string };
+      if (typeof json.error === "string") {
+        message = json.error;
+      }
+    } catch {
+      // Keep raw text when the body is not JSON.
+    }
+    throw new Error(message || `Account deletion failed (${response.status})`);
   }
 
   return (await response.json()) as DeleteAccountResponse;

--- a/apps/web/src/api/account.ts
+++ b/apps/web/src/api/account.ts
@@ -1,0 +1,21 @@
+export interface DeleteAccountResponse {
+  deleted: boolean;
+  message: string;
+}
+
+/** Permanently delete the signed-in cloud account and all associated data. */
+export async function deleteAccount(confirmation: string): Promise<DeleteAccountResponse> {
+  const response = await fetch("/api/account", {
+    method: "DELETE",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ confirmation }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `Account deletion failed (${response.status})`);
+  }
+
+  return (await response.json()) as DeleteAccountResponse;
+}

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -53,7 +53,7 @@ export default function Account() {
     }
 
     setLoadingResumeCount(true);
-    void listCloudResumesPage(1)
+    void listCloudResumesPage(1, 1)
       .then((page) => setResumeCount(page.total))
       .catch((error) => {
         console.error("Failed to load resume count:", error);

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -1,7 +1,9 @@
-import { Show, createSignal } from "solid-js";
+import { Show, createEffect, createSignal } from "solid-js";
 import { A, useNavigate } from "@solidjs/router";
+import { deleteAccount } from "../api/account";
+import { listCloudResumesPage } from "../api/resumes";
 import { authStore } from "../stores/auth";
-import { Button, Spinner, toast } from "../components/ui";
+import { Button, Input, Modal, Spinner, toast } from "../components/ui";
 
 function ProfileAvatar(props: { label: string }) {
   return (
@@ -33,10 +35,32 @@ function ComingSoonRow(props: { title: string; description: string }) {
 }
 
 export default function Account() {
-  const { state, signIn, signOut, displayName } = authStore;
+  const { state, signIn, signOut, clearUser, displayName } = authStore;
   const navigate = useNavigate();
   const [signingOut, setSigningOut] = createSignal(false);
   const [signingIn, setSigningIn] = createSignal(false);
+  const [deleteModalOpen, setDeleteModalOpen] = createSignal(false);
+  const [deleteConfirmation, setDeleteConfirmation] = createSignal("");
+  const [resumeCount, setResumeCount] = createSignal<number | null>(null);
+  const [loadingResumeCount, setLoadingResumeCount] = createSignal(false);
+  const [deletingAccount, setDeletingAccount] = createSignal(false);
+
+  createEffect(() => {
+    if (!deleteModalOpen()) {
+      setDeleteConfirmation("");
+      setResumeCount(null);
+      return;
+    }
+
+    setLoadingResumeCount(true);
+    void listCloudResumesPage(1)
+      .then((page) => setResumeCount(page.total))
+      .catch((error) => {
+        console.error("Failed to load resume count:", error);
+        setResumeCount(null);
+      })
+      .finally(() => setLoadingResumeCount(false));
+  });
 
   const handleSignOut = async () => {
     setSigningOut(true);
@@ -56,6 +80,26 @@ export default function Account() {
     setSigningIn(true);
     signIn();
   };
+
+  const handleDeleteAccount = async () => {
+    setDeletingAccount(true);
+    try {
+      await deleteAccount(deleteConfirmation());
+      clearUser();
+      setDeleteModalOpen(false);
+      toast.success("Account deleted");
+      navigate("/");
+    } catch (error) {
+      console.error("Account deletion failed:", error);
+      toast.error(
+        error instanceof Error ? error.message : "Failed to delete account. Please try again.",
+      );
+    } finally {
+      setDeletingAccount(false);
+    }
+  };
+
+  const deleteConfirmed = () => deleteConfirmation() === "DELETE";
 
   return (
     <div class="min-h-[calc(100vh-3.5rem)] bg-paper">
@@ -169,6 +213,17 @@ export default function Account() {
                     />
                   </section>
 
+                  <section class="rounded-2xl border border-red-200 bg-red-50/40 p-6 shadow-card">
+                    <h2 class="font-display text-lg font-semibold text-ink mb-2">Danger zone</h2>
+                    <p class="text-sm text-stone mb-4">
+                      Permanently delete your account, all cloud resumes, and version history. This
+                      action cannot be undone.
+                    </p>
+                    <Button variant="danger" onClick={() => setDeleteModalOpen(true)}>
+                      Delete my account
+                    </Button>
+                  </section>
+
                   <div class="flex justify-end">
                     <Button
                       variant="secondary"
@@ -178,6 +233,57 @@ export default function Account() {
                       Sign out
                     </Button>
                   </div>
+
+                  <Modal
+                    open={deleteModalOpen()}
+                    onOpenChange={setDeleteModalOpen}
+                    title="Delete account"
+                    description="This permanently removes your Rustume Cloud account and data."
+                    size="lg"
+                  >
+                    <div class="space-y-4">
+                      <p class="text-sm text-stone">This will permanently delete:</p>
+                      <ul class="list-disc pl-5 text-sm text-stone space-y-1">
+                        <li>Your account and profile</li>
+                        <li>
+                          <Show
+                            when={!loadingResumeCount() && resumeCount() !== null}
+                            fallback="All cloud resumes"
+                          >
+                            All {resumeCount()} resumes
+                          </Show>
+                        </li>
+                        <li>All version history</li>
+                        <li>Your subscription (if active)</li>
+                      </ul>
+
+                      <p class="text-sm text-stone">
+                        Bulk export is coming in a future release. Download individual resumes from
+                        the editor before deleting if you need local copies.
+                      </p>
+
+                      <Input
+                        label="Type DELETE to confirm"
+                        value={deleteConfirmation()}
+                        onInput={setDeleteConfirmation}
+                        placeholder="DELETE"
+                      />
+
+                      <div class="flex justify-end gap-3 pt-2">
+                        <Button variant="secondary" onClick={() => setDeleteModalOpen(false)}>
+                          Cancel
+                        </Button>
+                        <Button
+                          variant="danger"
+                          onClick={() => void handleDeleteAccount()}
+                          loading={deletingAccount()}
+                          disabled={!deleteConfirmed()}
+                        >
+                          Delete permanently
+                        </Button>
+                      </div>
+                    </div>
+                  </Modal>
                 </div>
               )}
             </Show>

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -250,7 +250,7 @@ export default function Account() {
                             when={!loadingResumeCount() && resumeCount() !== null}
                             fallback="All cloud resumes"
                           >
-                            All {resumeCount()} resumes
+                            All {resumeCount()} {resumeCount() === 1 ? "resume" : "resumes"}
                           </Show>
                         </li>
                         <li>All version history</li>

--- a/apps/web/src/pages/__tests__/Account.test.tsx
+++ b/apps/web/src/pages/__tests__/Account.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { Route, Router } from "@solidjs/router";
 import Account from "../Account";
 
@@ -27,6 +27,7 @@ vi.mock("../../stores/auth", () => ({
     },
     signIn: signInMock,
     signOut: signOutMock,
+    clearUser: vi.fn(),
     // Mirrors userDisplayName — vi.mock hoisting prevents importing the real function.
     displayName: (user: { email?: string; first_name?: string; last_name?: string }) => {
       const parts = [user.first_name, user.last_name].filter(Boolean);
@@ -34,6 +35,14 @@ vi.mock("../../stores/auth", () => ({
       return user.email ?? "Account";
     },
   },
+}));
+
+vi.mock("../../api/account", () => ({
+  deleteAccount: vi.fn(),
+}));
+
+vi.mock("../../api/resumes", () => ({
+  listCloudResumesPage: vi.fn().mockResolvedValue({ total: 2, items: [], page: 1, per_page: 100 }),
 }));
 
 vi.mock("../../components/ui", async (importOriginal) => {
@@ -107,5 +116,24 @@ describe("Account page", () => {
     expect(screen.getByText("Billing")).toBeInTheDocument();
     expect(screen.getByText("End-to-end encryption")).toBeInTheDocument();
     expect(screen.getAllByText("Coming soon").length).toBeGreaterThan(0);
+    expect(screen.getByText("Danger zone")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete my account" })).toBeInTheDocument();
+  });
+
+  it("opens the delete confirmation modal", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = {
+      id: "user-1",
+      plan: "free",
+      email: "dev@example.com",
+    };
+
+    renderAccount();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete my account" }));
+
+    expect(screen.getByText("Type DELETE to confirm")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete permanently" })).toBeDisabled();
   });
 });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -61,6 +61,10 @@ function createAuthStore() {
     return userDisplayName(user);
   }
 
+  function clearUser() {
+    setState("user", null);
+  }
+
   return {
     get state() {
       return state;
@@ -68,6 +72,7 @@ function createAuthStore() {
     refresh,
     signIn: login,
     signOut,
+    clearUser,
     displayName,
   };
 }

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -156,18 +156,12 @@ pub fn create_router_with_state(state: AppState) -> Router {
             ));
         }
 
-        let mut account_routes = Router::new()
+        let account_routes = Router::new()
             .route("/api/account", delete(delete_account))
             .route_layer(middleware::from_fn_with_state(
                 state.clone(),
                 require_auth_when_enabled,
             ));
-        if cloud_rate_limits {
-            account_routes = account_routes.route_layer(middleware::from_fn_with_state(
-                state_for_layers.clone(),
-                rate_limit_resume_crud,
-            ));
-        }
 
         router = router
             .merge(auth_routes)

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -2,7 +2,7 @@ use axum::{
     extract::DefaultBodyLimit,
     http::{header, HeaderValue, Method},
     middleware,
-    routing::{get, post},
+    routing::{delete, get, post},
     Router,
 };
 use std::path::PathBuf;
@@ -26,9 +26,9 @@ use crate::middleware::security::security_headers;
 use crate::observability::apply_sentry_layers;
 use crate::openapi::ApiDoc;
 use crate::routes::{
-    callback, create_resume, delete_resume, get_resume, health, import_resumes, list_resumes,
-    list_templates, login, logout, me, metrics, parse, render_pdf, render_preview, security_txt,
-    spa_fallback, static_dir, template_thumbnail, update_resume, validate,
+    callback, create_resume, delete_account, delete_resume, get_resume, health, import_resumes,
+    list_resumes, list_templates, login, logout, me, metrics, parse, render_pdf, render_preview,
+    security_txt, spa_fallback, static_dir, template_thumbnail, update_resume, validate,
 };
 use crate::state::AppState;
 
@@ -156,10 +156,24 @@ pub fn create_router_with_state(state: AppState) -> Router {
             ));
         }
 
+        let mut account_routes = Router::new()
+            .route("/api/account", delete(delete_account))
+            .route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_auth_when_enabled,
+            ));
+        if cloud_rate_limits {
+            account_routes = account_routes.route_layer(middleware::from_fn_with_state(
+                state_for_layers.clone(),
+                rate_limit_resume_crud,
+            ));
+        }
+
         router = router
             .merge(auth_routes)
             .merge(resume_routes)
-            .merge(import_routes);
+            .merge(import_routes)
+            .merge(account_routes);
     }
 
     let router = router

--- a/crates/server/src/auth/workos.rs
+++ b/crates/server/src/auth/workos.rs
@@ -94,6 +94,39 @@ impl WorkOsClient {
 
         Ok(payload.user)
     }
+
+    /// Delete a WorkOS user by ID. Best-effort during account erasure.
+    pub async fn delete_user(&self, workos_user_id: &str) -> Result<(), WorkOsAuthError> {
+        let response = self
+            .http
+            .delete(format!(
+                "{WORKOS_API_BASE}/user_management/users/{workos_user_id}"
+            ))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .map_err(|err| WorkOsAuthError::Transport(err.to_string()))?;
+
+        if response.status().is_success() || response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("failed to read response: {e}"));
+        let body = if body.chars().count() > 200 {
+            let truncated: String = body.chars().take(200).collect();
+            format!("{truncated}… (truncated)")
+        } else {
+            body
+        };
+        Err(WorkOsAuthError::Api {
+            status: status.as_u16(),
+            body,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/server/src/auth/workos.rs
+++ b/crates/server/src/auth/workos.rs
@@ -2,10 +2,12 @@
 
 use reqwest::Client;
 use serde::Deserialize;
+use std::time::Duration;
 
 use crate::db::User;
 
 const WORKOS_API_BASE: &str = "https://api.workos.com";
+const WORKOS_HTTP_TIMEOUT_SECS: u64 = 10;
 
 /// HTTP client for WorkOS User Management API calls.
 #[derive(Clone)]
@@ -103,6 +105,7 @@ impl WorkOsClient {
                 "{WORKOS_API_BASE}/user_management/users/{workos_user_id}"
             ))
             .bearer_auth(&self.api_key)
+            .timeout(Duration::from_secs(WORKOS_HTTP_TIMEOUT_SECS))
             .send()
             .await
             .map_err(|err| WorkOsAuthError::Transport(err.to_string()))?;

--- a/crates/server/src/auth/workos.rs
+++ b/crates/server/src/auth/workos.rs
@@ -67,6 +67,7 @@ impl WorkOsClient {
             .http
             .post(format!("{WORKOS_API_BASE}/user_management/authenticate"))
             .json(&body)
+            .timeout(Duration::from_secs(WORKOS_HTTP_TIMEOUT_SECS))
             .send()
             .await
             .map_err(|err| WorkOsAuthError::Transport(err.to_string()))?;

--- a/crates/server/src/db/migrations/006_audit_events_actor_fk.sql
+++ b/crates/server/src/db/migrations/006_audit_events_actor_fk.sql
@@ -1,0 +1,4 @@
+-- Retain audit history when a user is hard-deleted.
+-- actor_user_id remains as a historical UUID without a live FK.
+ALTER TABLE audit_events
+    DROP CONSTRAINT IF EXISTS audit_events_actor_user_id_fkey;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -207,6 +207,20 @@ pub struct AuthMeUnauthorizedResponse {
     pub require_auth: bool,
 }
 
+/// Request body for `DELETE /api/account`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DeleteAccountRequest {
+    /// Typed confirmation; must be exactly `DELETE`.
+    pub confirmation: String,
+}
+
+/// Response body for `DELETE /api/account`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DeleteAccountResponse {
+    pub deleted: bool,
+    pub message: String,
+}
+
 impl AuthUserResponse {
     /// Build a profile response with the hosted require-auth flag.
     pub fn from_user(user: User, require_auth: bool) -> Self {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -21,6 +21,7 @@
 //! - `GET/POST /api/resumes` - List and create resumes
 //! - `GET/PUT/DELETE /api/resumes/{id}` - Resume CRUD
 //! - `POST /api/resumes/import` - Bulk import from local storage
+//! - `DELETE /api/account` - Permanently delete account and all data
 //! - `GET /metrics` - Prometheus metrics
 
 pub mod app;
@@ -922,5 +923,29 @@ mod tests {
             serde_json::from_slice(&body).unwrap();
         assert!(payload.retry_after >= 1);
         assert!(payload.error.contains("Too many requests"));
+    }
+
+    #[tokio::test]
+    async fn test_delete_account_unauthenticated_401() {
+        let state = state::AppState::with_require_auth(
+            std::sync::Arc::new(routes::static_dir()),
+            Some(test_cloud_state()),
+            true,
+        );
+        let app = create_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/account")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"confirmation":"DELETE"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -5,9 +5,10 @@ use utoipa::Modify;
 use utoipa::OpenApi;
 
 use crate::db::{
-    AuthMeUnauthorizedResponse, AuthUserResponse, CreateResumeRequest, ImportFailure,
-    ImportResumeItem, ImportResumesRequest, ImportResumesResponse, PaginatedResumeSummaries,
-    ResumeListQuery, ResumeRow, ResumeSummary, UpdateResumeRequest,
+    AuthMeUnauthorizedResponse, AuthUserResponse, CreateResumeRequest, DeleteAccountRequest,
+    DeleteAccountResponse, ImportFailure, ImportResumeItem, ImportResumesRequest,
+    ImportResumesResponse, PaginatedResumeSummaries, ResumeListQuery, ResumeRow, ResumeSummary,
+    UpdateResumeRequest,
 };
 use crate::dto::{
     ParseFormat, ParseRequest, RenderPdfRequest, RenderPreviewRequest, TemplateInfo, ThemeInfo,
@@ -56,6 +57,7 @@ impl Modify for CookieAuthAddon {
         crate::routes::resumes::update_resume,
         crate::routes::resumes::delete_resume,
         crate::routes::resumes::import_resumes,
+        crate::routes::account::delete_account,
     ),
     components(
         schemas(
@@ -79,6 +81,8 @@ impl Modify for CookieAuthAddon {
             ImportResumesResponse,
             ImportFailure,
             ImportResumeItem,
+            DeleteAccountRequest,
+            DeleteAccountResponse,
             rustume_schema::ResumeData
         )
     ),
@@ -89,7 +93,8 @@ impl Modify for CookieAuthAddon {
         (name = "Render", description = "Resume rendering to PDF/PNG"),
         (name = "Validate", description = "Resume validation"),
         (name = "Auth", description = "Rustume Cloud authentication (cloud mode only)"),
-        (name = "Resumes", description = "Authenticated resume storage (cloud mode only)")
+        (name = "Resumes", description = "Authenticated resume storage (cloud mode only)"),
+        (name = "Account", description = "Account lifecycle (cloud mode only)")
     )
 )]
 /// Generated OpenAPI document served at `/api-docs/openapi.json`.

--- a/crates/server/src/routes/account.rs
+++ b/crates/server/src/routes/account.rs
@@ -87,15 +87,6 @@ pub async fn delete_account(
         );
     }
 
-    if let Err(err) = cloud.workos.delete_user(&workos_id).await {
-        warn!(
-            user_id = %user.id,
-            workos_id = %workos_id,
-            error = %err,
-            "WorkOS user deletion failed; continuing with local data erasure"
-        );
-    }
-
     if let Some(cookie) = jar.get(SESSION_COOKIE) {
         cloud.sessions.delete(cookie.value()).await.map_err(|err| {
             error!("session deletion failed during account delete: {err}");
@@ -111,6 +102,15 @@ pub async fn delete_account(
             error!("user deletion failed: {err}");
             ApiError::internal("failed to delete account")
         })?;
+
+    if let Err(err) = cloud.workos.delete_user(&workos_id).await {
+        warn!(
+            user_id = %user.id,
+            workos_id = %workos_id,
+            error = %err,
+            "WorkOS user deletion failed after local data erasure"
+        );
+    }
 
     if let (Some(service), Some(recipient)) = (cloud.email.as_ref(), email.as_deref()) {
         if let Err(err) = service.send_deletion_confirmation(recipient).await {

--- a/crates/server/src/routes/account.rs
+++ b/crates/server/src/routes/account.rs
@@ -1,0 +1,165 @@
+//! Account lifecycle routes for Rustume Cloud.
+
+use axum::{
+    extract::State,
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use axum_extra::extract::cookie::CookieJar;
+use tracing::{error, info, warn};
+
+use crate::audit::{record_event, AuditEvent};
+use crate::auth::session::SESSION_COOKIE;
+use crate::db::{DeleteAccountRequest, DeleteAccountResponse};
+use crate::email::log_send_failure;
+use crate::error::ApiError;
+use crate::middleware::auth::AuthUser;
+use crate::net::{self, trusted_client_ip};
+use crate::state::AppState;
+
+const DELETE_CONFIRMATION: &str = "DELETE";
+
+/// Permanently delete the authenticated user's account and all associated data.
+#[utoipa::path(
+    delete,
+    path = "/api/account",
+    tag = "Account",
+    request_body = DeleteAccountRequest,
+    responses(
+        (status = 200, description = "Account deleted", body = DeleteAccountResponse),
+        (status = 400, description = "Invalid confirmation", body = ApiError),
+        (status = 401, description = "Not authenticated", body = ApiError),
+        (status = 500, description = "Deletion failed", body = ApiError),
+    ),
+    security(("cookieAuth" = []))
+)]
+pub async fn delete_account(
+    AuthUser(user): AuthUser,
+    State(state): State<AppState>,
+    jar: CookieJar,
+    headers: HeaderMap,
+    Json(body): Json<DeleteAccountRequest>,
+) -> Result<Response, ApiError> {
+    if !is_valid_delete_confirmation(&body.confirmation) {
+        return Err(ApiError::new("Type DELETE to confirm account deletion"));
+    }
+
+    let cloud = state.cloud()?;
+    let ip_address = trusted_client_ip(&headers, net::trusted_proxy_enabled());
+    let ip = ip_address.as_deref();
+
+    let resume_count = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT COUNT(*)
+        FROM resumes
+        WHERE user_id = $1
+        "#,
+    )
+    .bind(user.id)
+    .fetch_one(&cloud.db)
+    .await
+    .map_err(internal_db_error)?;
+
+    let email = user.email.clone();
+    let workos_id = user.workos_id.clone();
+
+    record_event(
+        &cloud.db,
+        AuditEvent {
+            event_type: "account.delete",
+            actor_user_id: Some(user.id),
+            resource_type: Some("account"),
+            resource_id: Some(user.id),
+            metadata: serde_json::json!({
+                "resume_count": resume_count,
+                "had_paddle_customer": user.paddle_customer_id.is_some(),
+            }),
+            ip_address: ip,
+        },
+    )
+    .await;
+
+    if user.paddle_customer_id.is_some() {
+        info!(
+            user_id = %user.id,
+            "paddle subscription cancellation deferred until billing API is integrated"
+        );
+    }
+
+    if let Err(err) = cloud.workos.delete_user(&workos_id).await {
+        warn!(
+            user_id = %user.id,
+            workos_id = %workos_id,
+            error = %err,
+            "WorkOS user deletion failed; continuing with local data erasure"
+        );
+    }
+
+    if let Some(cookie) = jar.get(SESSION_COOKIE) {
+        cloud.sessions.delete(cookie.value()).await.map_err(|err| {
+            error!("session deletion failed during account delete: {err}");
+            ApiError::internal("internal server error")
+        })?;
+    }
+
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user.id)
+        .execute(&cloud.db)
+        .await
+        .map_err(|err| {
+            error!("user deletion failed: {err}");
+            ApiError::internal("failed to delete account")
+        })?;
+
+    if let (Some(service), Some(recipient)) = (cloud.email.as_ref(), email.as_deref()) {
+        if let Err(err) = service.send_deletion_confirmation(recipient).await {
+            log_send_failure("deletion_confirmation", recipient, &err);
+        }
+    }
+
+    let clear = cloud.sessions.clear_cookie();
+    let payload = DeleteAccountResponse {
+        deleted: true,
+        message: "Account and all data permanently deleted.".to_string(),
+    };
+    let mut response = (StatusCode::OK, Json(payload)).into_response();
+    append_set_cookie(&mut response, clear)?;
+    Ok(response)
+}
+
+fn is_valid_delete_confirmation(confirmation: &str) -> bool {
+    confirmation == DELETE_CONFIRMATION
+}
+
+fn internal_db_error(err: sqlx::Error) -> ApiError {
+    error!("database error: {err}");
+    ApiError::internal("internal server error")
+}
+
+fn append_set_cookie(
+    response: &mut Response,
+    cookie: axum_extra::extract::cookie::Cookie<'static>,
+) -> Result<(), ApiError> {
+    let header_value = cookie
+        .to_string()
+        .parse::<header::HeaderValue>()
+        .map_err(|err| ApiError::internal(format!("invalid cookie header: {err}")))?;
+    response
+        .headers_mut()
+        .append(header::SET_COOKIE, header_value);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_confirmation_requires_exact_match() {
+        assert!(is_valid_delete_confirmation("DELETE"));
+        assert!(!is_valid_delete_confirmation("delete"));
+        assert!(!is_valid_delete_confirmation("DELETE "));
+        assert!(!is_valid_delete_confirmation(""));
+    }
+}

--- a/crates/server/src/routes/account.rs
+++ b/crates/server/src/routes/account.rs
@@ -64,6 +64,32 @@ pub async fn delete_account(
     let email = user.email.clone();
     let workos_id = user.workos_id.clone();
 
+    if user.paddle_customer_id.is_some() {
+        info!(
+            user_id = %user.id,
+            "paddle subscription cancellation deferred until billing API is integrated"
+        );
+    }
+
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user.id)
+        .execute(&cloud.db)
+        .await
+        .map_err(|err| {
+            error!("user deletion failed: {err}");
+            ApiError::internal("failed to delete account")
+        })?;
+
+    if let Some(cookie) = jar.get(SESSION_COOKIE) {
+        if let Err(err) = cloud.sessions.delete(cookie.value()).await {
+            warn!(
+                user_id = %user.id,
+                error = %err,
+                "session cleanup failed after account deletion; user row already removed"
+            );
+        }
+    }
+
     record_event(
         &cloud.db,
         AuditEvent {
@@ -79,29 +105,6 @@ pub async fn delete_account(
         },
     )
     .await;
-
-    if user.paddle_customer_id.is_some() {
-        info!(
-            user_id = %user.id,
-            "paddle subscription cancellation deferred until billing API is integrated"
-        );
-    }
-
-    if let Some(cookie) = jar.get(SESSION_COOKIE) {
-        cloud.sessions.delete(cookie.value()).await.map_err(|err| {
-            error!("session deletion failed during account delete: {err}");
-            ApiError::internal("internal server error")
-        })?;
-    }
-
-    sqlx::query("DELETE FROM users WHERE id = $1")
-        .bind(user.id)
-        .execute(&cloud.db)
-        .await
-        .map_err(|err| {
-            error!("user deletion failed: {err}");
-            ApiError::internal("failed to delete account")
-        })?;
 
     if let Err(err) = cloud.workos.delete_user(&workos_id).await {
         warn!(

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,5 +1,6 @@
 //! HTTP route handlers for the Rustume API.
 
+pub mod account;
 pub mod auth;
 pub mod health;
 pub mod metrics;
@@ -11,6 +12,7 @@ pub mod static_files;
 pub mod templates;
 pub mod validate;
 
+pub use account::delete_account;
 pub use auth::{callback, login, logout, me};
 pub use health::health;
 pub use metrics::{init_metrics, metrics};


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(cloud): account deletion with full data erasure
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds permanent account deletion for Rustume Cloud: authenticated users can delete their account and all associated data after typing `DELETE` to confirm. Local DB rows are hard-deleted (resumes, sessions, subscriptions via CASCADE), WorkOS user removal runs best-effort after local erasure, and a confirmation email is sent when Resend is configured.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #256
- Relates to #255
- Relates to #254

## Details

**Server**
- New `DELETE /api/account` route with typed confirmation, audit event (`account.delete`), session invalidation, and user hard-delete
- Migration `006_audit_events_actor_fk.sql` drops `audit_events.actor_user_id` FK so historical audit rows survive user deletion
- `WorkOsClient::delete_user` for best-effort WorkOS cleanup after local data is erased
- Account route is auth-gated but not tied to the resume CRUD rate-limit bucket

**Web**
- Danger zone on `/account` with confirmation modal, resume count preview, and `deleteAccount()` API client
- Parses API error JSON for readable toast messages

**Deferred / follow-up**
- Paddle subscription cancellation API (schema only today; logged when `paddle_customer_id` is set)
- Bulk export link (#255) and linked-local `account_deleted` 403 behavior (#254)

**Testing**
- Server: confirmation validation unit test, unauthenticated `DELETE /api/account` returns 401
- Web: account API client tests, danger zone + modal tests
- `uv run lintro chk` and `uv run lintro tst` pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated account deletion via `DELETE /api/account`, including typed confirmation and automatic session cleanup.
  * Added an end-user “Danger zone” UI with a confirmation modal showing the associated cloud resume count and a typed **“DELETE”** requirement; deletion logs the user out, shows a toast, and redirects home.
* **API & Documentation**
  * Extended the OpenAPI spec and API documentation to include account deletion request/response.
* **Tests**
  * Added server integration coverage for unauthorized access, plus client and API tests for success/error handling and modal interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds permanent account deletion for Rustume Cloud: an authenticated `DELETE /api/account` endpoint hard-deletes the user row (cascading resumes and subscriptions), invalidates the current session, records an audit event, and best-efforts WorkOS user removal and a confirmation email. A "Danger zone" section on the frontend requires the user to type `DELETE` before the destructive button enables.

- **Server**: Deletion order is correct — DB row first, session-store cleanup next, audit event last; migration 006 drops the `actor_user_id` FK so historical audit rows survive the user delete.
- **Web**: `clearUser()` added to `authStore` for immediate client-side logout without a redundant API call; frontend confirmation modal fetches live resume count for contextual messaging.
- **Known deferral**: Paddle subscription cancellation is intentionally out of scope and is logged when `paddle_customer_id` is set.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the deletion flow is well-ordered (DB row first, session cleanup second, audit event last) and the migration correctly unblocks hard-deletes without losing historical audit records.

The two previously flagged ordering concerns are resolved in the current implementation. The only new finding is a minor display-only race in the frontend resume count that has no effect on the actual deletion. All destructive operations follow a safe, recoverable sequence.

No files require special attention; apps/web/src/pages/Account.tsx has a minor UI race in the resume count fetch but it does not affect data integrity.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/routes/account.rs | New DELETE /api/account handler; DB row deleted first, session store cleaned up after, then audit event recorded — correct ordering. WorkOS cleanup and email are best-effort. No new issues found. |
| apps/web/src/pages/Account.tsx | Adds danger zone section and delete confirmation modal. Minor race condition in createEffect can briefly display a stale resume count when the modal is toggled rapidly; no impact on the deletion itself. |
| crates/server/src/auth/workos.rs | Adds delete_user method with proper timeout, 404-treated-as-success semantics, and response body truncation for safe error logging. |
| crates/server/src/db/migrations/006_audit_events_actor_fk.sql | Drops actor_user_id FK on audit_events so DELETE FROM users succeeds without orphaning historical audit records. |
| apps/web/src/api/account.ts | Clean API client for DELETE /api/account with JSON error body parsing and graceful fallback to raw text. |
| apps/web/src/stores/auth.ts | Adds clearUser() as a lightweight client-side state reset used after account deletion (avoids a redundant logout API call on an already-gone account). |
| crates/server/src/app.rs | Adds account_routes sub-router gated by require_auth_when_enabled, consistent with existing auth/resume route setup. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User (Browser)
    participant FE as Account.tsx
    participant API as DELETE /api/account
    participant DB as Postgres
    participant SS as Session Store
    participant AE as Audit Events
    participant WOS as WorkOS
    participant EM as Email

    U->>FE: Click "Delete my account"
    FE->>FE: Fetch resume count (display only)
    U->>FE: Type "DELETE" and confirm
    FE->>API: "DELETE /api/account {confirmation:"DELETE"}"
    API->>API: "Validate confirmation == "DELETE""
    API->>DB: "SELECT COUNT(*) FROM resumes WHERE user_id=$1"
    API->>DB: "DELETE FROM users WHERE id=$1 (CASCADE resumes, subscriptions)"
    DB-->>API: OK
    API->>SS: delete(session_token)
    SS-->>API: OK (or warn on failure)
    API->>AE: INSERT audit_events (account.delete)
    AE-->>API: OK (no FK constraint after migration 006)
    API->>WOS: "DELETE /user_management/users/{workos_id} (best-effort)"
    WOS-->>API: 200 / 404 (both OK)
    API->>EM: send_deletion_confirmation (best-effort)
    API-->>FE: "200 {deleted:true} + Set-Cookie: clear"
    FE->>FE: clearUser(), navigate("/")
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User (Browser)
    participant FE as Account.tsx
    participant API as DELETE /api/account
    participant DB as Postgres
    participant SS as Session Store
    participant AE as Audit Events
    participant WOS as WorkOS
    participant EM as Email

    U->>FE: Click "Delete my account"
    FE->>FE: Fetch resume count (display only)
    U->>FE: Type "DELETE" and confirm
    FE->>API: "DELETE /api/account {confirmation:"DELETE"}"
    API->>API: "Validate confirmation == "DELETE""
    API->>DB: "SELECT COUNT(*) FROM resumes WHERE user_id=$1"
    API->>DB: "DELETE FROM users WHERE id=$1 (CASCADE resumes, subscriptions)"
    DB-->>API: OK
    API->>SS: delete(session_token)
    SS-->>API: OK (or warn on failure)
    API->>AE: INSERT audit_events (account.delete)
    AE-->>API: OK (no FK constraint after migration 006)
    API->>WOS: "DELETE /user_management/users/{workos_id} (best-effort)"
    WOS-->>API: 200 / 404 (both OK)
    API->>EM: send_deletion_confirmation (best-effort)
    API-->>FE: "200 {deleted:true} + Set-Cookie: clear"
    FE->>FE: clearUser(), navigate("/")
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: pluralize resume count and timeout ..."](https://github.com/lgtm-hq/rustume/commit/649f92f2113b548aa620e8b259b1dd11d849ce6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38722577)</sub>

<!-- /greptile_comment -->