### PR TITLE
feat(web): respect system color scheme for default theme

### DIFF
--- a/apps/web/src/stores/__tests__/editorTheme.test.ts
+++ b/apps/web/src/stores/__tests__/editorTheme.test.ts
@@ -43,17 +43,82 @@ vi.mock("@lgtm-hq/turbo-themes", () => ({
   },
 }));
 
+function mockMatchMedia(preferDark: boolean | undefined) {
+  if (preferDark === undefined) {
+    Object.defineProperty(window, "matchMedia", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    return;
+  }
+
+  Object.defineProperty(window, "matchMedia", {
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: preferDark,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+    configurable: true,
+    writable: true,
+  });
+}
+
+async function importFreshEditorTheme() {
+  vi.resetModules();
+  return import("../editorTheme");
+}
+
 import { useEditorTheme } from "../editorTheme";
 
 describe("useEditorTheme", () => {
   beforeEach(() => {
     localStorage.clear();
     turboThemesMock.failImport = false;
+    mockMatchMedia(true);
   });
 
-  it('initial themeId is "catppuccin-mocha"', () => {
+  it('initial themeId is "catppuccin-mocha" when system prefers dark', async () => {
+    mockMatchMedia(true);
+    const { useEditorTheme: useTheme } = await importFreshEditorTheme();
     createRoot((dispose) => {
-      const { state } = useEditorTheme();
+      const { state } = useTheme();
+      expect(state.themeId).toBe("catppuccin-mocha");
+      dispose();
+    });
+  });
+
+  it('initial themeId is "catppuccin-latte" when system prefers light', async () => {
+    mockMatchMedia(false);
+    const { useEditorTheme: useTheme } = await importFreshEditorTheme();
+    createRoot((dispose) => {
+      const { state } = useTheme();
+      expect(state.themeId).toBe("catppuccin-latte");
+      dispose();
+    });
+  });
+
+  it('initial themeId is "catppuccin-mocha" when matchMedia is unavailable', async () => {
+    mockMatchMedia(undefined);
+    const { useEditorTheme: useTheme } = await importFreshEditorTheme();
+    createRoot((dispose) => {
+      const { state } = useTheme();
+      expect(state.themeId).toBe("catppuccin-mocha");
+      dispose();
+    });
+  });
+
+  it("saved localStorage value wins over system color scheme", async () => {
+    localStorage.setItem("rustume-editor-theme", "catppuccin-mocha");
+    mockMatchMedia(false);
+    const { useEditorTheme: useTheme } = await importFreshEditorTheme();
+    createRoot((dispose) => {
+      const { state } = useTheme();
       expect(state.themeId).toBe("catppuccin-mocha");
       dispose();
     });

--- a/apps/web/src/stores/__tests__/editorTheme.test.ts
+++ b/apps/web/src/stores/__tests__/editorTheme.test.ts
@@ -160,6 +160,28 @@ describe("useEditorTheme", () => {
     });
   });
 
+  it("does not persist system default when flavor list lacks light default", async () => {
+    mockMatchMedia(false);
+    const flavorsWithoutLatte = turboThemesMock.flavors.filter(
+      (flavor) => flavor.id !== "catppuccin-latte",
+    );
+    vi.doMock("@lgtm-hq/turbo-themes", () => ({
+      get flavors() {
+        return flavorsWithoutLatte;
+      },
+    }));
+    const { useEditorTheme: useTheme } = await importFreshEditorTheme();
+    await createRoot(async (dispose) => {
+      const { state, ensureFlavorsLoaded } = useTheme();
+      expect(state.themeId).toBe("catppuccin-latte");
+      await ensureFlavorsLoaded();
+      expect(state.themeId).toBe("catppuccin-mocha");
+      expect(localStorage.getItem("rustume-editor-theme")).toBeNull();
+      dispose();
+    });
+    vi.doUnmock("@lgtm-hq/turbo-themes");
+  });
+
   it("setTheme with valid ID updates themeId and saves to localStorage", async () => {
     await createRoot(async (dispose) => {
       const { state, setTheme, ensureFlavorsLoaded } = useEditorTheme();

--- a/apps/web/src/stores/editorTheme.ts
+++ b/apps/web/src/stores/editorTheme.ts
@@ -122,12 +122,26 @@ export function useEditorTheme() {
 
       const savedExists = flavors.some((flavor) => flavor.id === state.themeId);
       if (!savedExists) {
-        setState("themeId", DEFAULT_THEME_ID);
+        const systemDefaultId = getSystemDefaultThemeId();
+        const fallbackId = flavors.some((flavor) => flavor.id === systemDefaultId)
+          ? systemDefaultId
+          : DEFAULT_THEME_ID;
+        setState("themeId", fallbackId);
+        // Only persist corrections for explicit saved preferences. System-derived
+        // defaults should stay ephemeral so future visits can re-read color scheme.
+        let hadSavedPreference = false;
         try {
-          localStorage.setItem(STORAGE_KEY, DEFAULT_THEME_ID);
+          hadSavedPreference = localStorage.getItem(STORAGE_KEY) !== null;
         } catch {
-          console.error("Failed to save theme to localStorage");
-          toast.warning("Could not save theme preference");
+          // ignore read errors; treat as no saved preference
+        }
+        if (hadSavedPreference) {
+          try {
+            localStorage.setItem(STORAGE_KEY, fallbackId);
+          } catch {
+            console.error("Failed to save theme to localStorage");
+            toast.warning("Could not save theme preference");
+          }
         }
       }
 

--- a/apps/web/src/stores/editorTheme.ts
+++ b/apps/web/src/stores/editorTheme.ts
@@ -4,6 +4,7 @@ import { toast } from "../components/ui";
 
 const STORAGE_KEY = "rustume-editor-theme";
 const DEFAULT_THEME_ID = "catppuccin-mocha";
+const LIGHT_DEFAULT_THEME_ID = "catppuccin-latte";
 
 export type { ThemeFlavor, ThemeTokens };
 
@@ -35,6 +36,18 @@ export interface EditorThemeState {
   flavorsReady: boolean;
 }
 
+function getSystemDefaultThemeId(): string {
+  try {
+    const mediaQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
+    if (mediaQuery && !mediaQuery.matches) {
+      return LIGHT_DEFAULT_THEME_ID;
+    }
+  } catch {
+    // fall through to dark default
+  }
+  return DEFAULT_THEME_ID;
+}
+
 function getInitialThemeId(): { themeId: string; failed: boolean } {
   if (typeof window === "undefined") {
     return { themeId: DEFAULT_THEME_ID, failed: false };
@@ -48,7 +61,7 @@ function getInitialThemeId(): { themeId: string; failed: boolean } {
     console.error("Failed to read theme from localStorage");
     return { themeId: DEFAULT_THEME_ID, failed: true };
   }
-  return { themeId: DEFAULT_THEME_ID, failed: false };
+  return { themeId: getSystemDefaultThemeId(), failed: false };
 }
 
 const initialTheme = getInitialThemeId();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): respect system color scheme for default theme
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

First-time visitors with no saved theme preference now get a default turbo-themes flavor that matches their OS light/dark setting instead of always receiving catppuccin-mocha.

When `localStorage` has no `rustume-editor-theme` value, `getInitialThemeId()` reads `prefers-color-scheme`: dark → `catppuccin-mocha`, light → `catppuccin-latte`. Saved preferences still win, and the auto-detected choice is not persisted until the user explicitly selects a theme.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #177

## Details

- Added `LIGHT_DEFAULT_THEME_ID` and `getSystemDefaultThemeId()` in `apps/web/src/stores/editorTheme.ts`.
- Guarded for SSR (`typeof window === "undefined"`) and environments where `window.matchMedia` is undefined (e.g. jsdom), falling back to the dark default.
- Extended `editorTheme.test.ts` with coverage for light/dark/unavailable matchMedia and localStorage precedence.

**Testing:** `uv run lintro fmt`, scoped `uv run lintro chk` on changed files, and `bun run test src/stores/__tests__/editorTheme.test.ts` (8/8 passing).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the default editor theme follow the user's system color scheme.

- Adds a light default theme id for light-mode systems.
- Reads `prefers-color-scheme` when no saved editor theme exists.
- Keeps saved theme preferences ahead of system defaults.
- Avoids saving system-derived fallback choices to `localStorage`.
- Adds tests for dark, light, unavailable `matchMedia`, saved preferences, and missing light flavor fallback.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/stores/editorTheme.ts | Adds system theme detection and updates fallback persistence so automatic defaults stay ephemeral. |
| apps/web/src/stores/__tests__/editorTheme.test.ts | Adds tests for system defaults, saved preference precedence, unavailable `matchMedia`, and missing light flavor fallback. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): avoid persisting system theme ..."](https://github.com/lgtm-hq/rustume/commit/9d3d5fede6f69f402c2909a36899c1d1402c3ff4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43669927)</sub>

<!-- /greptile_comment -->