### PR TITLE
chore(deps): group typst crates into a single Renovate update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,6 +56,18 @@
         "utoipa-swagger-ui",
         "utoipa-axum"
       ]
+    },
+    {
+      "groupName": "typst",
+      "groupSlug": "typst",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "typst",
+        "typst-assets",
+        "typst-pdf",
+        "typst-render"
+      ],
+      "matchPackagePatterns": ["^typst-"]
     }
   ]
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(deps): group typst crates into a single Renovate update
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Renovate currently opens separate PRs for each typst crate (`typst`, `typst-assets`,
`typst-pdf`, `typst-render`). Those crates share API surface and must be bumped
together; isolated PRs (#291–#294) fail CI. This adds a `packageRules` group in
`renovate.json` so Renovate opens a single combined update for the whole typst train.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #343

## Details

- Added a `typst` package group matching `typst`, `typst-assets`, `typst-pdf`,
  `typst-render`, and any other `^typst-` crate via `matchPackagePatterns`.
- Mirrors the existing `axum ecosystem` grouping pattern in `renovate.json`.
- After merge, the open typst Renovate PRs (#291–#294) should be closed so Renovate
  can recreate a single grouped PR.
- `uv run lintro fmt` passed; full `uv run lintro chk` completed with taplo and all
  non-Rust tools passing. Clippy hit the 120s lintro timeout (environmental, unrelated
  to this JSON-only change).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR groups Typst crate updates in Renovate. The main changes are:

- Added a Cargo package group named `typst`.
- Matched the current direct Typst crates explicitly.
- Added a `^typst-` pattern for future Typst-family crates.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Adds a Renovate package rule that groups direct Cargo updates for the Typst crate family. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): group typst crates into a s..."](https://github.com/lgtm-hq/rustume/commit/b947820b159caed4dcb49278fdae813173bbc9b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43669317)</sub>

<!-- /greptile_comment -->