### PR TITLE
chore(ci): adopt 📌 pinning check name and lgtm-ci v0.52.4

### DIFF
--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -15,11 +15,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-pinning:
+  validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      job-name: '📌 Validate Action Pinning'
+      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
       egress-policy: block
       egress-preset: github-tooling
       fail-on-error: true

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -75,3 +75,8 @@ name = "lgtm-hq/lgtm-ci/.github/actions/setup-node"
 ecosystem = "GitHub Actions"
 license.override = ["MIT"]
 reason = "MIT licensed composite action from lgtm-ci"
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0206"
+ignoreUntil = 2026-10-04
+reason = "rustybuzz — transitive via typst-layout/typst-library/krilla/usvg; informational (unmaintained), no patched version; blocked until typst ecosystem migrates"


### PR DESCRIPTION
## Summary

Adopts the canonical org check name `validate / 📌 Validate Action Pinning` (emoji canon, lgtm-ci#514) and bumps lgtm-ci to v0.52.4 (`768a6b7`).

The org ruleset has already been flipped to the new context in lockstep — merging this PR completes the rename. Older open PRs will need a rebase/re-run to report the new check name.

## Changes

- job id → `validate`, `job-name: 📌 Validate Action Pinning` (Rustume) / job-name added (holy-grail)
- lgtm-ci pin `66cad82` (v0.52.3) → `768a6b7` (v0.52.4)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the action-pinning validation workflow and related security tooling config.

- Renames the pinning validation job to `validate`.
- Adds the canonical `📌 Validate Action Pinning` job name input.
- Bumps the pinned `lgtm-ci` reusable workflow and tooling ref to v0.52.4.
- Adds a time-limited OSV suppression for `RUSTSEC-2026-0206`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/validate-action-pinning.yml | Renames the action-pinning validation job and updates the pinned `lgtm-ci` workflow/tooling ref. |
| .osv-scanner.toml | Adds a time-limited suppression entry for `RUSTSEC-2026-0206`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(security): suppress RUSTSEC-2026-0..."](https://github.com/lgtm-hq/rustume/commit/f7cdcf1ae9280c1fb0ac78fcc34d07ef4278a32d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43648226)</sub>

<!-- /greptile_comment -->