### PR TITLE
docs(cloud): hosting cost model and rate limit reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,9 +2708,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3678,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/apps/site/src/content/docs/api/cloud-endpoints.md
+++ b/apps/site/src/content/docs/api/cloud-endpoints.md
@@ -31,8 +31,10 @@ Variables](/docs/deployment/env-reference/).
 | `GET` | `/api/resumes/export` | Bulk JSON export (max 50 resumes) |
 | `GET` | `/api/resumes/export/pdf` | Bulk PDF export as ZIP (max 50 resumes) |
 
-Export endpoints share the PDF rate limit group and return `413` when the resume count exceeds the
-cap. See [Rate Limits](/docs/deployment/rate-limits/).
+Export endpoints enforce a resume-count cap and route-specific rate limits:
+
+JSON export uses the resume CRUD limit group; PDF export uses the PDF limit group (same as
+`POST /api/render/pdf`). See [Rate Limits](/docs/deployment/rate-limits/#bulk-export-cap).
 
 ## Connected workflows
 

--- a/apps/site/src/content/docs/api/cloud-endpoints.md
+++ b/apps/site/src/content/docs/api/cloud-endpoints.md
@@ -28,6 +28,11 @@ Variables](/docs/deployment/env-reference/).
 | `PUT` | `/api/resumes/{id}` | Update title and/or resume data |
 | `DELETE` | `/api/resumes/{id}` | Delete an owned resume |
 | `POST` | `/api/resumes/import` | Import locally stored resumes |
+| `GET` | `/api/resumes/export` | Bulk JSON export (max 50 resumes) |
+| `GET` | `/api/resumes/export/pdf` | Bulk PDF export as ZIP (max 50 resumes) |
+
+Export endpoints share the PDF rate limit group and return `413` when the resume count exceeds the
+cap. See [Rate Limits](/docs/deployment/rate-limits/).
 
 ## Connected workflows
 

--- a/apps/site/src/content/docs/api/core-endpoints.md
+++ b/apps/site/src/content/docs/api/core-endpoints.md
@@ -167,8 +167,10 @@ Always returns `200` — check the `valid` field. Nested field paths use dot not
 
 ## Rate limits
 
-Deployments may apply protective rate limits to keep the service healthy. Hosted billing is not used
-to hide parsing, rendering, templates, or connected capabilities from open-source users.
+Connected deployments apply per-route limits when `RUSTUME_CLOUD` is enabled. Defaults, route
+groups, `429` responses, and bulk export caps are documented in [Rate
+Limits](/docs/deployment/rate-limits/). Hosted billing does not hide parsing, rendering,
+templates, or connected capabilities from self-hosted operators.
 
 ## CLI equivalents
 

--- a/apps/site/src/content/docs/api/core-endpoints.md
+++ b/apps/site/src/content/docs/api/core-endpoints.md
@@ -167,8 +167,8 @@ Always returns `200` — check the `valid` field. Nested field paths use dot not
 
 ## Rate limits
 
-Connected deployments apply per-route limits when `RUSTUME_CLOUD` is enabled. Defaults, route
-groups, `429` responses, and bulk export caps are documented in [Rate
+Connected deployments apply per-route limits when `RUSTUME_CLOUD=true` and `DATABASE_URL` is
+configured. Defaults, route groups, `429` responses, and bulk export caps are documented in [Rate
 Limits](/docs/deployment/rate-limits/). Hosted billing does not hide parsing, rendering,
 templates, or connected capabilities from self-hosted operators.
 

--- a/apps/site/src/content/docs/deployment/env-reference.md
+++ b/apps/site/src/content/docs/deployment/env-reference.md
@@ -64,7 +64,7 @@ Limits](/docs/deployment/rate-limits/) for defaults, route groups, and client be
 | `RATE_LIMIT_HEALTH_PER_MIN` | `60` | Unauthenticated health checks (per IP) |
 | `RATE_LIMIT_METRICS_PER_MIN` | `60` | Metrics scrapes (per IP) |
 | `RATE_LIMIT_UNAUTHENTICATED_PER_MIN` | `30` | Other unauthenticated traffic (per IP) |
-| `RATE_LIMIT_BILLABLE_PER_MIN` | `30` | Templates, parse, validate |
+| `RATE_LIMIT_BILLABLE_PER_MIN` | `30` | Templates, parse, validate (available in all connected deployments; env name is historical) |
 
 ## Local connected example
 

--- a/apps/site/src/content/docs/deployment/env-reference.md
+++ b/apps/site/src/content/docs/deployment/env-reference.md
@@ -44,7 +44,9 @@ enabled, these identity and persistence settings are required:
 | `EMAIL_FROM` | Sender address for outbound mail (for example `noreply@rustume.com`) |
 
 Set `TRUSTED_PROXY=true` only when the server is behind a trusted proxy and may rely on
-`X-Forwarded-For` when calling WorkOS.
+`X-Forwarded-For` when calling WorkOS. The same flag enables `X-Real-IP` and append-mode
+`X-Forwarded-For` for rate-limit key extraction — see [Rate
+Limits](/docs/deployment/rate-limits/#scope).
 
 ## Rate limits (cloud mode)
 

--- a/apps/site/src/content/docs/deployment/env-reference.md
+++ b/apps/site/src/content/docs/deployment/env-reference.md
@@ -46,6 +46,24 @@ enabled, these identity and persistence settings are required:
 Set `TRUSTED_PROXY=true` only when the server is behind a trusted proxy and may rely on
 `X-Forwarded-For` when calling WorkOS.
 
+## Rate limits (cloud mode)
+
+When connected mode is enabled, per-route rate limits apply. See [Rate
+Limits](/docs/deployment/rate-limits/) for defaults, route groups, and client behavior.
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `RATE_LIMIT_RESUME_CRUD_PER_MIN` | `300` | Resume list/get/create/update/delete |
+| `RATE_LIMIT_RESUME_CRUD_BURST` | `30` | Short burst allowance for resume CRUD |
+| `RATE_LIMIT_IMPORT_PER_MIN` | `10` | Bulk import |
+| `RATE_LIMIT_PREVIEW_PER_MIN` | `60` | Preview render |
+| `RATE_LIMIT_PDF_PER_MIN` | `20` | PDF render and bulk PDF export |
+| `RATE_LIMIT_AUTH_PER_MIN` | `10` | Auth login/callback/logout/me |
+| `RATE_LIMIT_HEALTH_PER_MIN` | `60` | Unauthenticated health checks (per IP) |
+| `RATE_LIMIT_METRICS_PER_MIN` | `60` | Metrics scrapes (per IP) |
+| `RATE_LIMIT_UNAUTHENTICATED_PER_MIN` | `30` | Other unauthenticated traffic (per IP) |
+| `RATE_LIMIT_BILLABLE_PER_MIN` | `30` | Templates, parse, validate |
+
 ## Local connected example
 
 ```bash

--- a/apps/site/src/content/docs/deployment/env-reference.md
+++ b/apps/site/src/content/docs/deployment/env-reference.md
@@ -55,7 +55,7 @@ Limits](/docs/deployment/rate-limits/) for defaults, route groups, and client be
 
 | Variable | Default | Purpose |
 | --- | ---: | --- |
-| `RATE_LIMIT_RESUME_CRUD_PER_MIN` | `300` | Resume list/get/create/update/delete |
+| `RATE_LIMIT_RESUME_CRUD_PER_MIN` | `300` | Resume list/get/create/update/delete and bulk JSON export |
 | `RATE_LIMIT_RESUME_CRUD_BURST` | `30` | Short burst allowance for resume CRUD |
 | `RATE_LIMIT_IMPORT_PER_MIN` | `10` | Bulk import |
 | `RATE_LIMIT_PREVIEW_PER_MIN` | `60` | Preview render |

--- a/apps/site/src/content/docs/deployment/rate-limits.md
+++ b/apps/site/src/content/docs/deployment/rate-limits.md
@@ -37,7 +37,7 @@ All values are **requests per minute** unless noted.
 | Preview render | 60 | — | `POST /api/render/preview` |
 | PDF render & bulk PDF export | 20 | — | `POST /api/render/pdf`, `GET /api/resumes/export/pdf` |
 | Auth | 10 | — | Login, callback, logout, `/auth/me` |
-| Billable utilities | 30 | — | Templates, parse, validate |
+| Parse & utility | 30 | — | Templates, parse, validate |
 
 Resume CRUD allows short bursts (for example rapid autosave) via a separate burst bucket.
 
@@ -50,23 +50,34 @@ Resume CRUD allows short bursts (for example rapid autosave) via a separate burs
 | Other unauthenticated | 30 | Any route reached without a session |
 
 When `RUSTUME_REQUIRE_AUTH=true` (hosted Rustume Cloud), unauthenticated clients cannot reach
-billable render routes; the unauthenticated bucket mainly covers probes and stray traffic.
+render or connected API routes; the unauthenticated bucket mainly covers probes and stray traffic.
 
 ## Bulk export cap
 
-Bulk export endpoints enforce a separate **size cap**, not a per-minute quota:
+Bulk export endpoints enforce a separate **resume-count cap**, independent of per-minute rate limits.
 
 Bulk JSON export (`GET /api/resumes/export`) counts against the **resume CRUD** limit group.
 Bulk PDF export (`GET /api/resumes/export/pdf`) counts against the **PDF** limit group and
 renders each resume sequentially.
 
-| Endpoint | Rate limit group | Size cap | Over-limit response |
-| --- | --- | --- | --- |
-| `GET /api/resumes/export` | Resume CRUD | 50 resumes | `413 Payload Too Large` |
-| `GET /api/resumes/export/pdf` | PDF | 50 resumes (each rendered) | `413 Payload Too Large` |
+| Endpoint | Rate limit group | Maximum resumes per request |
+| --- | --- | ---: |
+| `GET /api/resumes/export` | Resume CRUD | 50 |
+| `GET /api/resumes/export/pdf` | PDF | 50 |
 
-The cap applies to owned resumes ordered by `updated_at`. It complements PDF rate limits by
-bounding per-request CPU and memory even when requests are spaced apart.
+**Trigger:** before any data is returned, the server counts all resumes you own. If the count
+exceeds 50, the entire request fails with `413 Payload Too Large` and an error message — there is
+no silent truncation to the 50 most recently updated resumes.
+
+**At or below 50:** the response includes every owned resume (ordered by `updated_at`, most recent
+first). The SQL query also applies `LIMIT 50` as a safety bound under concurrent writes.
+
+**Above 50:** bulk export cannot return the full library in one call. Export resumes individually,
+delete or archive older entries, or split work across multiple accounts — **pagination is not
+available** on these endpoints today.
+
+The cap complements PDF rate limits by bounding per-request CPU and memory even when requests are
+spaced apart.
 
 ## Configuration
 
@@ -83,7 +94,7 @@ RATE_LIMIT_AUTH_PER_MIN=10
 RATE_LIMIT_HEALTH_PER_MIN=60
 RATE_LIMIT_METRICS_PER_MIN=60
 RATE_LIMIT_UNAUTHENTICATED_PER_MIN=30
-RATE_LIMIT_BILLABLE_PER_MIN=30
+RATE_LIMIT_BILLABLE_PER_MIN=30   # templates, parse, validate (not subscription-gated)
 TRUSTED_PROXY=true   # only behind a trusted reverse proxy
 ```
 

--- a/apps/site/src/content/docs/deployment/rate-limits.md
+++ b/apps/site/src/content/docs/deployment/rate-limits.md
@@ -65,13 +65,12 @@ renders each resume sequentially.
 | `GET /api/resumes/export` | Resume CRUD | 50 |
 | `GET /api/resumes/export/pdf` | PDF | 50 |
 
-**Trigger:** before any data is returned, the server counts all resumes you own. If the count
-exceeds 50, the entire request fails with `413 Payload Too Large` and an error message — there is
-no silent truncation to the 50 most recently updated resumes.
+**Trigger:** before any data is returned, the server fetches up to 51 resumes you own (ordered by
+`updated_at`). If a 51st row is present, the entire request fails with `413 Payload Too Large` and
+an error message — there is no silent truncation to the 50 most recently updated resumes.
 
-**At or below 50:** the response includes every owned resume (ordered by `updated_at`, most recent
-first). The server fetches up to 51 rows in one query so the cap check and payload load cannot
-race under concurrent writes.
+**At or below 50:** the response includes every owned resume (most recent first). The single-query
+`LIMIT+1` check keeps the cap decision aligned with the returned payload under concurrent writes.
 
 **Above 50:** bulk export cannot return the full library in one call. Export resumes individually,
 delete or archive older entries, or split work across multiple accounts — **pagination is not

--- a/apps/site/src/content/docs/deployment/rate-limits.md
+++ b/apps/site/src/content/docs/deployment/rate-limits.md
@@ -32,7 +32,7 @@ All values are **requests per minute** unless noted.
 
 | Route group | Default | Burst | Examples |
 | --- | ---: | ---: | --- |
-| Resume CRUD | 300 | 30 | List, get, create, update, delete |
+| Resume CRUD | 300 | 30 | List, get, create, update, delete, `GET /api/resumes/export` |
 | Resume import | 10 | — | `POST /api/resumes/import` |
 | Preview render | 60 | — | `POST /api/render/preview` |
 | PDF render & bulk PDF export | 20 | — | `POST /api/render/pdf`, `GET /api/resumes/export/pdf` |
@@ -56,10 +56,14 @@ billable render routes; the unauthenticated bucket mainly covers probes and stra
 
 Bulk export endpoints enforce a separate **size cap**, not a per-minute quota:
 
-| Endpoint | Cap | Over-limit response |
-| --- | --- | --- |
-| `GET /api/resumes/export` | 50 resumes | `413 Payload Too Large` |
-| `GET /api/resumes/export/pdf` | 50 resumes (each rendered as PDF) | `413 Payload Too Large` |
+Bulk JSON export (`GET /api/resumes/export`) counts against the **resume CRUD** limit group.
+Bulk PDF export (`GET /api/resumes/export/pdf`) counts against the **PDF** limit group and
+renders each resume sequentially.
+
+| Endpoint | Rate limit group | Size cap | Over-limit response |
+| --- | --- | --- | --- |
+| `GET /api/resumes/export` | Resume CRUD | 50 resumes | `413 Payload Too Large` |
+| `GET /api/resumes/export/pdf` | PDF | 50 resumes (each rendered) | `413 Payload Too Large` |
 
 The cap applies to owned resumes ordered by `updated_at`. It complements PDF rate limits by
 bounding per-request CPU and memory even when requests are spaced apart.

--- a/apps/site/src/content/docs/deployment/rate-limits.md
+++ b/apps/site/src/content/docs/deployment/rate-limits.md
@@ -70,7 +70,8 @@ exceeds 50, the entire request fails with `413 Payload Too Large` and an error m
 no silent truncation to the 50 most recently updated resumes.
 
 **At or below 50:** the response includes every owned resume (ordered by `updated_at`, most recent
-first). The SQL query also applies `LIMIT 50` as a safety bound under concurrent writes.
+first). The server fetches up to 51 rows in one query so the cap check and payload load cannot
+race under concurrent writes.
 
 **Above 50:** bulk export cannot return the full library in one call. Export resumes individually,
 delete or archive older entries, or split work across multiple accounts — **pagination is not

--- a/apps/site/src/content/docs/deployment/rate-limits.md
+++ b/apps/site/src/content/docs/deployment/rate-limits.md
@@ -1,0 +1,115 @@
+---
+title: "Rate Limits"
+description: "Per-route request limits for Rustume Cloud and connected deployments, including defaults, configuration, and client behavior."
+category: deployment
+order: 25
+---
+
+Rustume applies **in-memory, per-key rate limits** when connected mode is enabled (`RUSTUME_CLOUD=true`
+with a configured database). Limits protect service capacity and control the cost of CPU-heavy
+operations (preview and PDF rendering) without blocking normal editing workflows.
+
+Self-hosted operators can tune or effectively disable limits by raising environment values. Browser-local
+deployments without connected mode do not install these middleware layers.
+
+## Scope
+
+| Deployment | Rate limiting |
+| --- | --- |
+| Browser-local (no `RUSTUME_CLOUD`) | Not applied |
+| Self-hosted connected | Applied; operator-configurable via env vars |
+| Rustume Cloud | Applied with production defaults |
+
+Limits are keyed by **authenticated user ID** for signed-in routes and by **client IP** for
+unauthenticated traffic. When `TRUSTED_PROXY=true`, IP extraction uses `X-Real-IP` and append-mode
+`X-Forwarded-For` from a trusted reverse proxy.
+
+## Default limits
+
+All values are **requests per minute** unless noted.
+
+### Authenticated routes
+
+| Route group | Default | Burst | Examples |
+| --- | ---: | ---: | --- |
+| Resume CRUD | 300 | 30 | List, get, create, update, delete |
+| Resume import | 10 | — | `POST /api/resumes/import` |
+| Preview render | 60 | — | `POST /api/render/preview` |
+| PDF render & bulk PDF export | 20 | — | `POST /api/render/pdf`, `GET /api/resumes/export/pdf` |
+| Auth | 10 | — | Login, callback, logout, `/auth/me` |
+| Billable utilities | 30 | — | Templates, parse, validate |
+
+Resume CRUD allows short bursts (for example rapid autosave) via a separate burst bucket.
+
+### Unauthenticated routes (per IP)
+
+| Route group | Default | Examples |
+| --- | ---: | --- |
+| Health | 60 | `GET /health` |
+| Metrics | 60 | `GET /metrics` (still requires `METRICS_TOKEN`) |
+| Other unauthenticated | 30 | Any route reached without a session |
+
+When `RUSTUME_REQUIRE_AUTH=true` (hosted Rustume Cloud), unauthenticated clients cannot reach
+billable render routes; the unauthenticated bucket mainly covers probes and stray traffic.
+
+## Bulk export cap
+
+Bulk export endpoints enforce a separate **size cap**, not a per-minute quota:
+
+| Endpoint | Cap | Over-limit response |
+| --- | --- | --- |
+| `GET /api/resumes/export` | 50 resumes | `413 Payload Too Large` |
+| `GET /api/resumes/export/pdf` | 50 resumes (each rendered as PDF) | `413 Payload Too Large` |
+
+The cap applies to owned resumes ordered by `updated_at`. It complements PDF rate limits by
+bounding per-request CPU and memory even when requests are spaced apart.
+
+## Configuration
+
+Override defaults with environment variables (see [Environment
+Variables](/docs/deployment/env-reference/#rate-limits-cloud-mode)):
+
+```bash
+RATE_LIMIT_RESUME_CRUD_PER_MIN=300
+RATE_LIMIT_RESUME_CRUD_BURST=30
+RATE_LIMIT_IMPORT_PER_MIN=10
+RATE_LIMIT_PREVIEW_PER_MIN=60
+RATE_LIMIT_PDF_PER_MIN=20
+RATE_LIMIT_AUTH_PER_MIN=10
+RATE_LIMIT_HEALTH_PER_MIN=60
+RATE_LIMIT_METRICS_PER_MIN=60
+RATE_LIMIT_UNAUTHENTICATED_PER_MIN=30
+RATE_LIMIT_BILLABLE_PER_MIN=30
+TRUSTED_PROXY=true   # only behind a trusted reverse proxy
+```
+
+Invalid values log a warning and fall back to the built-in default.
+
+## HTTP 429 response
+
+When a limit is exceeded, the API returns `429 Too Many Requests` with:
+
+```json
+{
+  "error": "Too many requests. Please try again shortly.",
+  "retry_after": 12
+}
+```
+
+Response headers include `Retry-After`, `X-RateLimit-Remaining: 0`, and `X-RateLimit-Reset`
+(Unix timestamp). The web app shows a brief toast for save operations and retries with backoff.
+
+## Operator notes
+
+- Limits are **process-local** (in-memory token buckets). Horizontal scaling multiplies effective
+  capacity per instance; tune env vars if you run multiple replicas.
+- PDF and preview limits exist because Typst rendering is CPU-bound. Normal interactive editing
+  should stay well below defaults.
+- Subscription grace and expiry rules are separate from rate limits; see [Subscription
+  Management](/docs/pricing/management/).
+
+## Read next
+
+- [Environment Variables](/docs/deployment/env-reference/) — full configuration reference
+- [Cloud Endpoints](/docs/api/cloud-endpoints/) — routes protected by these limits
+- [Hosting Economics](/docs/pricing/hosting-economics/) — what hosted billing funds

--- a/apps/site/src/content/docs/deployment/rate-limits.md
+++ b/apps/site/src/content/docs/deployment/rate-limits.md
@@ -20,9 +20,12 @@ deployments without connected mode do not install these middleware layers.
 | Self-hosted connected | Applied; operator-configurable via env vars |
 | Rustume Cloud | Applied with production defaults |
 
-Limits are keyed by **authenticated user ID** for signed-in routes and by **client IP** for
-unauthenticated traffic. When `TRUSTED_PROXY=true`, IP extraction uses `X-Real-IP` and append-mode
-`X-Forwarded-For` from a trusted reverse proxy.
+Limits apply **both** a per-user bucket (authenticated user ID) and a shared per-IP bucket for
+signed-in routes. When a session resolves to a user ID, middleware checks the IP limit and the
+user limit; multiple signed-in accounts behind the same office NAT or proxy can therefore receive
+`429` responses when the shared IP bucket is exhausted, even if each user is below their own
+quota. Unauthenticated traffic is keyed by **client IP** only. When `TRUSTED_PROXY=true`, IP
+extraction uses `X-Real-IP` and append-mode `X-Forwarded-For` from a trusted reverse proxy.
 
 ## Default limits
 

--- a/apps/site/src/content/docs/pricing/hosting-economics.md
+++ b/apps/site/src/content/docs/pricing/hosting-economics.md
@@ -1,0 +1,80 @@
+---
+title: "Hosting Economics"
+description: "How Rustume Cloud billing relates to service operation, capacity controls, and open-source parity."
+category: pricing
+order: 15
+---
+
+Rustume Cloud billing pays for **operated hosting** — not exclusive product features. The open-source
+connected application can provide the same resume workflows when you deploy and operate it yourself.
+
+This page summarizes the public economic model. Detailed production unit costs, margin targets, and
+infrastructure runbooks live in restricted operator documentation (not published on this site).
+
+## What a hosted subscription funds
+
+| Cost category | Included in hosted access | Self-hosted operator |
+| --- | --- | --- |
+| Application hosting & upgrades | Rustume operates | You deploy and patch |
+| Managed PostgreSQL & backups | Rustume operates | You provision (optional) |
+| Authentication (WorkOS) | Rustume configures | You configure WorkOS |
+| Observability & on-call | Rustume operates | You monitor |
+| Transactional email | Rustume operates (Resend) | You configure (optional) |
+| Billing & tax handling (Paddle) | Rustume operates | Not applicable |
+
+A subscription keeps the **ready-to-use deployment** (`app.rustume.com`) available. It does not unlock
+builder, export, sync, sharing, history, or API capabilities that self-hosted operators cannot also
+enable.
+
+## Capacity controls (not a feature paywall)
+
+Hosted service limits protect operational capacity and cost — they are **acceptable-use guardrails**,
+not a tiered feature matrix:
+
+| Control | Purpose |
+| --- | --- |
+| [Rate limits](/docs/deployment/rate-limits/) | Prevent abuse of CPU-heavy render paths and keep APIs responsive |
+| Bulk export cap (50 resumes) | Bound per-request PDF generation and archive size |
+| JSON complexity limits | Reject oversized or deeply nested resume payloads (server-wide) |
+
+Generous defaults are chosen so typical editing, preview, and occasional PDF export never hit limits.
+Power users who self-host can raise or remove limits via environment variables.
+
+## Cost drivers operators should know
+
+Even without publishing internal unit economics, these factors dominate hosted operating cost:
+
+1. **PDF and preview rendering** — CPU time per Typst compile; rate limits target this path first.
+2. **Database storage & I/O** — resume JSON, version history, and audit events grow with active users.
+3. **Egress** — PDF downloads and bulk export ZIP responses.
+4. **Third-party services** — WorkOS auth, Resend email, Paddle billing, observability vendors.
+
+Self-hosted deployments incur the same technical cost drivers when they enable connected mode; the
+difference is who pays the invoices and staffs on-call.
+
+## Billing state vs. product features
+
+Subscription status on Rustume Cloud controls **access to the operated deployment** (active, grace
+period after cancellation, or expired). It does not change what the application can do in a
+self-hosted connected deployment.
+
+During a grace period, users can still read, export, and delete data; write operations may be
+restricted until the period ends. See [Subscription Management](/docs/pricing/management/).
+
+## Public documentation boundary
+
+Per [Rustume Cloud launch criteria](https://github.com/lgtm-hq/Rustume/issues/243), this site documents
+architecture, user workflows, and operator-facing configuration. It intentionally omits:
+
+- Exact production cost per user or resume
+- Internal alert thresholds and SLO numbers
+- Recovery time objectives and restore runbooks
+- Live infrastructure identifiers
+
+Operators running private forks should maintain their own economics and incident documentation.
+
+## Read next
+
+- [Hosting Options](/docs/pricing/plans/) — capability comparison
+- [Rate Limits](/docs/deployment/rate-limits/) — defaults and env configuration
+- [Cloud Overview](/docs/cloud/overview/) — hosted vs self-hosted connected mode

--- a/apps/site/src/content/docs/pricing/hosting-economics.md
+++ b/apps/site/src/content/docs/pricing/hosting-economics.md
@@ -63,8 +63,8 @@ restricted until the period ends. See [Subscription Management](/docs/pricing/ma
 
 ## Public documentation boundary
 
-Per [Rustume Cloud launch criteria](https://github.com/lgtm-hq/Rustume/issues/243), this site documents
-architecture, user workflows, and operator-facing configuration. It intentionally omits:
+Rustume's public documentation covers architecture, user workflows, and operator-facing
+configuration. It intentionally omits restricted operations detail such as:
 
 - Exact production cost per user or resume
 - Internal alert thresholds and SLO numbers

--- a/apps/site/src/content/docs/pricing/hosting-economics.md
+++ b/apps/site/src/content/docs/pricing/hosting-economics.md
@@ -38,7 +38,9 @@ not a tiered feature matrix:
 | JSON complexity limits | Reject oversized or deeply nested resume payloads (server-wide) |
 
 Generous defaults are chosen so typical editing, preview, and occasional PDF export never hit limits.
-Power users who self-host can raise or remove limits via environment variables.
+Self-hosted operators can tune the [documented rate limits](/docs/deployment/rate-limits/#configuration)
+via environment variables. The **50-resume bulk export cap** is a fixed server limit today (not
+env-configurable); raise it only by changing the application source.
 
 ## Cost drivers operators should know
 

--- a/apps/site/src/content/docs/pricing/plans.md
+++ b/apps/site/src/content/docs/pricing/plans.md
@@ -11,3 +11,6 @@ charges for a ready-to-use hosted deployment: sign in, synchronize resumes, and 
 operate the infrastructure.
 
 ## Capability and operations comparison
+
+See [Hosting Economics](/docs/pricing/hosting-economics/) for what hosted billing funds and how
+[rate limits](/docs/deployment/rate-limits/) protect service capacity without gating product features.

--- a/apps/site/src/pages/cloud/index.astro
+++ b/apps/site/src/pages/cloud/index.astro
@@ -25,6 +25,8 @@ const cloudLinks = {
   history: { label: 'Version history', href: `${base}docs/cloud/version-history/` },
   apiKeys: { label: 'API keys', href: `${base}docs/api/api-keys/` },
   pricing: { label: 'Hosting options', href: `${base}docs/pricing/plans/` },
+  hostingEconomics: { label: 'Hosting economics', href: `${base}docs/pricing/hosting-economics/` },
+  rateLimits: { label: 'Rate limits', href: `${base}docs/deployment/rate-limits/` },
   environment: { label: 'Environment variables', href: `${base}docs/deployment/env-reference/` },
   stack: { label: 'Cloud stack', href: `${base}docs/architecture/cloud-stack/` },
 } satisfies Record<string, DocResource>;
@@ -149,7 +151,9 @@ const cloudLinks = {
       </p>
       <p>
         Checkout purchases access to the operated deployment, not feature entitlements. See
-        <a href={cloudLinks.pricing.href} class="doc-link">hosting comparison</a>
+        <a href={cloudLinks.pricing.href} class="doc-link">hosting comparison</a>,
+        <a href={cloudLinks.hostingEconomics.href} class="doc-link">hosting economics</a>,
+        <a href={cloudLinks.rateLimits.href} class="doc-link">rate limits</a>,
         and <a href={`${base}docs/pricing/management/`} class="doc-link">subscription management</a>.
       </p>
     </Section>

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -255,10 +255,15 @@ mod tests {
 
     fn database_url_for_tests() -> Option<String> {
         let url = std::env::var("TEST_DATABASE_URL")
-            .or_else(|_| std::env::var("DATABASE_URL"))
             .ok()
             .map(|url| url.trim().to_owned())
-            .filter(|url| !url.is_empty())?;
+            .filter(|url| !url.is_empty())
+            .or_else(|| {
+                std::env::var("DATABASE_URL")
+                    .ok()
+                    .map(|url| url.trim().to_owned())
+                    .filter(|url| !url.is_empty())
+            })?;
 
         if looks_like_test_database_url(&url) {
             Some(url)

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -171,9 +171,7 @@ async fn fetch_all_resumes(
     .map_err(internal_db_error)?;
 
     if rows.len() as i64 > MAX_EXPORT_RESUMES {
-        return Err(ApiError::payload_too_large(format!(
-            "Export exceeds maximum of {MAX_EXPORT_RESUMES} resumes (more than {MAX_EXPORT_RESUMES} found)"
-        )));
+        reject_export_over_resume_cap(rows.len() as i64)?;
     }
 
     Ok(rows)
@@ -231,9 +229,26 @@ mod tests {
     }
 
     fn database_url_for_tests() -> Option<String> {
-        std::env::var("DATABASE_URL")
+        if let Ok(url) = std::env::var("TEST_DATABASE_URL") {
+            let url = url.trim().to_owned();
+            if !url.is_empty() {
+                return Some(url);
+            }
+        }
+
+        let url = std::env::var("DATABASE_URL")
             .ok()
-            .filter(|url| !url.is_empty())
+            .map(|url| url.trim().to_owned())
+            .filter(|url| !url.is_empty())?;
+
+        if url.contains("_test") || url.contains("localhost") || url.contains("127.0.0.1") {
+            Some(url)
+        } else {
+            eprintln!(
+                "SKIP export integration tests: set TEST_DATABASE_URL or use a local/_test DATABASE_URL"
+            );
+            None
+        }
     }
 
     async fn connect_test_pool(database_url: &str) -> sqlx::PgPool {
@@ -241,7 +256,7 @@ mod tests {
             .max_connections(2)
             .connect(database_url)
             .await
-            .expect("connect to DATABASE_URL for export integration tests");
+            .expect("connect to test database for export integration tests");
         sqlx::migrate!("./src/db/migrations")
             .run(&pool)
             .await

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -23,11 +23,16 @@ use crate::subscription;
 const MAX_EXPORT_RESUMES: i64 = 50;
 
 /// Reject bulk export when the owned resume count exceeds the cap.
-fn reject_export_over_resume_cap(total: i64) -> Result<(), ApiError> {
-    if total > MAX_EXPORT_RESUMES {
-        return Err(ApiError::payload_too_large(format!(
-            "Export exceeds maximum of {MAX_EXPORT_RESUMES} resumes ({total} found)"
-        )));
+fn reject_export_over_resume_cap() -> ApiError {
+    ApiError::payload_too_large(format!(
+        "Export exceeds maximum of {MAX_EXPORT_RESUMES} resumes"
+    ))
+}
+
+/// Returns `Ok(())` when `count` is within the export cap (for unit tests).
+fn ensure_export_resume_count(count: i64) -> Result<(), ApiError> {
+    if count > MAX_EXPORT_RESUMES {
+        return Err(reject_export_over_resume_cap());
     }
     Ok(())
 }
@@ -171,7 +176,7 @@ async fn fetch_all_resumes(
     .map_err(internal_db_error)?;
 
     if rows.len() as i64 > MAX_EXPORT_RESUMES {
-        reject_export_over_resume_cap(rows.len() as i64)?;
+        return Err(reject_export_over_resume_cap());
     }
 
     Ok(rows)
@@ -216,36 +221,34 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn reject_export_over_resume_cap_allows_fifty() {
-        assert!(reject_export_over_resume_cap(50).is_ok());
+    fn ensure_export_resume_count_allows_fifty() {
+        assert!(ensure_export_resume_count(50).is_ok());
     }
 
     #[test]
-    fn reject_export_over_resume_cap_rejects_fifty_one() {
-        let err = reject_export_over_resume_cap(51).expect_err("expected cap rejection");
+    fn ensure_export_resume_count_rejects_fifty_one() {
+        let err = ensure_export_resume_count(51).expect_err("expected cap rejection");
         assert!(matches!(err.kind, ApiErrorKind::PayloadTooLarge));
         assert!(err.error.contains("50"));
-        assert!(err.error.contains("51"));
+        assert!(!err.error.contains("51"));
+    }
+
+    fn looks_like_test_database_url(url: &str) -> bool {
+        url.contains("_test")
     }
 
     fn database_url_for_tests() -> Option<String> {
-        if let Ok(url) = std::env::var("TEST_DATABASE_URL") {
-            let url = url.trim().to_owned();
-            if !url.is_empty() {
-                return Some(url);
-            }
-        }
-
-        let url = std::env::var("DATABASE_URL")
+        let url = std::env::var("TEST_DATABASE_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
             .ok()
             .map(|url| url.trim().to_owned())
             .filter(|url| !url.is_empty())?;
 
-        if url.contains("_test") || url.contains("localhost") || url.contains("127.0.0.1") {
+        if looks_like_test_database_url(&url) {
             Some(url)
         } else {
             eprintln!(
-                "SKIP export integration tests: set TEST_DATABASE_URL or use a local/_test DATABASE_URL"
+                "SKIP export integration tests: set TEST_DATABASE_URL (or DATABASE_URL) to a database whose name contains _test"
             );
             None
         }
@@ -333,13 +336,13 @@ mod tests {
         let user = seed_user_with_resumes(&pool, 51).await;
         let state = test_app_state(pool.clone());
 
-        let err = export_resumes_json(AuthUser(user.clone()), State(state))
-            .await
-            .expect_err("expected bulk JSON export to fail over cap");
-
-        assert!(matches!(err.kind, ApiErrorKind::PayloadTooLarge));
-
+        let result = export_resumes_json(AuthUser(user.clone()), State(state)).await;
         cleanup_user(&pool, user.id).await;
+
+        assert!(matches!(
+            result,
+            Err(err) if matches!(err.kind, ApiErrorKind::PayloadTooLarge)
+        ));
     }
 
     #[tokio::test]
@@ -353,13 +356,11 @@ mod tests {
         let user = seed_user_with_resumes(&pool, 50).await;
         let state = test_app_state(pool.clone());
 
-        let payload = export_resumes_json(AuthUser(user.clone()), State(state))
-            .await
-            .expect("expected bulk JSON export to succeed at cap");
-
-        assert_eq!(payload.resumes.len(), 50);
-
+        let result = export_resumes_json(AuthUser(user.clone()), State(state)).await;
         cleanup_user(&pool, user.id).await;
+
+        let payload = result.expect("expected bulk JSON export to succeed at cap");
+        assert_eq!(payload.resumes.len(), 50);
     }
 
     #[tokio::test]
@@ -373,13 +374,13 @@ mod tests {
         let user = seed_user_with_resumes(&pool, 51).await;
         let state = test_app_state(pool.clone());
 
-        let err = export_resumes_pdf(AuthUser(user.clone()), State(state))
-            .await
-            .expect_err("expected bulk PDF export to fail over cap");
-
-        assert!(matches!(err.kind, ApiErrorKind::PayloadTooLarge));
-
+        let result = export_resumes_pdf(AuthUser(user.clone()), State(state)).await;
         cleanup_user(&pool, user.id).await;
+
+        assert!(matches!(
+            result,
+            Err(err) if matches!(err.kind, ApiErrorKind::PayloadTooLarge)
+        ));
     }
 
     #[tokio::test]
@@ -393,10 +394,10 @@ mod tests {
         let user = seed_user_with_resumes(&pool, 50).await;
         let state = test_app_state(pool.clone());
 
-        let response = export_resumes_pdf(AuthUser(user.clone()), State(state))
-            .await
-            .expect("expected bulk PDF export to succeed at cap");
+        let result = export_resumes_pdf(AuthUser(user.clone()), State(state)).await;
+        cleanup_user(&pool, user.id).await;
 
+        let response = result.expect("expected bulk PDF export to succeed at cap");
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.headers().get(header::CONTENT_TYPE).unwrap(),
@@ -410,8 +411,6 @@ mod tests {
             body.starts_with(b"PK"),
             "expected ZIP archive bytes at cap boundary",
         );
-
-        cleanup_user(&pool, user.id).await;
     }
 
     #[test]

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -22,6 +22,16 @@ use crate::subscription;
 
 const MAX_EXPORT_RESUMES: i64 = 50;
 
+/// Reject bulk export when the owned resume count exceeds the cap.
+fn reject_export_over_resume_cap(total: i64) -> Result<(), ApiError> {
+    if total > MAX_EXPORT_RESUMES {
+        return Err(ApiError::payload_too_large(format!(
+            "Export exceeds maximum of {MAX_EXPORT_RESUMES} resumes ({total} found)"
+        )));
+    }
+    Ok(())
+}
+
 /// Resume fields required for bulk export.
 #[derive(Debug, sqlx::FromRow)]
 struct ExportResumeRow {
@@ -156,11 +166,7 @@ async fn fetch_all_resumes(
     .await
     .map_err(internal_db_error)?;
 
-    if total > MAX_EXPORT_RESUMES {
-        return Err(ApiError::payload_too_large(format!(
-            "Export exceeds maximum of {MAX_EXPORT_RESUMES} resumes ({total} found)"
-        )));
-    }
+    reject_export_over_resume_cap(total)?;
 
     sqlx::query_as::<_, ExportResumeRow>(
         r#"
@@ -208,6 +214,155 @@ fn export_pdf_filename(id: &Uuid, title: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cloud::CloudState;
+    use crate::error::ApiErrorKind;
+    use crate::state::AppState;
+    use crate::auth::{session::SessionService, workos::WorkOsClient};
+    use crate::email::EmailService;
+    use sqlx::postgres::PgPoolOptions;
+    use std::sync::Arc;
+
+    #[test]
+    fn reject_export_over_resume_cap_allows_fifty() {
+        assert!(reject_export_over_resume_cap(50).is_ok());
+    }
+
+    #[test]
+    fn reject_export_over_resume_cap_rejects_fifty_one() {
+        let err = reject_export_over_resume_cap(51).expect_err("expected cap rejection");
+        assert!(matches!(err.kind, ApiErrorKind::PayloadTooLarge));
+        assert!(err.error.contains("50"));
+        assert!(err.error.contains("51"));
+    }
+
+    async fn connect_test_pool() -> Option<sqlx::PgPool> {
+        let database_url = std::env::var("DATABASE_URL").ok()?;
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&database_url)
+            .await
+            .ok()?;
+        sqlx::migrate!("./src/db/migrations")
+            .run(&pool)
+            .await
+            .ok()?;
+        Some(pool)
+    }
+
+    async fn seed_user_with_resumes(pool: &sqlx::PgPool, count: i64) -> crate::db::User {
+        let user_id = Uuid::new_v4();
+        let workos_id = format!("workos_export_cap_{user_id}");
+
+        sqlx::query("INSERT INTO users (id, workos_id) VALUES ($1, $2)")
+            .bind(user_id)
+            .bind(&workos_id)
+            .execute(pool)
+            .await
+            .expect("insert user");
+
+        for index in 0..count {
+            sqlx::query("INSERT INTO resumes (user_id, title, data) VALUES ($1, $2, $3)")
+                .bind(user_id)
+                .bind(format!("Resume {index}"))
+                .bind(serde_json::json!({}))
+                .execute(pool)
+                .await
+                .expect("insert resume");
+        }
+
+        sqlx::query_as::<_, crate::db::User>("SELECT * FROM users WHERE id = $1")
+            .bind(user_id)
+            .fetch_one(pool)
+            .await
+            .expect("fetch user")
+    }
+
+    async fn cleanup_user(pool: &sqlx::PgPool, user_id: Uuid) {
+        sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await
+            .expect("cleanup user");
+    }
+
+    fn test_app_state(pool: sqlx::PgPool) -> AppState {
+        let sessions_pool = pool.clone();
+        AppState::with_require_auth(
+            Arc::new(crate::routes::static_dir()),
+            Some(Arc::new(CloudState {
+                db: pool,
+                workos: WorkOsClient::new("client_test".into(), "api_key_test".into()),
+                sessions: SessionService::new(
+                    sessions_pool,
+                    "test-session-secret-at-least-32-chars".into(),
+                    false,
+                ),
+                workos_redirect_uri: "http://localhost/auth/callback".into(),
+                email: Some(EmailService::new(
+                    "re_test".into(),
+                    "noreply@rustume.com".into(),
+                )),
+            })),
+            false,
+        )
+    }
+
+    #[tokio::test]
+    async fn export_resumes_json_rejects_over_fifty_resumes_with_413() {
+        let Some(pool) = connect_test_pool().await else {
+            eprintln!("SKIP export_resumes_json cap test: DATABASE_URL unavailable");
+            return;
+        };
+
+        let user = seed_user_with_resumes(&pool, 51).await;
+        let state = test_app_state(pool.clone());
+
+        let err = export_resumes_json(AuthUser(user.clone()), State(state))
+            .await
+            .expect_err("expected bulk JSON export to fail over cap");
+
+        assert!(matches!(err.kind, ApiErrorKind::PayloadTooLarge));
+
+        cleanup_user(&pool, user.id).await;
+    }
+
+    #[tokio::test]
+    async fn export_resumes_json_returns_all_resumes_at_fifty() {
+        let Some(pool) = connect_test_pool().await else {
+            eprintln!("SKIP export_resumes_json at-cap test: DATABASE_URL unavailable");
+            return;
+        };
+
+        let user = seed_user_with_resumes(&pool, 50).await;
+        let state = test_app_state(pool.clone());
+
+        let payload = export_resumes_json(AuthUser(user.clone()), State(state))
+            .await
+            .expect("expected bulk JSON export to succeed at cap");
+
+        assert_eq!(payload.resumes.len(), 50);
+
+        cleanup_user(&pool, user.id).await;
+    }
+
+    #[tokio::test]
+    async fn export_resumes_pdf_rejects_over_fifty_resumes_with_413() {
+        let Some(pool) = connect_test_pool().await else {
+            eprintln!("SKIP export_resumes_pdf cap test: DATABASE_URL unavailable");
+            return;
+        };
+
+        let user = seed_user_with_resumes(&pool, 51).await;
+        let state = test_app_state(pool.clone());
+
+        let err = export_resumes_pdf(AuthUser(user.clone()), State(state))
+            .await
+            .expect_err("expected bulk PDF export to fail over cap");
+
+        assert!(matches!(err.kind, ApiErrorKind::PayloadTooLarge));
+
+        cleanup_user(&pool, user.id).await;
+    }
 
     #[test]
     fn export_pdf_filename_sanitizes_title() {

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -29,14 +29,6 @@ fn reject_export_over_resume_cap() -> ApiError {
     ))
 }
 
-/// Returns `Ok(())` when `count` is within the export cap (for unit tests).
-fn ensure_export_resume_count(count: i64) -> Result<(), ApiError> {
-    if count > MAX_EXPORT_RESUMES {
-        return Err(reject_export_over_resume_cap());
-    }
-    Ok(())
-}
-
 /// Resume fields required for bulk export.
 #[derive(Debug, sqlx::FromRow)]
 struct ExportResumeRow {
@@ -220,6 +212,24 @@ mod tests {
     use sqlx::postgres::PgPoolOptions;
     use std::sync::Arc;
 
+    fn ensure_export_resume_count(count: i64) -> Result<(), ApiError> {
+        if count > MAX_EXPORT_RESUMES {
+            return Err(reject_export_over_resume_cap());
+        }
+        Ok(())
+    }
+
+    fn looks_like_test_database_url(url: &str) -> bool {
+        let db_name = url
+            .split(['?', '#'])
+            .next()
+            .unwrap_or(url)
+            .rsplit('/')
+            .next()
+            .unwrap_or("");
+        db_name.contains("_test")
+    }
+
     #[test]
     fn ensure_export_resume_count_allows_fifty() {
         assert!(ensure_export_resume_count(50).is_ok());
@@ -233,8 +243,14 @@ mod tests {
         assert!(!err.error.contains("51"));
     }
 
-    fn looks_like_test_database_url(url: &str) -> bool {
-        url.contains("_test")
+    #[test]
+    fn looks_like_test_database_url_matches_database_name_only() {
+        assert!(looks_like_test_database_url(
+            "postgres://user:pass@localhost:5432/rustume_test"
+        ));
+        assert!(!looks_like_test_database_url(
+            "postgres://user:pass@localhost:5432/rustume"
+        ));
     }
 
     fn database_url_for_tests() -> Option<String> {

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -235,18 +235,23 @@ mod tests {
         assert!(err.error.contains("51"));
     }
 
-    async fn connect_test_pool() -> Option<sqlx::PgPool> {
-        let database_url = std::env::var("DATABASE_URL").ok()?;
+    fn database_url_for_tests() -> Option<String> {
+        std::env::var("DATABASE_URL")
+            .ok()
+            .filter(|url| !url.is_empty())
+    }
+
+    async fn connect_test_pool(database_url: &str) -> sqlx::PgPool {
         let pool = PgPoolOptions::new()
             .max_connections(2)
-            .connect(&database_url)
+            .connect(database_url)
             .await
-            .ok()?;
+            .expect("connect to DATABASE_URL for export integration tests");
         sqlx::migrate!("./src/db/migrations")
             .run(&pool)
             .await
-            .ok()?;
-        Some(pool)
+            .expect("run migrations for export integration tests");
+        pool
     }
 
     async fn seed_user_with_resumes(pool: &sqlx::PgPool, count: i64) -> crate::db::User {
@@ -309,10 +314,11 @@ mod tests {
 
     #[tokio::test]
     async fn export_resumes_json_rejects_over_fifty_resumes_with_413() {
-        let Some(pool) = connect_test_pool().await else {
+        let Some(database_url) = database_url_for_tests() else {
             eprintln!("SKIP export_resumes_json cap test: DATABASE_URL unavailable");
             return;
         };
+        let pool = connect_test_pool(&database_url).await;
 
         let user = seed_user_with_resumes(&pool, 51).await;
         let state = test_app_state(pool.clone());
@@ -328,10 +334,11 @@ mod tests {
 
     #[tokio::test]
     async fn export_resumes_json_returns_all_resumes_at_fifty() {
-        let Some(pool) = connect_test_pool().await else {
+        let Some(database_url) = database_url_for_tests() else {
             eprintln!("SKIP export_resumes_json at-cap test: DATABASE_URL unavailable");
             return;
         };
+        let pool = connect_test_pool(&database_url).await;
 
         let user = seed_user_with_resumes(&pool, 50).await;
         let state = test_app_state(pool.clone());
@@ -347,10 +354,11 @@ mod tests {
 
     #[tokio::test]
     async fn export_resumes_pdf_rejects_over_fifty_resumes_with_413() {
-        let Some(pool) = connect_test_pool().await else {
+        let Some(database_url) = database_url_for_tests() else {
             eprintln!("SKIP export_resumes_pdf cap test: DATABASE_URL unavailable");
             return;
         };
+        let pool = connect_test_pool(&database_url).await;
 
         let user = seed_user_with_resumes(&pool, 51).await;
         let state = test_app_state(pool.clone());
@@ -360,6 +368,38 @@ mod tests {
             .expect_err("expected bulk PDF export to fail over cap");
 
         assert!(matches!(err.kind, ApiErrorKind::PayloadTooLarge));
+
+        cleanup_user(&pool, user.id).await;
+    }
+
+    #[tokio::test]
+    async fn export_resumes_pdf_returns_zip_at_fifty() {
+        let Some(database_url) = database_url_for_tests() else {
+            eprintln!("SKIP export_resumes_pdf at-cap test: DATABASE_URL unavailable");
+            return;
+        };
+        let pool = connect_test_pool(&database_url).await;
+
+        let user = seed_user_with_resumes(&pool, 50).await;
+        let state = test_app_state(pool.clone());
+
+        let response = export_resumes_pdf(AuthUser(user.clone()), State(state))
+            .await
+            .expect("expected bulk PDF export to succeed at cap");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/zip",
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read bulk PDF export body");
+        assert!(
+            body.starts_with(b"PK"),
+            "expected ZIP archive bytes at cap boundary",
+        );
 
         cleanup_user(&pool, user.id).await;
     }

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -154,21 +154,8 @@ async fn fetch_all_resumes(
     db: &sqlx::PgPool,
     user_id: Uuid,
 ) -> Result<Vec<ExportResumeRow>, ApiError> {
-    let total = sqlx::query_scalar::<_, i64>(
-        r#"
-        SELECT COUNT(*)
-        FROM resumes
-        WHERE user_id = $1
-        "#,
-    )
-    .bind(user_id)
-    .fetch_one(db)
-    .await
-    .map_err(internal_db_error)?;
-
-    reject_export_over_resume_cap(total)?;
-
-    sqlx::query_as::<_, ExportResumeRow>(
+    let fetch_limit = MAX_EXPORT_RESUMES + 1;
+    let rows = sqlx::query_as::<_, ExportResumeRow>(
         r#"
         SELECT id, title, data
         FROM resumes
@@ -178,10 +165,18 @@ async fn fetch_all_resumes(
         "#,
     )
     .bind(user_id)
-    .bind(MAX_EXPORT_RESUMES)
+    .bind(fetch_limit)
     .fetch_all(db)
     .await
-    .map_err(internal_db_error)
+    .map_err(internal_db_error)?;
+
+    if rows.len() as i64 > MAX_EXPORT_RESUMES {
+        return Err(ApiError::payload_too_large(format!(
+            "Export exceeds maximum of {MAX_EXPORT_RESUMES} resumes (more than {MAX_EXPORT_RESUMES} found)"
+        )));
+    }
+
+    Ok(rows)
 }
 
 fn internal_db_error(err: impl std::fmt::Display) -> ApiError {
@@ -214,11 +209,11 @@ fn export_pdf_filename(id: &Uuid, title: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::{session::SessionService, workos::WorkOsClient};
     use crate::cloud::CloudState;
+    use crate::email::EmailService;
     use crate::error::ApiErrorKind;
     use crate::state::AppState;
-    use crate::auth::{session::SessionService, workos::WorkOsClient};
-    use crate::email::EmailService;
     use sqlx::postgres::PgPoolOptions;
     use std::sync::Arc;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  docs(cloud): hosting cost model and rate limit reference
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds public documentation for Rustume Cloud rate limits and hosting economics (#260), completing the #243 launch checklist docs slice. Detailed production unit economics remain in private operator docs per issue scope.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (N/A — docs only)
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt` / `uv run lintro chk` / `uv run lintro tst`)

## Closes

- Closes #260
- Relates to #243

## Details

### New pages

- `deployment/rate-limits.md` — defaults, env overrides, 429 responses, bulk export caps, route groups
- `pricing/hosting-economics.md` — what hosted billing funds, capacity controls vs feature paywall, public doc boundary

### Updates

- `deployment/env-reference.md` — rate-limit env table; `TRUSTED_PROXY` also affects rate-limit IP keys
- `api/cloud-endpoints.md` — bulk export routes; JSON export uses resume CRUD limits, PDF export uses PDF limits
- `api/core-endpoints.md`, `pricing/plans.md`, `cloud/index.astro` — cross-links

### Testing

- `uv run lintro fmt` / `uv run lintro chk` — pass
- `uv run lintro tst` — pass

### AI review

- Greptile — export limit-group discrepancy fixed before merge
- CodeRabbit — 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded connected (cloud) rate-limits coverage, including `TRUSTED_PROXY=true`, IP keying rules, default per-route limits, `429` behavior, and bulk export resume-count cap semantics.
  - Updated environment reference for connected-mode rate-limit variables and proxy trust configuration.
  - Added export endpoint documentation for bulk JSON and bulk PDF (ZIP), including cap and route-specific rate-limit mapping.
  - Added “Hosting economics” and refreshed cloud/pricing navigation and cross-references.
- **Bug Fixes**
  - Bulk resume exports (JSON and PDF ZIP) now reliably enforce the resume-count cap and return `PayloadTooLarge` (HTTP 413) when exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds public documentation for Rustume Cloud rate limits and hosting economics, and replaces the two-query export cap check (COUNT then SELECT) with a more efficient single LIMIT+1 query alongside integration tests for the 50-resume cap.

- **New docs**: `deployment/rate-limits.md` (per-route limits, IP bucket behaviour, bulk export cap semantics) and `pricing/hosting-economics.md` (billing model, capacity controls, public doc scope), with cross-links wired into `env-reference.md`, `cloud-endpoints.md`, `core-endpoints.md`, `plans.md`, and `cloud/index.astro`.
- **Export refactor**: `fetch_all_resumes` now fetches up to 51 rows in one query and rejects with 413 if a 51st row is found, eliminating a TOCTOU window between the old COUNT and SELECT queries.
- **Tests**: New unit tests for the cap threshold helper and for `looks_like_test_database_url`, plus four database-gated integration tests covering the 413/200 boundary for both JSON and PDF export.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the code change is a well-understood query optimization and the documentation accurately reflects the implementation.

The only functional Rust change replaces a COUNT+SELECT pair with a single LIMIT+1 query. ResumeData is fully serde default so the PDF integration test seeds valid default-deserialisable rows. Cleanup is called before assertions in every integration test. The documentation pages are internally consistent and match the implementation.

No files require special attention. The database_url_for_tests helper in export.rs has a minor usability wrinkle with TEST_DATABASE_URL being subject to the _test name guard, but this does not affect correctness.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/server/src/routes/export.rs | Replaces COUNT+SELECT pattern with LIMIT+1 query for cap enforcement; removes count from error message; adds unit and DB-gated integration tests for JSON and PDF cap boundaries. Logic is correct. |
| apps/site/src/content/docs/deployment/rate-limits.md | New page documenting per-route limits, IP+user dual-bucket scope, 429 response format, bulk export cap semantics, and configuration env vars. Content accurately reflects the implementation. |
| apps/site/src/content/docs/pricing/hosting-economics.md | New page describing billing model, capacity controls, and public documentation scope. No internal issue links or sensitive operational data exposed. |
| apps/site/src/content/docs/deployment/env-reference.md | Adds rate-limit env var table and clarifies TRUSTED_PROXY scope for IP key extraction. Values match rate-limits.md defaults. |
| apps/site/src/content/docs/api/cloud-endpoints.md | Adds export endpoint rows to the route table and a brief note mapping each export endpoint to its rate-limit group. |
| apps/site/src/pages/cloud/index.astro | Adds hosting-economics and rate-limits links to cloudLinks and updates the billing paragraph with two additional doc links. |
| apps/site/src/content/docs/api/core-endpoints.md | Rate-limits section tightened to reference the new dedicated page; updated prose is accurate. |
| apps/site/src/content/docs/pricing/plans.md | Adds two-sentence cross-link to hosting-economics and rate-limits pages under Capability comparison. Minimal, correct change. |
| Cargo.lock | Routine patch bumps for memmap2 and quinn-proto; no concerning dependency changes. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant RL as Rate Limiter
    participant H as Export Handler
    participant DB as PostgreSQL

    C->>RL: GET /api/resumes/export[/pdf]
    RL-->>C: 429 (if IP or user bucket exhausted)
    RL->>H: pass (within limits)
    H->>DB: SELECT LIMIT 51 ORDER BY updated_at DESC
    DB-->>H: rows (0-51)
    alt "rows.len() > 50"
        H-->>C: 413 Payload Too Large
    else "rows.len() <= 50"
        alt JSON export
            H-->>C: 200 JSON ResumeBulkExport
        else PDF export
            loop for each resume row
                H->>H: spawn_blocking Typst render PDF bytes
            end
            H-->>C: 200 application/zip
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant RL as Rate Limiter
    participant H as Export Handler
    participant DB as PostgreSQL

    C->>RL: GET /api/resumes/export[/pdf]
    RL-->>C: 429 (if IP or user bucket exhausted)
    RL->>H: pass (within limits)
    H->>DB: SELECT LIMIT 51 ORDER BY updated_at DESC
    DB-->>H: rows (0-51)
    alt "rows.len() > 50"
        H-->>C: 413 Payload Too Large
    else "rows.len() <= 50"
        alt JSON export
            H-->>C: 200 JSON ResumeBulkExport
        else PDF export
            loop for each resume row
                H->>H: spawn_blocking Typst render PDF bytes
            end
            H-->>C: 200 application/zip
        end
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cloud Endpoints docs omit the claimed 429 response details**

   - **Bug**
     - The PR contract says the Cloud Endpoints documentation should include rate-limit mapping and 429 response details. In the rendered head site, `/docs/api/cloud-endpoints/` includes the bulk export rows and links to Rate Limits, but neither the source nor built page contains `429`/`Too Many Requests` wording. The generated verification script failed specifically on `docs/api/cloud-endpoints/index.html contains 429`, while the same check found 429 details only in core endpoints and the new rate-limits page.
   - **Cause**
     - `apps/site/src/content/docs/api/cloud-endpoints.md` adds bulk export cap/rate-limit group text at lines 31-37 but only links to the separate Rate Limits page; it does not include the promised 429 response details on the Cloud Endpoints page itself.
   - **Fix**
     - Add a concise Cloud Endpoints section or note describing the 429 response behavior, including `429 Too Many Requests` and the relevant retry/rate-limit headers or link context, near the existing export rate-limit text in `apps/site/src/content/docs/api/cloud-endpoints.md`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["test(server): fall back when TEST\_DATABA..."](https://github.com/lgtm-hq/rustume/commit/cd95b21f9d239561882b3dfbe722d5cb74c67cd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38803926)</sub>

<!-- /greptile_comment -->