### PR TITLE
feat(infra): scheduled pg_dump-to-R2 backup workflow, verification script, and restore runbook

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -82,8 +82,7 @@ jobs:
       - name: Install PostgreSQL client
         if: steps.secrets.outputs.skip != 'true'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql-client
+          sudo apt-get install -y --no-update postgresql-client
 
       - name: Install AWS CLI
         if: steps.secrets.outputs.skip != 'true'

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -40,6 +40,12 @@ jobs:
             github.com:443
             api.github.com:443
             codeload.github.com:443
+            archive.ubuntu.com:80
+            azure.archive.ubuntu.com:80
+            security.ubuntu.com:80
+            security.ubuntu.com:443
+            awscli.amazonaws.com:443
+            *.aws.neon.tech:5432
             ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com:443
 
       - name: Checkout

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Maintenance - Database Backup
+
+# Scheduled pg_dump of the Neon database to a dedicated R2 bucket, plus retention
+# pruning. Provider setup (Neon PITR, R2 bucket/token, repository secrets) and
+# live restore rehearsal remain human work tracked in #334.
+
+"on":
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (dump only, skip upload and prune deletions)"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: db-backup-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    name: 🗄️ Database Backup
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      BACKUP_ENV: production
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com:443
+
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        with:
+          persist-credentials: false
+
+      - name: Verify backup secrets
+        id: secrets
+        env:
+          BACKUP_DATABASE_URL: ${{ secrets.BACKUP_DATABASE_URL }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BACKUP_BUCKET: ${{ secrets.R2_BACKUP_BUCKET }}
+        run: |
+          missing=()
+          for name in BACKUP_DATABASE_URL R2_ACCOUNT_ID R2_ACCESS_KEY_ID \
+            R2_SECRET_ACCESS_KEY R2_BACKUP_BUCKET; do
+            if [[ -z "${!name}" ]]; then
+              missing+=("${name}")
+            fi
+          done
+          if ((${#missing[@]} > 0)); then
+            echo "skip=true" >>"${GITHUB_OUTPUT}"
+            echo "Backup secrets not configured (${missing[*]})."
+            echo "Skipping until provider setup in #334."
+            exit 0
+          fi
+          echo "skip=false" >>"${GITHUB_OUTPUT}"
+          echo "All backup secrets present."
+
+      - name: Install PostgreSQL client
+        if: steps.secrets.outputs.skip != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Install AWS CLI
+        if: steps.secrets.outputs.skip != 'true'
+        run: |
+          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+          unzip -q /tmp/awscliv2.zip -d /tmp
+          sudo /tmp/aws/install
+
+      - name: Create and upload backup
+        id: backup
+        if: >-
+          steps.secrets.outputs.skip != 'true' &&
+          inputs.dry_run != true &&
+          inputs.dry_run != 'true'
+        env:
+          BACKUP_DATABASE_URL: ${{ secrets.BACKUP_DATABASE_URL }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BACKUP_BUCKET: ${{ secrets.R2_BACKUP_BUCKET }}
+        run: bash scripts/ci/backup/backup-db.sh
+
+      - name: Dry run backup
+        if: >-
+          steps.secrets.outputs.skip != 'true' &&
+          (inputs.dry_run == true || inputs.dry_run == 'true')
+        env:
+          BACKUP_DATABASE_URL: ${{ secrets.BACKUP_DATABASE_URL }}
+        run: |
+          echo "Dry run: validating pg_dump only (no upload)."
+          dump_path="$(mktemp "${TMPDIR:-/tmp}/rustume-backup-dry-run.XXXXXXXXXX")"
+          if ! pg_dump -Fc "${BACKUP_DATABASE_URL}" >"${dump_path}"; then
+            echo "pg_dump failed during dry run" >&2
+            exit 1
+          fi
+          if [[ ! -s "${dump_path}" ]]; then
+            echo "pg_dump produced an empty file during dry run" >&2
+            exit 1
+          fi
+          rm -f "${dump_path}"
+          echo "Dry run pg_dump succeeded."
+
+      - name: Prune old backups
+        if: >-
+          steps.secrets.outputs.skip != 'true' &&
+          inputs.dry_run != true &&
+          inputs.dry_run != 'true'
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BACKUP_BUCKET: ${{ secrets.R2_BACKUP_BUCKET }}
+        run: bash scripts/ci/backup/prune-backups.sh
+
+      - name: Prune dry run
+        if: >-
+          steps.secrets.outputs.skip != 'true' &&
+          (inputs.dry_run == true || inputs.dry_run == 'true')
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BACKUP_BUCKET: ${{ secrets.R2_BACKUP_BUCKET }}
+        run: bash scripts/ci/backup/prune-backups.sh --dry-run
+
+      - name: Backup failure note
+        if: failure() && steps.secrets.outputs.skip != 'true'
+        run: |
+          echo "Backup workflow failed. The failed run is the primary alert."
+          echo "Grafana/Sentry alerting integration is tracked in #333 and #335."

--- a/.github/workflows/test-backup-shell.yml
+++ b/.github/workflows/test-backup-shell.yml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Test - Backup Shell Scripts
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/backup/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-backup-shell.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/ci/backup/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-backup-shell.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-backup-shell-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell-tests:
+    permissions:
+      contents: read
+      pull-requests: write # publish-test-summary posts shell coverage on PRs
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    with:
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      job-name: Backup Shell Tests
+      test-path: tests/bats/unit/backup
+      coverage: true
+      coverage-threshold: 0
+      upload-coverage: false
+      egress-policy: block
+      egress-preset: github-tooling
+      runner-image: ubuntu-24.04

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -1,0 +1,146 @@
+# Database backup and restore
+
+Scheduled logical backups of the Rustume Cloud Neon PostgreSQL database are created by
+`.github/workflows/db-backup.yml` and stored in a dedicated Cloudflare R2 bucket via
+`scripts/ci/backup/backup-db.sh`. Retention pruning runs immediately after each backup via
+`scripts/ci/backup/prune-backups.sh`.
+
+Provider-side setup (Neon PITR, R2 bucket creation, scoped access token, repository
+secrets, and a live restore rehearsal) is tracked in GitHub issue #334. This document
+covers the restore procedure operators should follow once backups exist.
+
+## Prerequisites
+
+- Access to the Neon project hosting Rustume Cloud PostgreSQL
+- Access to the R2 backups bucket (read-only token is sufficient for restore)
+- `postgresql-client` (`pg_restore`, `psql`) and AWS CLI v2 installed locally or in a
+  throwaway environment
+- The latest backup object key from R2 (pattern:
+  `rustume-<environment>-<UTC-timestamp>.dump.gz`)
+
+## RPO / RTO (fill after rehearsal)
+
+| Metric | Target | Measured (rehearsal date) | Notes |
+| --- | --- | --- | --- |
+| RPO (max data loss) | _TBD_ | _TBD_ | Depends on backup schedule and Neon PITR window |
+| RTO (time to restore service) | _TBD_ | _TBD_ | Includes branch creation, restore, verification, cutover |
+
+## Restore procedure
+
+### 1. Create a throwaway Neon branch
+
+1. Open the Neon console for the Rustume Cloud project.
+2. Create a new branch from the current production timeline (or from a specific point in
+   time if using PITR).
+3. Note the connection string for the new branch. Do **not** point production at this
+   branch yet.
+
+### 2. Download the latest backup
+
+```bash
+export R2_ACCOUNT_ID="<account-id>"
+export R2_ACCESS_KEY_ID="<read-scoped-key>"
+export R2_SECRET_ACCESS_KEY="<read-scoped-secret>"
+export R2_BACKUP_BUCKET="<backups-bucket>"
+export BACKUP_ENV="production"
+
+endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+latest="$(aws s3 ls "s3://${R2_BACKUP_BUCKET}/" --endpoint-url "${endpoint}" \
+  | awk '{print $4}' \
+  | grep -E "^rustume-${BACKUP_ENV}-[0-9]{8}T[0-9]{6}Z\\.dump\\.gz$" \
+  | sort \
+  | tail -1)"
+
+aws s3 cp "s3://${R2_BACKUP_BUCKET}/${latest}" "./${latest}" \
+  --endpoint-url "${endpoint}"
+gunzip -c "./${latest}" > restore.dump
+```
+
+### 3. Restore with pg_restore
+
+Use a clean database on the throwaway branch (drop/recreate the `public` schema or use an
+empty database created for the rehearsal):
+
+```bash
+export RESTORE_DATABASE_URL="postgresql://...throwaway-branch..."
+pg_restore --clean --if-exists --no-owner --no-acl \
+  --dbname="${RESTORE_DATABASE_URL}" restore.dump
+```
+
+Review `pg_restore` warnings. Failures on extensions or roles may be expected depending on
+Neon permissions; data-bearing tables must restore without error.
+
+### 4. Integrity verification
+
+Run row-count and referential sanity checks against the throwaway branch:
+
+```sql
+-- Core table row counts (adjust if schema evolves)
+SELECT 'users' AS table_name, COUNT(*) FROM users
+UNION ALL
+SELECT 'resumes', COUNT(*) FROM resumes
+UNION ALL
+SELECT 'subscriptions', COUNT(*) FROM subscriptions;
+
+-- Foreign-key orphan checks (examples)
+SELECT COUNT(*) AS orphan_resumes
+FROM resumes r
+LEFT JOIN users u ON u.id = r.user_id
+WHERE u.id IS NULL;
+
+SELECT COUNT(*) AS orphan_subscriptions
+FROM subscriptions s
+LEFT JOIN users u ON u.id = s.user_id
+WHERE u.id IS NULL;
+```
+
+Compare counts to production (or to the last known-good snapshot). Investigate any large
+unexpected deltas before promoting.
+
+Optional application-level smoke test: point a local or staging Rustume Cloud instance at
+the throwaway branch and verify login, resume load, and export flows.
+
+### 5. Promote or cut over
+
+Only after verification:
+
+1. Update the production `DATABASE_URL` (Railway service variable or Terraform-managed
+   secret) to the restored branch connection string, **or** merge the restored data back
+   into production using Neon’s promote/swap workflow if applicable.
+2. Redeploy or restart Rustume Cloud so connection pools pick up the new URL.
+3. Monitor error rates and Sentry/Grafana dashboards (#333 / #335).
+4. Document measured RPO/RTO in the table above.
+
+## Manual backup / prune (operators)
+
+Trigger from **Actions → Maintenance - Database Backup**. Use `dry_run: true` to validate
+connectivity without uploading or deleting objects.
+
+Local invocation (requires secrets):
+
+```bash
+BACKUP_DATABASE_URL=... \
+R2_ACCOUNT_ID=... \
+R2_ACCESS_KEY_ID=... \
+R2_SECRET_ACCESS_KEY=... \
+R2_BACKUP_BUCKET=... \
+  scripts/ci/backup/backup-db.sh
+
+R2_ACCOUNT_ID=... \
+R2_ACCESS_KEY_ID=... \
+R2_SECRET_ACCESS_KEY=... \
+R2_BACKUP_BUCKET=... \
+  scripts/ci/backup/prune-backups.sh --dry-run
+```
+
+## Alerting
+
+A failed scheduled backup surfaces as a failed GitHub Actions workflow run. Longer-term
+Grafana/Sentry alerting hooks for backup failures are tracked in #333 and #335.
+
+## Security notes
+
+- Backup credentials must be scoped to the backups bucket only.
+- Never commit or log connection strings, R2 keys, or dump contents.
+- Treat restored throwaway branches like production data; restrict access and delete when
+  the rehearsal completes.

--- a/scripts/ci/backup/backup-db.sh
+++ b/scripts/ci/backup/backup-db.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# Create a compressed custom-format pg_dump and upload it to the R2 backups bucket.
+#
+# Required:
+#   BACKUP_DATABASE_URL
+#   R2_ACCOUNT_ID
+#   R2_ACCESS_KEY_ID
+#   R2_SECRET_ACCESS_KEY
+#   R2_BACKUP_BUCKET
+#
+# Optional:
+#   BACKUP_ENV          Environment label in object names (default: production)
+#   BACKUP_TIMESTAMP    UTC timestamp for object naming (default: current time)
+#
+# Usage:
+#   BACKUP_DATABASE_URL=... R2_ACCOUNT_ID=... scripts/ci/backup/backup-db.sh
+
+while (($# > 0)); do
+	case "$1" in
+	--help | -h)
+		sed -n '1,20p' "$0"
+		exit 0
+		;;
+	*)
+		echo "Unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+require_env() {
+	local name="$1"
+	if [[ -z "${!name:-}" ]]; then
+		echo "${name} is required" >&2
+		exit 1
+	fi
+}
+
+require_env BACKUP_DATABASE_URL
+require_env R2_ACCOUNT_ID
+require_env R2_ACCESS_KEY_ID
+require_env R2_SECRET_ACCESS_KEY
+require_env R2_BACKUP_BUCKET
+
+ENV="${BACKUP_ENV:-production}"
+TIMESTAMP="${BACKUP_TIMESTAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OBJECT_KEY="rustume-${ENV}-${TIMESTAMP}.dump.gz"
+R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/rustume-backup.XXXXXXXXXX")"
+cleanup() {
+	rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+DUMP_PATH="${WORK_DIR}/backup.dump"
+GZIP_PATH="${WORK_DIR}/${OBJECT_KEY}"
+
+echo "Creating pg_dump for ${ENV}..."
+if ! pg_dump -Fc "${BACKUP_DATABASE_URL}" >"${DUMP_PATH}"; then
+	echo "pg_dump failed" >&2
+	exit 1
+fi
+
+if [[ ! -s "${DUMP_PATH}" ]]; then
+	echo "pg_dump produced an empty file; aborting upload" >&2
+	exit 1
+fi
+
+echo "Compressing dump..."
+if ! gzip -c "${DUMP_PATH}" >"${GZIP_PATH}"; then
+	echo "gzip failed" >&2
+	exit 1
+fi
+
+if [[ ! -s "${GZIP_PATH}" ]]; then
+	echo "Compressed dump is empty; aborting upload" >&2
+	exit 1
+fi
+
+echo "Uploading ${OBJECT_KEY} to R2 bucket ${R2_BACKUP_BUCKET}..."
+export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+export AWS_DEFAULT_REGION="auto"
+
+if ! aws s3 cp "${GZIP_PATH}" "s3://${R2_BACKUP_BUCKET}/${OBJECT_KEY}" \
+	--endpoint-url "${R2_ENDPOINT}"; then
+	echo "Upload to R2 failed" >&2
+	exit 1
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "object_key=${OBJECT_KEY}" >>"${GITHUB_OUTPUT}"
+fi
+
+echo "Backup uploaded: s3://${R2_BACKUP_BUCKET}/${OBJECT_KEY}"

--- a/scripts/ci/backup/prune-backups.sh
+++ b/scripts/ci/backup/prune-backups.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# Enforce grandfather-father-son retention for R2 database backups.
+#
+# Required:
+#   R2_ACCOUNT_ID
+#   R2_ACCESS_KEY_ID
+#   R2_SECRET_ACCESS_KEY
+#   R2_BACKUP_BUCKET
+#
+# Optional:
+#   BACKUP_ENV                 Environment label filter (default: production)
+#   BACKUP_DAILY_RETENTION     Daily backups to keep (default: 7)
+#   BACKUP_WEEKLY_RETENTION    Weekly backups to keep (default: 4)
+#   BACKUP_MONTHLY_RETENTION   Monthly backups to keep (default: 6)
+#   BACKUP_REFERENCE_EPOCH     Reference "now" for age math (default: current time)
+#
+# Usage:
+#   scripts/ci/backup/prune-backups.sh [--dry-run]
+
+DRY_RUN=false
+
+while (($# > 0)); do
+	case "$1" in
+	--help | -h)
+		cat <<'EOF'
+Enforce grandfather-father-son retention for R2 database backups.
+
+Usage:
+  scripts/ci/backup/prune-backups.sh [--dry-run]
+
+Environment:
+  R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BACKUP_BUCKET
+  BACKUP_ENV (default: production)
+  BACKUP_DAILY_RETENTION (default: 7)
+  BACKUP_WEEKLY_RETENTION (default: 4)
+  BACKUP_MONTHLY_RETENTION (default: 6)
+  BACKUP_REFERENCE_EPOCH (default: current epoch seconds)
+EOF
+		exit 0
+		;;
+	--dry-run)
+		DRY_RUN=true
+		shift
+		;;
+	*)
+		echo "Unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+require_env() {
+	local name="$1"
+	if [[ -z "${!name:-}" ]]; then
+		echo "${name} is required" >&2
+		exit 1
+	fi
+}
+
+require_env R2_ACCOUNT_ID
+require_env R2_ACCESS_KEY_ID
+require_env R2_SECRET_ACCESS_KEY
+require_env R2_BACKUP_BUCKET
+
+ENV="${BACKUP_ENV:-production}"
+DAILY_RETENTION="${BACKUP_DAILY_RETENTION:-7}"
+WEEKLY_RETENTION="${BACKUP_WEEKLY_RETENTION:-4}"
+MONTHLY_RETENTION="${BACKUP_MONTHLY_RETENTION:-6}"
+REFERENCE_EPOCH="${BACKUP_REFERENCE_EPOCH:-$(date -u +%s)}"
+R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+OBJECT_PREFIX="rustume-${ENV}-"
+
+validate_positive_int() {
+	local name="$1"
+	local value="$2"
+	if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+		echo "${name} must be a positive integer, got: ${value}" >&2
+		exit 1
+	fi
+}
+
+validate_positive_int "BACKUP_DAILY_RETENTION" "${DAILY_RETENTION}"
+validate_positive_int "BACKUP_WEEKLY_RETENTION" "${WEEKLY_RETENTION}"
+validate_positive_int "BACKUP_MONTHLY_RETENTION" "${MONTHLY_RETENTION}"
+
+export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+export AWS_DEFAULT_REGION="auto"
+
+parse_object_epoch() {
+	local key="$1"
+	local prefix="${OBJECT_PREFIX}"
+	local timestamp="${key#"${prefix}"}"
+	timestamp="${timestamp%.dump.gz}"
+	if [[ ! "${timestamp}" =~ ^[0-9]{8}T[0-9]{6}Z$ ]]; then
+		return 1
+	fi
+	local year month day hour minute second
+	year="${timestamp:0:4}"
+	month="${timestamp:4:2}"
+	day="${timestamp:6:2}"
+	hour="${timestamp:9:2}"
+	minute="${timestamp:11:2}"
+	second="${timestamp:13:2}"
+	date -u -d "${year}-${month}-${day} ${hour}:${minute}:${second}" +%s 2>/dev/null ||
+		date -u -j -f "%Y-%m-%d %H:%M:%S" "${year}-${month}-${day} ${hour}:${minute}:${second}" +%s
+}
+
+age_days() {
+	local object_epoch="$1"
+	echo $(((REFERENCE_EPOCH - object_epoch) / 86400))
+}
+
+should_keep_backup() {
+	local object_epoch="$1"
+	local age
+	age="$(age_days "${object_epoch}")"
+
+	if ((age < DAILY_RETENTION)); then
+		return 0
+	fi
+
+	local weekly_start=$((DAILY_RETENTION))
+	local weekly_end=$((DAILY_RETENTION + WEEKLY_RETENTION * 7))
+	if ((age >= weekly_start && age < weekly_end)); then
+		local week_id
+		week_id="$(date -u -d "@${object_epoch}" +%G-W%V 2>/dev/null ||
+			date -u -r "${object_epoch}" +%G-W%V 2>/dev/null || echo "")"
+		if [[ -z "${week_id}" ]]; then
+			return 1
+		fi
+		if [[ -n "${seen_weeks[${week_id}]:-}" ]]; then
+			return 1
+		fi
+		seen_weeks["${week_id}"]=1
+		return 0
+	fi
+
+	local monthly_start="${weekly_end}"
+	local monthly_end=$((weekly_end + MONTHLY_RETENTION * 30))
+	if ((age >= monthly_start && age < monthly_end)); then
+		local month_id
+		month_id="$(date -u -d "@${object_epoch}" +%Y-%m 2>/dev/null ||
+			date -u -r "${object_epoch}" +%Y-%m 2>/dev/null || echo "")"
+		if [[ -z "${month_id}" ]]; then
+			return 1
+		fi
+		if [[ -n "${seen_months[${month_id}]:-}" ]]; then
+			return 1
+		fi
+		seen_months["${month_id}"]=1
+		return 0
+	fi
+
+	return 1
+}
+
+declare -A seen_weeks=()
+declare -A seen_months=()
+
+list_output="$(aws s3 ls "s3://${R2_BACKUP_BUCKET}/" --endpoint-url "${R2_ENDPOINT}" 2>/dev/null || true)"
+if [[ -z "${list_output}" ]]; then
+	echo "No backups found in s3://${R2_BACKUP_BUCKET}/"
+	exit 0
+fi
+
+mapfile -t object_keys < <(
+	awk '{print $4}' <<<"${list_output}" |
+		grep -E "^${OBJECT_PREFIX}[0-9]{8}T[0-9]{6}Z\\.dump\\.gz$" |
+		sort -r
+)
+
+if ((${#object_keys[@]} == 0)); then
+	echo "No matching backups found for prefix ${OBJECT_PREFIX}"
+	exit 0
+fi
+
+kept=0
+deleted=0
+
+for key in "${object_keys[@]}"; do
+	object_epoch="$(parse_object_epoch "${key}")" || continue
+
+	if should_keep_backup "${object_epoch}"; then
+		echo "Keeping ${key} (age $(age_days "${object_epoch}")d)"
+		kept=$((kept + 1))
+		continue
+	fi
+
+	if [[ "${DRY_RUN}" == true ]]; then
+		echo "[dry-run] Would delete ${key} (age $(age_days "${object_epoch}")d)"
+	else
+		echo "Deleting ${key} (age $(age_days "${object_epoch}")d)"
+		if ! aws s3 rm "s3://${R2_BACKUP_BUCKET}/${key}" --endpoint-url "${R2_ENDPOINT}"; then
+			echo "Failed to delete ${key}" >&2
+			exit 1
+		fi
+	fi
+	deleted=$((deleted + 1))
+done
+
+echo "Retention complete. Kept: ${kept}, Deleted: ${deleted}, Dry run: ${DRY_RUN}"

--- a/scripts/ci/backup/prune-backups.sh
+++ b/scripts/ci/backup/prune-backups.sh
@@ -161,7 +161,10 @@ should_keep_backup() {
 declare -A seen_weeks=()
 declare -A seen_months=()
 
-list_output="$(aws s3 ls "s3://${R2_BACKUP_BUCKET}/" --endpoint-url "${R2_ENDPOINT}" 2>/dev/null || true)"
+if ! list_output="$(aws s3 ls "s3://${R2_BACKUP_BUCKET}/" --endpoint-url "${R2_ENDPOINT}")"; then
+	echo "Failed to list backups in s3://${R2_BACKUP_BUCKET}/" >&2
+	exit 1
+fi
 if [[ -z "${list_output}" ]]; then
 	echo "No backups found in s3://${R2_BACKUP_BUCKET}/"
 	exit 0

--- a/scripts/ci/backup/test.sh
+++ b/scripts/ci/backup/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# Run BATS tests for database backup scripts.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TEST_PATH="${ROOT}/tests/bats/unit/backup"
+
+if ! command -v bats >/dev/null 2>&1; then
+	echo "bats is required to run backup shell tests" >&2
+	exit 1
+fi
+
+echo "Running backup shell tests in ${TEST_PATH}"
+bats --recursive "${TEST_PATH}"

--- a/tests/bats/fixtures/backup/mock-aws.sh
+++ b/tests/bats/fixtures/backup/mock-aws.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+service="${1:-}"
+subcommand="${2:-}"
+shift 2 || true
+
+case "${service}:${subcommand}" in
+s3:cp)
+	dest=""
+	endpoint=""
+	while (($# > 0)); do
+		case "$1" in
+		--endpoint-url)
+			endpoint="$2"
+			shift 2
+			;;
+		s3://*)
+			dest="$1"
+			shift
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "${endpoint}" ]]; then
+		echo "aws s3 cp requires --endpoint-url in tests" >&2
+		exit 1
+	fi
+
+	if [[ "${MOCK_AWS_UPLOAD_FAIL:-0}" == "1" ]]; then
+		echo "upload failed" >&2
+		exit 1
+	fi
+
+	if [[ -n "${MOCK_AWS_UPLOAD_LOG:-}" ]]; then
+		echo "${dest}" >>"${MOCK_AWS_UPLOAD_LOG}"
+	fi
+	exit 0
+	;;
+s3:ls)
+	endpoint=""
+	while (($# > 0)); do
+		case "$1" in
+		--endpoint-url)
+			endpoint="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "${endpoint}" ]]; then
+		echo "aws s3 ls requires --endpoint-url in tests" >&2
+		exit 1
+	fi
+
+	if [[ -n "${MOCK_AWS_LS_FILE:-}" && -f "${MOCK_AWS_LS_FILE}" ]]; then
+		cat "${MOCK_AWS_LS_FILE}"
+	fi
+	exit 0
+	;;
+s3:rm)
+	key=""
+	endpoint=""
+	while (($# > 0)); do
+		case "$1" in
+		--endpoint-url)
+			endpoint="$2"
+			shift 2
+			;;
+		s3://*)
+			key="$1"
+			shift
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "${endpoint}" ]]; then
+		echo "aws s3 rm requires --endpoint-url in tests" >&2
+		exit 1
+	fi
+
+	if [[ -n "${MOCK_AWS_DELETE_LOG:-}" ]]; then
+		key="${key#s3://*/}"
+		echo "${key}" >>"${MOCK_AWS_DELETE_LOG}"
+	fi
+	exit 0
+	;;
+*)
+	echo "unsupported aws mock command: ${service} ${subcommand}" >&2
+	exit 1
+	;;
+esac

--- a/tests/bats/fixtures/backup/mock-aws.sh
+++ b/tests/bats/fixtures/backup/mock-aws.sh
@@ -59,6 +59,11 @@ s3:ls)
 		exit 1
 	fi
 
+	if [[ "${MOCK_AWS_LS_FAIL:-0}" == "1" ]]; then
+		echo "list failed" >&2
+		exit 1
+	fi
+
 	if [[ -n "${MOCK_AWS_LS_FILE:-}" && -f "${MOCK_AWS_LS_FILE}" ]]; then
 		cat "${MOCK_AWS_LS_FILE}"
 	fi

--- a/tests/bats/fixtures/backup/mock-pg-dump.sh
+++ b/tests/bats/fixtures/backup/mock-pg-dump.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+while (($# > 0)); do
+	case "$1" in
+	-Fc)
+		shift
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+
+if [[ "${MOCK_PG_DUMP_EMPTY:-0}" == "1" ]]; then
+	exit 0
+fi
+
+printf 'PGDMP'
+exit 0

--- a/tests/bats/helpers/common.bash
+++ b/tests/bats/helpers/common.bash
@@ -6,6 +6,7 @@ HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${HELPERS_DIR}/../../.." && pwd)"
 export PROJECT_ROOT
 export RAILWAY_SCRIPTS_DIR="${PROJECT_ROOT}/scripts/ci/railway"
+export BACKUP_SCRIPTS_DIR="${PROJECT_ROOT}/scripts/ci/backup"
 
 _load_bats_library() {
 	local name="$1"

--- a/tests/bats/unit/backup/test_backup_db.bats
+++ b/tests/bats/unit/backup/test_backup_db.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/backup/backup-db.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	touch "${GITHUB_OUTPUT}"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+setup_backup_mocks() {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+	cp "${PROJECT_ROOT}/tests/bats/fixtures/backup/mock-pg-dump.sh" "${mock_bin}/pg_dump"
+	cp "${PROJECT_ROOT}/tests/bats/fixtures/backup/mock-aws.sh" "${mock_bin}/aws"
+	chmod +x "${mock_bin}/pg_dump" "${mock_bin}/aws"
+	export PATH="${mock_bin}:${PATH}"
+}
+
+@test "backup-db: --help exits successfully" {
+	run bash "${BACKUP_SCRIPTS_DIR}/backup-db.sh" --help
+
+	assert_success
+	assert_output --partial "BACKUP_DATABASE_URL"
+}
+
+@test "backup-db: fails when required env is missing" {
+	run bash "${BACKUP_SCRIPTS_DIR}/backup-db.sh"
+
+	assert_failure
+	assert_output --partial "BACKUP_DATABASE_URL is required"
+}
+
+@test "backup-db: uploads object with expected naming" {
+	local upload_log="${BATS_TEST_TMPDIR}/upload.log"
+	touch "${upload_log}"
+
+	setup_backup_mocks
+
+	run env \
+		BACKUP_DATABASE_URL="postgresql://example" \
+		R2_ACCOUNT_ID="acct" \
+		R2_ACCESS_KEY_ID="key" \
+		R2_SECRET_ACCESS_KEY="secret" \
+		R2_BACKUP_BUCKET="backups" \
+		BACKUP_ENV="staging" \
+		BACKUP_TIMESTAMP="20240712T030000Z" \
+		MOCK_AWS_UPLOAD_LOG="${upload_log}" \
+		GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
+		bash "${BACKUP_SCRIPTS_DIR}/backup-db.sh"
+
+	assert_success
+	assert_output --partial "Backup uploaded"
+	assert_equal "rustume-staging-20240712T030000Z.dump.gz" "$(get_github_output object_key)"
+	assert_equal "s3://backups/rustume-staging-20240712T030000Z.dump.gz" "$(cat "${upload_log}")"
+}
+
+@test "backup-db: aborts when pg_dump produces empty output" {
+	setup_backup_mocks
+
+	run env \
+		BACKUP_DATABASE_URL="postgresql://example" \
+		R2_ACCOUNT_ID="acct" \
+		R2_ACCESS_KEY_ID="key" \
+		R2_SECRET_ACCESS_KEY="secret" \
+		R2_BACKUP_BUCKET="backups" \
+		MOCK_PG_DUMP_EMPTY="1" \
+		bash "${BACKUP_SCRIPTS_DIR}/backup-db.sh"
+
+	assert_failure
+	assert_output --partial "pg_dump produced an empty file"
+}
+
+@test "backup-db: propagates upload failure" {
+	setup_backup_mocks
+
+	run env \
+		BACKUP_DATABASE_URL="postgresql://example" \
+		R2_ACCOUNT_ID="acct" \
+		R2_ACCESS_KEY_ID="key" \
+		R2_SECRET_ACCESS_KEY="secret" \
+		R2_BACKUP_BUCKET="backups" \
+		MOCK_AWS_UPLOAD_FAIL="1" \
+		bash "${BACKUP_SCRIPTS_DIR}/backup-db.sh"
+
+	assert_failure
+	assert_output --partial "Upload to R2 failed"
+}

--- a/tests/bats/unit/backup/test_prune_backups.bats
+++ b/tests/bats/unit/backup/test_prune_backups.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/backup/prune-backups.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+setup_prune_mocks() {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+	cp "${PROJECT_ROOT}/tests/bats/fixtures/backup/mock-aws.sh" "${mock_bin}/aws"
+	chmod +x "${mock_bin}/aws"
+	export PATH="${mock_bin}:${PATH}"
+}
+
+reference_epoch() {
+	date -u -d "$1" +%s 2>/dev/null || date -u -j -f "%Y-%m-%d %H:%M:%S" "$1" +%s
+}
+
+write_listing() {
+	local file="$1"
+	shift
+	: >"${file}"
+	for key in "$@"; do
+		echo "2024-01-01 00:00:00    1024 ${key}" >>"${file}"
+	done
+}
+
+@test "prune-backups: --help exits successfully" {
+	run bash "${BACKUP_SCRIPTS_DIR}/prune-backups.sh" --help
+
+	assert_success
+	assert_output --partial "grandfather-father-son"
+}
+
+@test "prune-backups: keeps daily backups and deletes older duplicates" {
+	local list_file="${BATS_TEST_TMPDIR}/objects.txt"
+	local delete_log="${BATS_TEST_TMPDIR}/deletes.log"
+	touch "${delete_log}"
+
+	write_listing "${list_file}" \
+		"rustume-production-20240711T030000Z.dump.gz" \
+		"rustume-production-20240710T030000Z.dump.gz" \
+		"rustume-production-20240709T030000Z.dump.gz" \
+		"rustume-production-20240708T030000Z.dump.gz" \
+		"rustume-production-20240707T030000Z.dump.gz" \
+		"rustume-production-20240706T030000Z.dump.gz" \
+		"rustume-production-20240705T030000Z.dump.gz" \
+		"rustume-production-20240704T030000Z.dump.gz"
+
+	setup_prune_mocks
+
+	run env \
+		R2_ACCOUNT_ID="acct" \
+		R2_ACCESS_KEY_ID="key" \
+		R2_SECRET_ACCESS_KEY="secret" \
+		R2_BACKUP_BUCKET="backups" \
+		BACKUP_REFERENCE_EPOCH="$(reference_epoch "2024-07-12 03:00:00")" \
+		MOCK_AWS_LS_FILE="${list_file}" \
+		MOCK_AWS_DELETE_LOG="${delete_log}" \
+		bash "${BACKUP_SCRIPTS_DIR}/prune-backups.sh"
+
+	assert_success
+	assert_output --partial "Keeping rustume-production-20240711T030000Z.dump.gz"
+	assert_output --partial "Deleting rustume-production-20240704T030000Z.dump.gz"
+	assert_equal "rustume-production-20240704T030000Z.dump.gz" "$(cat "${delete_log}")"
+}
+
+@test "prune-backups: keeps weekly backup at daily boundary" {
+	local list_file="${BATS_TEST_TMPDIR}/objects.txt"
+	local delete_log="${BATS_TEST_TMPDIR}/deletes.log"
+	touch "${delete_log}"
+
+	write_listing "${list_file}" \
+		"rustume-production-20240712T030000Z.dump.gz" \
+		"rustume-production-20240705T030000Z.dump.gz" \
+		"rustume-production-20240704T030000Z.dump.gz"
+
+	setup_prune_mocks
+
+	run env \
+		R2_ACCOUNT_ID="acct" \
+		R2_ACCESS_KEY_ID="key" \
+		R2_SECRET_ACCESS_KEY="secret" \
+		R2_BACKUP_BUCKET="backups" \
+		BACKUP_REFERENCE_EPOCH="$(reference_epoch "2024-07-12 03:00:00")" \
+		MOCK_AWS_LS_FILE="${list_file}" \
+		MOCK_AWS_DELETE_LOG="${delete_log}" \
+		bash "${BACKUP_SCRIPTS_DIR}/prune-backups.sh"
+
+	assert_success
+	assert_output --partial "Keeping rustume-production-20240705T030000Z.dump.gz"
+	assert_output --partial "Deleting rustume-production-20240704T030000Z.dump.gz"
+}
+
+@test "prune-backups: dry-run makes no deletions" {
+	local list_file="${BATS_TEST_TMPDIR}/objects.txt"
+	local delete_log="${BATS_TEST_TMPDIR}/deletes.log"
+	touch "${delete_log}"
+
+	write_listing "${list_file}" \
+		"rustume-production-20240712T030000Z.dump.gz" \
+		"rustume-production-20231201T030000Z.dump.gz"
+
+	setup_prune_mocks
+
+	run env \
+		R2_ACCOUNT_ID="acct" \
+		R2_ACCESS_KEY_ID="key" \
+		R2_SECRET_ACCESS_KEY="secret" \
+		R2_BACKUP_BUCKET="backups" \
+		BACKUP_REFERENCE_EPOCH="$(reference_epoch "2024-07-12 03:00:00")" \
+		MOCK_AWS_LS_FILE="${list_file}" \
+		MOCK_AWS_DELETE_LOG="${delete_log}" \
+		bash "${BACKUP_SCRIPTS_DIR}/prune-backups.sh" --dry-run
+
+	assert_success
+	assert_output --partial "[dry-run] Would delete rustume-production-20231201T030000Z.dump.gz"
+	[[ ! -s "${delete_log}" ]]
+}
+
+@test "prune-backups: keeps one monthly backup beyond weekly window" {
+	local list_file="${BATS_TEST_TMPDIR}/objects.txt"
+	local delete_log="${BATS_TEST_TMPDIR}/deletes.log"
+	touch "${delete_log}"
+
+	write_listing "${list_file}" \
+		"rustume-production-20240712T030000Z.dump.gz" \
+		"rustume-production-20240515T030000Z.dump.gz" \
+		"rustume-production-20240510T030000Z.dump.gz" \
+		"rustume-production-20240420T030000Z.dump.gz"
+
+	setup_prune_mocks
+
+	run env \
+		R2_ACCOUNT_ID="acct" \
+		R2_ACCESS_KEY_ID="key" \
+		R2_SECRET_ACCESS_KEY="secret" \
+		R2_BACKUP_BUCKET="backups" \
+		BACKUP_REFERENCE_EPOCH="$(reference_epoch "2024-07-12 03:00:00")" \
+		MOCK_AWS_LS_FILE="${list_file}" \
+		MOCK_AWS_DELETE_LOG="${delete_log}" \
+		bash "${BACKUP_SCRIPTS_DIR}/prune-backups.sh"
+
+	assert_success
+	assert_output --partial "Keeping rustume-production-20240515T030000Z.dump.gz"
+	assert_output --partial "Deleting rustume-production-20240510T030000Z.dump.gz"
+	assert_output --partial "Keeping rustume-production-20240420T030000Z.dump.gz"
+}

--- a/tests/bats/unit/backup/test_prune_backups.bats
+++ b/tests/bats/unit/backup/test_prune_backups.bats
@@ -36,6 +36,21 @@ write_listing() {
 	done
 }
 
+@test "prune-backups: fails when listing backups fails" {
+	setup_prune_mocks
+
+	run env \
+		R2_ACCOUNT_ID="acct" \
+		R2_ACCESS_KEY_ID="key" \
+		R2_SECRET_ACCESS_KEY="secret" \
+		R2_BACKUP_BUCKET="backups" \
+		MOCK_AWS_LS_FAIL="1" \
+		bash "${BACKUP_SCRIPTS_DIR}/prune-backups.sh"
+
+	assert_failure
+	assert_output --partial "Failed to list backups in s3://backups/"
+}
+
 @test "prune-backups: --help exits successfully" {
 	run bash "${BACKUP_SCRIPTS_DIR}/prune-backups.sh" --help
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(infra): scheduled pg_dump-to-R2 backup workflow, verification script, and restore runbook
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds the code and documentation half of backup/DR (#334): scheduled `pg_dump` backups to a dedicated R2 bucket, grandfather-father-son retention pruning, a secret-aware GitHub Actions workflow safe to merge before provider setup, and an operator restore runbook.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #366

## Details

### Scripts
- `scripts/ci/backup/backup-db.sh` — custom-format `pg_dump`, gzip, upload to R2 via S3-compatible API; non-empty dump guard; object naming `rustume-{env}-{UTC timestamp}.dump.gz`
- `scripts/ci/backup/prune-backups.sh` — GFS retention (7 daily / 4 weekly / 6 monthly, env-overridable) with `--dry-run`

### CI
- `.github/workflows/db-backup.yml` — daily cron + `workflow_dispatch`; skips cleanly when backup secrets are absent; failure note references Grafana/Sentry alerting tracked in #333/#335
- `.github/workflows/test-backup-shell.yml` — BATS coverage via reusable shell test workflow

### Docs
- `docs/operations/backup-restore.md` — Neon branch restore, `pg_restore`, integrity queries, promote/cutover, RPO/RTO placeholders

### Tests
- `tests/bats/unit/backup/` with mocked `pg_dump`/`aws` fixtures covering naming, empty-dump abort, upload failure propagation, retention boundary math, and dry-run behavior

### Verification
- `bash scripts/ci/backup/test.sh`
- `uv run lintro fmt`
- `uv run lintro chk`

Provider-side Neon PITR, R2 bucket/token creation, repository secrets, and live restore rehearsal remain human work on #334.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds scheduled database backups and restore documentation. The main changes are:

- Daily GitHub Actions workflow for `pg_dump` backups to R2.
- Backup upload and retention-pruning shell scripts.
- BATS tests with mocked `pg_dump` and `aws` commands.
- Operator runbook for restore and verification.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the backup workflow install step should be fixed before merging.

- The prune listing failure now exits with an error instead of being treated as an empty bucket.
- The PostgreSQL client install command uses an unsupported option.
- With secrets configured, the scheduled job can fail before creating a dump.

.github/workflows/db-backup.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/db-backup.yml | Adds the scheduled backup workflow, but the PostgreSQL client install command can fail before backups run. |
| scripts/ci/backup/prune-backups.sh | Adds retention pruning and now treats failed backup listings as errors. |
| scripts/ci/backup/backup-db.sh | Adds dump creation, compression, empty-output checks, and R2 upload. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdb-backup.yml%3A85%0A**Install%20Step%20Fails**%0A%0AWhen%20backup%20secrets%20are%20configured%2C%20this%20step%20runs%20before%20any%20dump%20is%20created.%20%60apt-get%60%20does%20not%20support%20%60--no-update%60%2C%20so%20the%20command%20exits%20with%20an%20option%20error%20instead%20of%20installing%20%60postgresql-client%60.%20The%20scheduled%20workflow%20then%20fails%20before%20%60pg_dump%60%20runs%2C%20leaving%20the%20backup%20job%20unable%20to%20create%20backups.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20sudo%20apt-get%20install%20-y%20postgresql-client%0A%60%60%60%0A%0A&pr=405&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdb-backup.yml%3A85%0A**Install%20Step%20Fails**%0A%0AWhen%20backup%20secrets%20are%20configured%2C%20this%20step%20runs%20before%20any%20dump%20is%20created.%20%60apt-get%60%20does%20not%20support%20%60--no-update%60%2C%20so%20the%20command%20exits%20with%20an%20option%20error%20instead%20of%20installing%20%60postgresql-client%60.%20The%20scheduled%20workflow%20then%20fails%20before%20%60pg_dump%60%20runs%2C%20leaving%20the%20backup%20job%20unable%20to%20create%20backups.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20sudo%20apt-get%20install%20-y%20postgresql-client%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=405&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22feat%2F366-pg-dump-r2-backup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F366-pg-dump-r2-backup%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdb-backup.yml%3A85%0A**Install%20Step%20Fails**%0A%0AWhen%20backup%20secrets%20are%20configured%2C%20this%20step%20runs%20before%20any%20dump%20is%20created.%20%60apt-get%60%20does%20not%20support%20%60--no-update%60%2C%20so%20the%20command%20exits%20with%20an%20option%20error%20instead%20of%20installing%20%60postgresql-client%60.%20The%20scheduled%20workflow%20then%20fails%20before%20%60pg_dump%60%20runs%2C%20leaving%20the%20backup%20job%20unable%20to%20create%20backups.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20sudo%20apt-get%20install%20-y%20postgresql-client%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=405&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/366-pg-dum..."](https://github.com/lgtm-hq/rustume/commit/e7ec2ed6d732b1c4bee99b0308b71150a4bdc40a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43685827)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->