### PR TITLE
fix(server): evict stale rate limiter keys periodically

### DIFF
--- a/crates/server/src/middleware/rate_limit.rs
+++ b/crates/server/src/middleware/rate_limit.rs
@@ -11,8 +11,10 @@ use governor::{
     clock::{Clock, DefaultClock},
     RateLimiter,
 };
+use metrics::gauge;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
 use tracing::warn;
 
@@ -91,6 +93,55 @@ impl RateLimitState {
                 Err(RateLimitExceeded::new(wait))
             }
         }
+    }
+
+    /// Remove stale keyed state from all limiters and refresh the Prometheus gauge.
+    pub fn evict_stale(&self) {
+        self.resume_crud.retain_recent();
+        self.resume_crud.shrink_to_fit();
+        self.import.retain_recent();
+        self.import.shrink_to_fit();
+        self.preview.retain_recent();
+        self.preview.shrink_to_fit();
+        self.pdf.retain_recent();
+        self.pdf.shrink_to_fit();
+        self.auth.retain_recent();
+        self.auth.shrink_to_fit();
+        self.health.retain_recent();
+        self.health.shrink_to_fit();
+        self.metrics.retain_recent();
+        self.metrics.shrink_to_fit();
+        self.billable.retain_recent();
+        self.billable.shrink_to_fit();
+        self.unauthenticated.retain_recent();
+        self.unauthenticated.shrink_to_fit();
+
+        gauge!("rustume_rate_limit_keys").set(self.key_count() as f64);
+    }
+
+    /// Total number of keyed entries across all limiters.
+    fn key_count(&self) -> usize {
+        self.resume_crud.len()
+            + self.import.len()
+            + self.preview.len()
+            + self.pdf.len()
+            + self.auth.len()
+            + self.health.len()
+            + self.metrics.len()
+            + self.billable.len()
+            + self.unauthenticated.len()
+    }
+
+    /// Spawn a background task that evicts stale rate-limit keys on a fixed interval.
+    pub fn spawn_eviction_task(rate_limits: Arc<Self>) {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(5 * 60));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                rate_limits.evict_stale();
+            }
+        });
     }
 }
 
@@ -316,7 +367,10 @@ pub async fn rate_limit_billable(
 mod tests {
     use super::*;
     use crate::config::RateLimitConfig;
+    use std::num::NonZeroU32;
     use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
 
     fn test_rate_limits(limit: u32) -> Arc<RateLimitState> {
         let config = RateLimitConfig {
@@ -331,6 +385,21 @@ mod tests {
             ..Default::default()
         };
         Arc::new(RateLimitState::new(config))
+    }
+
+    fn test_rate_limits_with_quota(quota: governor::Quota) -> RateLimitState {
+        RateLimitState {
+            trusted_proxy: false,
+            resume_crud: RateLimiter::dashmap(quota),
+            import: RateLimiter::dashmap(quota),
+            preview: RateLimiter::dashmap(quota),
+            pdf: RateLimiter::dashmap(quota),
+            auth: RateLimiter::dashmap(quota),
+            health: RateLimiter::dashmap(quota),
+            metrics: RateLimiter::dashmap(quota),
+            billable: RateLimiter::dashmap(quota),
+            unauthenticated: RateLimiter::dashmap(quota),
+        }
     }
 
     #[test]
@@ -360,6 +429,20 @@ mod tests {
         assert!(limits
             .check(RateLimitGroup::Metrics, &key.to_string())
             .is_ok());
+    }
+
+    #[test]
+    fn evict_stale_drops_keys_after_quota_window() {
+        let quota = governor::Quota::per_second(NonZeroU32::new(1).expect("quota"));
+        let limits = test_rate_limits_with_quota(quota);
+        let key = "ip:evict-test".to_string();
+
+        assert!(limits.check(RateLimitGroup::Health, &key).is_ok());
+        assert_eq!(limits.key_count(), 1);
+
+        thread::sleep(Duration::from_secs(2));
+        limits.evict_stale();
+        assert_eq!(limits.key_count(), 0);
     }
 
     #[test]

--- a/crates/server/src/run.rs
+++ b/crates/server/src/run.rs
@@ -6,6 +6,7 @@ use tracing::info;
 use crate::app::create_router_with_state;
 use crate::cloud::{cloud_enabled, init_cloud, CloudConfig};
 use crate::config::DEFAULT_PORT;
+use crate::middleware::rate_limit::RateLimitState;
 use crate::observability::init_sentry;
 use crate::routes::{init_metrics, static_dir};
 use crate::shutdown::{health_probe, shutdown_signal};
@@ -38,7 +39,11 @@ pub async fn run() -> anyhow::Result<()> {
         None
     };
 
-    let app = create_router_with_state(AppState::new(static_root.clone(), cloud));
+    let app_state = AppState::new(static_root.clone(), cloud);
+    if let Some(rate_limits) = app_state.rate_limits.clone() {
+        RateLimitState::spawn_eviction_task(rate_limits);
+    }
+    let app = create_router_with_state(app_state);
 
     let port: u16 = std::env::var("PORT")
         .ok()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(server): evict stale rate limiter keys periodically
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Cloud rate limiters store per-key state in governor keyed `DashMap` stores that never evict entries. On a long-lived Railway instance, unique visitor IPs and user IDs accumulate indefinitely across nine route-group limiters — a slow memory leak.

This PR adds periodic eviction via `retain_recent()` + `shrink_to_fit()` on all nine limiters every five minutes, wired from server startup when cloud mode is active. A `rustume_rate_limit_keys` Prometheus gauge exposes aggregate keyed entry count for observability.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #347

## Details

- `RateLimitState::evict_stale()` cleans all nine keyed limiters and refreshes the gauge.
- `RateLimitState::spawn_eviction_task()` runs eviction on a 5-minute tokio interval with `MissedTickBehavior::Skip`.
- Eviction task is started from `run.rs` when `AppState` has cloud rate limits configured.
- Unit test `evict_stale_drops_keys_after_quota_window` exercises check → sleep past quota window → evict → assert `key_count()` drops to zero.
- Rate-limit decisions are unchanged; eviction only removes stale entries per governor's `retain_recent` semantics.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds periodic cleanup for cloud rate-limiter state. The main changes are:

- Evicts stale keys from all rate-limit groups.
- Shrinks the keyed limiter stores after eviction.
- Reports the aggregate key count through a Prometheus gauge.
- Starts the eviction loop during cloud server startup.
- Adds a unit test for stale key removal.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/middleware/rate_limit.rs | Adds stale key eviction, key counting, gauge refresh, a background eviction loop, and a unit test for expired keyed state. |
| crates/server/src/run.rs | Starts the rate-limit eviction task when cloud rate limits are configured before building the router. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): evict stale rate limiter ke..."](https://github.com/lgtm-hq/rustume/commit/8a7a226606a70473e64d27d3d349cba86f8f1bbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43679521)</sub>

<!-- /greptile_comment -->