### PR TITLE
refactor(parser): share resume format dispatch between server and CLI

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -25,9 +25,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
-use rustume_parser::{
-    JsonResumeParser, LinkedInParser, Parser as ResumeParser, ReactiveResumeV3Parser,
-};
+use rustume_parser::{parse_resume, ResumeFormat};
 use rustume_render::{get_template_theme, Renderer, TypstRenderer, TEMPLATES};
 use rustume_schema::ResumeData;
 use std::fs;
@@ -135,6 +133,17 @@ enum InputFormat {
     Rrv3,
     /// Native Rustume format
     Rustume,
+}
+
+impl From<InputFormat> for ResumeFormat {
+    fn from(format: InputFormat) -> Self {
+        match format {
+            InputFormat::JsonResume => Self::JsonResume,
+            InputFormat::LinkedIn => Self::LinkedIn,
+            InputFormat::Rrv3 => Self::Rrv3,
+            InputFormat::Rustume => Self::Rustume,
+        }
+    }
 }
 
 fn main() {
@@ -277,20 +286,14 @@ fn cmd_parse(
         None => detect_format(input, &data)?,
     };
 
-    let resume = match format {
-        InputFormat::JsonResume => JsonResumeParser
-            .parse(&data)
-            .context("Failed to parse JSON Resume")?,
-        InputFormat::LinkedIn => LinkedInParser
-            .parse(&data)
-            .context("Failed to parse LinkedIn export")?,
-        InputFormat::Rrv3 => ReactiveResumeV3Parser
-            .parse(&data)
-            .context("Failed to parse Reactive Resume v3")?,
-        InputFormat::Rustume => {
-            serde_json::from_slice(&data).context("Failed to parse Rustume JSON")?
-        }
+    let context_msg = match format {
+        InputFormat::JsonResume => "Failed to parse JSON Resume",
+        InputFormat::LinkedIn => "Failed to parse LinkedIn export",
+        InputFormat::Rrv3 => "Failed to parse Reactive Resume v3",
+        InputFormat::Rustume => "Failed to parse Rustume JSON",
     };
+
+    let resume = parse_resume(format.into(), &data).context(context_msg)?;
 
     let json = if pretty {
         serde_json::to_string_pretty(&resume)?

--- a/crates/parser/src/dispatch.rs
+++ b/crates/parser/src/dispatch.rs
@@ -1,0 +1,131 @@
+//! Shared resume format dispatch for server and CLI.
+
+use rustume_schema::ResumeData;
+
+use crate::{JsonResumeParser, LinkedInParser, ParseError, Parser, ReactiveResumeV3Parser};
+
+/// Supported resume input formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResumeFormat {
+    /// JSON Resume standard format (https://jsonresume.org)
+    JsonResume,
+    /// LinkedIn data export ZIP file
+    LinkedIn,
+    /// Reactive Resume v3 format
+    Rrv3,
+    /// Native Rustume format
+    Rustume,
+}
+
+impl ResumeFormat {
+    /// Human-readable label for error messages.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::JsonResume => "JSON Resume",
+            Self::LinkedIn => "LinkedIn export",
+            Self::Rrv3 => "Reactive Resume v3",
+            Self::Rustume => "Rustume JSON",
+        }
+    }
+}
+
+/// Parse resume data from the given format into unified Rustume schema.
+pub fn parse_resume(format: ResumeFormat, data: &[u8]) -> Result<ResumeData, ParseError> {
+    match format {
+        ResumeFormat::JsonResume => JsonResumeParser.parse(data),
+        ResumeFormat::LinkedIn => LinkedInParser.parse(data),
+        ResumeFormat::Rrv3 => ReactiveResumeV3Parser.parse(data),
+        ResumeFormat::Rustume => {
+            serde_json::from_slice(data).map_err(|err| ParseError::ValidationError(err.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn fixtures_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("Parser crate should have parent directory")
+            .parent()
+            .expect("crates directory should have parent (workspace root)")
+            .join("tests")
+            .join("fixtures")
+    }
+
+    #[test]
+    fn test_parse_json_resume_success() {
+        let data = fs::read(fixtures_path().join("json_resume/minimal.json"))
+            .expect("Failed to read minimal.json fixture");
+
+        let resume = parse_resume(ResumeFormat::JsonResume, &data).expect("parse should succeed");
+        assert_eq!(resume.basics.name, "John Doe");
+    }
+
+    #[test]
+    fn test_parse_json_resume_failure() {
+        let result = parse_resume(ResumeFormat::JsonResume, b"not valid json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_linkedin_success() {
+        let data = fs::read(fixtures_path().join("linkedin/complete_export.zip"))
+            .expect("Failed to read LinkedIn ZIP fixture");
+
+        let resume = parse_resume(ResumeFormat::LinkedIn, &data).expect("parse should succeed");
+        assert_eq!(resume.basics.name, "David Chen");
+    }
+
+    #[test]
+    fn test_parse_linkedin_failure() {
+        let result = parse_resume(ResumeFormat::LinkedIn, b"not a zip file");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_rrv3_success() {
+        let data = fs::read(fixtures_path().join("v3/complete.json"))
+            .expect("Failed to read complete.json fixture");
+
+        let resume = parse_resume(ResumeFormat::Rrv3, &data).expect("parse should succeed");
+        assert_eq!(resume.basics.name, "Alice Johnson");
+    }
+
+    #[test]
+    fn test_parse_rrv3_failure() {
+        let result = parse_resume(ResumeFormat::Rrv3, b"not valid json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_rustume_success() {
+        let resume = ResumeData::default();
+        let data = serde_json::to_vec(&resume).expect("serialize default resume");
+
+        let parsed = parse_resume(ResumeFormat::Rustume, &data).expect("parse should succeed");
+        assert_eq!(parsed.basics.name, resume.basics.name);
+    }
+
+    #[test]
+    fn test_parse_rustume_failure() {
+        let result = parse_resume(ResumeFormat::Rustume, b"{ invalid json }");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ParseError::ValidationError(_)
+        ));
+    }
+
+    #[test]
+    fn test_resume_format_labels() {
+        assert_eq!(ResumeFormat::JsonResume.label(), "JSON Resume");
+        assert_eq!(ResumeFormat::LinkedIn.label(), "LinkedIn export");
+        assert_eq!(ResumeFormat::Rrv3.label(), "Reactive Resume v3");
+        assert_eq!(ResumeFormat::Rustume.label(), "Rustume JSON");
+    }
+}

--- a/crates/parser/src/dispatch.rs
+++ b/crates/parser/src/dispatch.rs
@@ -35,9 +35,8 @@ pub fn parse_resume(format: ResumeFormat, data: &[u8]) -> Result<ResumeData, Par
         ResumeFormat::JsonResume => JsonResumeParser.parse(data),
         ResumeFormat::LinkedIn => LinkedInParser.parse(data),
         ResumeFormat::Rrv3 => ReactiveResumeV3Parser.parse(data),
-        ResumeFormat::Rustume => {
-            serde_json::from_slice(data).map_err(|err| ParseError::ValidationError(err.to_string()))
-        }
+        ResumeFormat::Rustume => serde_json::from_slice(data)
+            .map_err(|err| ParseError::DeserializeError(err.to_string())),
     }
 }
 
@@ -117,7 +116,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ParseError::ValidationError(_)
+            ParseError::DeserializeError(_)
         ));
     }
 

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -5,11 +5,13 @@
 //! - LinkedIn data export (ZIP)
 //! - Reactive Resume V3 format (migration)
 
+mod dispatch;
 mod json_resume;
 mod linkedin;
 mod reactive_resume_v3;
 mod traits;
 
+pub use dispatch::{parse_resume, ResumeFormat};
 pub use json_resume::{JsonResume, JsonResumeParser};
 pub use linkedin::{LinkedInData, LinkedInParser};
 pub use reactive_resume_v3::{ReactiveResumeV3Parser, V3Resume};

--- a/crates/parser/src/traits.rs
+++ b/crates/parser/src/traits.rs
@@ -12,6 +12,10 @@ pub enum ParseError {
     #[error("Invalid format: {0}")]
     ValidationError(String),
 
+    /// Raw JSON deserialization error without an extra format prefix.
+    #[error("{0}")]
+    DeserializeError(String),
+
     #[error("Conversion failed: {0}")]
     ConversionError(String),
 }

--- a/crates/server/src/dto.rs
+++ b/crates/server/src/dto.rs
@@ -1,3 +1,4 @@
+use rustume_parser::ResumeFormat;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -13,6 +14,17 @@ pub enum ParseFormat {
     Rrv3,
     /// Native Rustume format
     Rustume,
+}
+
+impl From<ParseFormat> for ResumeFormat {
+    fn from(format: ParseFormat) -> Self {
+        match format {
+            ParseFormat::JsonResume => Self::JsonResume,
+            ParseFormat::LinkedIn => Self::LinkedIn,
+            ParseFormat::Rrv3 => Self::Rrv3,
+            ParseFormat::Rustume => Self::Rustume,
+        }
+    }
 }
 
 /// Parse request body

--- a/crates/server/src/routes/parse.rs
+++ b/crates/server/src/routes/parse.rs
@@ -1,9 +1,9 @@
 use axum::Json;
-use rustume_parser::{JsonResumeParser, LinkedInParser, Parser, ReactiveResumeV3Parser};
+use rustume_parser::{parse_resume, ResumeFormat};
 use rustume_schema::ResumeData;
 use tracing::error;
 
-use crate::dto::{ParseFormat, ParseRequest};
+use crate::dto::ParseRequest;
 use crate::error::ApiError;
 
 /// Parse resume from various formats
@@ -37,24 +37,25 @@ pub async fn parse(Json(req): Json<ParseRequest>) -> Result<Json<ResumeData>, Ap
     };
 
     // Parse based on format
-    let resume = match req.format {
-        ParseFormat::JsonResume => JsonResumeParser.parse(&data).map_err(|err| {
+    let format = ResumeFormat::from(req.format);
+    let resume = parse_resume(format, &data).map_err(|err| match format {
+        ResumeFormat::JsonResume => {
             error!("JSON Resume parse failed: {err}");
             ApiError::new("Failed to parse JSON Resume input")
-        })?,
-        ParseFormat::LinkedIn => LinkedInParser.parse(&data).map_err(|err| {
+        }
+        ResumeFormat::LinkedIn => {
             error!("LinkedIn export parse failed: {err}");
             ApiError::new("Failed to parse LinkedIn export")
-        })?,
-        ParseFormat::Rrv3 => ReactiveResumeV3Parser.parse(&data).map_err(|err| {
+        }
+        ResumeFormat::Rrv3 => {
             error!("Reactive Resume v3 parse failed: {err}");
             ApiError::new("Failed to parse Reactive Resume v3 input")
-        })?,
-        ParseFormat::Rustume => serde_json::from_slice(&data).map_err(|err| {
+        }
+        ResumeFormat::Rustume => {
             error!("Rustume JSON parse failed: {err}");
             ApiError::new("Failed to parse Rustume JSON input")
-        })?,
-    };
+        }
+    })?;
 
     Ok(Json(resume))
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(parser): share resume format dispatch between server and CLI
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Extract shared resume format dispatch into `crates/parser/src/dispatch.rs` so the server and CLI no longer maintain parallel per-format match blocks. Both surfaces now call `parse_resume` with `ResumeFormat`, mapping errors at their respective boundaries.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #351

## Details

- Added `ResumeFormat` enum and `parse_resume` function in the parser crate
- Added `From` conversions from CLI `InputFormat` and server `ParseFormat` to `ResumeFormat`
- Replaced duplicate match blocks in `crates/cli/src/main.rs` and `crates/server/src/routes/parse.rs`
- Added unit tests for all supported formats in `dispatch.rs`
- CLI-specific format detection (extension sniffing, stdin ZIP detection) remains in the CLI

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR shares resume format parsing between the CLI and server.

- Adds `ResumeFormat` and `parse_resume` in the parser crate.
- Routes CLI parsing through the shared dispatch function.
- Routes server parsing through the shared dispatch function.
- Preserves per-surface error mapping at the CLI and API boundaries.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/parser/src/dispatch.rs | Adds shared format dispatch and tests for all supported formats. |
| crates/parser/src/traits.rs | Adds a raw deserialization error variant for native Rustume JSON parsing. |
| crates/cli/src/main.rs | Replaces per-format parser matching with the shared parser dispatch. |
| crates/server/src/routes/parse.rs | Uses the shared parser dispatch while keeping API-facing error messages local to the route. |
| crates/server/src/dto.rs | Adds a direct conversion from server parse formats to parser formats. |
| crates/parser/src/lib.rs | Exports the shared parser dispatch API from the parser crate. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(parser): preserve Rustume CLI deseri..."](https://github.com/lgtm-hq/rustume/commit/21c76cd2e8efdeb0ec3426dcd32166915b741e94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43676200)</sub>

<!-- /greptile_comment -->