### PR TITLE
chore(ci): adopt lgtm-ci v0.52.3 and fix path-filtered CodeQL check

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, coverage, release automation,
 and publishing. Most workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`96a42109637efd4c019d176e0902e3be23295716` (**v0.45.1** release commit; not the annotated
+`66cad82ead0e5d119928c895c7d7da9c837989e5` (**v0.52.3** release commit; not the annotated
 tag object SHA). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
@@ -17,7 +17,7 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 
 - **test-rust.yml** — Rust workspace compile check via `reusable-test-rust-build`
   (ruleset gate: `rust-build / 🔨 Build Check`)
-- **coverage.yml** — Single-runtime coverage (lgtm-ci v0.45.1
+- **coverage.yml** — Single-runtime coverage (lgtm-ci v0.52.3
   compat/coverage contract): `rust-coverage` and `web-coverage` each use
   `coverage: true` and `publish-test-summary: true`; uploads Pages coverage
   HTML artifacts and distinct PR coverage comments (suite name in heading)
@@ -73,16 +73,17 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 - **validate-action-pinning.yml** — SHA pin policy via `reusable-validate-action-pinning`
 - **ghcr-cleanup.yml** — GHCR prune (hybrid: `reusable-ghcr-cleanup` for untagged +
   inline tagged retention)
-- **renovate.yml** — Scheduled Renovate runs (lgtm-ci composites)
+- **renovate.yml** — Scheduled Renovate runs (direct `step-security/harden-runner` +
+  lgtm-ci `secure-checkout`; lgtm-ci removed its harden-runner composite in v0.50.0)
 
 ## Pin format
 
 Use the **release commit SHA**, not the annotated tag object SHA:
 
 ```yaml
-uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
 with:
-  tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1 release commit
+  tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3 release commit
 ```
 
 Sparse `lgtm-hq` tooling checkouts may use `actions/checkout` when `ref:` is quoted and

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -18,9 +18,9 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: "🏷️ Create Release Tag"
       version-source: cargo
       create-release: false

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -42,15 +42,19 @@ jobs:
 
     steps:
       - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        # Direct step-security invocation: lgtm-ci removed its harden-runner
+        # composite in v0.50.0 (the action pre hook must install the agent).
+        # Linux-only guard matches the lgtm-ci reusable preambles; the agent
+        # does not support the macOS/Windows matrix legs.
+        if: runner.os == 'Linux' || runner.environment == 'self-hosted'
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -61,7 +65,7 @@ jobs:
 
       - name: Setup Rust
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -42,12 +42,12 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read # checkout repository sources for lintro analysis
       packages: read # pull the pinned lintro image from GHCR
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: "🛠️ Lintro Code Quality & Analysis"
       lintro-tool-options: clippy:timeout=300
       timeout-minutes: 30
@@ -65,14 +65,14 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read # read quality job outputs and artifacts
       pull-requests: write # post or update the quality summary comment
     with:
       exit-code: >-
         ${{ needs.quality.outputs.exit-code != '' && needs.quality.outputs.exit-code || '1' }}
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: "🛠️ Lintro Code Quality & Analysis PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,13 +3,23 @@
 name: Security - CodeQL Code Scanning
 # GitHub CodeQL static analysis for security vulnerabilities.
 
+# analyze / 🔬 CodeQL Analysis is a required status check, so this workflow
+# must report on every PR and merge-queue entry. No on.pull_request.paths
+# filter: a path-filtered workflow that does not run leaves the required
+# context absent (not skipped), which permanently blocks the merge queue for
+# PRs that touch only non-matching files (workflow-contract § Required-check-
+# safe conditional workflows; deadlocked config-only PR #381). The analyze job
+# calls a reusable workflow, so the detect-changes step-gating variant cannot
+# apply — an if-skipped `uses:` job never materialises the nested
+# `analyze / 🔬 CodeQL Analysis` check run, recreating the deadlock. Always
+# run on PRs instead (ai-skills/py-lintro reference-consumer pattern).
+
 "on":
   push:
     branches: [main]
     paths: ["**.rs", "Cargo.toml", "Cargo.lock", ".github/**"]
   pull_request:
     branches: [main]
-    paths: ["**.rs", "Cargo.toml", "Cargo.lock", ".github/**"]
   merge_group:
   schedule:
     - cron: "0 6 * * 1"
@@ -24,14 +34,27 @@ concurrency:
 jobs:
   analyze:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: "🔬 CodeQL Analysis"
       languages: actions,rust
       language-build-modes: '{"rust":"none","actions":"none"}'
       egress-policy: block
       egress-preset: quality
+      # Harden-runner pre reads workflow inputs only (not resolved presets).
+      # Full list = reusable default + release-assets (CodeQL bundle download
+      # from github/codeql-action releases redirects there).
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,12 +25,12 @@ permissions:
 jobs:
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: "🦀 Rust Coverage"
       coverage: true
       upload-pages-coverage-html: true
@@ -42,12 +42,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,6 +60,10 @@ jobs:
       upload-pages-coverage-html: true
       pages-coverage-artifact-name: web-coverage-html
       pages-coverage-source-subpath: coverage
-      publish-test-summary: true
+      # TODO(lgtm-hq/lgtm-ci#511): revert to true once reusable-test-node's
+      # "Stage coverage for test summary" step sets the COVERAGE env var. At
+      # v0.52.3 the step hard-fails for single-version coverage callers on
+      # PRs, taking the required 🌐 Web Coverage check down with it.
+      publish-test-summary: false
       runner-image: ubuntu-24.04
       timeout-minutes: 30

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,11 +15,11 @@ concurrency:
 jobs:
   review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       job-name: "🔍 Dependency Review"
       fail-on-severity: high
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,7 +32,7 @@ jobs:
       actions: read
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -42,7 +42,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/deploy-railway-cloud.yml
+++ b/.github/workflows/deploy-railway-cloud.yml
@@ -50,8 +50,9 @@ jobs:
       RAILWAY_IMAGE: ghcr.io/lgtm-hq/rustume:main
     steps:
       - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        # Direct step-security invocation: lgtm-ci removed its harden-runner
+        # composite in v0.50.0 (the action pre hook must install the agent).
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -62,7 +63,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -75,7 +75,9 @@ jobs:
       sbom: ${{ github.event_name != 'pull_request' }}
       # Harden-runner pre reads workflow inputs only (not resolved presets).
       # Full list = reusable-docker default + gcr.io (distroless base image
-      # in docker/Dockerfile) + sigstore hosts (cosign-sign on push runs).
+      # in docker/Dockerfile) + sigstore hosts (cosign-sign on push runs) +
+      # trivy hosts (installer downloads from get.trivy.dev; vulnerability DB
+      # is pulled from ghcr.io with mirror.gcr.io / public.ecr.aws fallbacks).
       allowed-endpoints-mode: replace
       allowed-endpoints: >
         github.com:443
@@ -97,3 +99,6 @@ jobs:
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
+        get.trivy.dev:443
+        mirror.gcr.io:443
+        public.ecr.aws:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -73,3 +73,27 @@ jobs:
       # --load used during PR validation (validate-on-pr + scan).
       provenance: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
+      # Harden-runner pre reads workflow inputs only (not resolved presets).
+      # Full list = reusable-docker default + gcr.io (distroless base image
+      # in docker/Dockerfile) + sigstore hosts (cosign-sign on push runs).
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
+        docker.io:443
+        registry-1.docker.io:443
+        auth.docker.io:443
+        production.cloudflare.docker.com:443
+        production.cloudfront.docker.com:443
+        gcr.io:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -40,7 +40,7 @@ jobs:
   docker:
     name: 🐳 Docker Build & Publish
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       packages: write
@@ -48,7 +48,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -40,7 +40,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       packages: write
@@ -48,7 +48,7 @@ jobs:
       package-name: rustume
       min-age-days: ${{ inputs.min_age_days || 7 }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: audit
       runner-image: ubuntu-24.04
     secrets:
@@ -67,14 +67,15 @@ jobs:
 
     steps:
       - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        # Direct step-security invocation: lgtm-ci removed its harden-runner
+        # composite in v0.50.0 (the action pre hook must install the agent).
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -13,11 +13,11 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       job-name: "👤 Auto Assign PR Author"
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,12 +12,12 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       job-name: "🏷️ Auto Label PR"
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -29,8 +29,9 @@ jobs:
 
     steps:
       - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        # Direct step-security invocation: lgtm-ci removed its harden-runner
+        # composite in v0.50.0 (the action pre hook must install the agent).
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -41,7 +42,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           fetch-depth: 0
 
@@ -72,8 +73,9 @@ jobs:
 
     steps:
       - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        # Direct step-security invocation: lgtm-ci removed its harden-runner
+        # composite in v0.50.0 (the action pre hook must install the agent).
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -85,7 +87,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -105,7 +107,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -84,6 +84,7 @@ jobs:
             uploads.github.com:443
             codeload.github.com:443
             objects.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
 
       - name: Checkout
         # yamllint disable-line rule:line-length

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,8 +25,9 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        # Direct step-security invocation: lgtm-ci removed its harden-runner
+        # composite in v0.50.0 (the action pre hook must install the agent).
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -45,7 +46,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,18 +17,35 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       job-name: "🛡️ Scorecard Analysis"
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      # publish_results:true enforces an allowlist of actions that excludes
+      # lgtm-ci local composites (checkout-and-harden). That makes every run
+      # fail with "job has unallowed step". Keep SARIF upload to the Security
+      # tab; skip the public Scorecard API until the reusable workflow only
+      # uses allowlisted actions.
+      publish-results: false
       egress-policy: block
       egress-preset: scorecard
-      allowed-endpoints-mode: append
+      # replace: harden-runner pre reads inputs only (not resolved presets).
+      # Full list = scorecard reusable default + StepSecurity/sigstore/OSSF
+      # hosts used by this job.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
-        agent.api.stepsecurity.io:443
-        api.deps.dev:443
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        gcr.io:443
         api.osv.dev:443
         api.scorecard.dev:443
+        api.securityscorecards.dev:443
+        agent.api.stepsecurity.io:443
+        api.deps.dev:443
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443
         sigstore.dev:443

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -22,12 +22,12 @@ concurrency:
 jobs:
   security-audit:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       packages: read
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: "Scan dependencies"
       runner-image: ubuntu-24.04
       # yamllint disable-line rule:line-length
@@ -45,31 +45,32 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Harden runner
+        # Direct step-security invocation: lgtm-ci removed its harden-runner
+        # composite in v0.50.0 (the action pre hook must install the agent,
+        # so allowed-endpoints must be a literal — github-tooling preset).
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            uploads.github.com:443
+            pipelines.actions.githubusercontent.com:443
+
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+          ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
             scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
-
-      - name: Resolve egress allowlist
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
-        with:
-          egress-policy: block
-          egress-preset: github-tooling
-
-      - name: Harden runner
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: block
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Assert required check
         env:
@@ -83,12 +84,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs: security-audit
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       pull-requests: write
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: "💬 Post PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   check:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       job-name: "📝 Validate PR Title"
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       comment-marker: "<!-- semantic-pr-title -->"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -50,12 +50,12 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       ecosystems: rust
       auto-merge: true
       max-bump: minor
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -58,14 +58,34 @@ jobs:
       runner-image: ubuntu-24.04
       egress-policy: block
       egress-preset: github-pages
-      test-allowed-endpoints: |
+      # Harden-runner pre reads workflow inputs only (not resolved presets)
+      # and requires space-separated lists (folded scalars) — newline lists
+      # are ignored by the agent. Build list = reusable default +
+      # github-pages preset extras + bun toolchain (setup downloads the bun
+      # release, which redirects to release-assets) + npm registry.
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        actions.githubusercontent.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        registry.npmjs.org:443
+        bun.sh:443
+      test-allowed-endpoints: >
         github.com:443
         api.github.com:443
         codeload.github.com:443
         objects.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
         release-assets.githubusercontent.com:443
         raw.githubusercontent.com:443
         registry.npmjs.org:443
         bun.sh:443
         pypi.org:443
         files.pythonhosted.org:443
+        astral.sh:443

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -31,12 +31,12 @@ concurrency:
 jobs:
   site-quality:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       pull-requests: write # required: reusable declares this on internal publish job
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: Build and check documentation site
       test-job-name: Test documentation site
       node-version: '22'

--- a/.github/workflows/test-railway-shell.yml
+++ b/.github/workflows/test-railway-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: Railway Shell Tests
       test-path: tests/bats/unit/railway
       coverage: true

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -29,10 +29,10 @@ jobs:
     # ruleset check name stays rust-build / 🔨 Build Check — an extra nesting
     # hop would prefix build / and break required-status matching.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       job-name: "🔨 Build Check"
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       draft-pr-skip: true
       egress-policy: block
       egress-preset: quality

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   check-pinning:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       fail-on-error: true

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -19,10 +19,10 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       job-name: "🔍 Check Vulnerability Suppressions"
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `chore(ci): adopt lgtm-ci v0.52.3 and fix path-filtered CodeQL check`

- Type:
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Bumps all 36 `lgtm-hq/lgtm-ci` pins (`uses:` + `tooling-ref` + tooling checkout `ref:`)
from `96a4210…` (v0.45.1) to `66cad82ead0e5d119928c895c7d7da9c837989e5` (v0.52.3), and
makes the required `analyze / 🔬 CodeQL Analysis` check merge-queue-safe.

### Required-check path-filter fix (codeql.yml)

`on.pull_request.paths` is removed: a path-filtered workflow that does not run leaves
the required context **absent** (not skipped), which deadlocked config-only PR #381 at
merge-queue enqueue. The workflow now always runs on PRs and `merge_group`
(workflow-contract § "Required-check-safe conditional workflows"). The `push` paths
filter stays (cannot block PRs). Caller job id `analyze` is unchanged.

**Deviation from the detect-changes step-gating variant (holy-grail #143):** the
`analyze` job calls `reusable-codeql.yml`, so steps cannot be gated inside it, and
if-skipping a `uses:` caller job never materialises the nested
`analyze / 🔬 CodeQL Analysis` check run — recreating the deadlock. Always-run is the
pattern the reference consumers (ai-skills, py-lintro) use for reusable-codeql callers.
Audit of the other required-check callers (test-rust, coverage, ci-lintro-analysis,
semantic-pr-title, validate-action-pinning, security-dependency-review): none has PR- or
merge_group-level `paths:` filters (only push-to-main filters, which are safe).
Non-required workflows (site-quality, docker-build-publish, test-railway-shell) keep
their `paths:`.

### v0.45.1 → v0.52.3 migration notes applied

- **harden-runner composite removed (v0.50.0, lgtm-ci #412/#420):** all 6 consumer
  usages (`renovate`, `build-binary`, `ghcr-cleanup`, `deploy-railway-cloud`,
  `publish-release-on-tag` ×2, and the local `./.lgtm-ci-tooling/...` use in the
  `🔐 Security Audit` gate) now invoke `step-security/harden-runner@bf7454d # v2.20.0`
  directly so the action `pre` hook installs the egress agent. `build-binary` gets the
  same Linux-only guard as the lgtm-ci reusable preambles (macOS/Windows matrix legs).
- **Egress allowlists are read from workflow inputs only (not resolved presets):**
  - `codeql.yml` passes an explicit replace-mode list = reusable default +
    `release-assets.githubusercontent.com:443` (CodeQL bundle download), mirroring
    ai-skills.
  - `scorecards.yml` switches `append` → `replace` with the full merged list — under
    v0.52.3 semantics the append-mode caller list reached harden-runner verbatim
    (without the GitHub baseline), which blocked checkout in sibling migrations.
  - The `🔐 Security Audit` gate job passes the literal github-tooling baseline
    (the old resolve-egress-allowlist output is a step output, invisible to the
    `pre` hook) and drops the now-unneeded sparse-checkout action paths.
- **`scorecards.yml` sets `publish-results: false`** (ai-skills precedent): scorecard's
  `publish_results` action allowlist rejects lgtm-ci local composites
  (`checkout-and-harden`), failing every run with "job has unallowed step". SARIF upload
  to the Security tab is kept.
- **`reusable-sbom.yml` `fail-on-severity` default change (v0.52.0):** not consumed by
  this repo — no action.
- **`reusable-deploy-pages.yml` build-job removal (v0.49.x):** this repo uses
  `reusable-deploy-site-with-reports.yml` (still builds + deploys) — no action.
- **CI-verified egress fixes (found by running this PR's own checks):**
  - `site-quality.yml`: `test-allowed-endpoints` switched from a newline `|` list to a
    space-separated `>` folded scalar (newline lists are ignored by the harden-runner
    agent — the homebrew-tap#126 root cause), and the build job gets an explicit
    replace-mode list (reusable default + github-pages extras + bun/npm hosts; the bun
    release download redirects to `release-assets.githubusercontent.com`, absent from
    the reusable default).
  - `docker-build-publish.yml`: explicit replace-mode list = reusable-docker default +
    `gcr.io:443` (distroless base image) + sigstore hosts (cosign-sign on push runs).
    The amd64 build leg was blocked pulling the base image under real v0.52.3
    enforcement.
- **Upstream bug workaround (lgtm-hq/lgtm-ci#511):** `reusable-test-node.yml`'s
  "Stage coverage for test summary" step omits `COVERAGE` from its env while the
  staging script hard-requires it, failing the required `web-coverage / 🌐 Web
  Coverage` job for single-version coverage callers on PRs. `coverage.yml` sets
  `publish-test-summary: false` on `web-coverage` (TODO comment in-file) until the
  fix ships; revert restores the web coverage PR comment.
- Every caller `with:` input and secret was validated against the reusable workflow /
  composite action definitions at `66cad82` (scripted check, zero mismatches).

## Ruleset lockstep

None — all 9 required contexts of the `checks-rustume` org ruleset are preserved
verbatim, including the unprefixed `🔐 Security Audit` (the inline gate job was kept
rather than migrating to `reusable-required-check.yml`, which would have renamed it to
`security-audit-required / 🔐 Security Audit`).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (workflow-only change; no runtime surface)
- [x] Docs updated if user-facing (`.github/workflows/README.md`)
- [x] Local CI passed (`uv run lintro fmt` + `uv run lintro chk`: 0 issues; local
      `validate-action-pinning.sh`: 0 findings; all workflows YAML-parse)

## Related Issues

- Closes #383
- Relates to lgtm-hq/lgtm-ci#510

## Details

After merge (out of band, per issue checklist): re-enable the repo `merge-queue`
ruleset that was temporarily disabled on 2026-07-11 to land #381.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the repository CI workflows to use lgtm-ci v0.52.3. The main changes are:

- Updated reusable workflow and tooling pins across GitHub Actions.
- Made the CodeQL workflow run for all pull requests and merge groups.
- Replaced removed lgtm-ci harden-runner composites with direct StepSecurity usage.
- Added explicit egress allowlists for hardened workflows.
- Adjusted Scorecards and web coverage settings for the new reusable workflow behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql.yml | Updates the CodeQL reusable workflow pin, removes the pull request path filter, and adds an explicit egress allowlist. |
| .github/workflows/publish-release-on-tag.yml | Switches release jobs to direct harden-runner usage and adds the Actions pipeline endpoint for artifact access. |
| .github/workflows/security-dependency-review.yml | Updates lgtm-ci pins and replaces the local egress resolution flow with a direct harden-runner step. |
| .github/workflows/scorecards.yml | Updates the Scorecards reusable workflow pin, disables public result publishing, and expands the explicit egress allowlist. |
| .github/workflows/site-quality.yml | Updates the site quality reusable workflow pin and replaces build and test endpoint lists with explicit folded allowlists. |
| .github/workflows/docker-build-publish.yml | Updates the Docker reusable workflow pin and adds an explicit allowlist for image, signing, and scanning endpoints. |
| .github/workflows/coverage.yml | Updates coverage workflow pins and disables the web coverage test summary workaround for the current reusable workflow behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): allow trivy and artifact-pipeli..."](https://github.com/lgtm-hq/rustume/commit/3ec01414c1337953edb5b5a06dfa0f987bfb3673) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43517617)</sub>

<!-- /greptile_comment -->