### PR TITLE
refactor(server): small cleanups — ApiError dedup, urlencoding, drop ImportItemError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4277,6 +4277,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -6216,6 +6217,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ anyhow = "1.0"
 # Regex
 regex = "1.10"
 once_cell = "1.19"
+urlencoding = "2.1"
 
 # Logging
 tracing = "0.1"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -67,6 +67,7 @@ sentry-tower.workspace = true
 governor.workspace = true
 dashmap.workspace = true
 zip = { version = "3.0", default-features = false, features = ["deflate"] }
+urlencoding.workspace = true
 
 # Use jemalloc on musl to avoid musl's slower default allocator
 [target.'cfg(target_env = "musl")'.dependencies]

--- a/crates/server/src/auth/workos.rs
+++ b/crates/server/src/auth/workos.rs
@@ -36,9 +36,9 @@ impl WorkOsClient {
     pub fn authorize_url(&self, redirect_uri: &str, state: &str) -> String {
         format!(
             "{WORKOS_API_BASE}/user_management/authorize?response_type=code&client_id={}&redirect_uri={}&provider=authkit&state={}&prompt=login",
-            url_encode(&self.client_id),
-            url_encode(redirect_uri),
-            url_encode(state),
+            urlencoding::encode(&self.client_id),
+            urlencoding::encode(redirect_uri),
+            urlencoding::encode(state),
         )
     }
 
@@ -191,15 +191,34 @@ pub async fn upsert_user(
     .await
 }
 
-fn url_encode(value: &str) -> String {
-    let mut encoded = String::with_capacity(value.len());
-    for byte in value.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                encoded.push(byte as char);
+#[cfg(test)]
+mod tests {
+    fn legacy_url_encode(value: &str) -> String {
+        let mut encoded = String::with_capacity(value.len());
+        for byte in value.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    encoded.push(byte as char);
+                }
+                _ => encoded.push_str(&format!("%{byte:02X}")),
             }
-            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+        encoded
+    }
+
+    #[test]
+    fn urlencoding_matches_legacy_rfc3986_unreserved_set() {
+        let cases = [
+            ("client_123", "client_123"),
+            ("redirect-uri.test~", "redirect-uri.test~"),
+            ("space here", "space%20here"),
+            ("a+b&c=d/e:h", "a%2Bb%26c%3Dd%2Fe%3Ah"),
+            ("café", "caf%C3%A9"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(legacy_url_encode(input), expected);
+            assert_eq!(urlencoding::encode(input), expected);
         }
     }
-    encoded
 }

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -62,14 +62,18 @@ pub struct ApiError {
 }
 
 impl ApiError {
-    /// Create a 400 Bad Request error.
-    pub fn new(error: impl Into<String>) -> Self {
+    fn with_kind(kind: ApiErrorKind, error: impl Into<String>) -> Self {
         Self {
             error: error.into(),
             details: None,
             current_version: None,
-            kind: ApiErrorKind::BadRequest,
+            kind,
         }
+    }
+
+    /// Create a 400 Bad Request error.
+    pub fn new(error: impl Into<String>) -> Self {
+        Self::with_kind(ApiErrorKind::BadRequest, error)
     }
 
     /// Create a 422 Unprocessable Entity error with validation details.
@@ -84,52 +88,27 @@ impl ApiError {
 
     /// Create a 404 Not Found error.
     pub fn not_found(error: impl Into<String>) -> Self {
-        Self {
-            error: error.into(),
-            details: None,
-            current_version: None,
-            kind: ApiErrorKind::NotFound,
-        }
+        Self::with_kind(ApiErrorKind::NotFound, error)
     }
 
     /// Create a 500 Internal Server Error.
     pub fn internal(error: impl Into<String>) -> Self {
-        Self {
-            error: error.into(),
-            details: None,
-            current_version: None,
-            kind: ApiErrorKind::InternalError,
-        }
+        Self::with_kind(ApiErrorKind::InternalError, error)
     }
 
     /// Create a 401 Unauthorized error.
     pub fn unauthorized(error: impl Into<String>) -> Self {
-        Self {
-            error: error.into(),
-            details: None,
-            current_version: None,
-            kind: ApiErrorKind::Unauthorized,
-        }
+        Self::with_kind(ApiErrorKind::Unauthorized, error)
     }
 
     /// Create a 403 Forbidden error.
     pub fn forbidden(error: impl Into<String>) -> Self {
-        Self {
-            error: error.into(),
-            details: None,
-            current_version: None,
-            kind: ApiErrorKind::Forbidden,
-        }
+        Self::with_kind(ApiErrorKind::Forbidden, error)
     }
 
     /// Create a 409 Conflict error.
     pub fn conflict(error: impl Into<String>) -> Self {
-        Self {
-            error: error.into(),
-            details: None,
-            current_version: None,
-            kind: ApiErrorKind::Conflict,
-        }
+        Self::with_kind(ApiErrorKind::Conflict, error)
     }
 
     /// Create a 409 Conflict error with the current resource version.
@@ -144,12 +123,7 @@ impl ApiError {
 
     /// Create a 413 Payload Too Large error.
     pub fn payload_too_large(error: impl Into<String>) -> Self {
-        Self {
-            error: error.into(),
-            details: None,
-            current_version: None,
-            kind: ApiErrorKind::PayloadTooLarge,
-        }
+        Self::with_kind(ApiErrorKind::PayloadTooLarge, error)
     }
 }
 

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -313,15 +313,11 @@ pub async fn import_resumes(
     Ok(Json(ImportResumesResponse { imported, failed }))
 }
 
-struct ImportItemError {
-    error: String,
-}
-
 async fn import_single_resume(
     db: &sqlx::PgPool,
     user_id: Uuid,
     item: ImportResumeItem,
-) -> Result<ResumeRow, ImportItemError> {
+) -> Result<ResumeRow, ApiError> {
     let title = item.title.unwrap_or_else(|| "Untitled".to_string());
     let resume_id = item.id.unwrap_or_else(Uuid::new_v4);
 
@@ -343,9 +339,7 @@ async fn import_single_resume(
     .bind(item.data)
     .fetch_one(db)
     .await
-    .map_err(|err| ImportItemError {
-        error: map_import_db_error(err, resume_id).error,
-    })
+    .map_err(|err| map_import_db_error(err, resume_id))
 }
 
 fn internal_db_error(err: impl std::fmt::Display + Send + Sync + 'static) -> ApiError {


### PR DESCRIPTION
## Summary

- Deduplicate `ApiError` constructors behind a private `with_kind` helper; named helpers remain one-line aliases
- Replace hand-rolled `url_encode` in WorkOS auth with the `urlencoding` crate (byte-identical output verified by unit test)
- Drop `ImportItemError` wrapper; `import_single_resume` now returns `Result<ResumeRow, ApiError>` directly

## Closes

- Closes #350

## Test plan

- [x] `uv run lintro fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `env -u CARGO_HTTP_CAINFO cargo test --workspace`
- [x] New unit test `urlencoding_matches_legacy_rfc3986_unreserved_set` passes

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes small server cleanup changes. The main changes are:

- `ApiError` constructors now share a private helper.
- WorkOS auth URL encoding now uses the `urlencoding` crate.
- Resume import item errors now return `ApiError` directly from the private helper.
- Cargo manifests and lockfile now include `urlencoding`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/auth/workos.rs | Replaces the local WorkOS URL encoder with `urlencoding::encode` and adds an equivalence test. |
| crates/server/src/error.rs | Deduplicates repeated `ApiError` constructor setup while preserving the specialized constructors. |
| crates/server/src/routes/resumes.rs | Removes the private import error wrapper while keeping the batch failure response shape the same. |
| Cargo.toml | Adds `urlencoding` as a workspace dependency. |
| crates/server/Cargo.toml | Enables the workspace `urlencoding` dependency for the server crate. |
| Cargo.lock | Locks the new `urlencoding` dependency. |

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(server): dedup ApiError, use ur..."](https://github.com/lgtm-hq/rustume/commit/769add94e01645acceee084df240f2d8128dcad7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43678296)</sub>

<!-- /greptile_comment -->