### PR TITLE
feat(infra): author Terraform modules, env roots, and fmt/validate CI

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -40,6 +40,7 @@ jobs:
             api.github.com:443
             codeload.github.com:443
             releases.hashicorp.com:443
+            registry.terraform.io:443
 
       - name: Checkout
         # yamllint disable-line rule:line-length

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f4598171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Quality - Terraform Validate
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - 'scripts/ci/terraform/**'
+      - 'tests/bats/unit/terraform/**'
+      - '.github/workflows/terraform-validate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - 'scripts/ci/terraform/**'
+      - 'tests/bats/unit/terraform/**'
+      - '.github/workflows/terraform-validate.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terraform-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Terraform fmt & validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f4598171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            releases.hashicorp.com:443
+
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: 1.5.7
+
+      - name: Validate Terraform
+        run: bash scripts/ci/terraform/validate.sh

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -41,6 +41,7 @@ jobs:
             codeload.github.com:443
             releases.hashicorp.com:443
             registry.terraform.io:443
+            release-assets.githubusercontent.com:443
 
       - name: Checkout
         # yamllint disable-line rule:line-length

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,112 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.1"
+  constraints = "~> 5.21.0"
+  hashes = [
+    "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
+    "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
+    "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",
+    "zh:42c27f3cd62979e70716c51f682a3d131d51ad76d86dff83d8cdbfffcebac841",
+    "zh:4c8cd464f9b6ecde5cd4430bbba4be3b810826105e51ef6328b6a2b69f821443",
+    "zh:586ea42ef74d6c5bc4c9b89da6b1f8618a19f4e80272fe8d615e7d5b11c491af",
+    "zh:b09b86c7cac7085e01c9b7a828f09d13c44589d3e3cd42f0b694ca3e4cd3ed0a",
+    "zh:eac80665e60c701b37a6318f4e405d67f1720f8da5f93135c6256049282d3367",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "4.29.1"
+  constraints = "~> 4.29.1"
+  hashes = [
+    "h1:ZokPr+2AJYuUROPu2mOLFF/j2b8gYRTJwDtrxsfdL3k=",
+    "zh:0bce5770fcf130478c48225c9425a99e74e7df752554662ea7dc25897b213c64",
+    "zh:2ce7799cfb92d857378a0caa667dad374794bb2fd4006e1d88e5455b29aee778",
+    "zh:3345096847a6a495a274dbd67b8b5ed217a9dfd2f8e4663fa7b57d94539a05db",
+    "zh:39525aec4019302390890b5c9571cbcf9c3c0a5f4a93abb8287135b30071f36e",
+    "zh:41acb487e7fdedbceab28a173408da9db29c405ec94d428713011f2eefda5778",
+    "zh:43696d146f3c5cd41843bba7359d492d97f0db3b68b16db5778f466a19577ab5",
+    "zh:476399661b33239c3b378e37fd63b213eb939db4e23e4b6781ba0af814aa29cf",
+    "zh:4e920471e601359324d062017c18c67e8e280f401452c3555202e340ba50bc0d",
+    "zh:645a5adf42144189212640c9a4ad3ac30873a4392e59818959bcb2a7bfead206",
+    "zh:6aa97700e177bbbdc81465d5e2080bf92d6f5dade7e28e14f4826aa982b1dac3",
+    "zh:867f8c2434c226907500e15435968e4b377383f091f8b4938651b8b1135d2d5e",
+    "zh:86a3746155ec45ce106e340b095c0b229679b3fed8e9adfc633fbd6364836fbc",
+    "zh:997915fea563ef0def38d507a57c9735191581f152cfc5b97fd0b1330391e73e",
+    "zh:9d7cebfec828ed7b7756a374502c1f3e2d0919c6f79d646cf5a58f0c7763a8c5",
+    "zh:ba080261c6620d6303b6aa3ac160a9a817a4f7bee2adca7b236c5de7c7b8cfc9",
+    "zh:d334ecad372fc23815f6a67caf5848fefd38cbd08681beff3c39f12059654d05",
+    "zh:dc51a48b39f10c403af1457c4887e2d1218f49b6d6b8d21110da1b187328ab54",
+    "zh:e371fa3d3d7b1783f36b56a8f3240beb939747e22f169695cbffa0a616d94739",
+    "zh:e8cbe8e1dcbcc6f167597b494dab49c548e83f93b25371e757431d9989aa2f5a",
+  ]
+}
+
+provider "registry.terraform.io/jianyuan/sentry" {
+  version     = "0.14.13"
+  constraints = "~> 0.14.13"
+  hashes = [
+    "h1:CEkWh5kBoHRHf2MjOykGpMjar5wo4r09xu1sQtewEQg=",
+    "zh:06c89cb0f2bfe70eac1981397eb99d65797ad42f621ca801d64e4cc4da6a4acb",
+    "zh:0af239bf0a08e6147b221d4e6e35da7edfe0775ca71ed6532781b12a67a8d530",
+    "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",
+    "zh:191d502900ce0787f587a4c19a5ed1edf2c3febfd1b951c008934de11da8339d",
+    "zh:2e134b07260af18bd388c6cde0514f20e13f7e0eb4bd546a27a2d124e06d13f9",
+    "zh:652a8aca36b1dc8e653e75280e88bfc7b6fa6df8bf7aed394ec3e25c5d29aaa4",
+    "zh:8954b702b6039621e36915885c270e44a8a5de8bb7d59a9b35ab7df6aa3d6064",
+    "zh:94a1301d573bad0a94bd21be8f8969ddeb6a0e30e0f3defb47f5dbd4a86ab190",
+    "zh:9aa8a1e2fa458fc4ba68559150b651a8bf4578f287819f0f294d77b47401d2a3",
+    "zh:a47da69be5e91c80d91df006b0338e2afb321fc54f4ceede8fcad6a44f8c21a9",
+    "zh:d3afee7cf78ccf5d36964341a1f36acc2bdd3cfb725c1c356cd94415da5826be",
+    "zh:e6dfa07c57fefed763511da4d5aae008e6b66cc57321f425a2f88786c84ac4b4",
+    "zh:ee2f688ec678087a903232446822ab4defbfc72c733f1d5c5d35e26cf62cf76d",
+    "zh:f7eeac7838d6183f22408d7c98e5c51a6ad55343b85ab48cdfe13dda851a5fa5",
+  ]
+}
+
+provider "registry.terraform.io/terraform-community-providers/neon" {
+  version     = "0.1.15"
+  constraints = "~> 0.1.15"
+  hashes = [
+    "h1:FXjeHf/95BmmF1dOwsvi9mr4iaJUPS9Kb0X/QdTVWO0=",
+    "zh:0b84be9ae9f7ec3304a36afda51204d9900553aa5cf01ed0fef096c86d0adf8d",
+    "zh:1c31c1e731de15944cf894c34386cd1bbb2da3dfa7d333c661fe44143c7e94c2",
+    "zh:20267f0d52bfa54ec33a0057555cf34c9dda6156a510f29a8e8698a1cd7b39d6",
+    "zh:27355934dc1fb9bc459ace09e75c7b1efc7570149cd4d6be6c0474949c2816c8",
+    "zh:52fe56b59d7755f75df62824a1210da3a9bfb29360d987816dfe5458e5830165",
+    "zh:5483d6c093c20533aa3a89150a1ca5d09b05671505cad9b622ec2357a527e002",
+    "zh:698d2aeb2ab241b016dc7851cc5096200e735cc41cb30b4370db2ff5b1b9a236",
+    "zh:7bb97384eab45f966f3fc4996e4c4de97acc489cdd13b5d9bd3ed2c79ff0ba1a",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:95ab8b76481b15ed44bbd3226ee3ba946bc1797371bf88c65833c7106da1aa0d",
+    "zh:b7230c5048ba32f8bcf5461a529fbb72518fe8076aab2c38972a243c41c9a251",
+    "zh:c5691b68c0459e174e030ccb2c171c8768b4ba42c20282f1d6f16357d996c3c7",
+    "zh:c6b2b6597f4fe6e71b49c7e3fddc841d69d1212a7d8a349fb8e450741a9595fd",
+    "zh:c9b4a065252f1d5734dafbc75adffaea6e5324fa40a5bfdc4a829cbda62d4bf7",
+  ]
+}
+
+provider "registry.terraform.io/terraform-community-providers/railway" {
+  version     = "0.6.2"
+  constraints = "~> 0.6.1"
+  hashes = [
+    "h1:XOUbEGQtNH7Tl/03EAK+1oI2zcWZy2XXhc7N9mrBH5I=",
+    "zh:2165a426b2e346c2debb05517e3993f87253ddcdf145d94401ea2ab9178d35ab",
+    "zh:2f3f0f3423564c88ada05238f136034fc35634fc7978efc503b984ba35e83724",
+    "zh:3bb0618cddccca0d0c690044f7338e4cd103b45114ffbcca8769e864a1b2554b",
+    "zh:50fd5dc5cf749d8ecd10e5e4ee5cef04b541beb522aab6d4e1845ee812e0c088",
+    "zh:6a52b2c60121a695151d6a91e61c3fecabc0a40bf75d6b530d828eef0dc0619d",
+    "zh:7356f98cef110a5ca1a261fddde4b53c74b6a22848bdca642e2094f7708b3626",
+    "zh:7b47792310e502d0a0b4427133b161114dce2323bc61bf40dc6c4d67858b7629",
+    "zh:7e8740d239d76a869e0d8eb5dc6c1ec62459603ea6a057333006f8de1c12e2f0",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:99d7a179fe16211beb790e19a8f65d570a23ed4f6b752b5bd6d073195fc4cf9d",
+    "zh:9f31f26d0d93067fca796a718a9b39ebfb1fce4d24e382c215f33e0dde7b3420",
+    "zh:adb29c332488b29cc483f8cac00a0cc54cacd4cfe5bbd818a55a1c1b4394ebcd",
+    "zh:d16148e673900550273cbbb12f7dbd7f96ec0cfaa863ec93ec5b108258415637",
+    "zh:da40431bcd65e85bec7f301611cad5b4b772dae250e9622556072b6a3a7503b6",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -7,13 +7,42 @@ Terraform modules and environment wiring for the operated Rustume Cloud stack.
 | Path | Purpose |
 | --- | --- |
 | `modules/railway/` | Railway service deployed from CI-built GHCR images |
+| `modules/neon/` | Neon PostgreSQL project, branch, role, and database |
+| `modules/r2/` | Cloudflare R2 assets + backup buckets, lifecycle, scoped tokens |
+| `modules/cloudflare-dns/` | `rustume.com` apex → Pages, `app` → Railway |
+| `modules/monitoring/` | Grafana Cloud stack, `/metrics` scrape, Sentry, baseline dashboard |
+| `main.tf`, `variables.tf`, `outputs.tf` | Root module composing all providers |
+| `environments/*.tfvars` | Non-secret per-environment placeholders |
 
-Environment roots (for example `infra/staging/`, `infra/production/`) land with
-Phase 1 Terraform work ([#243](https://github.com/lgtm-hq/Rustume/issues/243)).
-They compose the modules here with Neon, DNS, and observability providers.
+## Codified vs manual ([#333](https://github.com/lgtm-hq/Rustume/issues/333))
+
+| Codified in this repo | Manual / human step |
+| --- | --- |
+| Module definitions, env roots, dashboard JSON | Remote state backend configuration |
+| `terraform fmt` + `validate` in CI | `terraform import` of live resources |
+| Placeholder tfvars (no secrets) | Provider API tokens / secrets injection |
+| | `terraform plan` / `apply` against production |
+
+Secrets are `sensitive = true` variables sourced from environment at apply time. Never commit
+token values or `*.auto.tfvars` with credentials.
 
 ## Deploy model
 
 Rustume Cloud does **not** compile Rust on Railway. CI publishes signed images from
 `docker/Dockerfile`; Railway pulls the pre-built artifact. See
 [docs/operations/rustume-cloud-deploy.md](../docs/operations/rustume-cloud-deploy.md).
+
+## Local validation
+
+```bash
+bash scripts/ci/terraform/validate.sh
+```
+
+## Applying (operators only)
+
+```bash
+cd infra
+terraform init            # configure backend first
+terraform plan -var-file=environments/production.tfvars
+# terraform apply ...     # human gate — not run in CI
+```

--- a/infra/README.md
+++ b/infra/README.md
@@ -23,8 +23,14 @@ Terraform modules and environment wiring for the operated Rustume Cloud stack.
 | Placeholder tfvars (no secrets) | Provider API tokens / secrets injection |
 | | `terraform plan` / `apply` against production |
 
-Secrets are `sensitive = true` variables sourced from environment at apply time. Never commit
-token values or `*.auto.tfvars` with credentials.
+Secrets use `sensitive = true` variables, which redact values in logs and CLI output only.
+Set required inputs before `terraform plan` or `terraform apply`:
+
+- Module variables: export `TF_VAR_<name>` (for example `TF_VAR_neon_api_token`).
+- Provider credentials: use each provider's documented environment variables when a
+  `TF_VAR_*` token is not set (`NEON_TOKEN`, `CLOUDFLARE_API_TOKEN`, etc.).
+
+Never commit token values or `*.auto.tfvars` with credentials.
 
 ## Deploy model
 

--- a/infra/environments/production.tfvars
+++ b/infra/environments/production.tfvars
@@ -1,0 +1,27 @@
+environment = "production"
+
+neon_project_name = "rustume-cloud-production"
+neon_region_id    = "aws-us-west-2"
+
+cloudflare_account_id = "00000000000000000000000000000000"
+cloudflare_zone_id    = "00000000000000000000000000000000"
+
+r2_assets_bucket_name  = "rustume-assets-production"
+r2_backups_bucket_name = "rustume-backups-production"
+# Look up via Cloudflare API/dashboard before apply.
+r2_read_write_permission_group_id = "00000000000000000000000000000000"
+
+railway_cname_target   = "responsible-celebration-production-8280.up.railway.app"
+railway_project_id     = "83fe27c6-ab4b-444e-97bb-f7773c92c87a"
+railway_environment_id = "78af5529-02bd-42b6-8436-99f6d0e39114"
+railway_source_image   = "ghcr.io/lgtm-hq/rustume:main"
+
+grafana_stack_name = "rustume-cloud-production"
+grafana_stack_slug = "rustumecloudprod"
+metrics_scrape_url = "https://app.rustume.com/metrics"
+
+sentry_organization = "lgtm-hq"
+sentry_team         = "rustume"
+
+cors_origin         = "https://app.rustume.com"
+workos_redirect_uri = "https://app.rustume.com/auth/callback"

--- a/infra/environments/production.tfvars
+++ b/infra/environments/production.tfvars
@@ -10,6 +10,8 @@ r2_assets_bucket_name  = "rustume-assets-production"
 r2_backups_bucket_name = "rustume-backups-production"
 # Look up via Cloudflare API/dashboard before apply.
 r2_read_write_permission_group_id = "00000000000000000000000000000000"
+# Replace with Railway egress and operator CIDRs before apply (see infra/modules/r2/README.md).
+r2_token_allowed_ip_ranges = ["203.0.113.10/32"]
 
 railway_cname_target   = "responsible-celebration-production-8280.up.railway.app"
 railway_project_id     = "83fe27c6-ab4b-444e-97bb-f7773c92c87a"

--- a/infra/environments/staging.tfvars
+++ b/infra/environments/staging.tfvars
@@ -9,6 +9,8 @@ cloudflare_zone_id    = "00000000000000000000000000000000"
 r2_assets_bucket_name             = "rustume-assets-staging"
 r2_backups_bucket_name            = "rustume-backups-staging"
 r2_read_write_permission_group_id = "00000000000000000000000000000000"
+# Replace with Railway egress and operator CIDRs before apply (see infra/modules/r2/README.md).
+r2_token_allowed_ip_ranges = ["203.0.113.10/32"]
 
 railway_cname_target   = "staging-placeholder.up.railway.app"
 railway_project_id     = "00000000-0000-0000-0000-000000000000"

--- a/infra/environments/staging.tfvars
+++ b/infra/environments/staging.tfvars
@@ -1,0 +1,26 @@
+environment = "staging"
+
+neon_project_name = "rustume-cloud-staging"
+neon_region_id    = "aws-us-west-2"
+
+cloudflare_account_id = "00000000000000000000000000000000"
+cloudflare_zone_id    = "00000000000000000000000000000000"
+
+r2_assets_bucket_name             = "rustume-assets-staging"
+r2_backups_bucket_name            = "rustume-backups-staging"
+r2_read_write_permission_group_id = "00000000000000000000000000000000"
+
+railway_cname_target   = "staging-placeholder.up.railway.app"
+railway_project_id     = "00000000-0000-0000-0000-000000000000"
+railway_environment_id = "00000000-0000-0000-0000-000000000000"
+railway_source_image   = "ghcr.io/lgtm-hq/rustume:main"
+
+grafana_stack_name = "rustume-cloud-staging"
+grafana_stack_slug = "rustumecloudstg"
+metrics_scrape_url = "https://app.staging.rustume.com/metrics"
+
+sentry_organization = "lgtm-hq"
+sentry_team         = "rustume"
+
+cors_origin         = "https://app.staging.rustume.com"
+workos_redirect_uri = "https://app.staging.rustume.com/auth/callback"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,57 @@
+module "neon" {
+  source = "./modules/neon"
+
+  project_name = var.neon_project_name
+  region_id    = var.neon_region_id
+}
+
+module "r2" {
+  source = "./modules/r2"
+
+  account_id                        = var.cloudflare_account_id
+  assets_bucket_name                = var.r2_assets_bucket_name
+  backups_bucket_name               = var.r2_backups_bucket_name
+  r2_read_write_permission_group_id = var.r2_read_write_permission_group_id
+}
+
+module "cloudflare_dns" {
+  source = "./modules/cloudflare-dns"
+
+  zone_id              = var.cloudflare_zone_id
+  railway_cname_target = var.railway_cname_target
+}
+
+module "monitoring" {
+  source = "./modules/monitoring"
+
+  stack_name         = var.grafana_stack_name
+  stack_slug         = var.grafana_stack_slug
+  metrics_scrape_url = var.metrics_scrape_url
+  metrics_token      = var.metrics_token
+
+  sentry_organization = var.sentry_organization
+  sentry_team         = var.sentry_team
+}
+
+module "railway" {
+  source = "./modules/railway"
+
+  project_id     = var.railway_project_id
+  environment_id = var.railway_environment_id
+  source_image   = var.railway_source_image
+
+  ghcr_read_token = var.ghcr_read_token
+  ghcr_username   = var.ghcr_username
+
+  environment_variables = {
+    RUSTUME_CLOUD       = "true"
+    DATABASE_URL        = module.neon.database_url
+    WORKOS_CLIENT_ID    = var.workos_client_id
+    WORKOS_API_KEY      = var.workos_api_key
+    WORKOS_REDIRECT_URI = var.workos_redirect_uri
+    SESSION_SECRET      = var.session_secret
+    CORS_ORIGIN         = var.cors_origin
+    METRICS_TOKEN       = var.metrics_token
+    SENTRY_DSN          = module.monitoring.sentry_dsn
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -13,6 +13,7 @@ module "r2" {
   backups_bucket_name               = var.r2_backups_bucket_name
   r2_read_write_permission_group_id = var.r2_read_write_permission_group_id
   token_allowed_ip_ranges           = var.r2_token_allowed_ip_ranges
+  enforce_ip_allowlist              = contains(["staging", "production"], var.environment)
 }
 
 module "cloudflare_dns" {
@@ -54,12 +55,5 @@ module "railway" {
     CORS_ORIGIN         = var.cors_origin
     METRICS_TOKEN       = var.metrics_token
     SENTRY_DSN          = module.monitoring.sentry_dsn
-  }
-}
-
-check "r2_token_ip_allowlist" {
-  assert {
-    condition     = !contains(["staging", "production"], var.environment) || length(var.r2_token_allowed_ip_ranges) > 0
-    error_message = "Set r2_token_allowed_ip_ranges in environments/<env>.tfvars before staging or production apply."
   }
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -56,3 +56,10 @@ module "railway" {
     SENTRY_DSN          = module.monitoring.sentry_dsn
   }
 }
+
+check "r2_token_ip_allowlist" {
+  assert {
+    condition     = !contains(["staging", "production"], var.environment) || length(var.r2_token_allowed_ip_ranges) > 0
+    error_message = "Set r2_token_allowed_ip_ranges in environments/<env>.tfvars before staging or production apply."
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -12,6 +12,7 @@ module "r2" {
   assets_bucket_name                = var.r2_assets_bucket_name
   backups_bucket_name               = var.r2_backups_bucket_name
   r2_read_write_permission_group_id = var.r2_read_write_permission_group_id
+  token_allowed_ip_ranges           = var.r2_token_allowed_ip_ranges
 }
 
 module "cloudflare_dns" {

--- a/infra/modules/cloudflare-dns/.terraform.lock.hcl
+++ b/infra/modules/cloudflare-dns/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.1"
+  constraints = "~> 5.21.0"
+  hashes = [
+    "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
+    "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
+    "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",
+    "zh:42c27f3cd62979e70716c51f682a3d131d51ad76d86dff83d8cdbfffcebac841",
+    "zh:4c8cd464f9b6ecde5cd4430bbba4be3b810826105e51ef6328b6a2b69f821443",
+    "zh:586ea42ef74d6c5bc4c9b89da6b1f8618a19f4e80272fe8d615e7d5b11c491af",
+    "zh:b09b86c7cac7085e01c9b7a828f09d13c44589d3e3cd42f0b694ca3e4cd3ed0a",
+    "zh:eac80665e60c701b37a6318f4e405d67f1720f8da5f93135c6256049282d3367",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/modules/cloudflare-dns/README.md
+++ b/infra/modules/cloudflare-dns/README.md
@@ -1,0 +1,18 @@
+# Cloudflare DNS module
+
+DNS records for `rustume.com`: apex → GitHub Pages, `app` → Railway custom domain.
+
+## Usage
+
+```hcl
+module "dns" {
+  source = "../modules/cloudflare-dns"
+
+  zone_id              = var.cloudflare_zone_id
+  railway_cname_target = "responsible-celebration-production-8280.up.railway.app"
+}
+```
+
+## Custom hostnames
+
+`custom_hostname_placeholder` output documents the hook for [#336](https://github.com/lgtm-hq/Rustume/issues/336). Add `cloudflare_custom_hostname` resources in a follow-up when tenant domains are codified.

--- a/infra/modules/cloudflare-dns/README.md
+++ b/infra/modules/cloudflare-dns/README.md
@@ -15,4 +15,6 @@ module "dns" {
 
 ## Custom hostnames
 
-`custom_hostname_placeholder` output documents the hook for [#336](https://github.com/lgtm-hq/Rustume/issues/336). Add `cloudflare_custom_hostname` resources in a follow-up when tenant domains are codified.
+`custom_hostname_placeholder` output documents the hook for
+[#336](https://github.com/lgtm-hq/Rustume/issues/336). Add `cloudflare_custom_hostname`
+resources in a follow-up when tenant domains are codified.

--- a/infra/modules/cloudflare-dns/main.tf
+++ b/infra/modules/cloudflare-dns/main.tf
@@ -14,6 +14,18 @@ resource "cloudflare_dns_record" "apex_pages" {
   comment = "GitHub Pages docs site (#300)"
 }
 
+resource "cloudflare_dns_record" "apex_pages_ipv6" {
+  for_each = toset(var.pages_ipv6_addresses)
+
+  zone_id = var.zone_id
+  name    = var.apex_domain
+  type    = "AAAA"
+  content = each.value
+  proxied = var.proxied
+  ttl     = var.ttl
+  comment = "GitHub Pages docs site IPv6 (#300)"
+}
+
 resource "cloudflare_dns_record" "app_railway" {
   zone_id = var.zone_id
   name    = local.app_fqdn

--- a/infra/modules/cloudflare-dns/main.tf
+++ b/infra/modules/cloudflare-dns/main.tf
@@ -1,0 +1,25 @@
+locals {
+  app_fqdn = "${var.app_subdomain}.${var.apex_domain}"
+}
+
+resource "cloudflare_dns_record" "apex_pages" {
+  for_each = toset(var.pages_ipv4_addresses)
+
+  zone_id = var.zone_id
+  name    = var.apex_domain
+  type    = "A"
+  content = each.value
+  proxied = var.proxied
+  ttl     = var.ttl
+  comment = "GitHub Pages docs site (#300)"
+}
+
+resource "cloudflare_dns_record" "app_railway" {
+  zone_id = var.zone_id
+  name    = local.app_fqdn
+  type    = "CNAME"
+  content = var.railway_cname_target
+  proxied = var.proxied
+  ttl     = var.ttl
+  comment = "Rustume Cloud API on Railway (#300)"
+}

--- a/infra/modules/cloudflare-dns/outputs.tf
+++ b/infra/modules/cloudflare-dns/outputs.tf
@@ -1,0 +1,23 @@
+output "apex_record_ids" {
+  description = "Cloudflare record IDs for apex A records."
+  value       = [for record in cloudflare_dns_record.apex_pages : record.id]
+}
+
+output "app_record_id" {
+  description = "Cloudflare record ID for app.rustume.com."
+  value       = cloudflare_dns_record.app_railway.id
+}
+
+output "app_fqdn" {
+  description = "Application fully qualified domain name."
+  value       = local.app_fqdn
+}
+
+output "custom_hostname_placeholder" {
+  description = "Reserved for per-tenant custom hostnames ([#336](https://github.com/lgtm-hq/Rustume/issues/336))."
+  value = {
+    module_ready   = true
+    zone_id        = var.zone_id
+    suggested_type = "cloudflare_custom_hostname"
+  }
+}

--- a/infra/modules/cloudflare-dns/variables.tf
+++ b/infra/modules/cloudflare-dns/variables.tf
@@ -1,0 +1,44 @@
+variable "zone_id" {
+  description = "Cloudflare zone identifier for rustume.com."
+  type        = string
+}
+
+variable "apex_domain" {
+  description = "Apex domain name."
+  type        = string
+  default     = "rustume.com"
+}
+
+variable "app_subdomain" {
+  description = "Rustume Cloud application subdomain label."
+  type        = string
+  default     = "app"
+}
+
+variable "pages_ipv4_addresses" {
+  description = "GitHub Pages apex A record targets."
+  type        = list(string)
+  default = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153",
+  ]
+}
+
+variable "railway_cname_target" {
+  description = "Railway custom-domain CNAME target for app.rustume.com."
+  type        = string
+}
+
+variable "proxied" {
+  description = "Whether Cloudflare should proxy the records (orange cloud)."
+  type        = bool
+  default     = true
+}
+
+variable "ttl" {
+  description = "DNS TTL in seconds (1 = automatic when proxied)."
+  type        = number
+  default     = 1
+}

--- a/infra/modules/cloudflare-dns/variables.tf
+++ b/infra/modules/cloudflare-dns/variables.tf
@@ -26,6 +26,17 @@ variable "pages_ipv4_addresses" {
   ]
 }
 
+variable "pages_ipv6_addresses" {
+  description = "GitHub Pages apex AAAA record targets."
+  type        = list(string)
+  default = [
+    "2606:50c0:8000::153",
+    "2606:50c0:8001::153",
+    "2606:50c0:8002::153",
+    "2606:50c0:8003::153",
+  ]
+}
+
 variable "railway_cname_target" {
   description = "Railway custom-domain CNAME target for app.rustume.com."
   type        = string

--- a/infra/modules/cloudflare-dns/versions.tf
+++ b/infra/modules/cloudflare-dns/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.21.0"
+    }
+  }
+}

--- a/infra/modules/monitoring/.terraform.lock.hcl
+++ b/infra/modules/monitoring/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "4.29.1"
+  constraints = "~> 4.29.1"
+  hashes = [
+    "h1:ZokPr+2AJYuUROPu2mOLFF/j2b8gYRTJwDtrxsfdL3k=",
+    "zh:0bce5770fcf130478c48225c9425a99e74e7df752554662ea7dc25897b213c64",
+    "zh:2ce7799cfb92d857378a0caa667dad374794bb2fd4006e1d88e5455b29aee778",
+    "zh:3345096847a6a495a274dbd67b8b5ed217a9dfd2f8e4663fa7b57d94539a05db",
+    "zh:39525aec4019302390890b5c9571cbcf9c3c0a5f4a93abb8287135b30071f36e",
+    "zh:41acb487e7fdedbceab28a173408da9db29c405ec94d428713011f2eefda5778",
+    "zh:43696d146f3c5cd41843bba7359d492d97f0db3b68b16db5778f466a19577ab5",
+    "zh:476399661b33239c3b378e37fd63b213eb939db4e23e4b6781ba0af814aa29cf",
+    "zh:4e920471e601359324d062017c18c67e8e280f401452c3555202e340ba50bc0d",
+    "zh:645a5adf42144189212640c9a4ad3ac30873a4392e59818959bcb2a7bfead206",
+    "zh:6aa97700e177bbbdc81465d5e2080bf92d6f5dade7e28e14f4826aa982b1dac3",
+    "zh:867f8c2434c226907500e15435968e4b377383f091f8b4938651b8b1135d2d5e",
+    "zh:86a3746155ec45ce106e340b095c0b229679b3fed8e9adfc633fbd6364836fbc",
+    "zh:997915fea563ef0def38d507a57c9735191581f152cfc5b97fd0b1330391e73e",
+    "zh:9d7cebfec828ed7b7756a374502c1f3e2d0919c6f79d646cf5a58f0c7763a8c5",
+    "zh:ba080261c6620d6303b6aa3ac160a9a817a4f7bee2adca7b236c5de7c7b8cfc9",
+    "zh:d334ecad372fc23815f6a67caf5848fefd38cbd08681beff3c39f12059654d05",
+    "zh:dc51a48b39f10c403af1457c4887e2d1218f49b6d6b8d21110da1b187328ab54",
+    "zh:e371fa3d3d7b1783f36b56a8f3240beb939747e22f169695cbffa0a616d94739",
+    "zh:e8cbe8e1dcbcc6f167597b494dab49c548e83f93b25371e757431d9989aa2f5a",
+  ]
+}
+
+provider "registry.terraform.io/jianyuan/sentry" {
+  version     = "0.14.13"
+  constraints = "~> 0.14.13"
+  hashes = [
+    "h1:CEkWh5kBoHRHf2MjOykGpMjar5wo4r09xu1sQtewEQg=",
+    "zh:06c89cb0f2bfe70eac1981397eb99d65797ad42f621ca801d64e4cc4da6a4acb",
+    "zh:0af239bf0a08e6147b221d4e6e35da7edfe0775ca71ed6532781b12a67a8d530",
+    "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",
+    "zh:191d502900ce0787f587a4c19a5ed1edf2c3febfd1b951c008934de11da8339d",
+    "zh:2e134b07260af18bd388c6cde0514f20e13f7e0eb4bd546a27a2d124e06d13f9",
+    "zh:652a8aca36b1dc8e653e75280e88bfc7b6fa6df8bf7aed394ec3e25c5d29aaa4",
+    "zh:8954b702b6039621e36915885c270e44a8a5de8bb7d59a9b35ab7df6aa3d6064",
+    "zh:94a1301d573bad0a94bd21be8f8969ddeb6a0e30e0f3defb47f5dbd4a86ab190",
+    "zh:9aa8a1e2fa458fc4ba68559150b651a8bf4578f287819f0f294d77b47401d2a3",
+    "zh:a47da69be5e91c80d91df006b0338e2afb321fc54f4ceede8fcad6a44f8c21a9",
+    "zh:d3afee7cf78ccf5d36964341a1f36acc2bdd3cfb725c1c356cd94415da5826be",
+    "zh:e6dfa07c57fefed763511da4d5aae008e6b66cc57321f425a2f88786c84ac4b4",
+    "zh:ee2f688ec678087a903232446822ab4defbfc72c733f1d5c5d35e26cf62cf76d",
+    "zh:f7eeac7838d6183f22408d7c98e5c51a6ad55343b85ab48cdfe13dda851a5fa5",
+  ]
+}

--- a/infra/modules/monitoring/README.md
+++ b/infra/modules/monitoring/README.md
@@ -1,0 +1,27 @@
+# Monitoring module
+
+Grafana Cloud stack, authenticated Metrics Endpoint scrape of `/metrics`, Sentry project,
+and a baseline dashboards-as-code JSON.
+
+Metric names align with `crates/server/src/routes/metrics.rs` (Prometheus recorder) and
+`rustume_rate_limit_keys` from `crates/server/src/middleware/rate_limit.rs`. HTTP route
+histograms use conventional `http_server_*` names for when Axum instrumentation lands ([#335](https://github.com/lgtm-hq/Rustume/issues/335)).
+
+## Usage
+
+```hcl
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  stack_name       = "rustume-cloud"
+  stack_slug       = "rustumecloud"
+  metrics_scrape_url = "https://app.rustume.com/metrics"
+  metrics_token    = var.metrics_token
+
+  sentry_organization = "lgtm-hq"
+  sentry_team         = "rustume"
+}
+```
+
+Grafana Connections API credentials and Sentry auth tokens are supplied via provider
+environment variables at apply time — never in committed tfvars.

--- a/infra/modules/monitoring/dashboards/rustume-cloud-baseline.json
+++ b/infra/modules/monitoring/dashboards/rustume-cloud-baseline.json
@@ -1,0 +1,203 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_total[5m])) by (route)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate per route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_total{status=~\"5..\"}[5m])) by (route)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Error rate (5xx) per route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p50 {{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p50 per route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p95 {{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p95 per route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p99 {{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p99 per route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "rustume_rate_limit_keys",
+          "legendFormat": "active keys",
+          "refId": "A"
+        }
+      ],
+      "title": "Rate-limit key cardinality",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "rustume",
+    "cloud"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Rustume Cloud — Baseline",
+  "uid": "rustume-cloud-baseline",
+  "version": 1
+}

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -1,0 +1,50 @@
+locals {
+  scrape_interval_valid = contains([30, 60, 120], var.metrics_scrape_interval_seconds)
+}
+
+resource "grafana_cloud_stack" "rustume" {
+  name        = var.stack_name
+  slug        = var.stack_slug
+  description = var.stack_description
+  region_slug = var.stack_region
+}
+
+resource "grafana_connections_metrics_endpoint_scrape_job" "rustume" {
+  stack_id                    = grafana_cloud_stack.rustume.id
+  name                        = "rustume-cloud-metrics"
+  enabled                     = true
+  url                         = var.metrics_scrape_url
+  authentication_method       = "bearer"
+  authentication_bearer_token = var.metrics_token
+  scrape_interval_seconds     = var.metrics_scrape_interval_seconds
+
+  lifecycle {
+    precondition {
+      condition     = local.scrape_interval_valid
+      error_message = "metrics_scrape_interval_seconds must be 30, 60, or 120."
+    }
+  }
+}
+
+resource "grafana_folder" "rustume" {
+  title = var.dashboard_folder_title
+}
+
+resource "grafana_dashboard" "baseline" {
+  folder      = grafana_folder.rustume.uid
+  config_json = file("${path.module}/dashboards/rustume-cloud-baseline.json")
+}
+
+resource "sentry_project" "rustume" {
+  organization = var.sentry_organization
+  teams        = [var.sentry_team]
+  name         = var.sentry_project_name
+  slug         = var.sentry_project_slug
+  platform     = "rust"
+}
+
+data "sentry_key" "rustume" {
+  organization = sentry_project.rustume.organization
+  project      = sentry_project.rustume.slug
+  first        = true
+}

--- a/infra/modules/monitoring/outputs.tf
+++ b/infra/modules/monitoring/outputs.tf
@@ -1,0 +1,35 @@
+output "grafana_stack_id" {
+  description = "Grafana Cloud stack identifier."
+  value       = grafana_cloud_stack.rustume.id
+}
+
+output "grafana_stack_url" {
+  description = "Grafana Cloud stack URL."
+  value       = grafana_cloud_stack.rustume.url
+}
+
+output "prometheus_remote_write_endpoint" {
+  description = "Hosted Prometheus remote-write endpoint."
+  value       = grafana_cloud_stack.rustume.prometheus_remote_write_endpoint
+}
+
+output "metrics_scrape_job_id" {
+  description = "Grafana Metrics Endpoint scrape job identifier."
+  value       = grafana_connections_metrics_endpoint_scrape_job.rustume.id
+}
+
+output "sentry_project_id" {
+  description = "Sentry project identifier."
+  value       = sentry_project.rustume.id
+}
+
+output "sentry_dsn" {
+  description = "Sentry DSN for server SENTRY_DSN."
+  value       = data.sentry_key.rustume.dsn.public
+  sensitive   = true
+}
+
+output "dashboard_uid" {
+  description = "Baseline Grafana dashboard UID."
+  value       = jsondecode(grafana_dashboard.baseline.config_json).uid
+}

--- a/infra/modules/monitoring/variables.tf
+++ b/infra/modules/monitoring/variables.tf
@@ -1,0 +1,66 @@
+variable "stack_name" {
+  description = "Grafana Cloud stack name."
+  type        = string
+}
+
+variable "stack_slug" {
+  description = "Grafana Cloud stack slug (URL-safe identifier)."
+  type        = string
+}
+
+variable "stack_description" {
+  description = "Human-readable Grafana stack description."
+  type        = string
+  default     = "Rustume Cloud observability"
+}
+
+variable "stack_region" {
+  description = "Grafana Cloud region slug."
+  type        = string
+  default     = "us"
+}
+
+variable "metrics_scrape_url" {
+  description = "Public HTTPS /metrics endpoint for Grafana Cloud to scrape."
+  type        = string
+}
+
+variable "metrics_token" {
+  description = "Bearer token for authenticated /metrics scrapes (METRICS_TOKEN)."
+  type        = string
+  sensitive   = true
+}
+
+variable "metrics_scrape_interval_seconds" {
+  description = "Grafana Metrics Endpoint scrape interval (30, 60, or 120)."
+  type        = number
+  default     = 60
+}
+
+variable "sentry_organization" {
+  description = "Sentry organization slug."
+  type        = string
+}
+
+variable "sentry_team" {
+  description = "Sentry team slug receiving the Rustume project."
+  type        = string
+}
+
+variable "sentry_project_name" {
+  description = "Sentry project display name."
+  type        = string
+  default     = "rustume-cloud"
+}
+
+variable "sentry_project_slug" {
+  description = "Sentry project slug."
+  type        = string
+  default     = "rustume-cloud"
+}
+
+variable "dashboard_folder_title" {
+  description = "Grafana folder title for Rustume dashboards."
+  type        = string
+  default     = "Rustume Cloud"
+}

--- a/infra/modules/monitoring/versions.tf
+++ b/infra/modules/monitoring/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 4.29.1"
+    }
+    sentry = {
+      source  = "jianyuan/sentry"
+      version = "~> 0.14.13"
+    }
+  }
+}

--- a/infra/modules/neon/.terraform.lock.hcl
+++ b/infra/modules/neon/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/terraform-community-providers/neon" {
+  version     = "0.1.15"
+  constraints = "~> 0.1.15"
+  hashes = [
+    "h1:FXjeHf/95BmmF1dOwsvi9mr4iaJUPS9Kb0X/QdTVWO0=",
+    "zh:0b84be9ae9f7ec3304a36afda51204d9900553aa5cf01ed0fef096c86d0adf8d",
+    "zh:1c31c1e731de15944cf894c34386cd1bbb2da3dfa7d333c661fe44143c7e94c2",
+    "zh:20267f0d52bfa54ec33a0057555cf34c9dda6156a510f29a8e8698a1cd7b39d6",
+    "zh:27355934dc1fb9bc459ace09e75c7b1efc7570149cd4d6be6c0474949c2816c8",
+    "zh:52fe56b59d7755f75df62824a1210da3a9bfb29360d987816dfe5458e5830165",
+    "zh:5483d6c093c20533aa3a89150a1ca5d09b05671505cad9b622ec2357a527e002",
+    "zh:698d2aeb2ab241b016dc7851cc5096200e735cc41cb30b4370db2ff5b1b9a236",
+    "zh:7bb97384eab45f966f3fc4996e4c4de97acc489cdd13b5d9bd3ed2c79ff0ba1a",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:95ab8b76481b15ed44bbd3226ee3ba946bc1797371bf88c65833c7106da1aa0d",
+    "zh:b7230c5048ba32f8bcf5461a529fbb72518fe8076aab2c38972a243c41c9a251",
+    "zh:c5691b68c0459e174e030ccb2c171c8768b4ba42c20282f1d6f16357d996c3c7",
+    "zh:c6b2b6597f4fe6e71b49c7e3fddc841d69d1212a7d8a349fb8e450741a9595fd",
+    "zh:c9b4a065252f1d5734dafbc75adffaea6e5324fa40a5bfdc4a829cbda62d4bf7",
+  ]
+}

--- a/infra/modules/neon/README.md
+++ b/infra/modules/neon/README.md
@@ -1,0 +1,27 @@
+# Neon module
+
+Provision a Neon PostgreSQL project with a primary branch, application role, and database.
+
+Provider: [`terraform-community-providers/neon`](https://registry.terraform.io/providers/terraform-community-providers/neon/latest/docs) (Neon API token via `NEON_TOKEN` or provider `token`).
+
+## Usage
+
+```hcl
+module "neon" {
+  source = "../modules/neon"
+
+  project_name = "rustume-cloud-production"
+  region_id    = "aws-us-west-2"
+  branch_name  = "main"
+  database_name = "rustume"
+  role_name    = "rustume_app"
+}
+```
+
+## Outputs
+
+`database_url` and `role_password` are marked sensitive. Pass `database_url` to the Railway module as `DATABASE_URL` at apply time — never commit the value.
+
+## Import
+
+Import existing Neon resources per provider docs before first `terraform apply` against live infrastructure ([#333](https://github.com/lgtm-hq/Rustume/issues/333)).

--- a/infra/modules/neon/README.md
+++ b/infra/modules/neon/README.md
@@ -2,14 +2,14 @@
 
 Provision a Neon PostgreSQL project with a primary branch, application role, and database.
 
-Provider: [`terraform-community-providers/neon`](https://registry.terraform.io/providers/terraform-community-providers/neon/latest/docs)
-(Neon API token via `NEON_TOKEN` or provider `token`).
+Provider: [`terraform-community-providers/neon`](https://registry.terraform.io/providers/terraform-community-providers/neon/0.1.15/docs)
+(`~> 0.1.15`; Neon API token via `NEON_TOKEN` or provider `token`).
 
 ## Usage
 
 ```hcl
 module "neon" {
-  source = "../modules/neon"
+  source = "./modules/neon"
 
   project_name = "rustume-cloud-production"
   region_id    = "aws-us-west-2"

--- a/infra/modules/neon/README.md
+++ b/infra/modules/neon/README.md
@@ -2,7 +2,8 @@
 
 Provision a Neon PostgreSQL project with a primary branch, application role, and database.
 
-Provider: [`terraform-community-providers/neon`](https://registry.terraform.io/providers/terraform-community-providers/neon/latest/docs) (Neon API token via `NEON_TOKEN` or provider `token`).
+Provider: [`terraform-community-providers/neon`](https://registry.terraform.io/providers/terraform-community-providers/neon/latest/docs)
+(Neon API token via `NEON_TOKEN` or provider `token`).
 
 ## Usage
 
@@ -20,8 +21,10 @@ module "neon" {
 
 ## Outputs
 
-`database_url` and `role_password` are marked sensitive. Pass `database_url` to the Railway module as `DATABASE_URL` at apply time — never commit the value.
+`database_url` and `role_password` are marked sensitive. Pass `database_url` to the
+Railway module as `DATABASE_URL` at apply time — never commit the value.
 
 ## Import
 
-Import existing Neon resources per provider docs before first `terraform apply` against live infrastructure ([#333](https://github.com/lgtm-hq/Rustume/issues/333)).
+Import existing Neon resources per provider docs before first `terraform apply` against
+live infrastructure ([#333](https://github.com/lgtm-hq/Rustume/issues/333)).

--- a/infra/modules/neon/main.tf
+++ b/infra/modules/neon/main.tf
@@ -1,0 +1,38 @@
+locals {
+  endpoint_cu_valid = var.endpoint_min_cu > 0 && var.endpoint_max_cu >= var.endpoint_min_cu
+}
+
+resource "neon_project" "rustume" {
+  name              = var.project_name
+  region_id         = var.region_id
+  pg_version        = var.pg_version
+  history_retention = var.history_retention_seconds
+
+  branch = {
+    name = var.branch_name
+    endpoint = {
+      min_cu = var.endpoint_min_cu
+      max_cu = var.endpoint_max_cu
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.endpoint_cu_valid
+      error_message = "endpoint_max_cu must be greater than or equal to endpoint_min_cu and both must be positive."
+    }
+  }
+}
+
+resource "neon_role" "app" {
+  project_id = neon_project.rustume.id
+  branch_id  = neon_project.rustume.branch.id
+  name       = var.role_name
+}
+
+resource "neon_database" "app" {
+  project_id = neon_project.rustume.id
+  branch_id  = neon_project.rustume.branch.id
+  name       = var.database_name
+  owner_name = neon_role.app.name
+}

--- a/infra/modules/neon/outputs.tf
+++ b/infra/modules/neon/outputs.tf
@@ -33,10 +33,10 @@ output "database_url" {
   description = "PostgreSQL connection URL for the application role."
   value = format(
     "postgresql://%s:%s@%s/%s?sslmode=require",
-    neon_role.app.name,
-    neon_role.app.password,
+    urlencode(neon_role.app.name),
+    urlencode(neon_role.app.password),
     neon_project.rustume.branch.endpoint.host,
-    neon_database.app.name,
+    urlencode(neon_database.app.name),
   )
   sensitive = true
 }

--- a/infra/modules/neon/outputs.tf
+++ b/infra/modules/neon/outputs.tf
@@ -1,0 +1,42 @@
+output "project_id" {
+  description = "Neon project identifier."
+  value       = neon_project.rustume.id
+}
+
+output "branch_id" {
+  description = "Primary branch identifier."
+  value       = neon_project.rustume.branch.id
+}
+
+output "database_name" {
+  description = "Application database name."
+  value       = neon_database.app.name
+}
+
+output "role_name" {
+  description = "Application role name."
+  value       = neon_role.app.name
+}
+
+output "role_password" {
+  description = "Application role password."
+  value       = neon_role.app.password
+  sensitive   = true
+}
+
+output "endpoint_host" {
+  description = "Primary branch read-write endpoint host."
+  value       = neon_project.rustume.branch.endpoint.host
+}
+
+output "database_url" {
+  description = "PostgreSQL connection URL for the application role."
+  value = format(
+    "postgresql://%s:%s@%s/%s?sslmode=require",
+    neon_role.app.name,
+    neon_role.app.password,
+    neon_project.rustume.branch.endpoint.host,
+    neon_database.app.name,
+  )
+  sensitive = true
+}

--- a/infra/modules/neon/variables.tf
+++ b/infra/modules/neon/variables.tf
@@ -1,0 +1,52 @@
+variable "project_name" {
+  description = "Neon project name."
+  type        = string
+}
+
+variable "region_id" {
+  description = "Neon region identifier (for example aws-us-west-2)."
+  type        = string
+  default     = "aws-us-west-2"
+}
+
+variable "pg_version" {
+  description = "PostgreSQL major version for the Neon project."
+  type        = number
+  default     = 16
+}
+
+variable "branch_name" {
+  description = "Primary branch name."
+  type        = string
+  default     = "main"
+}
+
+variable "database_name" {
+  description = "Application database name."
+  type        = string
+  default     = "rustume"
+}
+
+variable "role_name" {
+  description = "Application database role name."
+  type        = string
+  default     = "rustume_app"
+}
+
+variable "history_retention_seconds" {
+  description = "Point-in-time recovery retention window in seconds."
+  type        = number
+  default     = 86400
+}
+
+variable "endpoint_min_cu" {
+  description = "Minimum compute units for the default branch endpoint."
+  type        = number
+  default     = 0.25
+}
+
+variable "endpoint_max_cu" {
+  description = "Maximum compute units for the default branch endpoint."
+  type        = number
+  default     = 1
+}

--- a/infra/modules/neon/variables.tf
+++ b/infra/modules/neon/variables.tf
@@ -13,6 +13,11 @@ variable "pg_version" {
   description = "PostgreSQL major version for the Neon project."
   type        = number
   default     = 16
+
+  validation {
+    condition     = floor(var.pg_version) == var.pg_version && var.pg_version >= 14 && var.pg_version <= 18
+    error_message = "pg_version must be an integer between 14 and 18."
+  }
 }
 
 variable "branch_name" {
@@ -37,6 +42,11 @@ variable "history_retention_seconds" {
   description = "Point-in-time recovery retention window in seconds."
   type        = number
   default     = 86400
+
+  validation {
+    condition = floor(var.history_retention_seconds) == var.history_retention_seconds && var.history_retention_seconds >= 0 && var.history_retention_seconds <= 2592000
+    error_message = "history_retention_seconds must be an integer between 0 and 2592000."
+  }
 }
 
 variable "endpoint_min_cu" {

--- a/infra/modules/neon/variables.tf
+++ b/infra/modules/neon/variables.tf
@@ -44,7 +44,7 @@ variable "history_retention_seconds" {
   default     = 86400
 
   validation {
-    condition = floor(var.history_retention_seconds) == var.history_retention_seconds && var.history_retention_seconds >= 0 && var.history_retention_seconds <= 2592000
+    condition     = floor(var.history_retention_seconds) == var.history_retention_seconds && var.history_retention_seconds >= 0 && var.history_retention_seconds <= 2592000
     error_message = "history_retention_seconds must be an integer between 0 and 2592000."
   }
 }

--- a/infra/modules/neon/versions.tf
+++ b/infra/modules/neon/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    neon = {
+      source  = "terraform-community-providers/neon"
+      version = "~> 0.1.15"
+    }
+  }
+}

--- a/infra/modules/r2/.terraform.lock.hcl
+++ b/infra/modules/r2/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.1"
+  constraints = "~> 5.21.0"
+  hashes = [
+    "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
+    "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
+    "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",
+    "zh:42c27f3cd62979e70716c51f682a3d131d51ad76d86dff83d8cdbfffcebac841",
+    "zh:4c8cd464f9b6ecde5cd4430bbba4be3b810826105e51ef6328b6a2b69f821443",
+    "zh:586ea42ef74d6c5bc4c9b89da6b1f8618a19f4e80272fe8d615e7d5b11c491af",
+    "zh:b09b86c7cac7085e01c9b7a828f09d13c44589d3e3cd42f0b694ca3e4cd3ed0a",
+    "zh:eac80665e60c701b37a6318f4e405d67f1720f8da5f93135c6256049282d3367",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/modules/r2/README.md
+++ b/infra/modules/r2/README.md
@@ -19,9 +19,15 @@ module "r2" {
 }
 ```
 
-Token values are sensitive outputs — inject into Railway/CI secrets at apply time, never in tfvars committed to git.
+Token values are sensitive outputs — inject into Railway/CI secrets at apply time, never
+in tfvars committed to git.
 
 ## Notes
 
 - Lifecycle `max_age` is in **seconds** (provider quirk).
-- Bucket-scoped token policies depend on Cloudflare permission-group IDs; look up via dashboard or API before apply.
+- API tokens are scoped to individual buckets via
+  `com.cloudflare.edge.r2.bucket.<account>_<jurisdiction>_<bucket>` resources.
+- Set `token_allowed_ip_ranges` before production apply; empty defaults are for CI
+  validation only.
+- Bucket-scoped token policies depend on Cloudflare permission-group IDs; look up via
+  dashboard or API before apply.

--- a/infra/modules/r2/README.md
+++ b/infra/modules/r2/README.md
@@ -1,0 +1,27 @@
+# R2 module
+
+Cloudflare R2 buckets for Rustume Cloud assets and database backups, with lifecycle
+retention, object-lock versioning on backups, and scoped API tokens.
+
+## Usage
+
+```hcl
+module "r2" {
+  source = "../modules/r2"
+
+  account_id          = var.cloudflare_account_id
+  assets_bucket_name  = "rustume-assets-production"
+  backups_bucket_name = "rustume-backups-production"
+  backup_retention_days = 30
+
+  # Cloudflare dashboard → Account API tokens → permission group ID for R2 Object Read & Write.
+  r2_read_write_permission_group_id = var.r2_permission_group_id
+}
+```
+
+Token values are sensitive outputs — inject into Railway/CI secrets at apply time, never in tfvars committed to git.
+
+## Notes
+
+- Lifecycle `max_age` is in **seconds** (provider quirk).
+- Bucket-scoped token policies depend on Cloudflare permission-group IDs; look up via dashboard or API before apply.

--- a/infra/modules/r2/main.tf
+++ b/infra/modules/r2/main.tf
@@ -84,6 +84,13 @@ resource "cloudflare_api_token" "assets" {
   }]
 
   condition = local.token_ip_condition
+
+  lifecycle {
+    precondition {
+      condition     = !var.enforce_ip_allowlist || length(var.token_allowed_ip_ranges) > 0
+      error_message = "Set token_allowed_ip_ranges before staging or production apply."
+    }
+  }
 }
 
 resource "cloudflare_api_token" "backups" {
@@ -100,4 +107,11 @@ resource "cloudflare_api_token" "backups" {
   }]
 
   condition = local.token_ip_condition
+
+  lifecycle {
+    precondition {
+      condition     = !var.enforce_ip_allowlist || length(var.token_allowed_ip_ranges) > 0
+      error_message = "Set token_allowed_ip_ranges before staging or production apply."
+    }
+  }
 }

--- a/infra/modules/r2/main.tf
+++ b/infra/modules/r2/main.tf
@@ -1,0 +1,102 @@
+locals {
+  account_resource  = "com.cloudflare.api.account.${var.account_id}"
+  retention_seconds = var.backup_retention_days * 86400
+  token_ip_condition = length(var.token_allowed_ip_ranges) > 0 ? {
+    request_ip = {
+      in = var.token_allowed_ip_ranges
+    }
+  } : null
+}
+
+resource "cloudflare_r2_bucket" "assets" {
+  account_id    = var.account_id
+  name          = var.assets_bucket_name
+  location      = var.location
+  storage_class = "Standard"
+}
+
+resource "cloudflare_r2_bucket" "backups" {
+  account_id    = var.account_id
+  name          = var.backups_bucket_name
+  location      = var.location
+  storage_class = "Standard"
+}
+
+resource "cloudflare_r2_bucket_lifecycle" "backups" {
+  account_id  = var.account_id
+  bucket_name = cloudflare_r2_bucket.backups.name
+
+  rules = [{
+    id      = "expire-backups-after-retention"
+    enabled = true
+    conditions = {
+      prefix = ""
+    }
+    delete_objects_transition = {
+      condition = {
+        type    = "Age"
+        max_age = local.retention_seconds
+      }
+    }
+    abort_multipart_uploads_transition = {
+      condition = {
+        type    = "Age"
+        max_age = local.retention_seconds
+      }
+    }
+  }]
+
+  lifecycle {
+    precondition {
+      condition     = var.backup_retention_days > 0
+      error_message = "backup_retention_days must be a positive integer."
+    }
+  }
+}
+
+resource "cloudflare_r2_bucket_lock" "backups_versioning" {
+  account_id  = var.account_id
+  bucket_name = cloudflare_r2_bucket.backups.name
+
+  rules = [{
+    id      = "retain-backup-versions"
+    enabled = true
+    prefix  = ""
+    condition = {
+      type            = "Age"
+      max_age_seconds = local.retention_seconds
+    }
+  }]
+}
+
+resource "cloudflare_api_token" "assets" {
+  name = var.assets_token_name
+
+  policies = [{
+    effect = "allow"
+    permission_groups = [{
+      id = var.r2_read_write_permission_group_id
+    }]
+    resources = jsonencode({
+      (local.account_resource) = "*"
+    })
+  }]
+
+  condition = local.token_ip_condition
+}
+
+resource "cloudflare_api_token" "backups" {
+  name = var.backups_token_name
+
+  policies = [{
+    effect = "allow"
+    permission_groups = [{
+      id = var.r2_read_write_permission_group_id
+    }]
+    resources = jsonencode({
+      (local.account_resource) = "*"
+    })
+  }]
+
+  condition = local.token_ip_condition
+}

--- a/infra/modules/r2/main.tf
+++ b/infra/modules/r2/main.tf
@@ -13,6 +13,7 @@ resource "cloudflare_r2_bucket" "assets" {
   account_id    = var.account_id
   name          = var.assets_bucket_name
   location      = var.location
+  jurisdiction  = var.bucket_jurisdiction
   storage_class = "Standard"
 }
 
@@ -20,6 +21,7 @@ resource "cloudflare_r2_bucket" "backups" {
   account_id    = var.account_id
   name          = var.backups_bucket_name
   location      = var.location
+  jurisdiction  = var.bucket_jurisdiction
   storage_class = "Standard"
 }
 

--- a/infra/modules/r2/main.tf
+++ b/infra/modules/r2/main.tf
@@ -5,7 +5,7 @@ locals {
       in = var.token_allowed_ip_ranges
     }
   } : null
-  assets_bucket_resource = "com.cloudflare.edge.r2.bucket.${var.account_id}_${var.bucket_jurisdiction}_${cloudflare_r2_bucket.assets.name}"
+  assets_bucket_resource  = "com.cloudflare.edge.r2.bucket.${var.account_id}_${var.bucket_jurisdiction}_${cloudflare_r2_bucket.assets.name}"
   backups_bucket_resource = "com.cloudflare.edge.r2.bucket.${var.account_id}_${var.bucket_jurisdiction}_${cloudflare_r2_bucket.backups.name}"
 }
 

--- a/infra/modules/r2/main.tf
+++ b/infra/modules/r2/main.tf
@@ -1,11 +1,12 @@
 locals {
-  account_resource  = "com.cloudflare.api.account.${var.account_id}"
   retention_seconds = var.backup_retention_days * 86400
   token_ip_condition = length(var.token_allowed_ip_ranges) > 0 ? {
     request_ip = {
       in = var.token_allowed_ip_ranges
     }
   } : null
+  assets_bucket_resource = "com.cloudflare.edge.r2.bucket.${var.account_id}_${var.bucket_jurisdiction}_${cloudflare_r2_bucket.assets.name}"
+  backups_bucket_resource = "com.cloudflare.edge.r2.bucket.${var.account_id}_${var.bucket_jurisdiction}_${cloudflare_r2_bucket.backups.name}"
 }
 
 resource "cloudflare_r2_bucket" "assets" {
@@ -78,7 +79,7 @@ resource "cloudflare_api_token" "assets" {
       id = var.r2_read_write_permission_group_id
     }]
     resources = jsonencode({
-      (local.account_resource) = "*"
+      (local.assets_bucket_resource) = "*"
     })
   }]
 
@@ -94,7 +95,7 @@ resource "cloudflare_api_token" "backups" {
       id = var.r2_read_write_permission_group_id
     }]
     resources = jsonencode({
-      (local.account_resource) = "*"
+      (local.backups_bucket_resource) = "*"
     })
   }]
 

--- a/infra/modules/r2/outputs.tf
+++ b/infra/modules/r2/outputs.tf
@@ -1,0 +1,31 @@
+output "assets_bucket_name" {
+  description = "Assets bucket name."
+  value       = cloudflare_r2_bucket.assets.name
+}
+
+output "backups_bucket_name" {
+  description = "Backups bucket name."
+  value       = cloudflare_r2_bucket.backups.name
+}
+
+output "assets_token_id" {
+  description = "Scoped assets-bucket API token identifier."
+  value       = cloudflare_api_token.assets.id
+}
+
+output "assets_token_value" {
+  description = "Scoped assets-bucket API token secret."
+  value       = cloudflare_api_token.assets.value
+  sensitive   = true
+}
+
+output "backups_token_id" {
+  description = "Scoped backups-bucket API token identifier."
+  value       = cloudflare_api_token.backups.id
+}
+
+output "backups_token_value" {
+  description = "Scoped backups-bucket API token secret."
+  value       = cloudflare_api_token.backups.value
+  sensitive   = true
+}

--- a/infra/modules/r2/variables.tf
+++ b/infra/modules/r2/variables.tf
@@ -1,0 +1,49 @@
+variable "account_id" {
+  description = "Cloudflare account identifier."
+  type        = string
+}
+
+variable "assets_bucket_name" {
+  description = "R2 bucket for user-uploaded assets."
+  type        = string
+}
+
+variable "backups_bucket_name" {
+  description = "R2 bucket for database backups."
+  type        = string
+}
+
+variable "location" {
+  description = "R2 bucket location (for example WEUR, ENAM)."
+  type        = string
+  default     = "ENAM"
+}
+
+variable "backup_retention_days" {
+  description = "Days to retain backup objects before lifecycle deletion."
+  type        = number
+  default     = 30
+}
+
+variable "assets_token_name" {
+  description = "Display name for the scoped assets-bucket API token."
+  type        = string
+  default     = "rustume-r2-assets"
+}
+
+variable "backups_token_name" {
+  description = "Display name for the scoped backups-bucket API token."
+  type        = string
+  default     = "rustume-r2-backups"
+}
+
+variable "r2_read_write_permission_group_id" {
+  description = "Cloudflare permission group ID for R2 Object Read & Write."
+  type        = string
+}
+
+variable "token_allowed_ip_ranges" {
+  description = "Optional CIDR ranges restricting R2 API token usage."
+  type        = list(string)
+  default     = []
+}

--- a/infra/modules/r2/variables.tf
+++ b/infra/modules/r2/variables.tf
@@ -52,4 +52,15 @@ variable "token_allowed_ip_ranges" {
   description = "CIDR ranges restricting R2 API token usage. Leave empty only for local validation; set before production apply."
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = !var.enforce_ip_allowlist || length(var.token_allowed_ip_ranges) > 0
+    error_message = "Set token_allowed_ip_ranges before staging or production apply."
+  }
+}
+
+variable "enforce_ip_allowlist" {
+  description = "When true, require non-empty token_allowed_ip_ranges (set by root for staging/production)."
+  type        = bool
+  default     = false
 }

--- a/infra/modules/r2/variables.tf
+++ b/infra/modules/r2/variables.tf
@@ -42,8 +42,14 @@ variable "r2_read_write_permission_group_id" {
   type        = string
 }
 
+variable "bucket_jurisdiction" {
+  description = "R2 bucket jurisdiction segment used in API token resource identifiers (default for non-jurisdiction buckets)."
+  type        = string
+  default     = "default"
+}
+
 variable "token_allowed_ip_ranges" {
-  description = "Optional CIDR ranges restricting R2 API token usage."
+  description = "CIDR ranges restricting R2 API token usage. Leave empty only for local validation; set before production apply."
   type        = list(string)
   default     = []
 }

--- a/infra/modules/r2/variables.tf
+++ b/infra/modules/r2/variables.tf
@@ -14,15 +14,20 @@ variable "backups_bucket_name" {
 }
 
 variable "location" {
-  description = "R2 bucket location (for example WEUR, ENAM)."
+  description = "R2 bucket location (for example weur, enam)."
   type        = string
-  default     = "ENAM"
+  default     = "enam"
 }
 
 variable "backup_retention_days" {
   description = "Days to retain backup objects before lifecycle deletion."
   type        = number
   default     = 30
+
+  validation {
+    condition     = floor(var.backup_retention_days) == var.backup_retention_days && var.backup_retention_days > 0
+    error_message = "backup_retention_days must be a positive integer."
+  }
 }
 
 variable "assets_token_name" {

--- a/infra/modules/r2/variables.tf
+++ b/infra/modules/r2/variables.tf
@@ -58,9 +58,4 @@ variable "enforce_ip_allowlist" {
   description = "When true, require non-empty token_allowed_ip_ranges (set by root for staging/production)."
   type        = bool
   default     = false
-
-  validation {
-    condition     = !var.enforce_ip_allowlist || length(var.token_allowed_ip_ranges) > 0
-    error_message = "Set token_allowed_ip_ranges before staging or production apply."
-  }
 }

--- a/infra/modules/r2/variables.tf
+++ b/infra/modules/r2/variables.tf
@@ -52,15 +52,15 @@ variable "token_allowed_ip_ranges" {
   description = "CIDR ranges restricting R2 API token usage. Leave empty only for local validation; set before production apply."
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = !var.enforce_ip_allowlist || length(var.token_allowed_ip_ranges) > 0
-    error_message = "Set token_allowed_ip_ranges before staging or production apply."
-  }
 }
 
 variable "enforce_ip_allowlist" {
   description = "When true, require non-empty token_allowed_ip_ranges (set by root for staging/production)."
   type        = bool
   default     = false
+
+  validation {
+    condition     = !var.enforce_ip_allowlist || length(var.token_allowed_ip_ranges) > 0
+    error_message = "Set token_allowed_ip_ranges before staging or production apply."
+  }
 }

--- a/infra/modules/r2/versions.tf
+++ b/infra/modules/r2/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.21.0"
+    }
+  }
+}

--- a/infra/modules/railway/.terraform.lock.hcl
+++ b/infra/modules/railway/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/terraform-community-providers/railway" {
+  version     = "0.6.2"
+  constraints = "~> 0.6.1"
+  hashes = [
+    "h1:XOUbEGQtNH7Tl/03EAK+1oI2zcWZy2XXhc7N9mrBH5I=",
+    "zh:2165a426b2e346c2debb05517e3993f87253ddcdf145d94401ea2ab9178d35ab",
+    "zh:2f3f0f3423564c88ada05238f136034fc35634fc7978efc503b984ba35e83724",
+    "zh:3bb0618cddccca0d0c690044f7338e4cd103b45114ffbcca8769e864a1b2554b",
+    "zh:50fd5dc5cf749d8ecd10e5e4ee5cef04b541beb522aab6d4e1845ee812e0c088",
+    "zh:6a52b2c60121a695151d6a91e61c3fecabc0a40bf75d6b530d828eef0dc0619d",
+    "zh:7356f98cef110a5ca1a261fddde4b53c74b6a22848bdca642e2094f7708b3626",
+    "zh:7b47792310e502d0a0b4427133b161114dce2323bc61bf40dc6c4d67858b7629",
+    "zh:7e8740d239d76a869e0d8eb5dc6c1ec62459603ea6a057333006f8de1c12e2f0",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:99d7a179fe16211beb790e19a8f65d570a23ed4f6b752b5bd6d073195fc4cf9d",
+    "zh:9f31f26d0d93067fca796a718a9b39ebfb1fce4d24e382c215f33e0dde7b3420",
+    "zh:adb29c332488b29cc483f8cac00a0cc54cacd4cfe5bbd818a55a1c1b4394ebcd",
+    "zh:d16148e673900550273cbbb12f7dbd7f96ec0cfaa863ec93ec5b108258415637",
+    "zh:da40431bcd65e85bec7f301611cad5b4b772dae250e9622556072b6a3a7503b6",
+  ]
+}

--- a/infra/modules/railway/main.tf
+++ b/infra/modules/railway/main.tf
@@ -9,6 +9,14 @@ resource "railway_service" "rustume" {
 
   source_image = var.source_image
 
+  dynamic "regions" {
+    for_each = var.regions
+    content {
+      region       = regions.value.region
+      num_replicas = regions.value.num_replicas
+    }
+  }
+
   source_image_registry_username = local.ghcr_token_provided ? var.ghcr_username : null
   source_image_registry_password = local.ghcr_token_provided ? var.ghcr_read_token : null
 

--- a/infra/modules/railway/main.tf
+++ b/infra/modules/railway/main.tf
@@ -9,14 +9,6 @@ resource "railway_service" "rustume" {
 
   source_image = var.source_image
 
-  dynamic "regions" {
-    for_each = var.regions
-    content {
-      region       = regions.value.region
-      num_replicas = regions.value.num_replicas
-    }
-  }
-
   source_image_registry_username = local.ghcr_token_provided ? var.ghcr_username : null
   source_image_registry_password = local.ghcr_token_provided ? var.ghcr_read_token : null
 

--- a/infra/modules/railway/variables.tf
+++ b/infra/modules/railway/variables.tf
@@ -37,15 +37,3 @@ variable "environment_variables" {
   type        = map(string)
   default     = {}
 }
-
-variable "regions" {
-  description = "Desired Railway regions and replica counts. Provider v0.6.x does not expose regions on railway_service; configure in the Railway dashboard until supported."
-  type = list(object({
-    region       = string
-    num_replicas = optional(number, 1)
-  }))
-  default = [{
-    region       = "us-west2"
-    num_replicas = 1
-  }]
-}

--- a/infra/modules/railway/variables.tf
+++ b/infra/modules/railway/variables.tf
@@ -39,7 +39,7 @@ variable "environment_variables" {
 }
 
 variable "regions" {
-  description = "Railway regions and replica counts."
+  description = "Desired Railway regions and replica counts. Provider v0.6.x does not expose regions on railway_service; configure in the Railway dashboard until supported."
   type = list(object({
     region       = string
     num_replicas = optional(number, 1)

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,45 @@
+output "environment" {
+  description = "Active environment label."
+  value       = var.environment
+}
+
+output "neon_project_id" {
+  description = "Neon project identifier."
+  value       = module.neon.project_id
+}
+
+output "database_url" {
+  description = "Application database URL."
+  value       = module.neon.database_url
+  sensitive   = true
+}
+
+output "r2_assets_bucket" {
+  description = "Assets bucket name."
+  value       = module.r2.assets_bucket_name
+}
+
+output "r2_backups_bucket" {
+  description = "Backups bucket name."
+  value       = module.r2.backups_bucket_name
+}
+
+output "app_fqdn" {
+  description = "Rustume Cloud application hostname."
+  value       = module.cloudflare_dns.app_fqdn
+}
+
+output "grafana_stack_url" {
+  description = "Grafana Cloud stack URL."
+  value       = module.monitoring.grafana_stack_url
+}
+
+output "railway_service_id" {
+  description = "Railway service identifier."
+  value       = module.railway.service_id
+}
+
+output "custom_hostname_placeholder" {
+  description = "Hook for future custom-hostname work (#336)."
+  value       = module.cloudflare_dns.custom_hostname_placeholder
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,173 @@
+variable "environment" {
+  description = "Deployment environment label (staging or production)."
+  type        = string
+}
+
+variable "neon_project_name" {
+  description = "Neon project name."
+  type        = string
+}
+
+variable "neon_region_id" {
+  description = "Neon region identifier."
+  type        = string
+  default     = "aws-us-west-2"
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account identifier."
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone identifier for rustume.com."
+  type        = string
+}
+
+variable "r2_assets_bucket_name" {
+  description = "R2 assets bucket name."
+  type        = string
+}
+
+variable "r2_backups_bucket_name" {
+  description = "R2 backups bucket name."
+  type        = string
+}
+
+variable "r2_read_write_permission_group_id" {
+  description = "Cloudflare permission group ID for R2 Object Read & Write."
+  type        = string
+}
+
+variable "railway_cname_target" {
+  description = "Railway custom-domain CNAME target for app.rustume.com."
+  type        = string
+}
+
+variable "railway_project_id" {
+  description = "Railway project identifier."
+  type        = string
+}
+
+variable "railway_environment_id" {
+  description = "Railway environment identifier."
+  type        = string
+}
+
+variable "railway_source_image" {
+  description = "GHCR image reference deployed to Railway."
+  type        = string
+}
+
+variable "grafana_stack_name" {
+  description = "Grafana Cloud stack name."
+  type        = string
+}
+
+variable "grafana_stack_slug" {
+  description = "Grafana Cloud stack slug."
+  type        = string
+}
+
+variable "metrics_scrape_url" {
+  description = "Public HTTPS /metrics endpoint."
+  type        = string
+}
+
+variable "sentry_organization" {
+  description = "Sentry organization slug."
+  type        = string
+}
+
+variable "sentry_team" {
+  description = "Sentry team slug."
+  type        = string
+}
+
+variable "cors_origin" {
+  description = "Allowed browser origin for Rustume Cloud."
+  type        = string
+}
+
+variable "workos_redirect_uri" {
+  description = "WorkOS AuthKit redirect URI."
+  type        = string
+}
+
+# --- Sensitive (never commit values) ---
+
+variable "neon_api_token" {
+  description = "Neon API token."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "grafana_cloud_access_policy_token" {
+  description = "Grafana Cloud access policy token for stack management."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "metrics_token" {
+  description = "Bearer token protecting GET /metrics."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "sentry_auth_token" {
+  description = "Sentry user auth token."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "railway_api_token" {
+  description = "Railway API token."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "ghcr_read_token" {
+  description = "GitHub PAT with read:packages for GHCR pulls."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "ghcr_username" {
+  description = "GitHub username for GHCR auth."
+  type        = string
+  default     = null
+}
+
+variable "workos_client_id" {
+  description = "WorkOS client ID."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "workos_api_key" {
+  description = "WorkOS API key."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "session_secret" {
+  description = "Cookie signing secret."
+  type        = string
+  sensitive   = true
+  default     = null
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -39,6 +39,12 @@ variable "r2_read_write_permission_group_id" {
   type        = string
 }
 
+variable "r2_token_allowed_ip_ranges" {
+  description = "CIDR ranges restricting R2 API token usage. Required for production applies."
+  type        = list(string)
+  default     = []
+}
+
 variable "railway_cname_target" {
   description = "Railway custom-domain CNAME target for app.rustume.com."
   type        = string
@@ -112,6 +118,19 @@ variable "cloudflare_api_token" {
 
 variable "grafana_cloud_access_policy_token" {
   description = "Grafana Cloud access policy token for stack management."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "grafana_connections_api_url" {
+  description = "Grafana Connections API URL for metrics endpoint scrape jobs (from stack.connections_api_url)."
+  type        = string
+  default     = null
+}
+
+variable "grafana_connections_api_access_token" {
+  description = "Grafana Connections API access token with integration-management scopes."
   type        = string
   sensitive   = true
   default     = null

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -40,9 +40,14 @@ variable "r2_read_write_permission_group_id" {
 }
 
 variable "r2_token_allowed_ip_ranges" {
-  description = "CIDR ranges restricting R2 API token usage. Required for production applies."
+  description = "CIDR ranges restricting R2 API token usage. Required for staging and production applies."
   type        = list(string)
   default     = []
+
+  validation {
+    condition = contains(["staging", "production"], var.environment) ? length(var.r2_token_allowed_ip_ranges) > 0 : true
+    error_message = "Set r2_token_allowed_ip_ranges in environments/<env>.tfvars before staging or production apply."
+  }
 }
 
 variable "railway_cname_target" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -43,11 +43,6 @@ variable "r2_token_allowed_ip_ranges" {
   description = "CIDR ranges restricting R2 API token usage. Required for staging and production applies."
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = contains(["staging", "production"], var.environment) ? length(var.r2_token_allowed_ip_ranges) > 0 : true
-    error_message = "Set r2_token_allowed_ip_ranges in environments/<env>.tfvars before staging or production apply."
-  }
 }
 
 variable "railway_cname_target" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -45,7 +45,7 @@ variable "r2_token_allowed_ip_ranges" {
   default     = []
 
   validation {
-    condition = contains(["staging", "production"], var.environment) ? length(var.r2_token_allowed_ip_ranges) > 0 : true
+    condition     = contains(["staging", "production"], var.environment) ? length(var.r2_token_allowed_ip_ranges) > 0 : true
     error_message = "Set r2_token_allowed_ip_ranges in environments/<env>.tfvars before staging or production apply."
   }
 }

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  # Remote state backend is configured manually for live environments — see README.md (#333).
+  # backend "s3" {
+  #   bucket = "rustume-terraform-state"
+  #   key    = "production/terraform.tfstate"
+  #   region = "auto"
+  # }
+
+  required_providers {
+    neon = {
+      source  = "terraform-community-providers/neon"
+      version = "~> 0.1.15"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.21.0"
+    }
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 4.29.1"
+    }
+    sentry = {
+      source  = "jianyuan/sentry"
+      version = "~> 0.14.13"
+    }
+    railway = {
+      source  = "terraform-community-providers/railway"
+      version = "~> 0.6.1"
+    }
+  }
+}
+
+provider "neon" {}
+
+provider "cloudflare" {}
+
+provider "grafana" {
+  cloud_access_policy_token = var.grafana_cloud_access_policy_token
+}
+
+provider "sentry" {
+  token = var.sentry_auth_token
+}
+
+provider "railway" {
+  token = var.railway_api_token
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -32,9 +32,13 @@ terraform {
   }
 }
 
-provider "neon" {}
+provider "neon" {
+  token = var.neon_api_token
+}
 
-provider "cloudflare" {}
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
 
 provider "grafana" {
   cloud_access_policy_token    = var.grafana_cloud_access_policy_token

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -37,9 +37,9 @@ provider "neon" {}
 provider "cloudflare" {}
 
 provider "grafana" {
-  cloud_access_policy_token      = var.grafana_cloud_access_policy_token
-  connections_api_url            = var.grafana_connections_api_url
-  connections_api_access_token   = var.grafana_connections_api_access_token
+  cloud_access_policy_token    = var.grafana_cloud_access_policy_token
+  connections_api_url          = var.grafana_connections_api_url
+  connections_api_access_token = var.grafana_connections_api_access_token
 }
 
 provider "sentry" {

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -37,7 +37,9 @@ provider "neon" {}
 provider "cloudflare" {}
 
 provider "grafana" {
-  cloud_access_policy_token = var.grafana_cloud_access_policy_token
+  cloud_access_policy_token      = var.grafana_cloud_access_policy_token
+  connections_api_url            = var.grafana_connections_api_url
+  connections_api_access_token   = var.grafana_connections_api_access_token
 }
 
 provider "sentry" {

--- a/scripts/ci/terraform/validate.sh
+++ b/scripts/ci/terraform/validate.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Terraform fmt check and validate for infra/ (no backend, no apply).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+INFRA_DIR="${ROOT_DIR}/infra"
+
+echo "==> terraform fmt -check -recursive ${INFRA_DIR}"
+terraform fmt -check -recursive "${INFRA_DIR}"
+
+validate_dir() {
+	local dir="$1"
+	echo "==> terraform init -backend=false && terraform validate (${dir})"
+	(
+		cd "${dir}"
+		terraform init -backend=false -input=false >/dev/null
+		terraform validate
+	)
+}
+
+validate_dir "${INFRA_DIR}"
+
+for module_dir in "${INFRA_DIR}"/modules/*/; do
+	validate_dir "${module_dir}"
+done
+
+echo "Terraform fmt and validate passed."

--- a/tests/bats/unit/terraform/test_validate.bats
+++ b/tests/bats/unit/terraform/test_validate.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/terraform/validate.sh
+
+load "../../helpers/common"
+
+@test "terraform validate: --help not required, script runs fmt check" {
+	run bash "${PROJECT_ROOT}/scripts/ci/terraform/validate.sh"
+
+	if [[ "${status}" -eq 0 ]]; then
+		assert_output --partial "Terraform fmt and validate passed."
+	else
+		assert_failure
+		assert_output --partial "terraform"
+	fi
+}

--- a/tests/bats/unit/terraform/test_validate.bats
+++ b/tests/bats/unit/terraform/test_validate.bats
@@ -7,10 +7,6 @@ load "../../helpers/common"
 @test "terraform validate: --help not required, script runs fmt check" {
 	run bash "${PROJECT_ROOT}/scripts/ci/terraform/validate.sh"
 
-	if [[ "${status}" -eq 0 ]]; then
-		assert_output --partial "Terraform fmt and validate passed."
-	else
-		assert_failure
-		assert_output --partial "terraform"
-	fi
+	assert_success
+	assert_output --partial "Terraform fmt and validate passed."
 }


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(infra): author Terraform modules, env roots, and fmt/validate CI
  ```

- Type:
  - [x] feat (minor)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds the remaining offline Terraform for Rustume Cloud: Neon, R2, Cloudflare DNS, and monitoring modules; environment roots composing them with the existing Railway module; placeholder tfvars; and CI running `terraform fmt -check` plus `terraform validate` (backend=false). No plan/apply jobs or live infrastructure changes.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`)

## Closes

- Closes #365

## Details

### Modules
- `infra/modules/neon/` — project, branch, role, database (`terraform-community-providers/neon`)
- `infra/modules/r2/` — assets + backups buckets, lifecycle, object-lock retention, scoped API tokens
- `infra/modules/cloudflare-dns/` — apex A → GitHub Pages, `app` CNAME → Railway
- `infra/modules/monitoring/` — Grafana Cloud stack, Metrics Endpoint scrape job, Sentry project, baseline dashboard JSON

### Environment roots
- `infra/main.tf`, `variables.tf`, `outputs.tf`, `versions.tf`
- `infra/environments/production.tfvars` and `staging.tfvars` (placeholder, non-secret values)
- Commented backend block with README note that state setup stays manual on #333

### CI
- `.github/workflows/terraform-validate.yml` on `infra/**` changes
- `scripts/ci/terraform/validate.sh` for fmt check + per-module validate
- Optional BATS test under `tests/bats/unit/terraform/`

### Testing
- [x] `bash scripts/ci/terraform/validate.sh`
- [x] `uv run lintro fmt`
- [x] `uv run lintro chk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infrastructure configuration for production and staging environments.
  * Added automated provisioning for databases, object storage, DNS, application deployment, monitoring, and error tracking.
  * Added backup retention, access controls, environment-specific settings, and sensitive output handling.
  * Added baseline dashboards for request rates, errors, latency, and rate-limit usage.

* **Documentation**
  * Expanded infrastructure guides with setup, validation, secrets handling, and deployment instructions.

* **Tests**
  * Added automated formatting and validation checks for infrastructure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Terraform infrastructure for the Rustume Cloud stack. The main changes are:

- New Terraform modules for Neon, R2, Cloudflare DNS, monitoring, and Railway wiring.
- Root environment composition under `infra/` with staging and production tfvars.
- Terraform lockfiles and documentation for manual state, secrets, and apply flow.
- CI validation for Terraform formatting and module validation.
</details>


<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.



<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| infra/modules/r2/main.tf | Adds R2 buckets, retention policy, bucket lock, and scoped token resources. |
| infra/modules/r2/variables.tf | Defines R2 bucket, retention, token, and allowlist inputs. |
| infra/versions.tf | Configures required Terraform providers and root provider credentials. |
| infra/modules/monitoring/main.tf | Adds Grafana Cloud, metrics scrape, dashboard, and Sentry resources. |
| infra/modules/railway/variables.tf | Defines Railway module inputs without the removed region contract. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `infra/modules/railway/variables.tf`, line 41-50 ([link](https://github.com/lgtm-hq/rustume/blob/3229d8e88a0038a031676ae1df773485c04fe774/infra/modules/railway/variables.tf#L41-L50)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Region Input Ignored**

   The service no longer reads `var.regions`, but this input is still part of the module contract. If a caller sets `regions` to move the Railway service or change replica placement, Terraform accepts the value and plans no placement change, leaving the service in the dashboard/provider region instead of the declared configuration. Please either wire this input back into `railway_service` or remove it so callers cannot declare ignored placement.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20infra%2Fmodules%2Frailway%2Fvariables.tf%0ALine%3A%2041-50%0A%0AComment%3A%0A**Region%20Input%20Ignored**%0A%0AThe%20service%20no%20longer%20reads%20%60var.regions%60%2C%20but%20this%20input%20is%20still%20part%20of%20the%20module%20contract.%20If%20a%20caller%20sets%20%60regions%60%20to%20move%20the%20Railway%20service%20or%20change%20replica%20placement%2C%20Terraform%20accepts%20the%20value%20and%20plans%20no%20placement%20change%2C%20leaving%20the%20service%20in%20the%20dashboard%2Fprovider%20region%20instead%20of%20the%20declared%20configuration.%20Please%20either%20wire%20this%20input%20back%20into%20%60railway_service%60%20or%20remove%20it%20so%20callers%20cannot%20declare%20ignored%20placement.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20infra%2Fmodules%2Frailway%2Fvariables.tf%0ALine%3A%2041-50%0A%0AComment%3A%0A**Region%20Input%20Ignored**%0A%0AThe%20service%20no%20longer%20reads%20%60var.regions%60%2C%20but%20this%20input%20is%20still%20part%20of%20the%20module%20contract.%20If%20a%20caller%20sets%20%60regions%60%20to%20move%20the%20Railway%20service%20or%20change%20replica%20placement%2C%20Terraform%20accepts%20the%20value%20and%20plans%20no%20placement%20change%2C%20leaving%20the%20service%20in%20the%20dashboard%2Fprovider%20region%20instead%20of%20the%20declared%20configuration.%20Please%20either%20wire%20this%20input%20back%20into%20%60railway_service%60%20or%20remove%20it%20so%20callers%20cannot%20declare%20ignored%20placement.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22feat%2F365-terraform-modules%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F365-terraform-modules%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20infra%2Fmodules%2Frailway%2Fvariables.tf%0ALine%3A%2041-50%0A%0AComment%3A%0A**Region%20Input%20Ignored**%0A%0AThe%20service%20no%20longer%20reads%20%60var.regions%60%2C%20but%20this%20input%20is%20still%20part%20of%20the%20module%20contract.%20If%20a%20caller%20sets%20%60regions%60%20to%20move%20the%20Railway%20service%20or%20change%20replica%20placement%2C%20Terraform%20accepts%20the%20value%20and%20plans%20no%20placement%20change%2C%20leaving%20the%20service%20in%20the%20dashboard%2Fprovider%20region%20instead%20of%20the%20declared%20configuration.%20Please%20either%20wire%20this%20input%20back%20into%20%60railway_service%60%20or%20remove%20it%20so%20callers%20cannot%20declare%20ignored%20placement.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (10): Last reviewed commit: ["fix(infra): fmt neon vars and drop unuse..."](https://github.com/lgtm-hq/rustume/commit/c138a3e540b9cc033c8654417a42e5d01dd84b53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43711913)</sub>

<!-- /greptile_comment -->