### PR TITLE
feat(cloud): subscription cancellation, data portability, and grace period

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4363,6 +4363,7 @@ dependencies = [
  "utoipa-swagger-ui",
  "uuid",
  "validator",
+ "zip 3.0.0",
 ]
 
 [[package]]

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { onCleanup, onMount, createSignal, Show, type ParentComponent } from "so
 import { AppShell } from "./components/layout/AppShell";
 import { CloudImportPrompt } from "./components/Auth/CloudImportPrompt";
 import { RequireAuthGuard } from "./components/Auth/RequireAuthGuard";
+import { SubscriptionBanner } from "./components/Auth/SubscriptionBanner";
 import { Button, ToastRegion } from "./components/ui";
 import { authStore } from "./stores/auth";
 import { handleAuthQueryParams } from "./lib/authFeedback";
@@ -62,6 +63,7 @@ const App: ParentComponent = (props) => {
         </div>
       </Show>
       <RequireAuthGuard>
+        <SubscriptionBanner />
         <AppShell>{props.children}</AppShell>
       </RequireAuthGuard>
       <CloudImportPrompt />

--- a/apps/web/src/api/__tests__/auth.test.ts
+++ b/apps/web/src/api/__tests__/auth.test.ts
@@ -61,6 +61,36 @@ describe("probeAuth", () => {
     });
   });
 
+  it("maps subscription info from /auth/me", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "user-1",
+        plan: "pro",
+        subscription: {
+          status: "canceled",
+          expires_at: "2026-07-15T00:00:00Z",
+        },
+      }),
+    });
+
+    const result = await probeAuth();
+
+    expect(result).toEqual({
+      mode: "cloud",
+      user: {
+        id: "user-1",
+        plan: "pro",
+        subscription: {
+          status: "canceled",
+          expires_at: "2026-07-15T00:00:00Z",
+        },
+      },
+      requireAuth: false,
+    });
+  });
+
   it("maps require_auth from authenticated /auth/me", async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/apps/web/src/api/__tests__/auth.test.ts
+++ b/apps/web/src/api/__tests__/auth.test.ts
@@ -91,6 +91,69 @@ describe("probeAuth", () => {
     });
   });
 
+  it("maps expired subscription without expires_at", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "user-1",
+        plan: "pro",
+        subscription: { status: "canceled" },
+      }),
+    });
+
+    const result = await probeAuth();
+
+    expect(result).toEqual({
+      mode: "cloud",
+      user: {
+        id: "user-1",
+        plan: "pro",
+        subscription: { status: "canceled" },
+      },
+      requireAuth: false,
+    });
+  });
+
+  it("omits subscription when field is absent", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "user-1",
+        plan: "free",
+      }),
+    });
+
+    const result = await probeAuth();
+
+    expect(result).toEqual({
+      mode: "cloud",
+      user: { id: "user-1", plan: "free" },
+      requireAuth: false,
+    });
+  });
+
+  it("ignores malformed subscription payloads", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "user-1",
+        plan: "pro",
+        subscription: { status: 42, expires_at: "2026-07-15T00:00:00Z" },
+      }),
+    });
+
+    const result = await probeAuth();
+
+    expect(result).toEqual({
+      mode: "cloud",
+      user: { id: "user-1", plan: "pro" },
+      requireAuth: false,
+    });
+  });
+
   it("maps require_auth from authenticated /auth/me", async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/apps/web/src/api/__tests__/export.test.ts
+++ b/apps/web/src/api/__tests__/export.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { downloadResumesJson, exportResumesJson } from "../export";
+
+describe("export API", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+  });
+
+  it("parses bulk JSON export", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        exported_at: "2026-06-15T12:00:00Z",
+        resumes: [{ id: "resume-1", title: "Engineer", data: { basics: { name: "Ada" } } }],
+      }),
+    });
+
+    await expect(exportResumesJson()).resolves.toEqual({
+      exported_at: "2026-06-15T12:00:00Z",
+      resumes: [{ id: "resume-1", title: "Engineer", data: { basics: { name: "Ada" } } }],
+    });
+  });
+
+  it("throws ApiError with server message on failure", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: async () => JSON.stringify({ error: "Cloud subscription expired" }),
+    });
+
+    await expect(exportResumesJson()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 403,
+      message: "Cloud subscription expired",
+    });
+  });
+
+  it("downloads JSON via blob link", async () => {
+    const click = vi.fn();
+    const createObjectURL = vi.fn(() => "blob:export");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", {
+      createObjectURL,
+      revokeObjectURL,
+    });
+
+    const anchor = { click, href: "", download: "" } as HTMLAnchorElement;
+    const createElement = vi.spyOn(document, "createElement").mockReturnValue(anchor);
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        exported_at: "2026-06-15T12:00:00Z",
+        resumes: [],
+      }),
+    });
+
+    await downloadResumesJson();
+
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(click).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:export");
+    createElement.mockRestore();
+  });
+});

--- a/apps/web/src/api/__tests__/export.test.ts
+++ b/apps/web/src/api/__tests__/export.test.ts
@@ -53,8 +53,10 @@ describe("export API", () => {
       revokeObjectURL,
     });
 
-    const anchor = { click, href: "", download: "" } as HTMLAnchorElement;
+    const anchor = { click, href: "", download: "", remove: vi.fn() } as HTMLAnchorElement;
+    const appendChild = vi.spyOn(document.body, "appendChild").mockImplementation(() => anchor);
     const createElement = vi.spyOn(document, "createElement").mockReturnValue(anchor);
+    vi.useFakeTimers();
 
     fetchMock.mockResolvedValue({
       ok: true,
@@ -65,11 +67,16 @@ describe("export API", () => {
       }),
     });
 
-    await downloadResumesJson();
+    const downloadPromise = downloadResumesJson();
+    await vi.runAllTimersAsync();
+    await downloadPromise;
 
     expect(createObjectURL).toHaveBeenCalled();
     expect(click).toHaveBeenCalled();
+    expect(anchor.remove).toHaveBeenCalled();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:export");
+    vi.useRealTimers();
+    appendChild.mockRestore();
     createElement.mockRestore();
   });
 });

--- a/apps/web/src/api/__tests__/export.test.ts
+++ b/apps/web/src/api/__tests__/export.test.ts
@@ -58,25 +58,28 @@ describe("export API", () => {
     const createElement = vi.spyOn(document, "createElement").mockReturnValue(anchor);
     vi.useFakeTimers();
 
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        exported_at: "2026-06-15T12:00:00Z",
-        resumes: [],
-      }),
-    });
+    try {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          exported_at: "2026-06-15T12:00:00Z",
+          resumes: [],
+        }),
+      });
 
-    const downloadPromise = downloadResumesJson();
-    await vi.runAllTimersAsync();
-    await downloadPromise;
+      const downloadPromise = downloadResumesJson();
+      await vi.runAllTimersAsync();
+      await downloadPromise;
 
-    expect(createObjectURL).toHaveBeenCalled();
-    expect(click).toHaveBeenCalled();
-    expect(anchor.remove).toHaveBeenCalled();
-    expect(revokeObjectURL).toHaveBeenCalledWith("blob:export");
-    vi.useRealTimers();
-    appendChild.mockRestore();
-    createElement.mockRestore();
+      expect(createObjectURL).toHaveBeenCalled();
+      expect(click).toHaveBeenCalled();
+      expect(anchor.remove).toHaveBeenCalled();
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:export");
+    } finally {
+      vi.useRealTimers();
+      appendChild.mockRestore();
+      createElement.mockRestore();
+    }
   });
 });

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -50,6 +50,8 @@ function parseAuthUserPayload(payload: unknown): { user: AuthUser; requireAuth: 
   }
 
   const subscription = record.subscription;
+  // Malformed subscription payloads (missing or non-string status) are treated as
+  // absent so /auth/me parsing stays tolerant of partial API responses.
   if (typeof subscription === "object" && subscription !== null) {
     const status = (subscription as { status?: unknown }).status;
     if (typeof status === "string") {

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -1,9 +1,15 @@
+export interface SubscriptionInfo {
+  status: string;
+  expires_at?: string;
+}
+
 export interface AuthUser {
   id: string;
   plan: string;
   email?: string;
   first_name?: string;
   last_name?: string;
+  subscription?: SubscriptionInfo;
 }
 
 export type AuthProbeResult =
@@ -41,6 +47,18 @@ function parseAuthUserPayload(payload: unknown): { user: AuthUser; requireAuth: 
   }
   if (typeof record.last_name === "string") {
     user.last_name = record.last_name;
+  }
+
+  const subscription = record.subscription;
+  if (typeof subscription === "object" && subscription !== null) {
+    const status = (subscription as { status?: unknown }).status;
+    if (typeof status === "string") {
+      user.subscription = { status };
+      const expiresAt = (subscription as { expires_at?: unknown }).expires_at;
+      if (typeof expiresAt === "string") {
+        user.subscription.expires_at = expiresAt;
+      }
+    }
   }
 
   return { user, requireAuth: record.require_auth === true };

--- a/apps/web/src/api/export.ts
+++ b/apps/web/src/api/export.ts
@@ -49,8 +49,10 @@ export function downloadBlob(blob: Blob, filename: string): void {
   const anchor = document.createElement("a");
   anchor.href = url;
   anchor.download = filename;
+  document.body.appendChild(anchor);
   anchor.click();
-  URL.revokeObjectURL(url);
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 /** Download all resumes as a JSON file. */

--- a/apps/web/src/api/export.ts
+++ b/apps/web/src/api/export.ts
@@ -1,0 +1,69 @@
+import { ApiError } from "./client";
+
+async function throwApiError(response: Response): Promise<never> {
+  const text = await response.text();
+  let message = text;
+  try {
+    const json = JSON.parse(text) as { error?: string };
+    if (typeof json.error === "string") {
+      message = json.error;
+    }
+  } catch {
+    // Keep raw text when the body is not JSON.
+  }
+  throw new ApiError(response.status, message || response.statusText);
+}
+
+export interface ResumeExportItem {
+  id: string;
+  title: string;
+  data: unknown;
+}
+
+export interface ResumeBulkExport {
+  exported_at: string;
+  resumes: ResumeExportItem[];
+}
+
+/** Download all cloud resumes as a JSON bundle. */
+export async function exportResumesJson(): Promise<ResumeBulkExport> {
+  const response = await fetch("/api/resumes/export", { credentials: "include" });
+  if (!response.ok) {
+    throw await throwApiError(response);
+  }
+  return response.json() as Promise<ResumeBulkExport>;
+}
+
+/** Download all cloud resumes as a ZIP of PDF files. */
+export async function exportResumesPdf(): Promise<Blob> {
+  const response = await fetch("/api/resumes/export/pdf", { credentials: "include" });
+  if (!response.ok) {
+    throw await throwApiError(response);
+  }
+  return response.blob();
+}
+
+/** Trigger a browser download for exported data. */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+/** Download all resumes as a JSON file. */
+export async function downloadResumesJson(): Promise<void> {
+  const payload = await exportResumesJson();
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const stamp = payload.exported_at.slice(0, 10);
+  downloadBlob(blob, `rustume-export-${stamp}.json`);
+}
+
+/** Download all resumes as a ZIP of PDF files. */
+export async function downloadResumesPdf(): Promise<void> {
+  const blob = await exportResumesPdf();
+  const stamp = new Date().toISOString().slice(0, 10);
+  downloadBlob(blob, `rustume-resumes-${stamp}.zip`);
+}

--- a/apps/web/src/components/Auth/SubscriptionBanner.tsx
+++ b/apps/web/src/components/Auth/SubscriptionBanner.tsx
@@ -1,5 +1,7 @@
-import { Show, createMemo } from "solid-js";
+import { Show, createMemo, createSignal, onCleanup, onMount } from "solid-js";
 import { authStore } from "../../stores/auth";
+
+const COUNTDOWN_REFRESH_MS = 60_000;
 
 function daysUntil(isoDate: string): number {
   const end = new Date(isoDate).getTime();
@@ -18,8 +20,15 @@ function formatExpiryDate(isoDate: string): string {
 /** Banner shown during subscription cancellation grace period. */
 export function SubscriptionBanner() {
   const { state } = authStore;
+  const [now, setNow] = createSignal(Date.now());
+
+  onMount(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), COUNTDOWN_REFRESH_MS);
+    onCleanup(() => window.clearInterval(timer));
+  });
 
   const grace = createMemo(() => {
+    void now();
     const user = state.user;
     if (!user?.subscription) return null;
 

--- a/apps/web/src/components/Auth/SubscriptionBanner.tsx
+++ b/apps/web/src/components/Auth/SubscriptionBanner.tsx
@@ -1,0 +1,62 @@
+import { Show, createMemo } from "solid-js";
+import { authStore } from "../../stores/auth";
+
+function daysUntil(isoDate: string): number {
+  const end = new Date(isoDate).getTime();
+  const now = Date.now();
+  return Math.max(0, Math.ceil((end - now) / (1000 * 60 * 60 * 24)));
+}
+
+function formatExpiryDate(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+/** Banner shown during subscription cancellation grace period. */
+export function SubscriptionBanner() {
+  const { state } = authStore;
+
+  const grace = createMemo(() => {
+    const user = state.user;
+    if (!user?.subscription) return null;
+
+    const { status, expires_at: expiresAt } = user.subscription;
+    if (status !== "canceled" && status !== "past_due" && status !== "paused") {
+      return null;
+    }
+    if (!expiresAt) return null;
+
+    const remaining = daysUntil(expiresAt);
+    if (remaining <= 0) return null;
+
+    return { expiresAt, remaining };
+  });
+
+  return (
+    <Show when={state.cloudEnabled && grace()}>
+      {(info) => (
+        <div
+          class="border-b border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950"
+          role="status"
+        >
+          <div class="mx-auto flex max-w-6xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p>
+              Your cloud subscription ends on {formatExpiryDate(info().expiresAt)} (
+              {info().remaining} {info().remaining === 1 ? "day" : "days"} remaining). Export your
+              resumes before access ends.
+            </p>
+            <a
+              href="/account#export"
+              class="inline-flex items-center justify-center rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-ink hover:bg-border/50"
+            >
+              Export data
+            </a>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+}

--- a/apps/web/src/components/Auth/__tests__/SubscriptionBanner.test.tsx
+++ b/apps/web/src/components/Auth/__tests__/SubscriptionBanner.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { SubscriptionBanner } from "../SubscriptionBanner";
+
+const { mockAuthState } = vi.hoisted(() => ({
+  mockAuthState: {
+    loading: false,
+    cloudEnabled: true,
+    requireAuth: false,
+    user: null as {
+      id: string;
+      plan: string;
+      subscription?: { status: string; expires_at?: string };
+    } | null,
+  },
+}));
+
+vi.mock("../../../stores/auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+  },
+}));
+
+describe("SubscriptionBanner", () => {
+  it("shows grace period countdown for canceled subscriptions", () => {
+    const expiresAt = "2099-06-01T00:00:00Z";
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = {
+      id: "user-1",
+      plan: "pro",
+      subscription: { status: "canceled", expires_at: expiresAt },
+    };
+
+    render(() => <SubscriptionBanner />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(/subscription ends on/i);
+    expect(screen.getByRole("link", { name: "Export data" })).toHaveAttribute(
+      "href",
+      "/account#export",
+    );
+  });
+
+  it("hides when subscription is active", () => {
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = { id: "user-1", plan: "pro" };
+
+    render(() => <SubscriptionBanner />);
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -1,6 +1,7 @@
 import { Show, createEffect, createSignal } from "solid-js";
 import { A, useNavigate } from "@solidjs/router";
 import { deleteAccount } from "../api/account";
+import { downloadResumesJson, downloadResumesPdf } from "../api/export";
 import { listCloudResumesPage } from "../api/resumes";
 import { authStore } from "../stores/auth";
 import { Button, Input, Modal, Spinner, toast } from "../components/ui";
@@ -44,6 +45,8 @@ export default function Account() {
   const [resumeCount, setResumeCount] = createSignal<number | null>(null);
   const [loadingResumeCount, setLoadingResumeCount] = createSignal(false);
   const [deletingAccount, setDeletingAccount] = createSignal(false);
+  const [exportingJson, setExportingJson] = createSignal(false);
+  const [exportingPdf, setExportingPdf] = createSignal(false);
 
   createEffect(() => {
     if (!deleteModalOpen()) {
@@ -79,6 +82,32 @@ export default function Account() {
   const handleSignIn = () => {
     setSigningIn(true);
     signIn();
+  };
+
+  const handleExportJson = async () => {
+    setExportingJson(true);
+    try {
+      await downloadResumesJson();
+      toast.success("Resume export downloaded");
+    } catch (error) {
+      console.error("JSON export failed:", error);
+      toast.error(error instanceof Error ? error.message : "Failed to export resumes");
+    } finally {
+      setExportingJson(false);
+    }
+  };
+
+  const handleExportPdf = async () => {
+    setExportingPdf(true);
+    try {
+      await downloadResumesPdf();
+      toast.success("PDF export downloaded");
+    } catch (error) {
+      console.error("PDF export failed:", error);
+      toast.error(error instanceof Error ? error.message : "Failed to export PDFs");
+    } finally {
+      setExportingPdf(false);
+    }
   };
 
   const handleDeleteAccount = async () => {
@@ -202,6 +231,32 @@ export default function Account() {
                     </p>
                   </section>
 
+                  <section
+                    id="export"
+                    class="rounded-2xl border border-border bg-paper p-6 shadow-card"
+                  >
+                    <h2 class="font-display text-lg font-semibold text-ink mb-2">Export data</h2>
+                    <p class="text-sm text-stone mb-4">
+                      Download all cloud resumes for backup or migration to self-hosted Rustume.
+                    </p>
+                    <div class="flex flex-wrap gap-3">
+                      <Button
+                        variant="secondary"
+                        onClick={() => void handleExportJson()}
+                        loading={exportingJson()}
+                      >
+                        Download as JSON
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={() => void handleExportPdf()}
+                        loading={exportingPdf()}
+                      >
+                        Download as PDF (ZIP)
+                      </Button>
+                    </div>
+                  </section>
+
                   <section class="rounded-2xl border border-border bg-paper px-6 py-2 shadow-card">
                     <ComingSoonRow
                       title="Billing"
@@ -258,8 +313,8 @@ export default function Account() {
                       </ul>
 
                       <p class="text-sm text-stone">
-                        Bulk export is coming in a future release. Download individual resumes from
-                        the editor before deleting if you need local copies.
+                        Export your resumes from the account page before deleting if you need local
+                        copies.
                       </p>
 
                       <Input

--- a/apps/web/src/stores/__tests__/cloudStorage.test.ts
+++ b/apps/web/src/stores/__tests__/cloudStorage.test.ts
@@ -250,6 +250,17 @@ describe("saveCloudResume", () => {
 
     await expect(saveCloudResume("abc", data)).rejects.toBeInstanceOf(SubscriptionReadOnlyError);
   });
+
+  it("preserves expired-subscription 403 as ApiError", async () => {
+    const data = testResume("Expired");
+    const expiredError = new ApiError(
+      403,
+      "Cloud subscription expired — resume writes are disabled",
+    );
+    resumeApiMocks.upsertCloudResume.mockRejectedValue(expiredError);
+
+    await expect(saveCloudResume("abc", data)).rejects.toBe(expiredError);
+  });
 });
 
 describe("createCloudResumeWithId", () => {

--- a/apps/web/src/stores/__tests__/cloudStorage.test.ts
+++ b/apps/web/src/stores/__tests__/cloudStorage.test.ts
@@ -40,6 +40,12 @@ vi.mock("../../api/resumes", async (importOriginal) => {
   };
 });
 
+vi.mock("../../components/ui", () => ({
+  toast: {
+    warning: vi.fn(),
+  },
+}));
+
 import {
   clearCloudResumeVersion,
   clearCloudWriteBlock,
@@ -54,6 +60,7 @@ import {
   loadCloudResume,
   removeCloudResume,
   renameCloudResume,
+  SubscriptionReadOnlyError,
   saveCloudResume,
   setCloudResumeVersion,
 } from "../cloudStorage";
@@ -233,6 +240,15 @@ describe("saveCloudResume", () => {
 
     await expect(saveCloudResume("abc", data)).rejects.toBeInstanceOf(CloudWriteBlockedError);
     expect(resumeApiMocks.upsertCloudResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps subscription read-only 403 to SubscriptionReadOnlyError", async () => {
+    const data = testResume("Read only");
+    resumeApiMocks.upsertCloudResume.mockRejectedValue(
+      new ApiError(403, "Cloud account is read-only during subscription cancellation"),
+    );
+
+    await expect(saveCloudResume("abc", data)).rejects.toBeInstanceOf(SubscriptionReadOnlyError);
   });
 });
 

--- a/apps/web/src/stores/cloudStorage.ts
+++ b/apps/web/src/stores/cloudStorage.ts
@@ -27,6 +27,14 @@ export class CloudWriteBlockedError extends Error {
   }
 }
 
+/** Thrown when the cloud account is read-only during subscription cancellation. */
+export class SubscriptionReadOnlyError extends Error {
+  constructor(message = "Cloud account is read-only") {
+    super(message);
+    this.name = "SubscriptionReadOnlyError";
+  }
+}
+
 /** True when cloud mode is enabled and the user has an active session. */
 export function isCloudAuthenticated(): boolean {
   const { loading, cloudEnabled, user } = authStore.state;
@@ -63,6 +71,20 @@ export function isResumeVersionConflictError(error: unknown): error is ResumeVer
 
 export function isCloudWriteBlockedError(error: unknown): error is CloudWriteBlockedError {
   return error instanceof CloudWriteBlockedError;
+}
+
+export function isSubscriptionReadOnlyError(error: unknown): error is SubscriptionReadOnlyError {
+  return error instanceof SubscriptionReadOnlyError;
+}
+
+function rethrowSubscriptionForbidden(error: unknown): void {
+  if (error instanceof ApiError && error.status === 403) {
+    toast.warning(
+      "Cloud account is read-only — export your resumes before subscription access ends.",
+      "Read-only",
+    );
+    throw new SubscriptionReadOnlyError();
+  }
 }
 
 export function showResumeVersionConflictToast(id: string): void {
@@ -111,6 +133,7 @@ export async function saveCloudResume(id: string, data: ResumeData, title?: stri
     const row = await upsertCloudResume(id, data, resolvedTitle, getCloudResumeVersion(id));
     setCloudResumeVersion(id, row.version);
   } catch (error: unknown) {
+    rethrowSubscriptionForbidden(error);
     handleVersionConflict(id, error);
   }
 }
@@ -120,13 +143,18 @@ export async function createCloudResumeWithId(
   data: ResumeData,
   title?: string,
 ): Promise<void> {
-  const row = await createCloudResume({
-    id,
-    title: title ?? deriveTitleFromResume(data),
-    data,
-  });
-  clearCloudWriteBlock(id);
-  setCloudResumeVersion(id, row.version);
+  try {
+    const row = await createCloudResume({
+      id,
+      title: title ?? deriveTitleFromResume(data),
+      data,
+    });
+    clearCloudWriteBlock(id);
+    setCloudResumeVersion(id, row.version);
+  } catch (error: unknown) {
+    rethrowSubscriptionForbidden(error);
+    throw error;
+  }
 }
 
 export async function removeCloudResume(id: string): Promise<void> {
@@ -144,6 +172,7 @@ export async function renameCloudResume(id: string, title: string): Promise<void
     });
     setCloudResumeVersion(id, row.version);
   } catch (error: unknown) {
+    rethrowSubscriptionForbidden(error);
     handleVersionConflict(id, error);
   }
 }
@@ -154,9 +183,14 @@ export async function duplicateCloudResume(
   data: ResumeData,
   title: string,
 ): Promise<void> {
-  const row = await createCloudResume({ id: newId, title, data });
-  clearCloudWriteBlock(newId);
-  setCloudResumeVersion(newId, row.version);
+  try {
+    const row = await createCloudResume({ id: newId, title, data });
+    clearCloudWriteBlock(newId);
+    setCloudResumeVersion(newId, row.version);
+  } catch (error: unknown) {
+    rethrowSubscriptionForbidden(error);
+    throw error;
+  }
 }
 
 export async function cloudResumeExists(id: string): Promise<boolean> {

--- a/apps/web/src/stores/cloudStorage.ts
+++ b/apps/web/src/stores/cloudStorage.ts
@@ -79,11 +79,18 @@ export function isSubscriptionReadOnlyError(error: unknown): error is Subscripti
 
 function rethrowSubscriptionForbidden(error: unknown): void {
   if (error instanceof ApiError && error.status === 403) {
-    toast.warning(
-      "Cloud account is read-only — export your resumes before subscription access ends.",
-      "Read-only",
-    );
-    throw new SubscriptionReadOnlyError();
+    const message = error.message.toLowerCase();
+    if (
+      message.includes("read-only") ||
+      message.includes("subscription") ||
+      message.includes("grace")
+    ) {
+      toast.warning(
+        "Cloud account is read-only — export your resumes before subscription access ends.",
+        "Read-only",
+      );
+      throw new SubscriptionReadOnlyError();
+    }
   }
 }
 

--- a/apps/web/src/stores/cloudStorage.ts
+++ b/apps/web/src/stores/cloudStorage.ts
@@ -78,13 +78,11 @@ export function isSubscriptionReadOnlyError(error: unknown): error is Subscripti
 }
 
 function rethrowSubscriptionForbidden(error: unknown): void {
+  // Only grace-period read-only writes match; callers can use isSubscriptionReadOnlyError
+  // to avoid duplicate error UI.
   if (error instanceof ApiError && error.status === 403) {
     const message = error.message.toLowerCase();
-    if (
-      message.includes("read-only") ||
-      message.includes("subscription") ||
-      message.includes("grace")
-    ) {
+    if (message.includes("read-only")) {
       toast.warning(
         "Cloud account is read-only — export your resumes before subscription access ends.",
         "Read-only",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -66,6 +66,7 @@ sentry.workspace = true
 sentry-tower.workspace = true
 governor.workspace = true
 dashmap.workspace = true
+zip = { version = "3.0", default-features = false, features = ["deflate"] }
 
 # Use jemalloc on musl to avoid musl's slower default allocator
 [target.'cfg(target_env = "musl")'.dependencies]

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -23,12 +23,14 @@ use crate::middleware::rate_limit::{
     rate_limit_pdf, rate_limit_preview, rate_limit_resume_crud,
 };
 use crate::middleware::security::security_headers;
+use crate::middleware::subscription::require_subscription_render;
 use crate::observability::apply_sentry_layers;
 use crate::openapi::ApiDoc;
 use crate::routes::{
-    callback, create_resume, delete_account, delete_resume, get_resume, health, import_resumes,
-    list_resumes, list_templates, login, logout, me, metrics, parse, render_pdf, render_preview,
-    security_txt, spa_fallback, static_dir, template_thumbnail, update_resume, validate,
+    callback, create_resume, delete_account, delete_resume, export_resumes_json,
+    export_resumes_pdf, get_resume, health, import_resumes, list_resumes, list_templates, login,
+    logout, me, metrics, parse, render_pdf, render_preview, security_txt, spa_fallback, static_dir,
+    template_thumbnail, update_resume, validate,
 };
 use crate::state::AppState;
 
@@ -76,6 +78,12 @@ pub fn create_router_with_state(state: AppState) -> Router {
             rate_limit_preview,
         ));
     }
+    if state.cloud.is_some() {
+        preview_routes = preview_routes.route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_subscription_render,
+        ));
+    }
 
     let mut pdf_routes = Router::new()
         .route("/api/render/pdf", post(render_pdf))
@@ -87,6 +95,12 @@ pub fn create_router_with_state(state: AppState) -> Router {
         pdf_routes = pdf_routes.route_layer(middleware::from_fn_with_state(
             state_for_layers.clone(),
             rate_limit_pdf,
+        ));
+    }
+    if state.cloud.is_some() {
+        pdf_routes = pdf_routes.route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_subscription_render,
         ));
     }
 
@@ -163,10 +177,25 @@ pub fn create_router_with_state(state: AppState) -> Router {
                 require_auth_when_enabled,
             ));
 
+        let mut export_routes = Router::new()
+            .route("/api/resumes/export", get(export_resumes_json))
+            .route("/api/resumes/export/pdf", get(export_resumes_pdf))
+            .route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_auth_when_enabled,
+            ));
+        if cloud_rate_limits {
+            export_routes = export_routes.route_layer(middleware::from_fn_with_state(
+                state_for_layers.clone(),
+                rate_limit_pdf,
+            ));
+        }
+
         router = router
             .merge(auth_routes)
             .merge(resume_routes)
             .merge(import_routes)
+            .merge(export_routes)
             .merge(account_routes);
     }
 

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -177,15 +177,27 @@ pub fn create_router_with_state(state: AppState) -> Router {
                 require_auth_when_enabled,
             ));
 
-        let mut export_routes = Router::new()
+        let mut export_json_routes = Router::new()
             .route("/api/resumes/export", get(export_resumes_json))
+            .route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_auth_when_enabled,
+            ));
+        if cloud_rate_limits {
+            export_json_routes = export_json_routes.route_layer(middleware::from_fn_with_state(
+                state_for_layers.clone(),
+                rate_limit_resume_crud,
+            ));
+        }
+
+        let mut export_pdf_routes = Router::new()
             .route("/api/resumes/export/pdf", get(export_resumes_pdf))
             .route_layer(middleware::from_fn_with_state(
                 state.clone(),
                 require_auth_when_enabled,
             ));
         if cloud_rate_limits {
-            export_routes = export_routes.route_layer(middleware::from_fn_with_state(
+            export_pdf_routes = export_pdf_routes.route_layer(middleware::from_fn_with_state(
                 state_for_layers.clone(),
                 rate_limit_pdf,
             ));
@@ -195,7 +207,8 @@ pub fn create_router_with_state(state: AppState) -> Router {
             .merge(auth_routes)
             .merge(resume_routes)
             .merge(import_routes)
-            .merge(export_routes)
+            .merge(export_json_routes)
+            .merge(export_pdf_routes)
             .merge(account_routes);
     }
 

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -177,6 +177,17 @@ pub struct ImportResumesRequest {
     pub resumes: Vec<ImportResumeItem>,
 }
 
+/// Subscription summary returned by `GET /auth/me` for linked instances.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct SubscriptionInfo {
+    /// Paddle subscription status (`active`, `canceled`, etc.).
+    pub status: String,
+    /// Grace period end timestamp, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, format = "date-time")]
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
 /// Authenticated user profile returned by `GET /auth/me`.
 ///
 /// Includes account identity and display-friendly profile fields synced from
@@ -198,6 +209,27 @@ pub struct AuthUserResponse {
     pub last_name: Option<String>,
     /// Whether billable routes require sign-in on this deployment.
     pub require_auth: bool,
+    /// Subscription lifecycle state for grace-period UX and local sync.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription: Option<SubscriptionInfo>,
+}
+
+/// Single resume in a bulk JSON export.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ResumeExportItem {
+    #[schema(value_type = String, format = "uuid")]
+    pub id: Uuid,
+    pub title: String,
+    #[schema(value_type = Object)]
+    pub data: serde_json::Value,
+}
+
+/// Bulk JSON export payload for `GET /api/resumes/export`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ResumeBulkExport {
+    #[schema(value_type = String, format = "date-time")]
+    pub exported_at: DateTime<Utc>,
+    pub resumes: Vec<ResumeExportItem>,
 }
 
 /// Signed-out probe payload returned by `GET /auth/me` with HTTP 401.
@@ -223,7 +255,11 @@ pub struct DeleteAccountResponse {
 
 impl AuthUserResponse {
     /// Build a profile response with the hosted require-auth flag.
-    pub fn from_user(user: User, require_auth: bool) -> Self {
+    pub fn from_user(
+        user: User,
+        require_auth: bool,
+        subscription: Option<SubscriptionInfo>,
+    ) -> Self {
         Self {
             id: user.id,
             plan: user.plan,
@@ -231,6 +267,7 @@ impl AuthUserResponse {
             first_name: user.first_name,
             last_name: user.last_name,
             require_auth,
+            subscription,
         }
     }
 }
@@ -254,7 +291,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let response = AuthUserResponse::from_user(user, true);
+        let response = AuthUserResponse::from_user(user, true, None);
         let json = serde_json::to_value(&response).unwrap();
 
         assert_eq!(json["id"], Uuid::nil().to_string());
@@ -263,6 +300,7 @@ mod tests {
         assert_eq!(json["first_name"], "Ada");
         assert_eq!(json["last_name"], "Lovelace");
         assert_eq!(json["require_auth"], true);
+        assert!(json.get("subscription").is_none());
     }
 
     #[test]
@@ -279,10 +317,38 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let json = serde_json::to_value(AuthUserResponse::from_user(user, false)).unwrap();
+        let json = serde_json::to_value(AuthUserResponse::from_user(user, false, None)).unwrap();
 
         assert!(json.get("email").is_none());
         assert!(json.get("first_name").is_none());
         assert!(json.get("last_name").is_none());
+    }
+
+    #[test]
+    fn auth_user_response_includes_subscription_when_present() {
+        let user = User {
+            id: Uuid::nil(),
+            workos_id: "user_01".to_string(),
+            plan: "pro".to_string(),
+            paddle_customer_id: None,
+            email: None,
+            first_name: None,
+            last_name: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let expires_at = Utc::now();
+        let response = AuthUserResponse::from_user(
+            user,
+            true,
+            Some(SubscriptionInfo {
+                status: "canceled".to_string(),
+                expires_at: Some(expires_at),
+            }),
+        );
+        let json = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(json["subscription"]["status"], "canceled");
+        assert!(json["subscription"]["expires_at"].as_str().is_some());
     }
 }

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -24,6 +24,8 @@ pub enum ApiErrorKind {
     Forbidden,
     /// Conflict (409) - resource already exists
     Conflict,
+    /// Payload too large (413) - request exceeds size or count limits
+    PayloadTooLarge,
 }
 
 impl ApiErrorKind {
@@ -36,6 +38,7 @@ impl ApiErrorKind {
             ApiErrorKind::Unauthorized => StatusCode::UNAUTHORIZED,
             ApiErrorKind::Forbidden => StatusCode::FORBIDDEN,
             ApiErrorKind::Conflict => StatusCode::CONFLICT,
+            ApiErrorKind::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
         }
     }
 }
@@ -136,6 +139,16 @@ impl ApiError {
             details: None,
             current_version: Some(current_version),
             kind: ApiErrorKind::Conflict,
+        }
+    }
+
+    /// Create a 413 Payload Too Large error.
+    pub fn payload_too_large(error: impl Into<String>) -> Self {
+        Self {
+            error: error.into(),
+            details: None,
+            current_version: None,
+            kind: ApiErrorKind::PayloadTooLarge,
         }
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -21,6 +21,8 @@
 //! - `GET/POST /api/resumes` - List and create resumes
 //! - `GET/PUT/DELETE /api/resumes/{id}` - Resume CRUD
 //! - `POST /api/resumes/import` - Bulk import from local storage
+//! - `GET /api/resumes/export` - Bulk JSON export
+//! - `GET /api/resumes/export/pdf` - Bulk PDF export (ZIP)
 //! - `DELETE /api/account` - Permanently delete account and all data
 //! - `GET /metrics` - Prometheus metrics
 
@@ -41,6 +43,7 @@ pub mod routes;
 pub mod run;
 pub mod shutdown;
 pub mod state;
+pub mod subscription;
 pub mod validation;
 
 pub use app::{create_router, create_router_with_state, create_router_with_static_dir};

--- a/crates/server/src/middleware/mod.rs
+++ b/crates/server/src/middleware/mod.rs
@@ -3,3 +3,4 @@
 pub mod auth;
 pub mod rate_limit;
 pub mod security;
+pub mod subscription;

--- a/crates/server/src/middleware/subscription.rs
+++ b/crates/server/src/middleware/subscription.rs
@@ -1,0 +1,44 @@
+//! Subscription grace-period enforcement for authenticated cloud routes.
+
+use axum::{
+    extract::{FromRequestParts, Request, State},
+    middleware::Next,
+    response::Response,
+};
+use axum_extra::extract::CookieJar;
+
+use crate::auth::session::SESSION_COOKIE;
+use crate::error::ApiError;
+use crate::middleware::auth::AuthUser;
+use crate::state::AppState;
+use crate::subscription;
+
+/// Enforce subscription render access for signed-in cloud users.
+///
+/// Anonymous requests pass through when hosted require-auth is disabled.
+pub async fn require_subscription_render(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    if state.cloud.is_none() {
+        return Ok(next.run(request).await);
+    }
+
+    let (mut parts, body) = request.into_parts();
+    let jar = CookieJar::from_request_parts(&mut parts, &state)
+        .await
+        .map_err(|_| ApiError::internal("failed to read cookies"))?;
+
+    let has_session = jar.get(SESSION_COOKIE).is_some();
+    if !state.require_auth && !has_session {
+        return Ok(next.run(Request::from_parts(parts, body)).await);
+    }
+
+    let AuthUser(user) = AuthUser::from_request_parts(&mut parts, &state).await?;
+    let cloud = state.cloud()?;
+    let access = subscription::load_access(&cloud.db, user.id).await?;
+    access.ensure_render()?;
+
+    Ok(next.run(Request::from_parts(parts, body)).await)
+}

--- a/crates/server/src/middleware/subscription.rs
+++ b/crates/server/src/middleware/subscription.rs
@@ -16,6 +16,8 @@ use crate::subscription;
 /// Enforce subscription render access for signed-in cloud users.
 ///
 /// Anonymous requests pass through when hosted require-auth is disabled.
+/// Stale session cookies on open deployments also pass through so render stays
+/// available without manual cookie clearing.
 pub async fn require_subscription_render(
     State(state): State<AppState>,
     request: Request,
@@ -30,12 +32,18 @@ pub async fn require_subscription_render(
         .await
         .map_err(|_| ApiError::internal("failed to read cookies"))?;
 
-    let has_session = jar.get(SESSION_COOKIE).is_some();
-    if !state.require_auth && !has_session {
+    if jar.get(SESSION_COOKIE).is_none() && !state.require_auth {
         return Ok(next.run(Request::from_parts(parts, body)).await);
     }
 
-    let AuthUser(user) = AuthUser::from_request_parts(&mut parts, &state).await?;
+    let user = match AuthUser::from_request_parts(&mut parts, &state).await {
+        Ok(AuthUser(user)) => user,
+        Err(_err) if !state.require_auth => {
+            return Ok(next.run(Request::from_parts(parts, body)).await);
+        }
+        Err(err) => return Err(err),
+    };
+
     let cloud = state.cloud()?;
     let access = subscription::load_access(&cloud.db, user.id).await?;
     access.ensure_render()?;

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -7,8 +7,8 @@ use utoipa::OpenApi;
 use crate::db::{
     AuthMeUnauthorizedResponse, AuthUserResponse, CreateResumeRequest, DeleteAccountRequest,
     DeleteAccountResponse, ImportFailure, ImportResumeItem, ImportResumesRequest,
-    ImportResumesResponse, PaginatedResumeSummaries, ResumeListQuery, ResumeRow, ResumeSummary,
-    UpdateResumeRequest,
+    ImportResumesResponse, PaginatedResumeSummaries, ResumeBulkExport, ResumeExportItem,
+    ResumeListQuery, ResumeRow, ResumeSummary, SubscriptionInfo, UpdateResumeRequest,
 };
 use crate::dto::{
     ParseFormat, ParseRequest, RenderPdfRequest, RenderPreviewRequest, TemplateInfo, ThemeInfo,
@@ -57,6 +57,8 @@ impl Modify for CookieAuthAddon {
         crate::routes::resumes::update_resume,
         crate::routes::resumes::delete_resume,
         crate::routes::resumes::import_resumes,
+        crate::routes::export::export_resumes_json,
+        crate::routes::export::export_resumes_pdf,
         crate::routes::account::delete_account,
     ),
     components(
@@ -71,6 +73,9 @@ impl Modify for CookieAuthAddon {
             ValidationResponse,
             AuthUserResponse,
             AuthMeUnauthorizedResponse,
+            SubscriptionInfo,
+            ResumeBulkExport,
+            ResumeExportItem,
             ResumeSummary,
             PaginatedResumeSummaries,
             ResumeListQuery,

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -18,6 +18,7 @@ use crate::db::{AuthMeUnauthorizedResponse, AuthUserResponse};
 use crate::error::ApiError;
 use crate::net::{self, trusted_client_ip};
 use crate::state::AppState;
+use crate::subscription;
 
 const OAUTH_STATE_COOKIE: &str = "rustume_oauth_state";
 const OAUTH_STATE_TTL_MINUTES: i64 = 10;
@@ -241,7 +242,13 @@ pub async fn me(State(state): State<AppState>, jar: CookieJar) -> Result<Respons
                 ApiError::internal("internal server error")
             })?
         {
-            return Ok(Json(AuthUserResponse::from_user(user, require_auth)).into_response());
+            let access = subscription::load_access(&cloud.db, user.id).await?;
+            return Ok(Json(AuthUserResponse::from_user(
+                user,
+                require_auth,
+                access.to_info(),
+            ))
+            .into_response());
         }
     }
 

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -88,10 +88,12 @@ pub async fn export_resumes_pdf(
         let pdf = tokio::task::spawn_blocking({
             let renderer = renderer.clone();
             let resume = resume.clone();
+            let resume_id = row.id;
+            let resume_title = row.title.clone();
             move || {
-                renderer
-                    .render_pdf(&resume)
-                    .map_err(|err| format!("Failed to render PDF: {err}"))
+                renderer.render_pdf(&resume).map_err(|err| {
+                    format!("Failed to render PDF for resume '{resume_title}' ({resume_id}): {err}")
+                })
             }
         })
         .await

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -14,11 +14,21 @@ use uuid::Uuid;
 use zip::write::SimpleFileOptions;
 use zip::ZipWriter;
 
-use crate::db::{ResumeBulkExport, ResumeExportItem, ResumeRow};
+use crate::db::{ResumeBulkExport, ResumeExportItem};
 use crate::error::ApiError;
 use crate::middleware::auth::AuthUser;
 use crate::state::AppState;
 use crate::subscription;
+
+const MAX_EXPORT_RESUMES: i64 = 50;
+
+/// Resume fields required for bulk export.
+#[derive(Debug, sqlx::FromRow)]
+struct ExportResumeRow {
+    id: Uuid,
+    title: String,
+    data: serde_json::Value,
+}
 
 /// Export all resumes for the authenticated user as JSON.
 #[utoipa::path(
@@ -29,6 +39,7 @@ use crate::subscription;
         (status = 200, description = "Bulk JSON export", body = ResumeBulkExport),
         (status = 401, description = "Not authenticated", body = ApiError),
         (status = 403, description = "Subscription expired", body = ApiError),
+        (status = 413, description = "Too many resumes to export", body = ApiError),
     ),
     security(("cookieAuth" = []))
 )]
@@ -65,6 +76,7 @@ pub async fn export_resumes_json(
         (status = 200, description = "ZIP archive of PDF resumes", content_type = "application/zip"),
         (status = 401, description = "Not authenticated", body = ApiError),
         (status = 403, description = "Subscription expired", body = ApiError),
+        (status = 413, description = "Too many resumes to export", body = ApiError),
     ),
     security(("cookieAuth" = []))
 )]
@@ -128,10 +140,31 @@ pub async fn export_resumes_pdf(
         .into_response())
 }
 
-async fn fetch_all_resumes(db: &sqlx::PgPool, user_id: Uuid) -> Result<Vec<ResumeRow>, ApiError> {
-    sqlx::query_as::<_, ResumeRow>(
+async fn fetch_all_resumes(
+    db: &sqlx::PgPool,
+    user_id: Uuid,
+) -> Result<Vec<ExportResumeRow>, ApiError> {
+    let total = sqlx::query_scalar::<_, i64>(
         r#"
-        SELECT id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+        SELECT COUNT(*)
+        FROM resumes
+        WHERE user_id = $1
+        "#,
+    )
+    .bind(user_id)
+    .fetch_one(db)
+    .await
+    .map_err(internal_db_error)?;
+
+    if total > MAX_EXPORT_RESUMES {
+        return Err(ApiError::payload_too_large(format!(
+            "Export exceeds maximum of {MAX_EXPORT_RESUMES} resumes ({total} found)"
+        )));
+    }
+
+    sqlx::query_as::<_, ExportResumeRow>(
+        r#"
+        SELECT id, title, data
         FROM resumes
         WHERE user_id = $1
         ORDER BY updated_at DESC
@@ -140,10 +173,12 @@ async fn fetch_all_resumes(db: &sqlx::PgPool, user_id: Uuid) -> Result<Vec<Resum
     .bind(user_id)
     .fetch_all(db)
     .await
-    .map_err(|err| {
-        error!("export resume query failed: {err}");
-        ApiError::internal("internal server error")
-    })
+    .map_err(internal_db_error)
+}
+
+fn internal_db_error(err: impl std::fmt::Display) -> ApiError {
+    error!("export resume query failed: {err}");
+    ApiError::internal("internal server error")
 }
 
 fn export_pdf_filename(id: &Uuid, title: &str) -> String {
@@ -159,11 +194,11 @@ fn export_pdf_filename(id: &Uuid, title: &str) -> String {
             }
         })
         .collect();
-    let slug = slug.trim_matches('-');
-    let slug = if slug.is_empty() {
-        "resume".to_string()
-    } else {
+    let slug = slug.trim_matches(|c| c == '-' || c == '_');
+    let slug = if slug.chars().any(|ch| ch.is_ascii_alphanumeric()) {
         slug.to_string()
+    } else {
+        "resume".to_string()
     };
     format!("{slug}-{id}.pdf")
 }
@@ -185,5 +220,11 @@ mod tests {
     fn export_pdf_filename_falls_back_when_title_empty() {
         let id = Uuid::nil();
         assert_eq!(export_pdf_filename(&id, "   "), format!("resume-{id}.pdf"));
+    }
+
+    #[test]
+    fn export_pdf_filename_falls_back_for_symbol_only_titles() {
+        let id = Uuid::nil();
+        assert_eq!(export_pdf_filename(&id, "@@@"), format!("resume-{id}.pdf"));
     }
 }

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -1,0 +1,187 @@
+//! Bulk resume export routes for Rustume Cloud data portability.
+
+use axum::{
+    extract::State,
+    http::{header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use chrono::Utc;
+use rustume_render::Renderer;
+use rustume_schema::ResumeData;
+use tracing::error;
+use uuid::Uuid;
+use zip::write::SimpleFileOptions;
+use zip::ZipWriter;
+
+use crate::db::{ResumeBulkExport, ResumeExportItem, ResumeRow};
+use crate::error::ApiError;
+use crate::middleware::auth::AuthUser;
+use crate::state::AppState;
+use crate::subscription;
+
+/// Export all resumes for the authenticated user as JSON.
+#[utoipa::path(
+    get,
+    path = "/api/resumes/export",
+    tag = "Resumes",
+    responses(
+        (status = 200, description = "Bulk JSON export", body = ResumeBulkExport),
+        (status = 401, description = "Not authenticated", body = ApiError),
+        (status = 403, description = "Subscription expired", body = ApiError),
+    ),
+    security(("cookieAuth" = []))
+)]
+pub async fn export_resumes_json(
+    AuthUser(user): AuthUser,
+    State(state): State<AppState>,
+) -> Result<Json<ResumeBulkExport>, ApiError> {
+    let cloud = state.cloud()?;
+    let access = subscription::load_access(&cloud.db, user.id).await?;
+    access.ensure_export()?;
+
+    let rows = fetch_all_resumes(&cloud.db, user.id).await?;
+    let resumes = rows
+        .into_iter()
+        .map(|row| ResumeExportItem {
+            id: row.id,
+            title: row.title,
+            data: row.data,
+        })
+        .collect();
+
+    Ok(Json(ResumeBulkExport {
+        exported_at: Utc::now(),
+        resumes,
+    }))
+}
+
+/// Export all resumes for the authenticated user as a ZIP of PDF files.
+#[utoipa::path(
+    get,
+    path = "/api/resumes/export/pdf",
+    tag = "Resumes",
+    responses(
+        (status = 200, description = "ZIP archive of PDF resumes", content_type = "application/zip"),
+        (status = 401, description = "Not authenticated", body = ApiError),
+        (status = 403, description = "Subscription expired", body = ApiError),
+    ),
+    security(("cookieAuth" = []))
+)]
+pub async fn export_resumes_pdf(
+    AuthUser(user): AuthUser,
+    State(state): State<AppState>,
+) -> Result<Response, ApiError> {
+    let cloud = state.cloud()?;
+    let access = subscription::load_access(&cloud.db, user.id).await?;
+    access.ensure_export()?;
+
+    let rows = fetch_all_resumes(&cloud.db, user.id).await?;
+    let renderer = state.renderer.clone();
+    let mut archive = ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    for row in rows {
+        let resume: ResumeData = serde_json::from_value(row.data.clone())
+            .map_err(|_| ApiError::new("Invalid resume data format"))?;
+        let file_name = export_pdf_filename(&row.id, &row.title);
+        let pdf = tokio::task::spawn_blocking({
+            let renderer = renderer.clone();
+            let resume = resume.clone();
+            move || {
+                renderer
+                    .render_pdf(&resume)
+                    .map_err(|err| format!("Failed to render PDF: {err}"))
+            }
+        })
+        .await
+        .map_err(|err| ApiError::internal(format!("Render task failed: {err}")))?
+        .map_err(ApiError::internal)?;
+
+        archive
+            .start_file(file_name, options)
+            .map_err(|err| ApiError::internal(format!("Failed to create ZIP entry: {err}")))?;
+        std::io::Write::write_all(&mut archive, &pdf)
+            .map_err(|err| ApiError::internal(format!("Failed to write ZIP entry: {err}")))?;
+    }
+
+    let cursor = archive
+        .finish()
+        .map_err(|err| ApiError::internal(format!("Failed to finalize ZIP: {err}")))?;
+    let bytes = cursor.into_inner();
+
+    let content_disposition =
+        HeaderValue::from_static("attachment; filename=\"rustume-resumes.zip\"");
+    Ok((
+        StatusCode::OK,
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/zip"),
+            ),
+            (header::CONTENT_DISPOSITION, content_disposition),
+        ],
+        bytes,
+    )
+        .into_response())
+}
+
+async fn fetch_all_resumes(db: &sqlx::PgPool, user_id: Uuid) -> Result<Vec<ResumeRow>, ApiError> {
+    sqlx::query_as::<_, ResumeRow>(
+        r#"
+        SELECT id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+        FROM resumes
+        WHERE user_id = $1
+        ORDER BY updated_at DESC
+        "#,
+    )
+    .bind(user_id)
+    .fetch_all(db)
+    .await
+    .map_err(|err| {
+        error!("export resume query failed: {err}");
+        ApiError::internal("internal server error")
+    })
+}
+
+fn export_pdf_filename(id: &Uuid, title: &str) -> String {
+    let slug: String = title
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else if ch.is_whitespace() || ch == '-' || ch == '_' {
+                '-'
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let slug = slug.trim_matches('-');
+    let slug = if slug.is_empty() {
+        "resume".to_string()
+    } else {
+        slug.to_string()
+    };
+    format!("{slug}-{id}.pdf")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_pdf_filename_sanitizes_title() {
+        let id = Uuid::nil();
+        assert_eq!(
+            export_pdf_filename(&id, "Senior Engineer / Lead"),
+            format!("senior-engineer-_-lead-{id}.pdf")
+        );
+    }
+
+    #[test]
+    fn export_pdf_filename_falls_back_when_title_empty() {
+        let id = Uuid::nil();
+        assert_eq!(export_pdf_filename(&id, "   "), format!("resume-{id}.pdf"));
+    }
+}

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -94,7 +94,7 @@ pub async fn export_resumes_pdf(
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
     for row in rows {
-        let resume: ResumeData = serde_json::from_value(row.data.clone())
+        let resume: ResumeData = serde_json::from_value(row.data)
             .map_err(|_| ApiError::new("Invalid resume data format"))?;
         let file_name = export_pdf_filename(&row.id, &row.title);
         let pdf = tokio::task::spawn_blocking({
@@ -168,9 +168,11 @@ async fn fetch_all_resumes(
         FROM resumes
         WHERE user_id = $1
         ORDER BY updated_at DESC
+        LIMIT $2
         "#,
     )
     .bind(user_id)
+    .bind(MAX_EXPORT_RESUMES)
     .fetch_all(db)
     .await
     .map_err(internal_db_error)

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod account;
 pub mod auth;
+pub mod export;
 pub mod health;
 pub mod metrics;
 pub mod parse;
@@ -14,6 +15,7 @@ pub mod validate;
 
 pub use account::delete_account;
 pub use auth::{callback, login, logout, me};
+pub use export::{export_resumes_json, export_resumes_pdf};
 pub use health::health;
 pub use metrics::{init_metrics, metrics};
 pub use parse::parse;

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -18,6 +18,7 @@ use crate::error::ApiError;
 use crate::middleware::auth::AuthUser;
 use crate::net::{self, trusted_client_ip};
 use crate::state::AppState;
+use crate::subscription;
 use crate::validation::{validate_resume_json, validate_title};
 
 /// List resumes for the authenticated user.
@@ -38,6 +39,8 @@ pub async fn list_resumes(
     Query(query): Query<ResumeListQuery>,
 ) -> Result<Json<PaginatedResumeSummaries>, ApiError> {
     let cloud = state.cloud()?;
+    let access = subscription::load_access(&cloud.db, user.id).await?;
+    access.ensure_read()?;
     let (page, per_page, offset) = query.normalized();
 
     let total = sqlx::query_scalar::<_, i64>(
@@ -94,6 +97,9 @@ pub async fn get_resume(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ResumeRow>, ApiError> {
+    let cloud = state.cloud()?;
+    let access = subscription::load_access(&cloud.db, user.id).await?;
+    access.ensure_read()?;
     fetch_owned_resume(&state, user.id, id).await.map(Json)
 }
 
@@ -115,6 +121,8 @@ pub async fn create_resume(
     Json(body): Json<CreateResumeRequest>,
 ) -> Result<(StatusCode, Json<ResumeRow>), ApiError> {
     let cloud = state.cloud()?;
+    let access = subscription::load_access(&cloud.db, user.id).await?;
+    access.ensure_write()?;
     let title = body.title.unwrap_or_else(|| "Untitled".to_string());
     validate_title(title.as_str())?;
     validate_resume_json(&body.data)?;
@@ -164,6 +172,8 @@ pub async fn update_resume(
     }
 
     let cloud = state.cloud()?;
+    let access = subscription::load_access(&cloud.db, user.id).await?;
+    access.ensure_write()?;
     let existing = fetch_owned_resume(&state, user.id, id).await?;
     let title = body.title.unwrap_or(existing.title);
     validate_title(title.as_str())?;
@@ -196,6 +206,8 @@ pub async fn delete_resume(
     headers: HeaderMap,
 ) -> Result<StatusCode, ApiError> {
     let cloud = state.cloud()?;
+    let access = subscription::load_access(&cloud.db, user.id).await?;
+    access.ensure_delete()?;
     let result = sqlx::query("DELETE FROM resumes WHERE id = $1 AND user_id = $2")
         .bind(id)
         .bind(user.id)
@@ -250,6 +262,8 @@ pub async fn import_resumes(
     }
 
     let cloud = state.cloud()?;
+    let access = subscription::load_access(&cloud.db, user.id).await?;
+    access.ensure_write()?;
     let requested_count = body.resumes.len();
     let mut imported = Vec::new();
     let mut failed = Vec::new();

--- a/crates/server/src/subscription/mod.rs
+++ b/crates/server/src/subscription/mod.rs
@@ -61,6 +61,10 @@ impl SubscriptionAccess {
     /// Build access rules from a subscription row, if any.
     pub fn from_row(status: &str, period_end: Option<DateTime<Utc>>) -> Self {
         let Some(status) = SubscriptionStatus::parse(status) else {
+            tracing::warn!(
+                status = status,
+                "unknown subscription status, defaulting to Active"
+            );
             return Self::Active;
         };
 

--- a/crates/server/src/subscription/mod.rs
+++ b/crates/server/src/subscription/mod.rs
@@ -1,0 +1,231 @@
+//! Subscription status and grace-period access rules for Rustume Cloud.
+
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use tracing::error;
+use uuid::Uuid;
+
+use crate::db::SubscriptionInfo;
+use crate::error::ApiError;
+
+/// Known subscription status values stored in PostgreSQL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscriptionStatus {
+    Active,
+    Canceled,
+    PastDue,
+    Paused,
+    Trialing,
+}
+
+impl SubscriptionStatus {
+    /// Parse a database status string.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "active" => Some(Self::Active),
+            "canceled" => Some(Self::Canceled),
+            "past_due" => Some(Self::PastDue),
+            "paused" => Some(Self::Paused),
+            "trialing" => Some(Self::Trialing),
+            _ => None,
+        }
+    }
+
+    /// Serialize to the database/API status string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Canceled => "canceled",
+            Self::PastDue => "past_due",
+            Self::Paused => "paused",
+            Self::Trialing => "trialing",
+        }
+    }
+}
+
+/// Effective subscription access for API enforcement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubscriptionAccess {
+    /// Full read/write access (active subscription or no subscription row).
+    Active,
+    /// Canceled subscription still within the grace period.
+    GracePeriod {
+        expires_at: DateTime<Utc>,
+        status: SubscriptionStatus,
+    },
+    /// Subscription expired or otherwise blocked from resume access.
+    Expired { status: SubscriptionStatus },
+}
+
+impl SubscriptionAccess {
+    /// Build access rules from a subscription row, if any.
+    pub fn from_row(status: &str, period_end: Option<DateTime<Utc>>) -> Self {
+        let Some(status) = SubscriptionStatus::parse(status) else {
+            return Self::Active;
+        };
+
+        let now = Utc::now();
+        match status {
+            SubscriptionStatus::Active | SubscriptionStatus::Trialing => Self::Active,
+            SubscriptionStatus::Canceled => match period_end {
+                Some(expires_at) if expires_at > now => Self::GracePeriod { expires_at, status },
+                _ => Self::Expired { status },
+            },
+            SubscriptionStatus::PastDue | SubscriptionStatus::Paused => match period_end {
+                Some(expires_at) if expires_at > now => Self::GracePeriod { expires_at, status },
+                _ => Self::Expired { status },
+            },
+        }
+    }
+
+    /// No subscription row — free users retain full access.
+    pub fn without_subscription() -> Self {
+        Self::Active
+    }
+
+    /// API-facing subscription summary for `/auth/me`.
+    pub fn to_info(&self) -> Option<SubscriptionInfo> {
+        match self {
+            Self::Active => None,
+            Self::GracePeriod { expires_at, status } => Some(SubscriptionInfo {
+                status: status.as_str().to_string(),
+                expires_at: Some(*expires_at),
+            }),
+            Self::Expired { status } => Some(SubscriptionInfo {
+                status: status.as_str().to_string(),
+                expires_at: None,
+            }),
+        }
+    }
+
+    /// Reject when resume reads are not allowed.
+    pub fn ensure_read(&self) -> Result<(), ApiError> {
+        if matches!(self, Self::Expired { .. }) {
+            return Err(ApiError::forbidden(
+                "Cloud subscription expired — resume access is disabled",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Reject when resume writes are not allowed.
+    pub fn ensure_write(&self) -> Result<(), ApiError> {
+        match self {
+            Self::Active => Ok(()),
+            Self::GracePeriod { .. } => Err(ApiError::forbidden(
+                "Cloud account is read-only during subscription cancellation",
+            )),
+            Self::Expired { .. } => Err(ApiError::forbidden(
+                "Cloud subscription expired — resume writes are disabled",
+            )),
+        }
+    }
+
+    /// Reject when resume deletes are not allowed.
+    pub fn ensure_delete(&self) -> Result<(), ApiError> {
+        self.ensure_read()
+    }
+
+    /// Reject when render endpoints are not allowed.
+    pub fn ensure_render(&self) -> Result<(), ApiError> {
+        self.ensure_read()
+    }
+
+    /// Reject when bulk export endpoints are not allowed.
+    pub fn ensure_export(&self) -> Result<(), ApiError> {
+        self.ensure_read()
+    }
+}
+
+/// Load the latest subscription access for a user.
+pub async fn load_access(pool: &PgPool, user_id: Uuid) -> Result<SubscriptionAccess, ApiError> {
+    let row = sqlx::query_as::<_, SubscriptionRow>(
+        r#"
+        SELECT status, current_period_end
+        FROM subscriptions
+        WHERE user_id = $1
+        ORDER BY updated_at DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(internal_db_error)?;
+
+    Ok(row
+        .map(|row| SubscriptionAccess::from_row(&row.status, row.current_period_end))
+        .unwrap_or_else(SubscriptionAccess::without_subscription))
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct SubscriptionRow {
+    status: String,
+    current_period_end: Option<DateTime<Utc>>,
+}
+
+fn internal_db_error(err: impl std::fmt::Display) -> ApiError {
+    error!("subscription lookup failed: {err}");
+    ApiError::internal("internal server error")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn active_status_grants_full_access() {
+        let access = SubscriptionAccess::from_row("active", None);
+        assert_eq!(access, SubscriptionAccess::Active);
+        assert!(access.ensure_write().is_ok());
+        assert!(access.ensure_read().is_ok());
+    }
+
+    #[test]
+    fn canceled_before_period_end_is_grace_period() {
+        let expires_at = Utc.with_ymd_and_hms(2099, 1, 1, 0, 0, 0).unwrap();
+        let access = SubscriptionAccess::from_row("canceled", Some(expires_at));
+        assert_eq!(
+            access,
+            SubscriptionAccess::GracePeriod {
+                expires_at,
+                status: SubscriptionStatus::Canceled,
+            }
+        );
+        assert!(access.ensure_read().is_ok());
+        assert!(access.ensure_write().is_err());
+        assert!(access.ensure_delete().is_ok());
+    }
+
+    #[test]
+    fn canceled_after_period_end_is_expired() {
+        let expires_at = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+        let access = SubscriptionAccess::from_row("canceled", Some(expires_at));
+        assert_eq!(
+            access,
+            SubscriptionAccess::Expired {
+                status: SubscriptionStatus::Canceled,
+            }
+        );
+        assert!(access.ensure_read().is_err());
+        assert!(access.ensure_write().is_err());
+    }
+
+    #[test]
+    fn grace_period_info_includes_expires_at() {
+        let expires_at = Utc.with_ymd_and_hms(2099, 6, 1, 0, 0, 0).unwrap();
+        let access = SubscriptionAccess::GracePeriod {
+            expires_at,
+            status: SubscriptionStatus::Canceled,
+        };
+        let info = access.to_info().expect("grace info");
+        assert_eq!(info.status, "canceled");
+        assert_eq!(info.expires_at, Some(expires_at));
+    }
+
+    #[test]
+    fn active_subscription_omits_info_from_auth_me() {
+        assert!(SubscriptionAccess::Active.to_info().is_none());
+    }
+}


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(cloud): subscription cancellation, data portability, and grace period
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Implements the Paddle-free slice of subscription cancellation lifecycle (#255): grace-period access enforcement, bulk data export, and web UX for canceled subscriptions. Paddle webhooks, retention cron, and cloud→local replication are deferred to follow-up issues.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #255

## Details

**Server**
- `SubscriptionAccess` rules: active/trialing = full access; canceled/past_due/paused within `current_period_end` = grace (read + delete + render + export, no writes); expired = 403 on resume/render/export routes
- Subscription checks on resume CRUD, import, render preview/PDF, and new bulk export endpoints
- `GET /api/resumes/export` (JSON bundle) and `GET /api/resumes/export/pdf` (ZIP of PDFs)
- `/auth/me` includes optional `subscription: { status, expires_at }` for linked instances
- Stale session cookies on open deployments bypass subscription render checks (no regression)

**Web**
- `SubscriptionBanner` grace-period countdown with export CTA
- Account page export section (JSON + PDF ZIP downloads)
- `cloudStorage` maps subscription read-only 403s to user-facing toasts

**Deferred (not in this PR)**
- Paddle webhook handling and `/api/subscription`
- Retention cron and post-grace data deletion
- Cloud → local replication (#254) and Phase 3B local state machine

**Testing**
- Rust unit tests for subscription access matrix and export filename sanitization
- Vitest coverage for auth subscription parsing, export API, SubscriptionBanner, and read-only cloud writes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription status banner now shows expiration (“ends on”) and remaining time during grace periods, with an “Export data” link
  * Added bulk resume export from the account page as JSON or a PDF ZIP download
  * Cloud subscription-based access controls now cover resume operations and export, plus render preview/PDF enforcement
* **Bug Fixes**
  * Improved handling of cloud writes during subscription cancellation by surfacing read-only behavior
  * Account deletion confirmation now reminds users to export resumes first
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements the Paddle-free slice of subscription cancellation lifecycle for Rustume Cloud: server-side access enforcement across all resume CRUD, render, and export routes; two new bulk-export endpoints (`GET /api/resumes/export` JSON and `GET /api/resumes/export/pdf` ZIP); and a grace-period countdown banner with export CTA on the web client.

- **Server** — new `subscription::load_access` DB lookup added to every cloud route; three-tier `SubscriptionAccess` enum (`Active` / `GracePeriod` / `Expired`) drives `ensure_read/write/delete/render/export` guards; `/auth/me` now surfaces `{ status, expires_at }` for linked instances; `MAX_EXPORT_RESUMES = 50` cap prevents unbounded per-request work in the PDF ZIP handler.
- **Web** — `SubscriptionBanner` reads subscription state from the auth store and shows a day countdown with an \"Export data\" link; `rethrowSubscriptionForbidden` in `cloudStorage.ts` converts grace-period 403 write responses into a typed `SubscriptionReadOnlyError` with a warning toast; export buttons added to the Account page.
- **Testing** — Rust unit tests cover the full access matrix and filename sanitization; Vitest covers auth parsing, export API, banner render, and cloud-write error mapping.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all access-control paths are covered by unit tests and the logic is correctly implemented end-to-end.

The access enforcement logic is well-tested, the export cap prevents the previously-flagged unbounded resource issue, and the grace-period/expired split is correctly threaded from the DB query through to the client banner. The three open comments are forward-compatibility and UX wording suggestions that do not affect correctness today.

crates/server/src/subscription/mod.rs — the fail-open default for unknown Paddle status strings is worth a second look before Paddle's status set expands.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/subscription/mod.rs | New subscription access module — access matrix, DB lookup, and ensure_* guards are well-structured; unknown status defaults to Active (fail-open) which could grant full access if Paddle adds new blocking statuses. |
| crates/server/src/routes/export.rs | New bulk export endpoints (JSON + PDF ZIP); MAX_EXPORT_RESUMES=50 cap added; fetch_all_resumes does COUNT then SELECT as two separate queries (benign since LIMIT is applied in SELECT anyway). |
| crates/server/src/routes/resumes.rs | Subscription access checks added to all CRUD routes (list, get, create, update, delete, import); each adds one extra DB round-trip via load_access but logic is correct. |
| crates/server/src/middleware/subscription.rs | New render subscription middleware correctly passes through anonymous requests on open deployments and stale session cookies per the PR design. |
| apps/web/src/stores/cloudStorage.ts | rethrowSubscriptionForbidden correctly maps grace-period 403s to SubscriptionReadOnlyError; matching relies on "read-only" substring which is fragile if server message changes. |
| apps/web/src/components/Auth/SubscriptionBanner.tsx | Grace-period countdown banner with export CTA; message "ends on" is accurate for canceled subscriptions but misleading for past_due/paused which are recoverable states. |
| apps/web/src/api/export.ts | Clean export API client — JSON and PDF ZIP download helpers with proper error handling and blob URL cleanup. |
| apps/web/src/api/auth.ts | SubscriptionInfo added to AuthUser; parseAuthUserPayload handles malformed payloads tolerantly with type guards on status and expires_at. |
| crates/server/src/routes/auth.rs | GET /auth/me now loads subscription access and passes it to the response builder; only runs for cloud deployments. |
| apps/web/src/pages/Account.tsx | Export section added to account page with JSON and PDF ZIP download buttons; delete modal copy updated to reference export. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Middleware as require_subscription_render
    participant Handler
    participant Sub as subscription::load_access
    participant DB

    Note over Client,DB: Resume CRUD / Export
    Client->>Handler: GET /api/resumes (auth cookie)
    Handler->>Sub: load_access(db, user_id)
    Sub->>DB: SELECT status, current_period_end WHERE user_id LIMIT 1
    DB-->>Sub: SubscriptionRow
    Sub-->>Handler: "SubscriptionAccess (Active | GracePeriod | Expired)"
    alt Active or GracePeriod
        Handler-->>Client: 200 OK
    else Expired
        Handler-->>Client: 403 Forbidden
    end

    Note over Client,DB: Render preview/PDF
    Client->>Middleware: POST /api/render/pdf (with session cookie)
    Middleware->>Sub: load_access(db, user_id)
    Sub->>DB: SELECT status, current_period_end
    DB-->>Sub: SubscriptionRow
    Sub-->>Middleware: SubscriptionAccess
    alt Active or GracePeriod
        Middleware->>Handler: next()
        Handler-->>Client: 200 PDF
    else Expired
        Middleware-->>Client: 403 Forbidden
    end

    Note over Client,DB: GET /auth/me
    Client->>Handler: GET /auth/me
    Handler->>Sub: load_access(db, user_id)
    Sub-->>Handler: SubscriptionAccess.to_info()
    Handler-->>Client: "{ user, subscription: { status, expires_at } }"
    Client->>Client: SubscriptionBanner shows grace countdown

    Note over Client,DB: Write blocked in grace period
    Client->>Handler: PUT /api/resumes/:id
    Handler->>Sub: load_access → ensure_write()
    Sub-->>Handler: Err(403 read-only during cancellation)
    Handler-->>Client: 403 Forbidden
    Client->>Client: rethrowSubscriptionForbidden → SubscriptionReadOnlyError toast
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Middleware as require_subscription_render
    participant Handler
    participant Sub as subscription::load_access
    participant DB

    Note over Client,DB: Resume CRUD / Export
    Client->>Handler: GET /api/resumes (auth cookie)
    Handler->>Sub: load_access(db, user_id)
    Sub->>DB: SELECT status, current_period_end WHERE user_id LIMIT 1
    DB-->>Sub: SubscriptionRow
    Sub-->>Handler: "SubscriptionAccess (Active | GracePeriod | Expired)"
    alt Active or GracePeriod
        Handler-->>Client: 200 OK
    else Expired
        Handler-->>Client: 403 Forbidden
    end

    Note over Client,DB: Render preview/PDF
    Client->>Middleware: POST /api/render/pdf (with session cookie)
    Middleware->>Sub: load_access(db, user_id)
    Sub->>DB: SELECT status, current_period_end
    DB-->>Sub: SubscriptionRow
    Sub-->>Middleware: SubscriptionAccess
    alt Active or GracePeriod
        Middleware->>Handler: next()
        Handler-->>Client: 200 PDF
    else Expired
        Middleware-->>Client: 403 Forbidden
    end

    Note over Client,DB: GET /auth/me
    Client->>Handler: GET /auth/me
    Handler->>Sub: load_access(db, user_id)
    Sub-->>Handler: SubscriptionAccess.to_info()
    Handler-->>Client: "{ user, subscription: { status, expires_at } }"
    Client->>Client: SubscriptionBanner shows grace countdown

    Note over Client,DB: Write blocked in grace period
    Client->>Handler: PUT /api/resumes/:id
    Handler->>Sub: load_access → ensure_write()
    Sub-->>Handler: Err(403 read-only during cancellation)
    Handler-->>Client: 403 Forbidden
    Client->>Client: rethrowSubscriptionForbidden → SubscriptionReadOnlyError toast
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fserver%2Fsrc%2Fsubscription%2Fmod.rs%3A63-69%0A**Unknown%20Paddle%20status%20defaults%20to%20%60Active%60%2C%20granting%20full%20access**%0A%0A%60SubscriptionStatus%3A%3Aparse%60%20returns%20%60None%60%20for%20any%20string%20not%20in%20the%20explicit%20match%20arms%2C%20and%20%60from_row%60%20falls%20back%20to%20%60SubscriptionAccess%3A%3AActive%60%20with%20only%20a%20%60WARN%60%20log.%20If%20Paddle%20introduces%20a%20new%20blocking%20status%20%28e.g.%20%60%22suspended%22%60%20or%20%60%22fraud_review%22%60%29%20before%20the%20server's%20enum%20is%20updated%2C%20affected%20users%20would%20silently%20receive%20full%20write%20access.%20Defaulting%20to%20%60Expired%60%20is%20the%20safer%20fail-closed%20posture%3B%20the%20warning%20log%20is%20already%20there%20so%20the%20drift%20would%20be%20detectable.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20Some%28status%29%20%3D%20SubscriptionStatus%3A%3Aparse%28status%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20tracing%3A%3Awarn!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20status%20%3D%20status%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22unknown%20subscription%20status%2C%20defaulting%20to%20Expired%20%28fail-closed%29%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Self%3A%3AExpired%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20status%3A%20SubscriptionStatus%3A%3ACanceled%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fcomponents%2FAuth%2FSubscriptionBanner.tsx%3A55-59%0A**Banner%20copy%20says%20%22ends%20on%22%20for%20%60past_due%60%20%2F%20%60paused%60%20subscriptions%2C%20which%20implies%20cancellation**%0A%0A%60past_due%60%20means%20a%20payment%20has%20failed%20and%20is%20being%20retried%3B%20%60paused%60%20means%20the%20subscription%20was%20voluntarily%20paused.%20Neither%20is%20canceled%2C%20and%20a%20user%20could%20resolve%20the%20payment%20or%20resume%20and%20regain%20full%20access.%20The%20message%20%22Your%20cloud%20subscription%20ends%20on%20%E2%80%A6%22%20could%20alarm%20users%20and%20drive%20unnecessary%20churn.%20Consider%20conditional%20copy%20that%20distinguishes%20a%20definite%20cancellation%20%28%60canceled%60%29%20from%20a%20disrupted%20but%20recoverable%20state%20%28%60past_due%60%2C%20%60paused%60%29.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fstores%2FcloudStorage.ts%3A85%0A**Fragile%20substring%20matching%20couples%20client%20error%20classification%20to%20server%20message%20wording**%0A%0A%60message.includes%28%22read-only%22%29%60%20works%20today%20because%20the%20server%20returns%20%60%22Cloud%20account%20is%20read-only%20during%20subscription%20cancellation%22%60%20for%20grace-period%20writes%2C%20but%20this%20contract%20is%20implicit.%20A%20server-side%20rewording%20%28e.g.%20to%20%22writes%20are%20disabled%22%29%20would%20silently%20stop%20classifying%20grace-period%20403s%20as%20%60SubscriptionReadOnlyError%60%2C%20making%20every%20blocked%20save%20appear%20as%20a%20generic%20network%20error.%20Consider%20adding%20a%20structured%20%60%22code%22%3A%20%22subscription_read_only%22%60%20field%20to%20the%20server%20error%20JSON%20so%20the%20client%20can%20match%20on%20a%20stable%20token%20rather%20than%20prose.%0A%0A&pr=328&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fserver%2Fsrc%2Fsubscription%2Fmod.rs%3A63-69%0A**Unknown%20Paddle%20status%20defaults%20to%20%60Active%60%2C%20granting%20full%20access**%0A%0A%60SubscriptionStatus%3A%3Aparse%60%20returns%20%60None%60%20for%20any%20string%20not%20in%20the%20explicit%20match%20arms%2C%20and%20%60from_row%60%20falls%20back%20to%20%60SubscriptionAccess%3A%3AActive%60%20with%20only%20a%20%60WARN%60%20log.%20If%20Paddle%20introduces%20a%20new%20blocking%20status%20%28e.g.%20%60%22suspended%22%60%20or%20%60%22fraud_review%22%60%29%20before%20the%20server's%20enum%20is%20updated%2C%20affected%20users%20would%20silently%20receive%20full%20write%20access.%20Defaulting%20to%20%60Expired%60%20is%20the%20safer%20fail-closed%20posture%3B%20the%20warning%20log%20is%20already%20there%20so%20the%20drift%20would%20be%20detectable.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20Some%28status%29%20%3D%20SubscriptionStatus%3A%3Aparse%28status%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20tracing%3A%3Awarn!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20status%20%3D%20status%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22unknown%20subscription%20status%2C%20defaulting%20to%20Expired%20%28fail-closed%29%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Self%3A%3AExpired%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20status%3A%20SubscriptionStatus%3A%3ACanceled%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fcomponents%2FAuth%2FSubscriptionBanner.tsx%3A55-59%0A**Banner%20copy%20says%20%22ends%20on%22%20for%20%60past_due%60%20%2F%20%60paused%60%20subscriptions%2C%20which%20implies%20cancellation**%0A%0A%60past_due%60%20means%20a%20payment%20has%20failed%20and%20is%20being%20retried%3B%20%60paused%60%20means%20the%20subscription%20was%20voluntarily%20paused.%20Neither%20is%20canceled%2C%20and%20a%20user%20could%20resolve%20the%20payment%20or%20resume%20and%20regain%20full%20access.%20The%20message%20%22Your%20cloud%20subscription%20ends%20on%20%E2%80%A6%22%20could%20alarm%20users%20and%20drive%20unnecessary%20churn.%20Consider%20conditional%20copy%20that%20distinguishes%20a%20definite%20cancellation%20%28%60canceled%60%29%20from%20a%20disrupted%20but%20recoverable%20state%20%28%60past_due%60%2C%20%60paused%60%29.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fstores%2FcloudStorage.ts%3A85%0A**Fragile%20substring%20matching%20couples%20client%20error%20classification%20to%20server%20message%20wording**%0A%0A%60message.includes%28%22read-only%22%29%60%20works%20today%20because%20the%20server%20returns%20%60%22Cloud%20account%20is%20read-only%20during%20subscription%20cancellation%22%60%20for%20grace-period%20writes%2C%20but%20this%20contract%20is%20implicit.%20A%20server-side%20rewording%20%28e.g.%20to%20%22writes%20are%20disabled%22%29%20would%20silently%20stop%20classifying%20grace-period%20403s%20as%20%60SubscriptionReadOnlyError%60%2C%20making%20every%20blocked%20save%20appear%20as%20a%20generic%20network%20error.%20Consider%20adding%20a%20structured%20%60%22code%22%3A%20%22subscription_read_only%22%60%20field%20to%20the%20server%20error%20JSON%20so%20the%20client%20can%20match%20on%20a%20stable%20token%20rather%20than%20prose.%0A%0A&repo=lgtm-hq%2Frustume&pr=328&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22feat%2F255-subscription-cancellation-data-portability-and-grace-period%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F255-subscription-cancellation-data-portability-and-grace-period%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fserver%2Fsrc%2Fsubscription%2Fmod.rs%3A63-69%0A**Unknown%20Paddle%20status%20defaults%20to%20%60Active%60%2C%20granting%20full%20access**%0A%0A%60SubscriptionStatus%3A%3Aparse%60%20returns%20%60None%60%20for%20any%20string%20not%20in%20the%20explicit%20match%20arms%2C%20and%20%60from_row%60%20falls%20back%20to%20%60SubscriptionAccess%3A%3AActive%60%20with%20only%20a%20%60WARN%60%20log.%20If%20Paddle%20introduces%20a%20new%20blocking%20status%20%28e.g.%20%60%22suspended%22%60%20or%20%60%22fraud_review%22%60%29%20before%20the%20server's%20enum%20is%20updated%2C%20affected%20users%20would%20silently%20receive%20full%20write%20access.%20Defaulting%20to%20%60Expired%60%20is%20the%20safer%20fail-closed%20posture%3B%20the%20warning%20log%20is%20already%20there%20so%20the%20drift%20would%20be%20detectable.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20let%20Some%28status%29%20%3D%20SubscriptionStatus%3A%3Aparse%28status%29%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20tracing%3A%3Awarn!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20status%20%3D%20status%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22unknown%20subscription%20status%2C%20defaulting%20to%20Expired%20%28fail-closed%29%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20Self%3A%3AExpired%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20status%3A%20SubscriptionStatus%3A%3ACanceled%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fcomponents%2FAuth%2FSubscriptionBanner.tsx%3A55-59%0A**Banner%20copy%20says%20%22ends%20on%22%20for%20%60past_due%60%20%2F%20%60paused%60%20subscriptions%2C%20which%20implies%20cancellation**%0A%0A%60past_due%60%20means%20a%20payment%20has%20failed%20and%20is%20being%20retried%3B%20%60paused%60%20means%20the%20subscription%20was%20voluntarily%20paused.%20Neither%20is%20canceled%2C%20and%20a%20user%20could%20resolve%20the%20payment%20or%20resume%20and%20regain%20full%20access.%20The%20message%20%22Your%20cloud%20subscription%20ends%20on%20%E2%80%A6%22%20could%20alarm%20users%20and%20drive%20unnecessary%20churn.%20Consider%20conditional%20copy%20that%20distinguishes%20a%20definite%20cancellation%20%28%60canceled%60%29%20from%20a%20disrupted%20but%20recoverable%20state%20%28%60past_due%60%2C%20%60paused%60%29.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fstores%2FcloudStorage.ts%3A85%0A**Fragile%20substring%20matching%20couples%20client%20error%20classification%20to%20server%20message%20wording**%0A%0A%60message.includes%28%22read-only%22%29%60%20works%20today%20because%20the%20server%20returns%20%60%22Cloud%20account%20is%20read-only%20during%20subscription%20cancellation%22%60%20for%20grace-period%20writes%2C%20but%20this%20contract%20is%20implicit.%20A%20server-side%20rewording%20%28e.g.%20to%20%22writes%20are%20disabled%22%29%20would%20silently%20stop%20classifying%20grace-period%20403s%20as%20%60SubscriptionReadOnlyError%60%2C%20making%20every%20blocked%20save%20appear%20as%20a%20generic%20network%20error.%20Consider%20adding%20a%20structured%20%60%22code%22%3A%20%22subscription_read_only%22%60%20field%20to%20the%20server%20error%20JSON%20so%20the%20client%20can%20match%20on%20a%20stable%20token%20rather%20than%20prose.%0A%0A&repo=lgtm-hq%2Frustume&pr=328&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["test(cloud): restore export test timers ..."](https://github.com/lgtm-hq/rustume/commit/29beb92428a68e9f9d870ce95faa71e10cee3afd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38785991)</sub>

<!-- /greptile_comment -->