### PR TITLE
fix(ci): remove duplicate release trigger from docker publish

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -3,7 +3,11 @@
 name: Build - Docker Image & Registry
 # Builds and publishes Docker images to GHCR via lgtm-ci reusable-docker.
 # - PRs: native multi-arch validation (build + smoke + blocking scan, no push)
-# - main/tags/release: publish, cosign sign, SBOM, provenance, registry cache
+# - main/tags: publish, cosign sign, SBOM, provenance, registry cache
+#   (no `release:` trigger: publish-release-on-tag.yml creates the GitHub
+#   Release from the tag, so a release trigger would rebuild the identical
+#   image a second time — see #454. Tag pushes always fire: GitHub does not
+#   evaluate `paths` filters for tag pushes.)
 #
 # Rustume Cloud deploy tags (reusable-docker metadata-action):
 #   main push  -> ghcr.io/lgtm-hq/rustume:main, :sha-<commit>
@@ -29,8 +33,6 @@ name: Build - Docker Image & Registry
   pull_request:
     branches: [main]
     paths: *docker-paths
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -60,14 +62,11 @@ jobs:
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-
-        ${{ startsWith(github.ref, 'refs/tags/')
-        && github.ref_name
-        || (github.event_name == 'release' && github.event.release.tag_name || '') }}
+        ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
       push: >-
         ${{ github.event_name != 'pull_request'
         && (github.ref == 'refs/heads/main'
-        || startsWith(github.ref, 'refs/tags/v')
-        || github.event_name == 'release') }}
+        || startsWith(github.ref, 'refs/tags/v')) }}
       validate-on-pr: ${{ github.event_name == 'pull_request' }}
       platforms: linux/amd64,linux/arm64
       runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'


### PR DESCRIPTION
## Summary

Epic #453, sub-issue #454. `docker-build-publish.yml` triggered on both `push: tags: v*.*.*` and `release: types: [published]`. Since `publish-release-on-tag.yml` creates the GitHub Release *from* the tag, one version produced two identical cold (`no-cache`) multi-arch publish runs — ~4 full Rust+WASM compiles per release.

## Changes

- Drop the `release:` trigger; the tag push is the canonical event and always fires (GitHub does not evaluate `paths` filters for tag pushes — documented in the workflow header).
- Simplify `version:`/`push:` expressions that referenced the release event.

## Testing

- YAML lint clean.
- Verified surviving trigger produces all tags (`:semver`, `:latest`, `:sha-`) — tag path is unchanged, only the duplicate event is removed.
- Full verification on next release: exactly one publish run per tag.

Closes #454. Epic: #453.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the duplicate Docker publish path for GitHub Releases. The main changes are:

- Drops the `release: published` workflow trigger.
- Keeps main, tag, pull request, and manual workflow entry points.
- Simplifies Docker publish inputs to use tag refs instead of release events.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed workflow logic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-build-publish.yml | Removes release-event Docker publishing and keeps tag pushes as the release publish path. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): remove duplicate release trigge..."](https://github.com/lgtm-hq/rustume/commit/09c0d3452e0cc92884816a84030414073feaba7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43835331)</sub>

<!-- /greptile_comment -->