### PR TITLE
feat(render): load Typst templates at runtime instead of embedding in binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,6 +2291,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4200,12 +4219,14 @@ name = "rustume-render"
 version = "0.26.1"
 dependencies = [
  "chrono",
+ "include_dir",
  "rstest",
  "rustume-parser",
  "rustume-schema",
  "rustume-utils",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tracing",
  "typst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,9 @@ web-sys = { version = "0.3", features = [
   "IdbTransaction",
 ] }
 
+# Embedded directories
+include_dir = "0.7"
+
 # Error handling
 thiserror = "2.0"
 anyhow = "1.0"

--- a/apps/site/src/content/docs/contributing/development.md
+++ b/apps/site/src/content/docs/contributing/development.md
@@ -95,6 +95,24 @@ cd apps/web && bun run test            # Vitest for web app
 
 See [Architecture overview](/docs/architecture/overview/) for the full test matrix.
 
+## Typst template overrides
+
+Native CLI and server builds embed Typst templates at compile time. To iterate on a template
+without rebuilding Rust, copy `crates/render/src/typst_engine/templates/*.typ` into a directory and
+set `RUSTUME_TEMPLATES_DIR` to that path. Files present in the override directory replace the
+embedded copy on each render; missing names fall back to the embedded defaults. The WASM build
+always uses embedded templates only.
+
+```bash
+mkdir -p ~/rustume-templates
+cp crates/render/src/typst_engine/templates/*.typ ~/rustume-templates/
+export RUSTUME_TEMPLATES_DIR=~/rustume-templates
+# edit templates, then re-run preview/PDF without cargo build
+```
+
+See [Templates](/docs/getting-started/templates/#iterating-on-templates) and
+[Environment variables](/docs/deployment/env-reference/) for more detail.
+
 ## Cloud development
 
 To develop [Rustume Cloud](/docs/cloud/overview/) features locally:

--- a/apps/site/src/content/docs/deployment/env-reference.md
+++ b/apps/site/src/content/docs/deployment/env-reference.md
@@ -24,6 +24,7 @@ open-source application or maintaining the hosted service.
 | `RUST_LOG` | `info` | Rust tracing filter |
 | `CORS_ORIGIN` | `*` | Allowed browser origins; set an explicit origin for credentialed requests |
 | `RUSTUME_STATIC_DIR` | `/app/web` | Built web UI directory |
+| `RUSTUME_TEMPLATES_DIR` | unset | Directory of `.typ` template overrides (native CLI/server only; see [Templates](/docs/getting-started/templates/#iterating-on-templates)) |
 | `SENTRY_DSN` | unset | Optional Sentry error tracking |
 | `METRICS_TOKEN` | unset | Required bearer token for `/metrics` to return telemetry |
 

--- a/apps/site/src/pages/docs/getting-started/templates.astro
+++ b/apps/site/src/pages/docs/getting-started/templates.astro
@@ -107,4 +107,25 @@ rustume preview resume.json -t azurill -o preview.png`}</code></pre>
     The web editor includes a visual theme editor for adjusting colors without editing JSON directly.
     See also: <a href={`${base}docs/getting-started/quickstart/`}>Quickstart</a>.
   </p>
+
+  <h2 id="iterating-on-templates">Iterating on templates</h2>
+  <p>
+    Typst templates ship embedded in the native CLI and server binary. To iterate on a template
+    without rebuilding Rust, copy the files from
+    <code>crates/render/src/typst_engine/templates/</code> into a working directory and point
+    <code>RUSTUME_TEMPLATES_DIR</code> at it. Matching <code>&lt;name&gt;.typ</code> files override
+    the embedded copy on each render; other templates still load from the embedded defaults.
+  </p>
+
+  <pre class="astro-code"><code>{`mkdir -p ~/rustume-templates
+cp crates/render/src/typst_engine/templates/*.typ ~/rustume-templates/
+export RUSTUME_TEMPLATES_DIR=~/rustume-templates
+# edit ~/rustume-templates/rhyhorn.typ, then re-run preview/PDF — no cargo build needed
+rustume preview resume.json -t rhyhorn -o preview.png`}</code></pre>
+
+  <p>
+    The browser WASM build always uses embedded templates only. See
+    <a href={`${base}docs/deployment/env-reference/`}>Environment variables</a> for deployment
+    configuration.
+  </p>
 </DocsStandaloneLayout>

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -22,6 +22,9 @@ typst-assets.workspace = true
 # Date/time for Typst World
 chrono.workspace = true
 
+# Embedded template directory
+include_dir.workspace = true
+
 # Error handling
 thiserror.workspace = true
 
@@ -31,3 +34,4 @@ tracing.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 rustume-parser = { path = "../parser" }
+tempfile = "3"

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -2,6 +2,12 @@
 //!
 //! Uses Typst for high-quality PDF rendering without browser dependencies.
 //!
+//! ## Template overrides
+//!
+//! Native builds embed Typst templates at compile time. Set `RUSTUME_TEMPLATES_DIR` to a
+//! directory of `<name>.typ` files to override embedded templates at render time without
+//! rebuilding. WASM builds use embedded templates only.
+//!
 //! # Example
 //!
 //! ```ignore

--- a/crates/render/src/typst_engine/engine.rs
+++ b/crates/render/src/typst_engine/engine.rs
@@ -218,7 +218,7 @@ impl TypstRenderer {
 
         debug!("Starting Typst compilation");
         let source = self.generate_source(resume)?;
-        let world = RustumeWorld::new(source);
+        let world = RustumeWorld::new(source)?;
 
         debug!("Compiling Typst document");
         let result = typst::compile(&world);

--- a/crates/render/src/typst_engine/world.rs
+++ b/crates/render/src/typst_engine/world.rs
@@ -19,6 +19,7 @@ use std::sync::OnceLock;
 
 use chrono::Datelike;
 use include_dir::{include_dir, Dir};
+use crate::traits::RenderError;
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime};
 use typst::syntax::{FileId, Source, VirtualPath};
@@ -80,25 +81,36 @@ fn templates_override_dir() -> Option<PathBuf> {
 
 /// Read a template override from disk when the override directory contains `<name>.typ`.
 #[cfg(not(target_arch = "wasm32"))]
-fn read_override_template(dir: &Path, name: &str) -> Option<String> {
+fn read_override_template(dir: &Path, name: &str) -> std::io::Result<Option<String>> {
     let path = dir.join(format!("{name}.typ"));
     if !path.is_file() {
-        return None;
+        return Ok(None);
     }
-    std::fs::read_to_string(&path).ok()
+    std::fs::read_to_string(&path).map(Some)
 }
 
 /// Resolve template content: override directory first, then embedded defaults.
-fn resolve_template_content(name: &str) -> Option<String> {
+fn resolve_template_content(name: &str) -> Result<String, RenderError> {
     if let Some(dir) = templates_override_dir() {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            if let Some(content) = read_override_template(&dir, name) {
-                return Some(content);
+            match read_override_template(&dir, name) {
+                Ok(Some(content)) => return Ok(content),
+                Ok(None) => {}
+                Err(err) => {
+                    let path = dir.join(format!("{name}.typ"));
+                    return Err(RenderError::RenderFailed(format!(
+                        "Failed to read template override '{}': {err}",
+                        path.display(),
+                    )));
+                }
             }
         }
     }
-    embedded_templates().get(name).cloned()
+    embedded_templates()
+        .get(name)
+        .cloned()
+        .ok_or_else(|| RenderError::TemplateNotFound(name.to_string()))
 }
 
 /// Set an injectable templates override directory for unit tests.
@@ -121,27 +133,25 @@ pub struct RustumeWorld {
 
 impl RustumeWorld {
     /// Create a new world with the given main source content.
-    pub fn new(main_content: String) -> Self {
+    pub fn new(main_content: String) -> Result<Self, RenderError> {
         let main_id = FileId::new(None, VirtualPath::new("main.typ"));
         let main = Source::new(main_id, main_content);
 
         // Pre-load template sources (override resolved per render).
         let mut sources = HashMap::new();
         for name in embedded_templates().keys() {
-            let Some(content) = resolve_template_content(name) else {
-                continue;
-            };
+            let content = resolve_template_content(name)?;
             let path = format!("templates/{name}.typ");
             let id = FileId::new(None, VirtualPath::new(&path));
             sources.insert(id, Source::new(id, content));
         }
 
-        Self {
+        Ok(Self {
             main,
             library: OnceLock::new(),
             book: OnceLock::new(),
             sources,
-        }
+        })
     }
 
     /// Get the main source file ID.
@@ -304,6 +314,9 @@ mod tests {
     use super::*;
     use std::fs;
 
+    /// Serializes override tests that mutate process-global template state.
+    static OVERRIDE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
     const EXPECTED_TEMPLATES: &[&str] = &[
         "rhyhorn",
         "azurill",
@@ -345,6 +358,7 @@ mod tests {
 
     #[test]
     fn override_dir_takes_precedence_over_embedded() {
+        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         let marker = "OVERRIDE_MARKER_FOR_RHYHORN";
@@ -359,6 +373,7 @@ mod tests {
 
     #[test]
     fn override_dir_falls_back_to_embedded_for_missing_files() {
+        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         set_test_templates_override(Some(temp.path().to_path_buf()));
@@ -371,5 +386,36 @@ mod tests {
         reset_test_override();
 
         assert_eq!(resolved, embedded);
+    }
+
+    #[test]
+    fn override_dir_errors_on_unreadable_file() {
+        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
+        reset_test_override();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let override_path = temp.path().join("rhyhorn.typ");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            fs::write(&override_path, "content").expect("write override");
+            fs::set_permissions(&override_path, fs::Permissions::from_mode(0o000))
+                .expect("chmod override");
+        }
+        #[cfg(not(unix))]
+        {
+            fs::create_dir(&override_path).expect("create override dir");
+        }
+
+        set_test_templates_override(Some(temp.path().to_path_buf()));
+        let err = resolve_template_content("rhyhorn").expect_err("expected read error");
+        reset_test_override();
+
+        match err {
+            RenderError::RenderFailed(message) => {
+                assert!(message.contains("Failed to read template override"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/crates/render/src/typst_engine/world.rs
+++ b/crates/render/src/typst_engine/world.rs
@@ -85,10 +85,21 @@ fn templates_override_dir() -> Option<PathBuf> {
 #[cfg(not(target_arch = "wasm32"))]
 fn read_override_template(dir: &Path, name: &str) -> std::io::Result<Option<String>> {
     let path = dir.join(format!("{name}.typ"));
-    match std::fs::symlink_metadata(&path) {
+    match path.symlink_metadata() {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(err) => Err(err),
         Ok(meta) if meta.is_file() => std::fs::read_to_string(&path).map(Some),
+        Ok(meta) if meta.file_type().is_symlink() => match std::fs::metadata(&path) {
+            Ok(target) if target.is_file() => std::fs::read_to_string(&path).map(Some),
+            Ok(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "template override is not a regular file: {}",
+                    path.display()
+                ),
+            )),
+            Err(err) => Err(err),
+        },
         Ok(_) => Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!(
@@ -394,6 +405,23 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let marker = "OVERRIDE_MARKER_FOR_RHYHORN";
         fs::write(temp.path().join("rhyhorn.typ"), marker).expect("write override");
+
+        set_test_templates_override(Some(temp.path().to_path_buf()));
+        let content = resolve_template_content("rhyhorn").expect("rhyhorn content");
+        reset_test_override();
+
+        assert!(content.contains(marker));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn override_dir_follows_symlink_to_file() {
+        reset_test_override();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let marker = "SYMLINK_OVERRIDE_MARKER";
+        let target = temp.path().join("actual.typ");
+        fs::write(&target, marker).expect("write target");
+        std::os::unix::fs::symlink(&target, temp.path().join("rhyhorn.typ")).expect("symlink");
 
         set_test_templates_override(Some(temp.path().to_path_buf()));
         let content = resolve_template_content("rhyhorn").expect("rhyhorn content");

--- a/crates/render/src/typst_engine/world.rs
+++ b/crates/render/src/typst_engine/world.rs
@@ -15,7 +15,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 use crate::traits::RenderError;
 use chrono::Datelike;
@@ -137,31 +137,43 @@ pub struct RustumeWorld {
     library: OnceLock<LazyHash<Library>>,
     /// The font book.
     book: OnceLock<LazyHash<FontBook>>,
-    /// Additional source files (templates).
-    sources: HashMap<FileId, Source>,
+    /// Lazily resolved template sources (override errors only fail when that
+    /// template is actually requested by Typst).
+    sources: Mutex<HashMap<FileId, Source>>,
 }
 
 impl RustumeWorld {
     /// Create a new world with the given main source content.
+    ///
+    /// Template overrides are resolved lazily in [`typst::World::source`] so a
+    /// broken override for an unused template cannot block rendering another.
     pub fn new(main_content: String) -> Result<Self, RenderError> {
         let main_id = FileId::new(None, VirtualPath::new("main.typ"));
         let main = Source::new(main_id, main_content);
-
-        // Pre-load template sources (override resolved per render).
-        let mut sources = HashMap::new();
-        for name in embedded_templates().keys() {
-            let content = resolve_template_content(name)?;
-            let path = format!("templates/{name}.typ");
-            let id = FileId::new(None, VirtualPath::new(&path));
-            sources.insert(id, Source::new(id, content));
-        }
 
         Ok(Self {
             main,
             library: OnceLock::new(),
             book: OnceLock::new(),
-            sources,
+            sources: Mutex::new(HashMap::new()),
         })
+    }
+
+    /// Resolve `templates/<name>.typ` from an override dir or embedded defaults.
+    fn load_template_source(id: FileId) -> FileResult<Source> {
+        let path = id.vpath().as_rootless_path();
+        let path_str = path.to_string_lossy();
+        let Some(name) = path_str
+            .strip_prefix("templates/")
+            .and_then(|rest| rest.strip_suffix(".typ"))
+            .filter(|name| !name.is_empty() && !name.contains('/'))
+        else {
+            return Err(FileError::NotFound(path.into()));
+        };
+
+        let content = resolve_template_content(name)
+            .map_err(|err| FileError::Other(Some(err.to_string().into())))?;
+        Ok(Source::new(id, content))
     }
 
     /// Get the main source file ID.
@@ -289,12 +301,25 @@ impl typst::World for RustumeWorld {
 
     fn source(&self, id: FileId) -> FileResult<Source> {
         if id == self.main.id() {
-            Ok(self.main.clone())
-        } else if let Some(source) = self.sources.get(&id) {
-            Ok(source.clone())
-        } else {
-            Err(FileError::NotFound(id.vpath().as_rootless_path().into()))
+            return Ok(self.main.clone());
         }
+
+        {
+            let sources = self
+                .sources
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(source) = sources.get(&id) {
+                return Ok(source.clone());
+            }
+        }
+
+        let source = Self::load_template_source(id)?;
+        let mut sources = self
+            .sources
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Ok(sources.entry(id).or_insert(source).clone())
     }
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
@@ -439,5 +464,27 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn unused_broken_override_does_not_block_other_template() {
+        reset_test_override();
+        let temp = tempfile::tempdir().expect("tempdir");
+        // Broken override for an unused template must not prevent loading rhyhorn.
+        fs::create_dir(temp.path().join("azurill.typ")).expect("create azurill override dir");
+        set_test_templates_override(Some(temp.path().to_path_buf()));
+
+        let world = RustumeWorld::new("// unused-override isolation".into())
+            .expect("world construction must ignore unused overrides");
+        let rhyhorn_id = FileId::new(None, VirtualPath::new("templates/rhyhorn.typ"));
+        let source = typst::World::source(&world, rhyhorn_id).expect("rhyhorn should load");
+        assert!(!source.text().is_empty());
+
+        let azurill_id = FileId::new(None, VirtualPath::new("templates/azurill.typ"));
+        assert!(
+            typst::World::source(&world, azurill_id).is_err(),
+            "broken azurill override should still fail when requested"
+        );
+        reset_test_override();
     }
 }

--- a/crates/render/src/typst_engine/world.rs
+++ b/crates/render/src/typst_engine/world.rs
@@ -2,11 +2,23 @@
 //!
 //! This module provides the `World` trait implementation required by Typst
 //! to compile documents.
+//!
+//! ## Template loading
+//!
+//! Templates are embedded at build time via [`include_dir!`] and serve as the
+//! default set. On native targets, set `RUSTUME_TEMPLATES_DIR` to a directory
+//! containing `<name>.typ` files. Override files are resolved on each render
+//! (no server restart required); names not present in the override directory
+//! fall back to the embedded copy. WASM builds use embedded templates only.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::Mutex;
 use std::sync::OnceLock;
 
 use chrono::Datelike;
+use include_dir::{include_dir, Dir};
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime};
 use typst::syntax::{FileId, Source, VirtualPath};
@@ -14,30 +26,85 @@ use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
 use typst::{Library, LibraryExt};
 
-/// Embedded templates
-static TEMPLATES: OnceLock<HashMap<&'static str, &'static str>> = OnceLock::new();
+/// Embedded template directory (all `.typ` files under `templates/`).
+static TEMPLATE_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src/typst_engine/templates");
+
+/// Cached embedded template contents keyed by file stem (without `.typ`).
+static EMBEDDED_TEMPLATES: OnceLock<HashMap<String, String>> = OnceLock::new();
+
+/// Injectable override directory for unit tests (avoids process-global env vars).
+#[cfg(test)]
+static TEST_TEMPLATES_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
 
 /// Shared font cache to avoid duplicate font loading
 static FONTS_CACHE: OnceLock<(FontBook, Vec<Font>)> = OnceLock::new();
 
-fn get_templates() -> &'static HashMap<&'static str, &'static str> {
-    TEMPLATES.get_or_init(|| {
+/// Return the cached map of embedded template name → content.
+fn embedded_templates() -> &'static HashMap<String, String> {
+    EMBEDDED_TEMPLATES.get_or_init(|| {
         let mut map = HashMap::new();
-        map.insert("rhyhorn", include_str!("templates/rhyhorn.typ"));
-        map.insert("azurill", include_str!("templates/azurill.typ"));
-        map.insert("pikachu", include_str!("templates/pikachu.typ"));
-        map.insert("nosepass", include_str!("templates/nosepass.typ"));
-        map.insert("bronzor", include_str!("templates/bronzor.typ"));
-        map.insert("chikorita", include_str!("templates/chikorita.typ"));
-        map.insert("ditto", include_str!("templates/ditto.typ"));
-        map.insert("gengar", include_str!("templates/gengar.typ"));
-        map.insert("glalie", include_str!("templates/glalie.typ"));
-        map.insert("kakuna", include_str!("templates/kakuna.typ"));
-        map.insert("leafish", include_str!("templates/leafish.typ"));
-        map.insert("onyx", include_str!("templates/onyx.typ"));
-        map.insert("_common", include_str!("templates/_common.typ"));
+        for file in TEMPLATE_DIR.files() {
+            let Some(stem) = file.path().file_stem().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let Some(content) = file.contents_utf8() else {
+                continue;
+            };
+            map.insert(stem.to_string(), content.to_string());
+        }
         map
     })
+}
+
+/// Resolve the override directory: test injectable path on native, env var otherwise.
+fn templates_override_dir() -> Option<PathBuf> {
+    #[cfg(test)]
+    {
+        if let Ok(guard) = TEST_TEMPLATES_OVERRIDE.lock() {
+            if let Some(dir) = guard.clone() {
+                return Some(dir);
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::env::var_os("RUSTUME_TEMPLATES_DIR").map(PathBuf::from)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        None
+    }
+}
+
+/// Read a template override from disk when the override directory contains `<name>.typ`.
+#[cfg(not(target_arch = "wasm32"))]
+fn read_override_template(dir: &Path, name: &str) -> Option<String> {
+    let path = dir.join(format!("{name}.typ"));
+    if !path.is_file() {
+        return None;
+    }
+    std::fs::read_to_string(&path).ok()
+}
+
+/// Resolve template content: override directory first, then embedded defaults.
+fn resolve_template_content(name: &str) -> Option<String> {
+    if let Some(dir) = templates_override_dir() {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if let Some(content) = read_override_template(&dir, name) {
+                return Some(content);
+            }
+        }
+    }
+    embedded_templates().get(name).cloned()
+}
+
+/// Set an injectable templates override directory for unit tests.
+#[cfg(test)]
+pub(crate) fn set_test_templates_override(dir: Option<PathBuf>) {
+    *TEST_TEMPLATES_OVERRIDE.lock().unwrap() = dir;
 }
 
 /// The Rustume Typst world.
@@ -58,12 +125,15 @@ impl RustumeWorld {
         let main_id = FileId::new(None, VirtualPath::new("main.typ"));
         let main = Source::new(main_id, main_content);
 
-        // Pre-load template sources
+        // Pre-load template sources (override resolved per render).
         let mut sources = HashMap::new();
-        for (name, content) in get_templates().iter() {
-            let path = format!("templates/{}.typ", name);
+        for name in embedded_templates().keys() {
+            let Some(content) = resolve_template_content(name) else {
+                continue;
+            };
+            let path = format!("templates/{name}.typ");
             let id = FileId::new(None, VirtualPath::new(&path));
-            sources.insert(id, Source::new(id, (*content).to_string()));
+            sources.insert(id, Source::new(id, content));
         }
 
         Self {
@@ -226,5 +296,80 @@ impl typst::World for RustumeWorld {
             adjusted.month() as u8,
             adjusted.day() as u8,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    const EXPECTED_TEMPLATES: &[&str] = &[
+        "rhyhorn",
+        "azurill",
+        "pikachu",
+        "nosepass",
+        "bronzor",
+        "chikorita",
+        "ditto",
+        "gengar",
+        "glalie",
+        "kakuna",
+        "leafish",
+        "onyx",
+    ];
+
+    fn reset_test_override() {
+        set_test_templates_override(None);
+    }
+
+    #[test]
+    fn embedded_templates_include_all_defaults() {
+        let embedded = embedded_templates();
+        for name in EXPECTED_TEMPLATES {
+            assert!(
+                embedded.contains_key(*name),
+                "embedded set missing template '{name}'"
+            );
+        }
+        assert!(
+            embedded.contains_key("_common"),
+            "embedded set missing '_common'"
+        );
+        assert_eq!(
+            embedded.len(),
+            EXPECTED_TEMPLATES.len() + 1,
+            "unexpected embedded template count"
+        );
+    }
+
+    #[test]
+    fn override_dir_takes_precedence_over_embedded() {
+        reset_test_override();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let marker = "OVERRIDE_MARKER_FOR_RHYHORN";
+        fs::write(temp.path().join("rhyhorn.typ"), marker).expect("write override");
+
+        set_test_templates_override(Some(temp.path().to_path_buf()));
+        let content = resolve_template_content("rhyhorn").expect("rhyhorn content");
+        reset_test_override();
+
+        assert!(content.contains(marker));
+    }
+
+    #[test]
+    fn override_dir_falls_back_to_embedded_for_missing_files() {
+        reset_test_override();
+        let temp = tempfile::tempdir().expect("tempdir");
+        set_test_templates_override(Some(temp.path().to_path_buf()));
+
+        let embedded = embedded_templates()
+            .get("azurill")
+            .expect("embedded azurill")
+            .clone();
+        let resolved = resolve_template_content("azurill").expect("azurill content");
+        reset_test_override();
+
+        assert_eq!(resolved, embedded);
     }
 }

--- a/crates/render/src/typst_engine/world.rs
+++ b/crates/render/src/typst_engine/world.rs
@@ -11,8 +11,6 @@
 //! (no server restart required); names not present in the override directory
 //! fall back to the embedded copy. WASM builds use embedded templates only.
 
-#[cfg(test)]
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -33,11 +31,9 @@ static TEMPLATE_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src/typst_engin
 /// Cached embedded template contents keyed by file stem (without `.typ`).
 static EMBEDDED_TEMPLATES: OnceLock<HashMap<String, String>> = OnceLock::new();
 
-// Per-thread override directory for unit tests (avoids cross-test races).
+// Shared override directory for unit tests (visible to typst worker threads).
 #[cfg(test)]
-thread_local! {
-    static TEST_TEMPLATES_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
-}
+static TEST_TEMPLATES_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
 
 /// Shared font cache to avoid duplicate font loading
 static FONTS_CACHE: OnceLock<(FontBook, Vec<Font>)> = OnceLock::new();
@@ -63,18 +59,19 @@ fn embedded_templates() -> &'static HashMap<String, String> {
 fn templates_override_dir() -> Option<PathBuf> {
     #[cfg(test)]
     {
-        if let Some(dir) =
-            TEST_TEMPLATES_OVERRIDE.with(|override_dir| override_dir.borrow().clone())
-        {
-            return Some(dir);
-        }
+        TEST_TEMPLATES_OVERRIDE
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone())
     }
 
+    #[cfg(not(test))]
     #[cfg(not(target_arch = "wasm32"))]
     {
         std::env::var_os("RUSTUME_TEMPLATES_DIR").map(PathBuf::from)
     }
 
+    #[cfg(not(test))]
     #[cfg(target_arch = "wasm32")]
     {
         None
@@ -137,7 +134,7 @@ fn resolve_template_content(name: &str) -> Result<String, RenderError> {
 /// Set an injectable templates override directory for unit tests.
 #[cfg(test)]
 pub(crate) fn set_test_templates_override(dir: Option<PathBuf>) {
-    TEST_TEMPLATES_OVERRIDE.with(|override_dir| *override_dir.borrow_mut() = dir);
+    *TEST_TEMPLATES_OVERRIDE.lock().unwrap() = dir;
 }
 
 /// The Rustume Typst world.
@@ -360,6 +357,8 @@ mod tests {
     use super::*;
     use std::fs;
 
+    static OVERRIDE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
     const EXPECTED_TEMPLATES: &[&str] = &[
         "rhyhorn",
         "azurill",
@@ -401,6 +400,7 @@ mod tests {
 
     #[test]
     fn override_dir_takes_precedence_over_embedded() {
+        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         let marker = "OVERRIDE_MARKER_FOR_RHYHORN";
@@ -416,6 +416,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn override_dir_follows_symlink_to_file() {
+        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         let marker = "SYMLINK_OVERRIDE_MARKER";
@@ -432,6 +433,7 @@ mod tests {
 
     #[test]
     fn override_dir_falls_back_to_embedded_for_missing_files() {
+        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         set_test_templates_override(Some(temp.path().to_path_buf()));
@@ -448,6 +450,7 @@ mod tests {
 
     #[test]
     fn override_dir_errors_on_unreadable_file() {
+        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         let override_path = temp.path().join("rhyhorn.typ");
@@ -478,6 +481,7 @@ mod tests {
 
     #[test]
     fn override_dir_errors_on_non_file_path() {
+        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         fs::create_dir(temp.path().join("rhyhorn.typ")).expect("create override dir");
@@ -496,6 +500,7 @@ mod tests {
 
     #[test]
     fn unused_broken_override_does_not_block_other_template() {
+        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         // Broken override for an unused template must not prevent loading rhyhorn.

--- a/crates/render/src/typst_engine/world.rs
+++ b/crates/render/src/typst_engine/world.rs
@@ -11,15 +11,15 @@
 //! (no server restart required); names not present in the override directory
 //! fall back to the embedded copy. WASM builds use embedded templates only.
 
+#[cfg(test)]
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-#[cfg(test)]
-use std::sync::Mutex;
 use std::sync::OnceLock;
 
+use crate::traits::RenderError;
 use chrono::Datelike;
 use include_dir::{include_dir, Dir};
-use crate::traits::RenderError;
 use typst::diag::{FileError, FileResult};
 use typst::foundations::{Bytes, Datetime};
 use typst::syntax::{FileId, Source, VirtualPath};
@@ -33,9 +33,11 @@ static TEMPLATE_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src/typst_engin
 /// Cached embedded template contents keyed by file stem (without `.typ`).
 static EMBEDDED_TEMPLATES: OnceLock<HashMap<String, String>> = OnceLock::new();
 
-/// Injectable override directory for unit tests (avoids process-global env vars).
+// Per-thread override directory for unit tests (avoids cross-test races).
 #[cfg(test)]
-static TEST_TEMPLATES_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
+thread_local! {
+    static TEST_TEMPLATES_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
 
 /// Shared font cache to avoid duplicate font loading
 static FONTS_CACHE: OnceLock<(FontBook, Vec<Font>)> = OnceLock::new();
@@ -61,10 +63,10 @@ fn embedded_templates() -> &'static HashMap<String, String> {
 fn templates_override_dir() -> Option<PathBuf> {
     #[cfg(test)]
     {
-        if let Ok(guard) = TEST_TEMPLATES_OVERRIDE.lock() {
-            if let Some(dir) = guard.clone() {
-                return Some(dir);
-            }
+        if let Some(dir) =
+            TEST_TEMPLATES_OVERRIDE.with(|override_dir| override_dir.borrow().clone())
+        {
+            return Some(dir);
         }
     }
 
@@ -83,10 +85,18 @@ fn templates_override_dir() -> Option<PathBuf> {
 #[cfg(not(target_arch = "wasm32"))]
 fn read_override_template(dir: &Path, name: &str) -> std::io::Result<Option<String>> {
     let path = dir.join(format!("{name}.typ"));
-    if !path.is_file() {
-        return Ok(None);
+    match std::fs::symlink_metadata(&path) {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+        Ok(meta) if meta.is_file() => std::fs::read_to_string(&path).map(Some),
+        Ok(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "template override is not a regular file: {}",
+                path.display()
+            ),
+        )),
     }
-    std::fs::read_to_string(&path).map(Some)
 }
 
 /// Resolve template content: override directory first, then embedded defaults.
@@ -116,7 +126,7 @@ fn resolve_template_content(name: &str) -> Result<String, RenderError> {
 /// Set an injectable templates override directory for unit tests.
 #[cfg(test)]
 pub(crate) fn set_test_templates_override(dir: Option<PathBuf>) {
-    *TEST_TEMPLATES_OVERRIDE.lock().unwrap() = dir;
+    TEST_TEMPLATES_OVERRIDE.with(|override_dir| *override_dir.borrow_mut() = dir);
 }
 
 /// The Rustume Typst world.
@@ -314,9 +324,6 @@ mod tests {
     use super::*;
     use std::fs;
 
-    /// Serializes override tests that mutate process-global template state.
-    static OVERRIDE_TEST_LOCK: Mutex<()> = Mutex::new(());
-
     const EXPECTED_TEMPLATES: &[&str] = &[
         "rhyhorn",
         "azurill",
@@ -358,7 +365,6 @@ mod tests {
 
     #[test]
     fn override_dir_takes_precedence_over_embedded() {
-        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         let marker = "OVERRIDE_MARKER_FOR_RHYHORN";
@@ -373,7 +379,6 @@ mod tests {
 
     #[test]
     fn override_dir_falls_back_to_embedded_for_missing_files() {
-        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         set_test_templates_override(Some(temp.path().to_path_buf()));
@@ -390,7 +395,6 @@ mod tests {
 
     #[test]
     fn override_dir_errors_on_unreadable_file() {
-        let _lock = OVERRIDE_TEST_LOCK.lock().unwrap();
         reset_test_override();
         let temp = tempfile::tempdir().expect("tempdir");
         let override_path = temp.path().join("rhyhorn.typ");
@@ -414,6 +418,24 @@ mod tests {
         match err {
             RenderError::RenderFailed(message) => {
                 assert!(message.contains("Failed to read template override"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn override_dir_errors_on_non_file_path() {
+        reset_test_override();
+        let temp = tempfile::tempdir().expect("tempdir");
+        fs::create_dir(temp.path().join("rhyhorn.typ")).expect("create override dir");
+
+        set_test_templates_override(Some(temp.path().to_path_buf()));
+        let err = resolve_template_content("rhyhorn").expect_err("expected non-file error");
+        reset_test_override();
+
+        match err {
+            RenderError::RenderFailed(message) => {
+                assert!(message.contains("not a regular file"));
             }
             other => panic!("unexpected error: {other:?}"),
         }


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(render): load Typst templates at runtime instead of embedding in binary
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Typst templates are now embedded via `include_dir!` with an optional runtime override directory (`RUSTUME_TEMPLATES_DIR`). Native CLI and server builds resolve overrides on each render so template authors can iterate without rebuilding Rust. WASM builds remain embedded-only.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #348

## Details

- Replaced 13 hardcoded `include_str!` entries in `world.rs` with `include_dir!` over `templates/`
- Added `RUSTUME_TEMPLATES_DIR` lookup (override dir → embedded defaults) gated behind `#[cfg(not(target_arch = "wasm32"))]`
- Override resolution happens per render (no server restart required)
- Added unit tests for embedded set completeness, override precedence, and fallback behavior
- Documented override workflow in env reference, development guide, and templates page

### Testing strategy

- `cargo test --workspace` — all tests pass, including existing 12-template render suite and new unit tests
- `cargo clippy -p rustume-render --all-targets -- -D warnings` — clean
- `make wasm` — WASM build succeeds (embedded-only path)
- `uv run lintro fmt` and `uv run lintro chk` — formatting clean; clippy/gitleaks timed out in lintro due to environment limits but were verified directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native CLI and server builds now support overriding embedded Typst templates using `RUSTUME_TEMPLATES_DIR`.
  * Template overrides are applied automatically when matching `.typ` files are available, with embedded templates used as a fallback.
  * Template changes can be previewed without rebuilding the application.

* **Documentation**
  * Added guidance for configuring, iterating on, and deploying Typst template overrides.
  * Clarified that browser WASM builds always use embedded templates.

* **Bug Fixes**
  * Improved error handling when templates cannot be loaded during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves Typst templates from hardcoded string embeds to runtime-resolvable template loading. The main changes are:

- Added `include_dir` embedding for the render crate templates.
- Added native `RUSTUME_TEMPLATES_DIR` override support.
- Changed template loading to resolve lazily during Typst source lookup.
- Updated render construction to handle template-loading errors.
- Added tests and docs for override behavior.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the remaining test isolation concern should be handled before merging.

- Runtime template loading now avoids failing on broken overrides for unused templates.
- The latest changes still rely on shared test override state that can affect unrelated render tests.

crates/render/src/typst_engine/world.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/render/src/typst_engine/world.rs | Adds embedded template directory loading, native override resolution, lazy Typst source loading, and override tests. |
| crates/render/src/typst_engine/engine.rs | Updates Typst world construction to propagate render setup errors. |
| crates/render/Cargo.toml | Adds the template embedding dependency and test-only temp directory support. |

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(render): share test template overrid..."](https://github.com/lgtm-hq/rustume/commit/2d7ca4f449d7e35f580dc2cc69bbabda551375dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43677942)</sub>

<!-- /greptile_comment -->