### PR TITLE
test(server): drop env-mutating CORS integration test

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -56,31 +56,6 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
-    use std::sync::{Mutex, OnceLock};
-
-    static CORS_ORIGIN_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = std::env::var(key).ok();
-            std::env::set_var(key, value);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
     use dto::{
         ParseFormat, ParseRequest, RenderPdfRequest, RenderPreviewRequest, TemplateInfo,
         ValidationResponse,
@@ -268,35 +243,6 @@ mod tests {
 
         // Check PNG magic bytes
         assert!(body.starts_with(&[0x89, 0x50, 0x4E, 0x47]));
-    }
-
-    #[tokio::test]
-    async fn test_cors_headers() {
-        let app = {
-            let _lock = CORS_ORIGIN_TEST_LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .unwrap();
-            let _guard = EnvVarGuard::set("CORS_ORIGIN", "*");
-            create_router()
-        };
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("OPTIONS")
-                    .uri("/api/templates")
-                    .header("origin", "http://localhost:3000")
-                    .header("access-control-request-method", "GET")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert!(response
-            .headers()
-            .contains_key("access-control-allow-origin"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(server): drop env-mutating CORS integration test
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Removes the process-wide `CORS_ORIGIN` env-mutating integration test that Greptile flagged on #407. CORS behavior remains covered by deterministic `build_cors_layer_for_origin` unit tests in `app.rs`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Relates to #342

## Details

Follow-up after #407 merged before the Greptile env-lock thread fix landed on the branch.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes a process-wide CORS env mutation from the server tests.

- Deleted the `CORS_ORIGIN` integration test in `crates/server/src/lib.rs`.
- Removed the test-only env var guard helper.
- Removed the test-only lock and sync imports.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The removed test helpers have no remaining references.
- Core CORS origin behavior remains covered by deterministic tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/lib.rs | Removed an env-mutating CORS integration test and its unused test support code. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(server): drop env-mutating CORS int..."](https://github.com/lgtm-hq/rustume/commit/3270f41f40c716fbf23a82a6b5fab78043d30e95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43694127)</sub>

<!-- /greptile_comment -->