### PR TITLE
fix(ci): unblock release PR egress and pages deploy after v0.52.3

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -15,7 +15,7 @@ name: Deploy - GitHub Pages
 
 permissions:
   contents: read
-  actions: read
+  actions: write
 
 jobs:
   deploy:
@@ -29,7 +29,10 @@ jobs:
       contents: read
       pages: write
       id-token: write
-      actions: read
+      # write (not read): v0.52.3 reusable build job declares actions: write
+      # to prune stale Pages artifacts; a lower caller grant is a
+      # startup_failure at workflow validation.
+      actions: write
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -58,6 +58,26 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
+      # Harden-runner pre reads workflow inputs only (not resolved presets)
+      # and requires space-separated lists (folded scalars) — newline lists
+      # are ignored by the agent. Build list = github-tooling preset +
+      # Rust toolchain hosts: rustup install (sh.rustup.rs,
+      # static.rust-lang.org) and cargo generate-lockfile via the rust
+      # ecosystem updater (crates.io index/dl hosts).
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
+        static.rust-lang.org:443
+        sh.rustup.rs:443
+        crates.io:443
+        index.crates.io:443
+        static.crates.io:443
       runner-image: ubuntu-24.04
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): unblock release PR egress and pages deploy after v0.52.3
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Two main-branch workflows broke after adopting lgtm-ci v0.52.3 (#385):

1. **Release - Automated PR Creation** (runs 29163231825, 29158945106): the `Create Version PR` job failed at `rustup toolchain install stable` with `Connection refused` to `static.rust-lang.org`. Harden-runner's pre hook reads only the raw `allowed-endpoints` workflow input — never the resolved `egress-preset` — so with `egress-policy: block` and an empty caller allowlist, all non-baseline egress was blocked. Fix: pass `allowed-endpoints-mode: replace` plus a complete space-separated folded-scalar allowlist (github-tooling baseline + `static.rust-lang.org:443 sh.rustup.rs:443 crates.io:443 index.crates.io:443 static.crates.io:443` for rustup and `cargo generate-lockfile`), mirroring the site-quality.yml fix in 80eaf43.

2. **Deploy - GitHub Pages** (runs 29158717291, 29158594512, both `startup_failure`): v0.52.3's `reusable-deploy-site-with-reports.yml` build job now declares `actions: write` (to prune stale Pages artifacts / self-heal reruns), but the caller job only granted `actions: read`, failing workflow permission validation before any job started. Fix: raise the caller grant to `actions: write`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (workflow config only — no testable surface)
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (`uv run lintro chk` clean on changed files)

## Related Issues

Closes #389

## Details

Both fixes are caller-side only; no lgtm-ci pin changes. The release allowlist matches lgtm-ci's own `rust-release` preset hosts for the Rust toolchain portion. Verified against the reusable workflow sources at v0.52.3 (`66cad82`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the CI workflow callers for the lgtm-ci v0.52.3 release. The main changes are:

- Grants `actions: write` to the Pages deploy reusable workflow caller.
- Adds an explicit harden-runner egress allowlist for release PR creation.
- Includes Rust toolchain and crates endpoints for the semantic release job.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after checking the replacement egress list.

- The Pages permission change matches the called workflow’s stated permission requirement.
- The release allowlist covers the core GitHub and Rust endpoints.
- The replacement mode can still block any tooling download host that is part of the reusable workflow but missing from the explicit list.

.github/workflows/semantic-release.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-pages.yml | Raises the Pages deploy workflow and job `actions` permission from read to write for the reusable workflow call. |
| .github/workflows/semantic-release.yml | Adds a replacement harden-runner allowlist for GitHub tooling and Rust package egress during release PR creation. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fsemantic-release.yml%3A68-80%0A**Replacement%20Allowlist%20Can%20Omit%20Tooling%20Downloads**%0A%0AWith%20%60allowed-endpoints-mode%3A%20replace%60%2C%20this%20list%20becomes%20the%20whole%20egress%20policy%20for%20the%20release%20PR%20job.%20If%20the%20reusable%20workflow%20or%20one%20of%20its%20bundled%20actions%20downloads%20GitHub%20release%20assets%20or%20container%20blobs%2C%20endpoints%20such%20as%20%60release-assets.githubusercontent.com%60%20or%20%60pkg-containers.githubusercontent.com%60%20are%20blocked%2C%20and%20release%20PR%20creation%20can%20fail%20before%20it%20reaches%20the%20Rust%20steps%20this%20change%20was%20meant%20to%20unblock.%0A%0A&pr=390&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fsemantic-release.yml%3A68-80%0A**Replacement%20Allowlist%20Can%20Omit%20Tooling%20Downloads**%0A%0AWith%20%60allowed-endpoints-mode%3A%20replace%60%2C%20this%20list%20becomes%20the%20whole%20egress%20policy%20for%20the%20release%20PR%20job.%20If%20the%20reusable%20workflow%20or%20one%20of%20its%20bundled%20actions%20downloads%20GitHub%20release%20assets%20or%20container%20blobs%2C%20endpoints%20such%20as%20%60release-assets.githubusercontent.com%60%20or%20%60pkg-containers.githubusercontent.com%60%20are%20blocked%2C%20and%20release%20PR%20creation%20can%20fail%20before%20it%20reaches%20the%20Rust%20steps%20this%20change%20was%20meant%20to%20unblock.%0A%0A&repo=lgtm-hq%2Frustume&pr=390&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2Frelease-pr-egress%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frelease-pr-egress%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fsemantic-release.yml%3A68-80%0A**Replacement%20Allowlist%20Can%20Omit%20Tooling%20Downloads**%0A%0AWith%20%60allowed-endpoints-mode%3A%20replace%60%2C%20this%20list%20becomes%20the%20whole%20egress%20policy%20for%20the%20release%20PR%20job.%20If%20the%20reusable%20workflow%20or%20one%20of%20its%20bundled%20actions%20downloads%20GitHub%20release%20assets%20or%20container%20blobs%2C%20endpoints%20such%20as%20%60release-assets.githubusercontent.com%60%20or%20%60pkg-containers.githubusercontent.com%60%20are%20blocked%2C%20and%20release%20PR%20creation%20can%20fail%20before%20it%20reaches%20the%20Rust%20steps%20this%20change%20was%20meant%20to%20unblock.%0A%0A&repo=lgtm-hq%2Frustume&pr=390&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): unblock release PR egress and p..."](https://github.com/lgtm-hq/rustume/commit/d75c33d7050b1de86adbddbea4fd4b9763601d18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43549736)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->