### PR TITLE
perf(ci): add concurrency groups to coverage and docker workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,12 @@ name: Coverage Reports
 permissions:
   contents: read
 
+# Cancel superseded PR runs; never cancel main (post-merge coverage must
+# complete so Pages coverage publishing and required gates stay reliable).
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   rust-server-db-integration:
     name: "🐘 Server DB Integration"

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -36,6 +36,14 @@ name: Build - Docker Image & Registry
 permissions:
   contents: read
 
+# Cancel superseded PR validate runs; never cancel main/tag/release publishes
+# (a cancelled publish would leave GHCR tags, signatures, and the Railway
+# deploy chain in a partial state).
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request' }}
+
 jobs:
   docker:
     name: 🐳 Docker Build & Publish


### PR DESCRIPTION
## Summary

First sub-issue of epic #453: the two heaviest workflows (`coverage.yml`, `docker-build-publish.yml`) had no `concurrency` block, so superseded PR commits ran 3 coverage jobs + a 2-arch docker validate to completion. Lighter workflows (`test-rust.yml`, `ci-lintro-analysis.yml`) already cancel superseded runs.

## Changes

- `coverage.yml`: `coverage-${{ github.ref }}` group; cancel-in-progress on non-main refs only (post-merge coverage always completes).
- `docker-build-publish.yml`: `docker-${{ github.ref }}` group; cancel-in-progress **only** for `pull_request` events — main pushes, tag publishes, releases, and dispatches are never cancelled mid-publish (GHCR tags/signatures/Railway chain must not be left partial).

## Testing

- Workflow YAML lint clean.
- Behavior verifiable on this PR: push a follow-up commit and the in-flight coverage + docker runs for the previous commit cancel.

Closes #455. Epic: #453.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds concurrency controls to the two heaviest CI workflows. The main changes are:

- Coverage runs now share a `coverage-${{ github.ref }}` group.
- Coverage cancellation is disabled for `refs/heads/main`.
- Docker runs now share a `docker-${{ github.ref }}` group.
- Docker cancellation is limited to pull request events.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/coverage.yml | Adds ref-scoped concurrency while preserving main-branch coverage completion. |
| .github/workflows/docker-build-publish.yml | Adds ref-scoped concurrency and limits cancellation to pull request validation runs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(ci): add concurrency groups to cove..."](https://github.com/lgtm-hq/rustume/commit/39087bcb63d80c4daec93b789f9694b2db65c6db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43827934)</sub>

<!-- /greptile_comment -->