### PR TITLE
fix(server): default CORS to same-origin when unset

### DIFF
--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -226,6 +226,10 @@ pub fn create_router_with_state(state: AppState) -> Router {
 }
 
 fn build_cors_layer() -> CorsLayer {
+    build_cors_layer_for_origin(std::env::var("CORS_ORIGIN").ok())
+}
+
+fn build_cors_layer_for_origin(origin: Option<String>) -> CorsLayer {
     let base = CorsLayer::new()
         .allow_methods([
             Method::GET,
@@ -249,14 +253,110 @@ fn build_cors_layer() -> CorsLayer {
             "X-RateLimit-Reset".parse::<header::HeaderName>().unwrap(),
         ]);
 
-    match std::env::var("CORS_ORIGIN").ok() {
-        Some(origin) if !origin.is_empty() && origin != "*" => {
+    match origin.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }) {
+        Some(origin) if origin == "*" => base.allow_origin(Any),
+        Some(origin) => {
             let origins: Vec<HeaderValue> = origin
                 .split(',')
                 .filter_map(|o| o.trim().parse().ok())
                 .collect();
             base.allow_origin(origins).allow_credentials(true)
         }
-        _ => base.allow_origin(Any),
+        None => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, routing::get, Router};
+    use tower::ServiceExt;
+
+    async fn cors_preflight(cors: CorsLayer, origin: &str) -> axum::http::Response<Body> {
+        let app = Router::new()
+            .route("/test", get(|| async { "ok" }))
+            .layer(cors);
+
+        app.oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/test")
+                .header("origin", origin)
+                .header("access-control-request-method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn cors_unset_rejects_cross_origin() {
+        let response =
+            cors_preflight(build_cors_layer_for_origin(None), "https://evil.example").await;
+
+        assert!(
+            !response
+                .headers()
+                .contains_key("access-control-allow-origin"),
+            "unset CORS_ORIGIN must not allow arbitrary cross-origin access"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_empty_rejects_cross_origin() {
+        let response = cors_preflight(
+            build_cors_layer_for_origin(Some(String::new())),
+            "https://evil.example",
+        )
+        .await;
+
+        assert!(
+            !response
+                .headers()
+                .contains_key("access-control-allow-origin"),
+            "empty CORS_ORIGIN must not allow arbitrary cross-origin access"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_wildcard_allows_cross_origin() {
+        let response = cors_preflight(
+            build_cors_layer_for_origin(Some("*".to_string())),
+            "https://evil.example",
+        )
+        .await;
+
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .unwrap(),
+            "*"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_specific_origin_allows_matching_origin() {
+        let response = cors_preflight(
+            build_cors_layer_for_origin(Some("http://localhost:3000".to_string())),
+            "http://localhost:3000",
+        )
+        .await;
+
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .unwrap(),
+            "http://localhost:3000"
+        );
     }
 }

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -263,11 +263,34 @@ fn build_cors_layer_for_origin(origin: Option<String>) -> CorsLayer {
     }) {
         Some(origin) if origin == "*" => base.allow_origin(Any),
         Some(origin) => {
-            let origins: Vec<HeaderValue> = origin
+            let parts: Vec<&str> = origin
                 .split(',')
-                .filter_map(|o| o.trim().parse().ok())
+                .map(str::trim)
+                .filter(|part| !part.is_empty())
                 .collect();
-            base.allow_origin(origins).allow_credentials(true)
+            let had_entries = !parts.is_empty();
+            let mut origins = Vec::with_capacity(parts.len());
+            for part in parts {
+                match part.parse::<HeaderValue>() {
+                    Ok(value) => origins.push(value),
+                    Err(error) => tracing::warn!(
+                        origin = part,
+                        error = %error,
+                        "Invalid CORS_ORIGIN entry; skipping"
+                    ),
+                }
+            }
+            if origins.is_empty() {
+                if had_entries {
+                    tracing::warn!(
+                        cors_origin = %origin,
+                        "CORS_ORIGIN contained no valid origins; cross-origin requests will be denied"
+                    );
+                }
+                base
+            } else {
+                base.allow_origin(origins).allow_credentials(true)
+            }
         }
         None => base,
     }
@@ -357,6 +380,22 @@ mod tests {
                 .get("access-control-allow-origin")
                 .unwrap(),
             "http://localhost:3000"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_invalid_origin_rejects_cross_origin() {
+        let response = cors_preflight(
+            build_cors_layer_for_origin(Some("not-a-valid-origin".to_string())),
+            "https://evil.example",
+        )
+        .await;
+
+        assert!(
+            !response
+                .headers()
+                .contains_key("access-control-allow-origin"),
+            "invalid CORS_ORIGIN must not allow cross-origin access"
         );
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -247,7 +247,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_cors_headers() {
+        std::env::set_var("CORS_ORIGIN", "*");
         let app = create_router();
+        std::env::remove_var("CORS_ORIGIN");
 
         let response = app
             .oneshot(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -56,6 +56,31 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
+    use std::sync::{Mutex, OnceLock};
+
+    static CORS_ORIGIN_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
     use dto::{
         ParseFormat, ParseRequest, RenderPdfRequest, RenderPreviewRequest, TemplateInfo,
         ValidationResponse,
@@ -247,9 +272,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_cors_headers() {
-        std::env::set_var("CORS_ORIGIN", "*");
+        let _lock = CORS_ORIGIN_TEST_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap();
+        let _guard = EnvVarGuard::set("CORS_ORIGIN", "*");
         let app = create_router();
-        std::env::remove_var("CORS_ORIGIN");
 
         let response = app
             .oneshot(

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -272,12 +272,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_cors_headers() {
-        let _lock = CORS_ORIGIN_TEST_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap();
-        let _guard = EnvVarGuard::set("CORS_ORIGIN", "*");
-        let app = create_router();
+        let app = {
+            let _lock = CORS_ORIGIN_TEST_LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap();
+            let _guard = EnvVarGuard::set("CORS_ORIGIN", "*");
+            create_router()
+        };
 
         let response = app
             .oneshot(

--- a/crates/server/src/run.rs
+++ b/crates/server/src/run.rs
@@ -58,7 +58,7 @@ pub async fn run() -> anyhow::Result<()> {
     );
     info!(
         "CORS origin: {}",
-        std::env::var("CORS_ORIGIN").unwrap_or_else(|_| "*".to_string())
+        std::env::var("CORS_ORIGIN").unwrap_or_else(|_| "(same-origin only)".to_string())
     );
 
     let listener = tokio::net::TcpListener::bind(addr)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(server): default CORS to same-origin when unset
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

When `CORS_ORIGIN` is unset or empty, the server no longer falls back to `allow_origin(Any)`. Cross-origin browser requests are rejected unless an operator explicitly opts in via `CORS_ORIGIN=*` or a specific origin list. Cloud deploys that already set `CORS_ORIGIN` are unchanged.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`cargo test -p rustume-server`, `uv run lintro chk` — clippy/rustfmt green; gitleaks timed out locally)

## Related Issues

Closes #342

## Details

- Extracted `build_cors_layer_for_origin` so CORS behavior is testable without env mutation.
- Added unit tests for unset, empty, wildcard, and specific-origin configurations.
- Updated startup log to report `(same-origin only)` when `CORS_ORIGIN` is unset.
- Updated existing integration test to set `CORS_ORIGIN=*` explicitly when verifying CORS headers.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the server CORS default to same-origin behavior when no origin is configured. The main changes are:

- Extracted CORS layer construction for direct testing.
- Treated unset and empty `CORS_ORIGIN` as cross-origin deny by default.
- Preserved explicit wildcard and specific-origin CORS configuration.
- Added warnings and tests for invalid CORS origin entries.
- Updated the startup log and CORS integration test setup.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the test isolation issue should be fixed before merging.

- The production CORS default now closes cross-origin access when no origin is configured.
- Invalid origin entries are warned about instead of disappearing silently.
- The CORS integration test still mutates process-wide env state in a way concurrent tests can observe.

crates/server/src/lib.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/app.rs | Adds explicit CORS origin handling and tests for unset, empty, wildcard, specific, and invalid origins. |
| crates/server/src/lib.rs | Updates the CORS integration test setup, but the process-wide env mutation can still leak into concurrent router tests. |
| crates/server/src/run.rs | Updates the startup log text for an unset CORS origin. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fserver%2Fsrc%2Flib.rs%3A274-280%0A**Env%20Lock%20Stays%20Local**%0A%0AThis%20still%20mutates%20the%20process-wide%20%60CORS_ORIGIN%60%20value%20while%20only%20this%20test%20takes%20the%20mutex.%20If%20another%20test%20calls%20%60create_router%28%29%60%20during%20this%20block%2C%20%60build_cors_layer%28%29%60%20reads%20%60CORS_ORIGIN%3D*%60%20and%20snapshots%20an%20allow-all%20CORS%20layer%20for%20that%20test%20too.%20The%20guard%20restores%20the%20env%20afterward%2C%20but%20it%20does%20not%20protect%20router%20construction%20in%20concurrently%20running%20tests%20that%20do%20not%20take%20the%20same%20lock.%20Use%20the%20explicit%20CORS%20builder%20in%20this%20test%2C%20or%20route%20every%20env-reading%20router%20construction%20in%20tests%20through%20the%20same%20synchronized%20setup.%0A%0A&pr=407&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fserver%2Fsrc%2Flib.rs%3A274-280%0A**Env%20Lock%20Stays%20Local**%0A%0AThis%20still%20mutates%20the%20process-wide%20%60CORS_ORIGIN%60%20value%20while%20only%20this%20test%20takes%20the%20mutex.%20If%20another%20test%20calls%20%60create_router%28%29%60%20during%20this%20block%2C%20%60build_cors_layer%28%29%60%20reads%20%60CORS_ORIGIN%3D*%60%20and%20snapshots%20an%20allow-all%20CORS%20layer%20for%20that%20test%20too.%20The%20guard%20restores%20the%20env%20afterward%2C%20but%20it%20does%20not%20protect%20router%20construction%20in%20concurrently%20running%20tests%20that%20do%20not%20take%20the%20same%20lock.%20Use%20the%20explicit%20CORS%20builder%20in%20this%20test%2C%20or%20route%20every%20env-reading%20router%20construction%20in%20tests%20through%20the%20same%20synchronized%20setup.%0A%0A&repo=lgtm-hq%2Frustume&pr=407&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F342-cors-require-origin%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F342-cors-require-origin%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fserver%2Fsrc%2Flib.rs%3A274-280%0A**Env%20Lock%20Stays%20Local**%0A%0AThis%20still%20mutates%20the%20process-wide%20%60CORS_ORIGIN%60%20value%20while%20only%20this%20test%20takes%20the%20mutex.%20If%20another%20test%20calls%20%60create_router%28%29%60%20during%20this%20block%2C%20%60build_cors_layer%28%29%60%20reads%20%60CORS_ORIGIN%3D*%60%20and%20snapshots%20an%20allow-all%20CORS%20layer%20for%20that%20test%20too.%20The%20guard%20restores%20the%20env%20afterward%2C%20but%20it%20does%20not%20protect%20router%20construction%20in%20concurrently%20running%20tests%20that%20do%20not%20take%20the%20same%20lock.%20Use%20the%20explicit%20CORS%20builder%20in%20this%20test%2C%20or%20route%20every%20env-reading%20router%20construction%20in%20tests%20through%20the%20same%20synchronized%20setup.%0A%0A&repo=lgtm-hq%2Frustume&pr=407&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/342-cors-re..."](https://github.com/lgtm-hq/rustume/commit/485eb0623effc813f174ebc5df0eedf7c2291148) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43686059)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->