### PR TITLE
feat(web): add automated axe-core accessibility checks to the vitest suite

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -31,8 +31,10 @@
         "@types/bun": "1.3.14",
         "@types/node": "25.9.5",
         "@vitest/coverage-istanbul": "4.1.10",
+        "axe-core": "^4.12.1",
         "jsdom": "29.1.1",
         "vitest": "4.1.10",
+        "vitest-axe": "^0.1.0",
       },
       "peerDependencies": {
         "typescript": "^6.0.0",
@@ -581,6 +583,8 @@
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
+    "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
+
     "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.7", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ=="],
 
     "babel-plugin-polyfill-corejs2": ["babel-plugin-polyfill-corejs2@0.4.17", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-define-polyfill-provider": "^0.6.8", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w=="],
@@ -614,6 +618,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -880,6 +886,8 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "linkifyjs": ["linkifyjs@4.3.3", "", {}, "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
@@ -1161,6 +1169,8 @@
 
     "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
 
+    "vitest-axe": ["vitest-axe@0.1.0", "", { "dependencies": { "aria-query": "^5.0.0", "axe-core": "^4.4.2", "chalk": "^5.0.1", "dom-accessibility-api": "^0.5.14", "lodash-es": "^4.17.21", "redent": "^3.0.0" }, "peerDependencies": { "vitest": ">=0.16.0" } }, "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA=="],
+
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
@@ -1254,6 +1264,8 @@
     "source-map/whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "vitest-axe/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,8 +40,10 @@
     "@types/bun": "1.3.14",
     "@types/node": "25.9.5",
     "@vitest/coverage-istanbul": "4.1.10",
+    "axe-core": "^4.12.1",
     "jsdom": "29.1.1",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "vitest-axe": "^0.1.0"
   },
   "peerDependencies": {
     "typescript": "^6.0.0"

--- a/apps/web/src/api/__tests__/client.test.ts
+++ b/apps/web/src/api/__tests__/client.test.ts
@@ -1,5 +1,14 @@
 import { get, post, put, fetchBlob, fetchBlobWithHeaders, ApiError } from "../client";
 
+vi.mock("../../components/ui", () => ({
+  toast: {
+    warning: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
 describe("ApiError", () => {
   it("has status and message properties", () => {
     const error = new ApiError(404, "Not Found");

--- a/apps/web/src/components/builder/__tests__/SectionPanel.test.tsx
+++ b/apps/web/src/components/builder/__tests__/SectionPanel.test.tsx
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { render } from "@solidjs/testing-library";
+import { axeConfig } from "../../../test/a11y";
+import { SectionPanel } from "../SectionPanel";
+import { resumeStore } from "../../../stores/resume";
+import { uiStore } from "../../../stores/ui";
+
+vi.mock("../../../wasm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../wasm")>();
+  return {
+    ...actual,
+    saveResume: vi.fn().mockResolvedValue(undefined),
+    isWasmReady: () => false,
+  };
+});
+
+describe("SectionPanel accessibility", () => {
+  beforeEach(() => {
+    resumeStore.createNewResume("section-panel-test");
+    uiStore.setSectionPanelOpen(true);
+  });
+
+  it("has no axe violations when the panel is expanded", async () => {
+    const { container } = render(() => <SectionPanel />);
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/layout/__tests__/AppShell.test.tsx
+++ b/apps/web/src/components/layout/__tests__/AppShell.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { render } from "@solidjs/testing-library";
+import { Route, Router } from "@solidjs/router";
+import { axeConfig } from "../../../test/a11y";
+import { AppShell } from "../AppShell";
+
+const { mockAuthState } = vi.hoisted(() => ({
+  mockAuthState: {
+    loading: false,
+    cloudEnabled: false,
+    requireAuth: false,
+    user: null as { id: string; plan: string } | null,
+  },
+}));
+
+vi.mock("../../../stores/auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    displayName: () => "User",
+  },
+}));
+
+vi.mock("../../../hooks/useOnline", () => ({
+  useOnline: () => () => true,
+}));
+
+vi.mock("@solidjs/router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solidjs/router")>();
+  return {
+    ...actual,
+    useLocation: () => ({
+      pathname: "/",
+      search: "",
+      hash: "",
+      state: null,
+      query: {},
+    }),
+  };
+});
+
+describe("AppShell accessibility", () => {
+  it("has no axe violations when rendered", async () => {
+    const { container } = render(() => (
+      <Router>
+        <Route
+          path="*"
+          component={() => (
+            <AppShell>
+              <div>Page content</div>
+            </AppShell>
+          )}
+        />
+      </Router>
+    ));
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/ui/__tests__/Modal.test.tsx
+++ b/apps/web/src/components/ui/__tests__/Modal.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { render } from "@solidjs/testing-library";
+import { axeConfig } from "../../../test/a11y";
+import { Modal } from "../Modal";
+
+describe("Modal accessibility", () => {
+  it("has no axe violations when open", async () => {
+    const onOpenChange = vi.fn();
+    const { container } = render(() => (
+      <Modal
+        open
+        title="Confirm action"
+        description="Review the details before continuing."
+        onOpenChange={onOpenChange}
+      >
+        <p>Modal body content</p>
+      </Modal>
+    ));
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/pages/__tests__/Account.test.tsx
+++ b/apps/web/src/pages/__tests__/Account.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { axeConfig } from "../../test/a11y";
 import { Route, Router } from "@solidjs/router";
 import Account from "../Account";
 
@@ -135,5 +137,34 @@ describe("Account page", () => {
 
     expect(screen.getByText("Type DELETE to confirm")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Delete permanently" })).toBeDisabled();
+  });
+});
+
+describe("Account accessibility", () => {
+  it("has no axe violations when signed out", async () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.requireAuth = false;
+    mockAuthState.user = null;
+
+    const { container } = renderAccount();
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
+  });
+
+  it("has no axe violations when signed in", async () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = {
+      id: "user-1",
+      plan: "free",
+      email: "dev@example.com",
+      first_name: "Ada",
+      last_name: "Lovelace",
+    };
+
+    const { container } = renderAccount();
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/pages/__tests__/Editor.test.tsx
+++ b/apps/web/src/pages/__tests__/Editor.test.tsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import { Route, MemoryRouter, createMemoryHistory } from "@solidjs/router";
+import { axeConfig } from "../../test/a11y";
+import Editor from "../Editor";
+
+const { mockAuthState, navigateMock, ResumeNotFoundErrorMock, RESUME_ID } = vi.hoisted(() => {
+  class ResumeNotFoundError extends Error {
+    constructor(id: string) {
+      super(`Resume not found: ${id}`);
+      this.name = "ResumeNotFoundError";
+    }
+  }
+
+  return {
+    mockAuthState: {
+      loading: false,
+      cloudEnabled: false,
+      requireAuth: false,
+      user: null as { id: string; plan: string } | null,
+    },
+    navigateMock: vi.fn(),
+    ResumeNotFoundErrorMock: ResumeNotFoundError,
+    RESUME_ID: "resume-test-id",
+  };
+});
+
+vi.mock("../../stores/auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    displayName: () => "User",
+  },
+}));
+
+vi.mock("../../wasm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../wasm")>();
+  return {
+    ...actual,
+    getResume: vi.fn().mockRejectedValue(new ResumeNotFoundErrorMock(RESUME_ID)),
+    isWasmReady: () => false,
+    saveResume: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("../../api/render", () => ({
+  renderPreview: vi.fn().mockResolvedValue(new Blob()),
+  downloadPdf: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../components/ui")>();
+  return {
+    ...actual,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@solidjs/router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solidjs/router")>();
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+function renderEditor() {
+  const history = createMemoryHistory();
+  history.set({ value: `/edit/${RESUME_ID}`, scroll: false, replace: true });
+
+  return render(() => (
+    <MemoryRouter history={history}>
+      <Route path="/edit/:id" component={Editor} />
+    </MemoryRouter>
+  ));
+}
+
+describe("Editor accessibility", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+  });
+
+  it("has no axe violations when the basics tab is loaded", async () => {
+    const { container } = renderEditor();
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("Full Name")).toBeInTheDocument();
+      },
+      { timeout: 10000 },
+    );
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
+  }, 15000);
+});

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render, screen } from "@solidjs/testing-library";
+import { axeConfig } from "../../test/a11y";
 import { Route, Router } from "@solidjs/router";
 import Home from "../Home";
 
@@ -87,5 +89,17 @@ describe("Home cloud sign-in CTA", () => {
     renderHome();
 
     expect(screen.queryByTestId("home-cloud-sign-in")).not.toBeInTheDocument();
+  });
+});
+
+describe("Home accessibility", () => {
+  it("has no axe violations when rendered", async () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = false;
+    mockAuthState.user = null;
+
+    const { container } = renderHome();
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/pages/__tests__/NotFound.test.tsx
+++ b/apps/web/src/pages/__tests__/NotFound.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { axeConfig } from "../../test/a11y";
 import { Route, Router } from "@solidjs/router";
 import NotFound from "../NotFound";
 
@@ -50,5 +52,17 @@ describe("NotFound page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Back to resumes" }));
     expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
+  });
+});
+
+describe("NotFound accessibility", () => {
+  it("has no axe violations when rendered", async () => {
+    const { container } = render(() => (
+      <Router>
+        <Route path="*" component={NotFound} />
+      </Router>
+    ));
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/pages/__tests__/Unauthorized.test.tsx
+++ b/apps/web/src/pages/__tests__/Unauthorized.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { axeConfig } from "../../test/a11y";
 import { Route, Router } from "@solidjs/router";
 import Unauthorized from "../Unauthorized";
 
@@ -45,5 +47,17 @@ describe("Unauthorized page", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Sign in to sync across devices" }));
     expect(signInMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Unauthorized accessibility", () => {
+  it("has no axe violations when rendered", async () => {
+    const { container } = render(() => (
+      <Router>
+        <Route path="*" component={Unauthorized} />
+      </Router>
+    ));
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/test/a11y.ts
+++ b/apps/web/src/test/a11y.ts
@@ -1,0 +1,9 @@
+import type { RunOptions } from "axe-core";
+
+// jsdom has no layout engine — color-contrast cannot run in vitest.
+// Manual contrast checks are tracked under #352/#368.
+export const axeConfig: RunOptions = {
+  rules: {
+    "color-contrast": { enabled: false },
+  },
+};

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,4 +1,9 @@
 import "@testing-library/jest-dom/vitest";
+import * as axeMatchers from "vitest-axe/matchers";
+import { expect } from "vitest";
+import "vitest-axe/extend-expect";
+
+expect.extend(axeMatchers);
 
 // Provide a full localStorage mock — Node.js's built-in localStorage
 // (visible from the --localstorage-file warnings) lacks clear().


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add automated axe-core accessibility checks to the vitest suite
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds automated axe-core accessibility checks to the `apps/web` vitest suite so structural a11y regressions (missing labels, invalid ARIA, broken roles) fail CI on every PR.

- Installs `vitest-axe` and `axe-core` as web dev dependencies
- Registers axe matchers in `apps/web/src/test/setup.ts`
- Adds shared `axeConfig` helper that disables `color-contrast` (jsdom has no layout engine; contrast tracked under #352/#368)
- Adds `toHaveNoViolations()` assertions to page tests (Home, Account, NotFound, Unauthorized, Editor) and key composites (AppShell, Modal, SectionPanel)
- Stabilizes a flaky 429 retry exhaustion test by mocking toast UI imports under fake timers

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`cd apps/web && bun run test` and `uv run lintro chk`)

## Closes

- Closes #364

## Details

Runs automatically in the existing coverage workflow via `bun run test` — no new CI job required. All 280 web tests pass locally after rebasing onto latest `main`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds automated accessibility checks to the web Vitest suite. The main changes are:

- Adds `axe-core` and `vitest-axe` web test dependencies.
- Registers axe matchers in the shared Vitest setup.
- Adds a shared axe config that disables jsdom-incompatible contrast checks.
- Adds axe assertions for key pages and UI components.
- Mocks toast UI in API and editor tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small test mock cleanup.

- The axe setup and new accessibility checks fit the existing jsdom test path.
- One editor test mock omits a toast method that a reachable store path can call.

apps/web/src/pages/__tests__/Editor.test.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/test/setup.ts | Registers jest-dom and vitest-axe matchers for the web test suite. |
| apps/web/src/test/a11y.ts | Adds shared axe options and disables `color-contrast` for jsdom. |
| apps/web/src/pages/__tests__/Editor.test.tsx | Adds an editor accessibility test with mocked auth, wasm, API, router, and toast dependencies. |
| apps/web/src/api/__tests__/client.test.ts | Adds a toast mock for API client rate-limit tests. |
| apps/web/package.json | Adds accessibility testing dependencies for the web app. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fpages%2F__tests__%2FEditor.test.tsx%3A59-63%0A**Toast%20Warning%20Mock%20Missing**%0A%0AThis%20mock%20replaces%20the%20real%20%60toast%60%20object%20but%20drops%20%60warning%60.%20The%20editor%20imports%20%60resumeStore%60%2C%20and%20that%20store%20can%20call%20%60toast.warning%60%20on%20localStorage%20corruption%2C%20so%20this%20test%20file%20can%20fail%20with%20%60TypeError%3A%20toast.warning%20is%20not%20a%20function%60%20instead%20of%20exercising%20the%20editor%20state.%0A%0A%60%60%60suggestion%0A%20%20%20%20toast%3A%20%7B%0A%20%20%20%20%20%20success%3A%20vi.fn%28%29%2C%0A%20%20%20%20%20%20error%3A%20vi.fn%28%29%2C%0A%20%20%20%20%20%20warning%3A%20vi.fn%28%29%2C%0A%20%20%20%20%20%20info%3A%20vi.fn%28%29%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A&pr=406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fpages%2F__tests__%2FEditor.test.tsx%3A59-63%0A**Toast%20Warning%20Mock%20Missing**%0A%0AThis%20mock%20replaces%20the%20real%20%60toast%60%20object%20but%20drops%20%60warning%60.%20The%20editor%20imports%20%60resumeStore%60%2C%20and%20that%20store%20can%20call%20%60toast.warning%60%20on%20localStorage%20corruption%2C%20so%20this%20test%20file%20can%20fail%20with%20%60TypeError%3A%20toast.warning%20is%20not%20a%20function%60%20instead%20of%20exercising%20the%20editor%20state.%0A%0A%60%60%60suggestion%0A%20%20%20%20toast%3A%20%7B%0A%20%20%20%20%20%20success%3A%20vi.fn%28%29%2C%0A%20%20%20%20%20%20error%3A%20vi.fn%28%29%2C%0A%20%20%20%20%20%20warning%3A%20vi.fn%28%29%2C%0A%20%20%20%20%20%20info%3A%20vi.fn%28%29%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22feat%2F364-axe-core-vitest%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F364-axe-core-vitest%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fpages%2F__tests__%2FEditor.test.tsx%3A59-63%0A**Toast%20Warning%20Mock%20Missing**%0A%0AThis%20mock%20replaces%20the%20real%20%60toast%60%20object%20but%20drops%20%60warning%60.%20The%20editor%20imports%20%60resumeStore%60%2C%20and%20that%20store%20can%20call%20%60toast.warning%60%20on%20localStorage%20corruption%2C%20so%20this%20test%20file%20can%20fail%20with%20%60TypeError%3A%20toast.warning%20is%20not%20a%20function%60%20instead%20of%20exercising%20the%20editor%20state.%0A%0A%60%60%60suggestion%0A%20%20%20%20toast%3A%20%7B%0A%20%20%20%20%20%20success%3A%20vi.fn%28%29%2C%0A%20%20%20%20%20%20error%3A%20vi.fn%28%29%2C%0A%20%20%20%20%20%20warning%3A%20vi.fn%28%29%2C%0A%20%20%20%20%20%20info%3A%20vi.fn%28%29%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(web): add axe-core accessibility ch..."](https://github.com/lgtm-hq/rustume/commit/487532ade2e86ad54b6244bc6c4f03d94090ff76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43685825)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->