### PR TITLE
chore(renovate): drop rules superseded by org preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,20 +36,10 @@
   ],
   "packageRules": [
     {
-      "matchCategories": ["docker"],
-      "pinDigests": true
-    },
-    {
       "matchManagers": ["docker-compose", "dockerfile"],
       "matchUpdateTypes": ["digest"],
       "automerge": true,
       "automergeType": "branch"
-    },
-    {
-      "groupName": "linting tools",
-      "groupSlug": "linting-tools",
-      "matchPackageNames": ["ghcr.io/lgtm-hq/py-lintro"],
-      "automerge": false
     },
     {
       "groupName": "axum ecosystem",


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

lgtm-hq/.github#25 gave the org preset a canonical `lintro` group and `config:best-practices` (which includes `docker:pinDigests`):

- Remove the `linting tools` group (`ghcr.io/lgtm-hq/py-lintro`) — superseded by the preset `lintro` group
- Remove `matchCategories: ["docker"], pinDigests: true` — covered by `docker:pinDigests`
- Keep the docker digest branch-automerge rule and the axum ecosystem group

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed

## Closes

- Closes #382

## Details

Config-only. `renovate-config-validator --strict` → validated successfully.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR trims repo-local Renovate rules that are expected to come from the org preset.

- Removes the local Docker `pinDigests` package rule.
- Removes the local `ghcr.io/lgtm-hq/py-lintro` grouping rule.
- Keeps Docker digest branch automerge and the axum ecosystem group.
</details>

<h3>Confidence Score: 5/5</h3>

This looks mergeable after confirming the org preset supplies the removed Renovate behavior.

- The changed config is small and isolated.
- The removed Docker pinning and py-lintro override now rely on inherited preset behavior.
- If that preset does not apply here, Docker updates can become tag-only and py-lintro digest updates can automerge.

renovate.json

<details open><summary><h3>Security Review</h3></summary>

The Docker digest pinning removal can weaken supply-chain protections if the inherited preset does not apply `docker:pinDigests` for this repo.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Removes two local Renovate package rules and leaves the remaining digest automerge and axum grouping rules unchanged. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Arenovate.json%3A37-43%0A**Docker%20Pinning%20Depends%20On%20Preset**%0A%0ARemoving%20the%20local%20%60matchCategories%3A%20%5B%22docker%22%5D%60%20rule%20makes%20digest%20pinning%20depend%20entirely%20on%20the%20inherited%20preset.%20If%20that%20preset%20is%20not%20loaded%20or%20does%20not%20include%20%60docker%3ApinDigests%60%20for%20this%20repo%2C%20Renovate%20falls%20back%20to%20tag-only%20Docker%20updates%20while%20the%20remaining%20digest%20automerge%20rule%20only%20controls%20updates%20after%20a%20digest%20already%20exists.%0A%0A%60%60%60suggestion%0A%20%20%22packageRules%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22matchCategories%22%3A%20%5B%22docker%22%5D%2C%0A%20%20%20%20%20%20%22pinDigests%22%3A%20true%0A%20%20%20%20%7D%2C%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22matchManagers%22%3A%20%5B%22docker-compose%22%2C%20%22dockerfile%22%5D%2C%0A%20%20%20%20%20%20%22matchUpdateTypes%22%3A%20%5B%22digest%22%5D%2C%0A%20%20%20%20%20%20%22automerge%22%3A%20true%2C%0A%20%20%20%20%20%20%22automergeType%22%3A%20%22branch%22%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Arenovate.json%3A38-43%0A**Lintro%20Updates%20Lose%20Override**%0A%0ARemoving%20the%20%60ghcr.io%2Flgtm-hq%2Fpy-lintro%60%20rule%20also%20removes%20its%20explicit%20%60automerge%3A%20false%60%20override.%20If%20the%20org%20preset%20does%20not%20provide%20the%20replacement%20%60lintro%60%20group%2C%20py-lintro%20digest%20updates%20can%20match%20the%20remaining%20Docker%20digest%20automerge%20rule%20and%20merge%20without%20the%20review%20that%20the%20old%20local%20rule%20required.%0A%0A%60%60%60suggestion%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22matchManagers%22%3A%20%5B%22docker-compose%22%2C%20%22dockerfile%22%5D%2C%0A%20%20%20%20%20%20%22matchUpdateTypes%22%3A%20%5B%22digest%22%5D%2C%0A%20%20%20%20%20%20%22automerge%22%3A%20true%2C%0A%20%20%20%20%20%20%22automergeType%22%3A%20%22branch%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22groupName%22%3A%20%22linting%20tools%22%2C%0A%20%20%20%20%20%20%22groupSlug%22%3A%20%22linting-tools%22%2C%0A%20%20%20%20%20%20%22matchPackageNames%22%3A%20%5B%22ghcr.io%2Flgtm-hq%2Fpy-lintro%22%5D%2C%0A%20%20%20%20%20%20%22automerge%22%3A%20false%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A&pr=384&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Arenovate.json%3A37-43%0A**Docker%20Pinning%20Depends%20On%20Preset**%0A%0ARemoving%20the%20local%20%60matchCategories%3A%20%5B%22docker%22%5D%60%20rule%20makes%20digest%20pinning%20depend%20entirely%20on%20the%20inherited%20preset.%20If%20that%20preset%20is%20not%20loaded%20or%20does%20not%20include%20%60docker%3ApinDigests%60%20for%20this%20repo%2C%20Renovate%20falls%20back%20to%20tag-only%20Docker%20updates%20while%20the%20remaining%20digest%20automerge%20rule%20only%20controls%20updates%20after%20a%20digest%20already%20exists.%0A%0A%60%60%60suggestion%0A%20%20%22packageRules%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22matchCategories%22%3A%20%5B%22docker%22%5D%2C%0A%20%20%20%20%20%20%22pinDigests%22%3A%20true%0A%20%20%20%20%7D%2C%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22matchManagers%22%3A%20%5B%22docker-compose%22%2C%20%22dockerfile%22%5D%2C%0A%20%20%20%20%20%20%22matchUpdateTypes%22%3A%20%5B%22digest%22%5D%2C%0A%20%20%20%20%20%20%22automerge%22%3A%20true%2C%0A%20%20%20%20%20%20%22automergeType%22%3A%20%22branch%22%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Arenovate.json%3A38-43%0A**Lintro%20Updates%20Lose%20Override**%0A%0ARemoving%20the%20%60ghcr.io%2Flgtm-hq%2Fpy-lintro%60%20rule%20also%20removes%20its%20explicit%20%60automerge%3A%20false%60%20override.%20If%20the%20org%20preset%20does%20not%20provide%20the%20replacement%20%60lintro%60%20group%2C%20py-lintro%20digest%20updates%20can%20match%20the%20remaining%20Docker%20digest%20automerge%20rule%20and%20merge%20without%20the%20review%20that%20the%20old%20local%20rule%20required.%0A%0A%60%60%60suggestion%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22matchManagers%22%3A%20%5B%22docker-compose%22%2C%20%22dockerfile%22%5D%2C%0A%20%20%20%20%20%20%22matchUpdateTypes%22%3A%20%5B%22digest%22%5D%2C%0A%20%20%20%20%20%20%22automerge%22%3A%20true%2C%0A%20%20%20%20%20%20%22automergeType%22%3A%20%22branch%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22groupName%22%3A%20%22linting%20tools%22%2C%0A%20%20%20%20%20%20%22groupSlug%22%3A%20%22linting-tools%22%2C%0A%20%20%20%20%20%20%22matchPackageNames%22%3A%20%5B%22ghcr.io%2Flgtm-hq%2Fpy-lintro%22%5D%2C%0A%20%20%20%20%20%20%22automerge%22%3A%20false%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=384&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22chore%2F382-drop-superseded-rules%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F382-drop-superseded-rules%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Arenovate.json%3A37-43%0A**Docker%20Pinning%20Depends%20On%20Preset**%0A%0ARemoving%20the%20local%20%60matchCategories%3A%20%5B%22docker%22%5D%60%20rule%20makes%20digest%20pinning%20depend%20entirely%20on%20the%20inherited%20preset.%20If%20that%20preset%20is%20not%20loaded%20or%20does%20not%20include%20%60docker%3ApinDigests%60%20for%20this%20repo%2C%20Renovate%20falls%20back%20to%20tag-only%20Docker%20updates%20while%20the%20remaining%20digest%20automerge%20rule%20only%20controls%20updates%20after%20a%20digest%20already%20exists.%0A%0A%60%60%60suggestion%0A%20%20%22packageRules%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22matchCategories%22%3A%20%5B%22docker%22%5D%2C%0A%20%20%20%20%20%20%22pinDigests%22%3A%20true%0A%20%20%20%20%7D%2C%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22matchManagers%22%3A%20%5B%22docker-compose%22%2C%20%22dockerfile%22%5D%2C%0A%20%20%20%20%20%20%22matchUpdateTypes%22%3A%20%5B%22digest%22%5D%2C%0A%20%20%20%20%20%20%22automerge%22%3A%20true%2C%0A%20%20%20%20%20%20%22automergeType%22%3A%20%22branch%22%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Arenovate.json%3A38-43%0A**Lintro%20Updates%20Lose%20Override**%0A%0ARemoving%20the%20%60ghcr.io%2Flgtm-hq%2Fpy-lintro%60%20rule%20also%20removes%20its%20explicit%20%60automerge%3A%20false%60%20override.%20If%20the%20org%20preset%20does%20not%20provide%20the%20replacement%20%60lintro%60%20group%2C%20py-lintro%20digest%20updates%20can%20match%20the%20remaining%20Docker%20digest%20automerge%20rule%20and%20merge%20without%20the%20review%20that%20the%20old%20local%20rule%20required.%0A%0A%60%60%60suggestion%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22matchManagers%22%3A%20%5B%22docker-compose%22%2C%20%22dockerfile%22%5D%2C%0A%20%20%20%20%20%20%22matchUpdateTypes%22%3A%20%5B%22digest%22%5D%2C%0A%20%20%20%20%20%20%22automerge%22%3A%20true%2C%0A%20%20%20%20%20%20%22automergeType%22%3A%20%22branch%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22groupName%22%3A%20%22linting%20tools%22%2C%0A%20%20%20%20%20%20%22groupSlug%22%3A%20%22linting-tools%22%2C%0A%20%20%20%20%20%20%22matchPackageNames%22%3A%20%5B%22ghcr.io%2Flgtm-hq%2Fpy-lintro%22%5D%2C%0A%20%20%20%20%20%20%22automerge%22%3A%20false%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=384&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore(renovate): drop rules superseded b..."](https://github.com/lgtm-hq/rustume/commit/3287951b17cabba3271fac12729afd3000e1e60e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43515677)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->