### PR TITLE
chore(ci): adopt canonical emoji check names

### DIFF
--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -48,7 +48,7 @@ jobs:
       packages: read # pull the pinned lintro image from GHCR
     with:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
-      job-name: "🛠️ Lintro Code Quality & Analysis"
+      job-name: "🛠️ Lintro Code Quality"
       lintro-tool-options: clippy:timeout=300
       timeout-minutes: 30
       runner-image: ubuntu-24.04
@@ -73,6 +73,6 @@ jobs:
       exit-code: >-
         ${{ needs.quality.outputs.exit-code != '' && needs.quality.outputs.exit-code || '1' }}
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
-      job-name: "🛠️ Lintro Code Quality & Analysis PR Comment"
+      job-name: "🛠️ Lintro Code Quality PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@
 name: Security - CodeQL Code Scanning
 # GitHub CodeQL static analysis for security vulnerabilities.
 
-# analyze / 🔬 CodeQL Analysis is a required status check, so this workflow
+# codeql / 🔬 CodeQL Analysis is a required status check, so this workflow
 # must report on every PR and merge-queue entry. No on.pull_request.paths
 # filter: a path-filtered workflow that does not run leaves the required
 # context absent (not skipped), which permanently blocks the merge queue for
@@ -11,7 +11,7 @@ name: Security - CodeQL Code Scanning
 # safe conditional workflows; deadlocked config-only PR #381). The analyze job
 # calls a reusable workflow, so the detect-changes step-gating variant cannot
 # apply — an if-skipped `uses:` job never materialises the nested
-# `analyze / 🔬 CodeQL Analysis` check run, recreating the deadlock. Always
+# `codeql / 🔬 CodeQL Analysis` check run, recreating the deadlock. Always
 # run on PRs instead (ai-skills/py-lintro reference-consumer pattern).
 
 "on":
@@ -32,7 +32,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyze:
+  codeql:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  semantic-title:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ci): adopt canonical emoji check names
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Renames workflow caller job ids and `job-name` inputs to the org's canonical
emoji check-name scheme (lgtm-hq/lgtm-ci#514):

- `.github/workflows/ci-lintro-analysis.yml` — `job-name` drops "& Analysis":
  `🛠️ Lintro Code Quality & Analysis` → `🛠️ Lintro Code Quality` (and the
  non-required PR-comment job-name rebranded to match:
  `🛠️ Lintro Code Quality PR Comment`).
- `.github/workflows/codeql.yml` — caller job id `analyze` → `codeql`
  (display name `🔬 CodeQL Analysis` unchanged; header comments updated).
  Concurrency group (`codeql-${{ github.ref }}`) and the always-run-on-PR
  required-check-safe pattern are untouched.
- `.github/workflows/semantic-pr-title.yml` — caller job id `check` →
  `semantic-title` (display name `📝 Validate PR Title` unchanged).

Unchanged (already canon-style): `rust-build` 🔨, `rust-coverage` 🦀,
`web-coverage` 🌐, and the inline 🔐 Security Audit.

## Ruleset lockstep

The `checks-rustume` org ruleset must be updated to the new required contexts
at merge time (coordinator-managed, with a temporary merge-queue disable):

| Old required context | New required context |
| --- | --- |
| `quality / 🛠️ Lintro Code Quality & Analysis` | `quality / 🛠️ Lintro Code Quality` |
| `analyze / 🔬 CodeQL Analysis` | `codeql / 🔬 CodeQL Analysis` |
| `check / 📝 Validate PR Title` | `semantic-title / 📝 Validate PR Title` |

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (n/a — CI config only)
- [ ] Docs updated if user-facing (n/a)
- [x] Local CI passed (`uv run lintro chk`)

## Related Issues

Closes #387 | Related lgtm-hq/lgtm-ci#514

## Details

Workflow-only rename; no reusable-workflow version bumps. Do NOT merge until
the coordinator flips the `checks-rustume` ruleset contexts per the table
above, otherwise required checks will never report and the merge queue
deadlocks.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR renames CI check contexts to the canonical emoji naming scheme.

- Lintro check names drop `& Analysis`.
- CodeQL caller job id changes from `analyze` to `codeql`.
- PR title validation caller job id changes from `check` to `semantic-title`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after the external ruleset contexts are updated in lockstep.

- The workflow changes are limited to check names and caller job ids.
- Triggers, reusable workflow pins, permissions, and dependencies are unchanged.
- The remaining risk is an external required-check context mismatch during rollout.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci-lintro-analysis.yml | Renames the Lintro reusable workflow `job-name` values while keeping job ids, triggers, outputs, permissions, and dependencies unchanged. |
| .github/workflows/codeql.yml | Renames the CodeQL caller job id to `codeql` and updates comments to match the new required check context. |
| .github/workflows/semantic-pr-title.yml | Renames the semantic PR title caller job id to `semantic-title` while leaving the reusable workflow call unchanged. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fci-lintro-analysis.yml%3A51%0A**Required%20Context%20Name%20Changes**%0A%0AWhen%20this%20workflow%20runs%20on%20PRs%20or%20merge%20queue%20entries%2C%20the%20required%20check%20name%20changes%20from%20%60quality%20%2F%20%F0%9F%9B%A0%EF%B8%8F%20Lintro%20Code%20Quality%20%26%20Analysis%60%20to%20%60quality%20%2F%20%F0%9F%9B%A0%EF%B8%8F%20Lintro%20Code%20Quality%60.%20If%20the%20external%20ruleset%20still%20requires%20the%20old%20context%20at%20merge%20time%2C%20the%20workflow%20can%20pass%20while%20the%20required%20check%20remains%20absent%2C%20leaving%20merges%20waiting%20indefinitely.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fcodeql.yml%3A35%0A**CodeQL%20Context%20Prefix%20Changes**%0A%0ARenaming%20the%20caller%20job%20changes%20the%20reported%20reusable-workflow%20check%20from%20%60analyze%20%2F%20%F0%9F%94%AC%20CodeQL%20Analysis%60%20to%20%60codeql%20%2F%20%F0%9F%94%AC%20CodeQL%20Analysis%60.%20If%20the%20external%20ruleset%20is%20not%20updated%20before%20this%20lands%2C%20the%20CodeQL%20run%20can%20complete%20under%20the%20new%20name%20while%20the%20old%20required%20context%20stays%20missing%20for%20PRs%20and%20merge%20queue%20entries.%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fsemantic-pr-title.yml%3A18%0A**Title%20Check%20Context%20Changes**%0A%0AThis%20job%20id%20rename%20changes%20the%20required%20check%20context%20from%20%60check%20%2F%20%F0%9F%93%9D%20Validate%20PR%20Title%60%20to%20%60semantic-title%20%2F%20%F0%9F%93%9D%20Validate%20PR%20Title%60.%20If%20branch%20protection%20still%20lists%20the%20old%20context%20when%20this%20workflow%20runs%2C%20successful%20title%20validation%20will%20not%20satisfy%20the%20required%20check%20and%20PRs%20can%20remain%20blocked.%0A%0A&pr=388&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fci-lintro-analysis.yml%3A51%0A**Required%20Context%20Name%20Changes**%0A%0AWhen%20this%20workflow%20runs%20on%20PRs%20or%20merge%20queue%20entries%2C%20the%20required%20check%20name%20changes%20from%20%60quality%20%2F%20%F0%9F%9B%A0%EF%B8%8F%20Lintro%20Code%20Quality%20%26%20Analysis%60%20to%20%60quality%20%2F%20%F0%9F%9B%A0%EF%B8%8F%20Lintro%20Code%20Quality%60.%20If%20the%20external%20ruleset%20still%20requires%20the%20old%20context%20at%20merge%20time%2C%20the%20workflow%20can%20pass%20while%20the%20required%20check%20remains%20absent%2C%20leaving%20merges%20waiting%20indefinitely.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fcodeql.yml%3A35%0A**CodeQL%20Context%20Prefix%20Changes**%0A%0ARenaming%20the%20caller%20job%20changes%20the%20reported%20reusable-workflow%20check%20from%20%60analyze%20%2F%20%F0%9F%94%AC%20CodeQL%20Analysis%60%20to%20%60codeql%20%2F%20%F0%9F%94%AC%20CodeQL%20Analysis%60.%20If%20the%20external%20ruleset%20is%20not%20updated%20before%20this%20lands%2C%20the%20CodeQL%20run%20can%20complete%20under%20the%20new%20name%20while%20the%20old%20required%20context%20stays%20missing%20for%20PRs%20and%20merge%20queue%20entries.%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fsemantic-pr-title.yml%3A18%0A**Title%20Check%20Context%20Changes**%0A%0AThis%20job%20id%20rename%20changes%20the%20required%20check%20context%20from%20%60check%20%2F%20%F0%9F%93%9D%20Validate%20PR%20Title%60%20to%20%60semantic-title%20%2F%20%F0%9F%93%9D%20Validate%20PR%20Title%60.%20If%20branch%20protection%20still%20lists%20the%20old%20context%20when%20this%20workflow%20runs%2C%20successful%20title%20validation%20will%20not%20satisfy%20the%20required%20check%20and%20PRs%20can%20remain%20blocked.%0A%0A&repo=lgtm-hq%2Frustume&pr=388&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22chore%2F387-emoji-check-names%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F387-emoji-check-names%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fci-lintro-analysis.yml%3A51%0A**Required%20Context%20Name%20Changes**%0A%0AWhen%20this%20workflow%20runs%20on%20PRs%20or%20merge%20queue%20entries%2C%20the%20required%20check%20name%20changes%20from%20%60quality%20%2F%20%F0%9F%9B%A0%EF%B8%8F%20Lintro%20Code%20Quality%20%26%20Analysis%60%20to%20%60quality%20%2F%20%F0%9F%9B%A0%EF%B8%8F%20Lintro%20Code%20Quality%60.%20If%20the%20external%20ruleset%20still%20requires%20the%20old%20context%20at%20merge%20time%2C%20the%20workflow%20can%20pass%20while%20the%20required%20check%20remains%20absent%2C%20leaving%20merges%20waiting%20indefinitely.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fcodeql.yml%3A35%0A**CodeQL%20Context%20Prefix%20Changes**%0A%0ARenaming%20the%20caller%20job%20changes%20the%20reported%20reusable-workflow%20check%20from%20%60analyze%20%2F%20%F0%9F%94%AC%20CodeQL%20Analysis%60%20to%20%60codeql%20%2F%20%F0%9F%94%AC%20CodeQL%20Analysis%60.%20If%20the%20external%20ruleset%20is%20not%20updated%20before%20this%20lands%2C%20the%20CodeQL%20run%20can%20complete%20under%20the%20new%20name%20while%20the%20old%20required%20context%20stays%20missing%20for%20PRs%20and%20merge%20queue%20entries.%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fsemantic-pr-title.yml%3A18%0A**Title%20Check%20Context%20Changes**%0A%0AThis%20job%20id%20rename%20changes%20the%20required%20check%20context%20from%20%60check%20%2F%20%F0%9F%93%9D%20Validate%20PR%20Title%60%20to%20%60semantic-title%20%2F%20%F0%9F%93%9D%20Validate%20PR%20Title%60.%20If%20branch%20protection%20still%20lists%20the%20old%20context%20when%20this%20workflow%20runs%2C%20successful%20title%20validation%20will%20not%20satisfy%20the%20required%20check%20and%20PRs%20can%20remain%20blocked.%0A%0A&repo=lgtm-hq%2Frustume&pr=388&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): adopt canonical emoji check n..."](https://github.com/lgtm-hq/rustume/commit/f17f0379313ff201fb8e6bbe5b16d6dd43a3c468) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43532710)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->