### PR TITLE
chore(renovate): migrate fileMatch to managerFilePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "docker/Dockerfile"
+      "managerFilePatterns": [
+        "/^docker/Dockerfile$/"
       ],
       "matchStrings": [
         "ARG BUN_VERSION=(?<currentValue>\\S+)",
@@ -17,7 +17,7 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["docker/Dockerfile"],
+      "managerFilePatterns": ["/^docker/Dockerfile$/"],
       "matchStrings": [
         "cargo install cargo-chef@(?<currentValue>\\S+) --locked"
       ],
@@ -26,7 +26,7 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["scripts/ci/site/preview-pages-local.sh"],
+      "managerFilePatterns": ["/^scripts/ci/site/preview-pages-local\\.sh$/"],
       "matchStrings": [
         "CARGO_LLVM_COV_VERSION=\"\\$\\{CARGO_LLVM_COV_VERSION:-(?<currentValue>\\S+)\\}\""
       ],


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`renovate-config-validator --strict` warned "Config migration necessary": all 3 custom managers (oven-sh/bun, cargo-chef, cargo-llvm-cov) used the deprecated `fileMatch` option. Migrated to `managerFilePatterns` with anchored regex patterns, matching the convention already used by every other lgtm-hq repo config.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #380

## Details

Validated with `bunx --package renovate renovate-config-validator --strict renovate.json` → "Config validated successfully", no migration warning. Config-only change; no runtime code affected.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the Renovate custom manager file matching keys. The main changes are:

- Migrates three regex custom managers from `fileMatch` to `managerFilePatterns`.
- Anchors the Dockerfile patterns to `docker/Dockerfile`.
- Anchors the cargo-llvm-cov pattern to `scripts/ci/site/preview-pages-local.sh`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed config.
- The updated patterns still target the intended repository-relative files.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Renovate custom manager path matching was migrated to `managerFilePatterns`; no concrete issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(renovate): migrate fileMatch to ma..."](https://github.com/lgtm-hq/rustume/commit/45816660b36e574fba3ec1b59a09485adcc82fb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43505902)</sub>

<!-- /greptile_comment -->