### PR TITLE
fix(server): reject unknown-shaped JSON in /api/validate

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -136,6 +136,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_validate_unknown_shape() {
+        let app = create_router();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/validate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"foo":1}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: ValidationResponse = serde_json::from_slice(&body).unwrap();
+
+        assert!(
+            !result.valid,
+            "Unknown JSON shape must not return valid:true"
+        );
+        assert!(result.errors.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_validate_partial_resume_still_valid() {
+        let app = create_router();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/validate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"basics":{"name":"Ada Lovelace","email":"ada@example.com"}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let result: ValidationResponse = serde_json::from_slice(&body).unwrap();
+
+        assert!(result.valid);
+        assert!(result.errors.is_none());
+    }
+
+    #[tokio::test]
     async fn test_parse_json_resume() {
         let app = create_router();
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -166,6 +166,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_validate_malformed_body_returns_bad_request() {
+        let app = create_router();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/validate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"basics":"not-an-object"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn test_validate_partial_resume_still_valid() {
         let app = create_router();
 

--- a/crates/server/src/routes/validate.rs
+++ b/crates/server/src/routes/validate.rs
@@ -1,8 +1,23 @@
 use axum::Json;
 use rustume_schema::ResumeData;
+use serde_json::Value;
 use validator::Validate;
 
 use crate::dto::ValidationResponse;
+
+/// Top-level `ResumeData` fields (serde `camelCase` names).
+const RESUME_DATA_TOP_LEVEL_FIELDS: &[&str] = &["basics", "sections", "metadata"];
+
+/// Returns true when the JSON object contains at least one recognized resume field.
+pub fn has_recognized_resume_shape(value: &Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+
+    RESUME_DATA_TOP_LEVEL_FIELDS
+        .iter()
+        .any(|field| obj.contains_key(*field))
+}
 
 /// Validate resume data
 ///
@@ -17,7 +32,26 @@ use crate::dto::ValidationResponse;
         (status = 200, description = "Validation result", body = ValidationResponse)
     )
 )]
-pub async fn validate(Json(resume): Json<ResumeData>) -> Json<ValidationResponse> {
+pub async fn validate(Json(value): Json<Value>) -> Json<ValidationResponse> {
+    if !has_recognized_resume_shape(&value) {
+        return Json(ValidationResponse {
+            valid: false,
+            errors: Some(vec![
+                "No recognized resume fields found in request body".to_string()
+            ]),
+        });
+    }
+
+    let resume: ResumeData = match serde_json::from_value(value) {
+        Ok(resume) => resume,
+        Err(_) => {
+            return Json(ValidationResponse {
+                valid: false,
+                errors: Some(vec!["Invalid resume data format".to_string()]),
+            });
+        }
+    };
+
     match resume.validate() {
         Ok(_) => Json(ValidationResponse {
             valid: true,
@@ -83,4 +117,28 @@ pub fn validation_errors(errors: &validator::ValidationErrors) -> Vec<String> {
     let mut result = Vec::new();
     collect_errors(errors, "", &mut result);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn has_recognized_resume_shape_accepts_known_fields() {
+        assert!(has_recognized_resume_shape(&json!({"basics": {}})));
+        assert!(has_recognized_resume_shape(&json!({"sections": {}})));
+        assert!(has_recognized_resume_shape(&json!({"metadata": {}})));
+        assert!(has_recognized_resume_shape(
+            &json!({"basics": {}, "foo": 1})
+        ));
+    }
+
+    #[test]
+    fn has_recognized_resume_shape_rejects_unknown_input() {
+        assert!(!has_recognized_resume_shape(&json!({"foo": 1})));
+        assert!(!has_recognized_resume_shape(&json!({})));
+        assert!(!has_recognized_resume_shape(&json!([])));
+        assert!(!has_recognized_resume_shape(&json!("resume")));
+    }
 }

--- a/crates/server/src/routes/validate.rs
+++ b/crates/server/src/routes/validate.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use validator::Validate;
 
 use crate::dto::ValidationResponse;
+use crate::error::ApiError;
 
 /// Top-level `ResumeData` fields (serde `camelCase` names).
 const RESUME_DATA_TOP_LEVEL_FIELDS: &[&str] = &["basics", "sections", "metadata"];
@@ -32,35 +33,28 @@ pub fn has_recognized_resume_shape(value: &Value) -> bool {
         (status = 200, description = "Validation result", body = ValidationResponse)
     )
 )]
-pub async fn validate(Json(value): Json<Value>) -> Json<ValidationResponse> {
+pub async fn validate(Json(value): Json<Value>) -> Result<Json<ValidationResponse>, ApiError> {
     if !has_recognized_resume_shape(&value) {
-        return Json(ValidationResponse {
+        return Ok(Json(ValidationResponse {
             valid: false,
             errors: Some(vec![
                 "No recognized resume fields found in request body".to_string()
             ]),
-        });
+        }));
     }
 
-    let resume: ResumeData = match serde_json::from_value(value) {
-        Ok(resume) => resume,
-        Err(_) => {
-            return Json(ValidationResponse {
-                valid: false,
-                errors: Some(vec!["Invalid resume data format".to_string()]),
-            });
-        }
-    };
+    let resume: ResumeData =
+        serde_json::from_value(value).map_err(|_| ApiError::new("Invalid resume data format"))?;
 
     match resume.validate() {
-        Ok(_) => Json(ValidationResponse {
+        Ok(_) => Ok(Json(ValidationResponse {
             valid: true,
             errors: None,
-        }),
-        Err(e) => Json(ValidationResponse {
+        })),
+        Err(e) => Ok(Json(ValidationResponse {
             valid: false,
             errors: Some(validation_errors(&e)),
-        }),
+        })),
     }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(server): reject unknown-shaped JSON in /api/validate
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

`/api/validate` previously deserialized arbitrary JSON into a fully-defaulted `ResumeData` and returned `valid:true` for unrelated payloads such as `{"foo":1}`.

This PR implements **Option B (shape check)** from issue #345: before validation, the handler inspects the raw JSON and rejects bodies that contain none of the recognized top-level `ResumeData` fields (`basics`, `sections`, `metadata`). Well-formed and partial resume payloads still validate normally.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #345

## Details

**Design choice:** Option B — shape check (not `deny_unknown_fields`, not warnings array). This avoids breaking older stored documents with extra fields while still catching garbage input.

**Implementation:**
- Accept raw JSON in the validate handler and run `has_recognized_resume_shape` before deserializing into `ResumeData`.
- Return `valid:false` with a clear error when no recognized top-level fields are present.

**Tests:**
- Unit tests for `has_recognized_resume_shape` (accepts known fields, rejects `{"foo":1}`, `{}`, arrays, strings).
- Integration tests: `test_validate_unknown_shape`, `test_validate_partial_resume_still_valid`.
- Existing validate tests remain green.

**Verification:**
- `uv run lintro fmt`
- `uv run lintro chk`
- `cargo test -p rustume-server validate`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tightens `/api/validate` so unrelated JSON is no longer accepted as a valid resume. The main changes are:

- Parse the request body as raw JSON before resume deserialization.
- Reject objects with no recognized resume fields.
- Preserve bad-request handling for malformed known fields.
- Add tests for unknown, malformed, and partial resume payloads.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/routes/validate.rs | Updates the validate handler to reject unknown-shaped JSON before deserializing recognized resume payloads. |
| crates/server/src/lib.rs | Adds coverage for unknown-shaped input, malformed known-field input, and partial valid resume input. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(server): return 400 for malformed va..."](https://github.com/lgtm-hq/rustume/commit/0e0409c8cd676e607363f6a3fa29dc28abd78b67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43676103)</sub>

<!-- /greptile_comment -->