### PR TITLE
fix(ci): run DB-backed integration tests against a Postgres service

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,71 @@ permissions:
   contents: read
 
 jobs:
+  rust-server-db-integration:
+    name: "🐘 Server DB Integration"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: rustume_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/rustume_test
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            release-assets.githubusercontent.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
+            static.rust-lang.org:443
+            sh.rustup.rs:443
+            crates.io:443
+            static.crates.io:443
+            index.crates.io:443
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: 66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+          sparse-checkout: |
+            .github/actions/setup-rust
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+      - name: Setup Rust
+        uses: ./.lgtm-ci-tooling/.github/actions/setup-rust
+      - name: Setup nextest toolchain
+        run: bash .lgtm-ci-tooling/scripts/ci/testing/rust/setup-rust-nextest.sh
+      - name: Run server DB integration tests
+        run: bash scripts/ci/testing/rust/run-server-db-integration-ci.sh
+
   rust-coverage:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
@@ -33,6 +98,7 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: "🦀 Rust Coverage"
       coverage: true
+      setup-script: scripts/ci/testing/rust/setup-postgres-test-db.sh
       upload-pages-coverage-html: true
       pages-coverage-artifact-name: rust-coverage-html
       comment-marker: rust-coverage-report

--- a/scripts/ci/testing/rust/run-server-db-integration-ci.sh
+++ b/scripts/ci/testing/rust/run-server-db-integration-ci.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: CI entrypoint for server DB integration tests with a Postgres service container.
+
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+: "${TEST_DATABASE_URL:?TEST_DATABASE_URL is required}"
+
+bash "$GITHUB_WORKSPACE/scripts/ci/testing/rust/run-server-db-migrations.sh"
+bash "$GITHUB_WORKSPACE/scripts/ci/testing/rust/run-server-db-integration-tests.sh"

--- a/scripts/ci/testing/rust/run-server-db-integration-tests.sh
+++ b/scripts/ci/testing/rust/run-server-db-integration-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Run server DB-backed integration tests that require TEST_DATABASE_URL.
+
+set -euo pipefail
+
+: "${TEST_DATABASE_URL:?TEST_DATABASE_URL is required}"
+: "${NEXTEST_PROFILE:=ci}"
+
+nextest_args=(
+	run
+	-p rustume-server
+	--profile "$NEXTEST_PROFILE"
+	--all-features
+	-E 'test(/export_resumes_|looks_like_test_database_url/)'
+)
+
+echo "Running: cargo nextest ${nextest_args[*]}"
+cargo nextest "${nextest_args[@]}"

--- a/scripts/ci/testing/rust/run-server-db-migrations.sh
+++ b/scripts/ci/testing/rust/run-server-db-migrations.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Apply server SQLx migrations against TEST_DATABASE_URL for CI.
+
+set -euo pipefail
+
+: "${TEST_DATABASE_URL:?TEST_DATABASE_URL is required}"
+: "${SQLX_CLI_VERSION:=0.9.0}"
+: "${MIGRATIONS_DIR:=crates/server/src/db/migrations}"
+
+if ! command -v sqlx >/dev/null 2>&1; then
+	echo "Installing sqlx-cli ${SQLX_CLI_VERSION}..."
+	cargo install sqlx-cli \
+		--no-default-features \
+		--features rustls,postgres \
+		--locked \
+		--force \
+		--version "$SQLX_CLI_VERSION"
+fi
+
+echo "Running SQLx migrations from ${MIGRATIONS_DIR}..."
+sqlx migrate run \
+	--source "$MIGRATIONS_DIR" \
+	--database-url "$TEST_DATABASE_URL"

--- a/scripts/ci/testing/rust/setup-postgres-test-db.sh
+++ b/scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -35,14 +35,8 @@ wait_for_postgres() {
 }
 
 start_postgres() {
-	if docker ps --format '{{.Names}}' | grep -qx "$POSTGRES_CONTAINER_NAME"; then
-		echo "Postgres container ${POSTGRES_CONTAINER_NAME} already running"
-		wait_for_postgres
-		return 0
-	fi
-
 	if docker ps -a --format '{{.Names}}' | grep -qx "$POSTGRES_CONTAINER_NAME"; then
-		echo "Removing stale Postgres container ${POSTGRES_CONTAINER_NAME}..."
+		echo "Removing existing Postgres container ${POSTGRES_CONTAINER_NAME}..."
 		docker rm -f "$POSTGRES_CONTAINER_NAME" >/dev/null
 	fi
 

--- a/scripts/ci/testing/rust/setup-postgres-test-db.sh
+++ b/scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Provision Postgres 16 for Rust CI, migrate, and export TEST_DATABASE_URL.
+#
+# Reusable Rust test workflows cannot attach GitHub Actions service containers, so
+# this script starts an equivalent postgres:16 container with a pg_isready health wait.
+
+set -euo pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+: "${POSTGRES_USER:=postgres}"
+: "${POSTGRES_PASSWORD:=postgres}"
+: "${POSTGRES_DB:=rustume_test}"
+: "${POSTGRES_PORT:=5432}"
+: "${POSTGRES_IMAGE:=postgres:16}"
+: "${POSTGRES_CONTAINER_NAME:=rustume-ci-postgres}"
+: "${POSTGRES_READY_TIMEOUT_SECONDS:=60}"
+
+TEST_DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}"
+
+wait_for_postgres() {
+	local attempt=0
+
+	while ((attempt < POSTGRES_READY_TIMEOUT_SECONDS)); do
+		if docker exec "$POSTGRES_CONTAINER_NAME" \
+			pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; then
+			return 0
+		fi
+		attempt=$((attempt + 1))
+		sleep 1
+	done
+
+	echo "Postgres did not become ready within ${POSTGRES_READY_TIMEOUT_SECONDS}s" >&2
+	return 1
+}
+
+start_postgres() {
+	if docker ps --format '{{.Names}}' | grep -qx "$POSTGRES_CONTAINER_NAME"; then
+		echo "Postgres container ${POSTGRES_CONTAINER_NAME} already running"
+		wait_for_postgres
+		return 0
+	fi
+
+	if docker ps -a --format '{{.Names}}' | grep -qx "$POSTGRES_CONTAINER_NAME"; then
+		echo "Starting existing Postgres container ${POSTGRES_CONTAINER_NAME}..."
+		docker start "$POSTGRES_CONTAINER_NAME" >/dev/null
+		wait_for_postgres
+		return 0
+	fi
+
+	echo "Starting Postgres container (${POSTGRES_IMAGE})..."
+	docker run -d \
+		--name "$POSTGRES_CONTAINER_NAME" \
+		-e "POSTGRES_USER=${POSTGRES_USER}" \
+		-e "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+		-e "POSTGRES_DB=${POSTGRES_DB}" \
+		-p "${POSTGRES_PORT}:5432" \
+		"$POSTGRES_IMAGE" >/dev/null
+
+	wait_for_postgres
+}
+
+start_postgres
+
+export TEST_DATABASE_URL
+bash "$GITHUB_WORKSPACE/scripts/ci/testing/rust/run-server-db-migrations.sh"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+	echo "TEST_DATABASE_URL=${TEST_DATABASE_URL}" >>"$GITHUB_ENV"
+fi
+
+: "${INSTALL_COVERAGE_TOOLS:=false}"
+export INSTALL_COVERAGE_TOOLS
+bash "$GITHUB_WORKSPACE/.lgtm-ci-tooling/scripts/ci/testing/rust/setup-rust-nextest.sh"

--- a/scripts/ci/testing/rust/setup-postgres-test-db.sh
+++ b/scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -42,10 +42,8 @@ start_postgres() {
 	fi
 
 	if docker ps -a --format '{{.Names}}' | grep -qx "$POSTGRES_CONTAINER_NAME"; then
-		echo "Starting existing Postgres container ${POSTGRES_CONTAINER_NAME}..."
-		docker start "$POSTGRES_CONTAINER_NAME" >/dev/null
-		wait_for_postgres
-		return 0
+		echo "Removing stale Postgres container ${POSTGRES_CONTAINER_NAME}..."
+		docker rm -f "$POSTGRES_CONTAINER_NAME" >/dev/null
 	fi
 
 	echo "Starting Postgres container (${POSTGRES_IMAGE})..."


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): run DB-backed integration tests against a Postgres service
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

DB-backed server integration tests (export resume cap enforcement) previously self-skipped in CI because no workflow provisioned Postgres or set `TEST_DATABASE_URL`. This PR adds CI plumbing so those tests execute against a `_test`-suffixed database.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt` and `uv run lintro chk`; clippy/gitleaks timed out locally on unrelated full-workspace scans)

## Closes

- Closes #341

## Details

- Added a **🐘 Server DB Integration** job to `coverage.yml` with a `postgres:16` service container, health check, and `TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/rustume_test`.
- Added CI scripts under `scripts/ci/testing/rust/` to run SQLx migrations and execute export integration tests via nextest.
- Wired `setup-postgres-test-db.sh` into the existing **🦀 Rust Coverage** reusable job so the full workspace coverage run also receives `TEST_DATABASE_URL` (reusable workflows cannot attach service containers, so this job starts an equivalent `postgres:16` container via Docker before tests).

### Test plan

- [ ] Coverage Reports workflow shows **🐘 Server DB Integration** passing
- [ ] **🦀 Rust Coverage** logs contain no `SKIP export` messages
- [ ] Export integration tests (`export_resumes_json_*`, `export_resumes_pdf_*`) pass against Postgres

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR runs DB-backed Rust server tests against Postgres in CI. The main changes are:

- A new Server DB Integration workflow job with a Postgres service.
- New CI scripts for migrations and targeted export integration tests.
- A Postgres setup script for the Rust coverage reusable workflow.
- Coverage wiring that exports `TEST_DATABASE_URL` for DB-backed tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/coverage.yml | Adds a Postgres-backed integration job and connects the coverage workflow to the new database setup script. |
| scripts/ci/testing/rust/setup-postgres-test-db.sh | Creates a fresh Postgres container, applies migrations, and exports the test database URL. |
| scripts/ci/testing/rust/run-server-db-integration-ci.sh | Runs the migration step before the DB-backed integration tests. |
| scripts/ci/testing/rust/run-server-db-integration-tests.sh | Runs the targeted Rust server export tests with nextest. |
| scripts/ci/testing/rust/run-server-db-migrations.sh | Installs sqlx-cli when needed and applies server migrations to the configured test database. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): always recreate Postgres contai..."](https://github.com/lgtm-hq/rustume/commit/c7b17f0bac3a272cc36ba2a7441414b89fb15cc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43684894)</sub>

<!-- /greptile_comment -->