### PR TITLE
fix(ci): allow timestamp.sigstore.dev egress for cosign signing on main

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -109,6 +109,7 @@ jobs:
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
+        timestamp.sigstore.dev:443
         get.trivy.dev:443
         mirror.gcr.io:443
         public.ecr.aws:443


### PR DESCRIPTION
## Summary

Every main-push docker publish fails at Merge Manifests: cosign requests an RFC 3161 timestamp from `timestamp.sigstore.dev`, which is missing from the harden-runner allowlist (fulcio/rekor/tuf-repo-cdn are present). Connection refused → signing fails → no `:main` image published (run 29252726133).

PRs never exercise signing (push-only), so #440 validated green while main broke post-merge.

## Changes

- Add `timestamp.sigstore.dev:443` to the docker workflow egress allowlist.

## Testing

- Both platform builds + verifies already succeed on main; only the signing step fails. This run's merge to main re-triggers the publish path end-to-end.

Related: #459 (fail-fast egress), #463 (infra auto-rerun). Epic: #453.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and publishing automation to support an additional security verification endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #465

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the Docker publish workflow egress list for cosign signing. The main change is:

- Adds `timestamp.sigstore.dev:443` to the existing Sigstore allowlist.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The added endpoint matches the existing Sigstore signing flow and keeps the allowlist narrowly scoped.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-build-publish.yml | Adds the Sigstore timestamp service to the harden-runner egress allowlist used by Docker publish signing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): allow timestamp.sigstore.dev eg..."](https://github.com/lgtm-hq/rustume/commit/792d21d69da3d77ba55448c855aaf7f562b1d83d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43818461)</sub>

<!-- /greptile_comment -->