### PR TITLE
perf(ci): skip docker publish and railway deploy on version-bump-only merges

### DIFF
--- a/.github/workflows/deploy-railway-cloud.yml
+++ b/.github/workflows/deploy-railway-cloud.yml
@@ -33,14 +33,52 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Mirror of the classify gate in docker-build-publish.yml (#457): a
+  # release-version-bump-only merge skips the docker build but its run still
+  # concludes "success", so without this gate we would redeploy a byte-
+  # identical :main image. Candidates are nominated by commit message; the
+  # diff classifier decides (bump PRs carrying dependency updates deploy).
+  classify:
+    name: 🔎 Classify Release Bump
+    if: >-
+      github.event_name == 'workflow_run'
+      && startsWith(github.event.workflow_run.head_commit.message,
+      'chore(release): version')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      bump-only: ${{ steps.check.outputs.bump-only }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Classify diff
+        id: check
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: bash scripts/ci/docker/classify_release_bump.sh
+
   deploy:
     name: 🚀 Deploy to Railway
+    needs: classify
     if: >-
-      (github.event_name == 'workflow_dispatch' &&
+      always() &&
+      needs.classify.outputs.bump-only != 'true' &&
+      ((github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main') ||
       (github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository)
+      github.event.workflow_run.head_repository.full_name == github.repository))
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -45,8 +45,50 @@ concurrency:
     ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Skip the publish for release-version-bump-only merges (#457): the bump
+  # commit changes nothing that reaches the image, and the tag build that
+  # follows produces the release image anyway. The commit-message check only
+  # nominates candidates; the diff classifier decides (a bump PR that also
+  # carries dependency updates, or a hand-crafted bump-looking commit that
+  # touches code, still builds). Note: on a skipped build this run still
+  # concludes "success" (classify ran), so deploy-railway-cloud.yml carries
+  # its own matching classify gate to skip the redundant redeploy.
+  classify:
+    name: 🔎 Classify Release Bump
+    if: >-
+      github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && startsWith(github.event.head_commit.message, 'chore(release): version')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      bump-only: ${{ steps.check.outputs.bump-only }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Classify diff
+        id: check
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: bash scripts/ci/docker/classify_release_bump.sh
+
   docker:
     name: 🐳 Docker Build & Publish
+    needs: classify
+    if: >-
+      always() && needs.classify.outputs.bump-only != 'true'
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:

--- a/.github/workflows/test-docker-shell.yml
+++ b/.github/workflows/test-docker-shell.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Test - Docker Shell Scripts
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/docker/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-docker-shell.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/ci/docker/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-docker-shell.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-docker-shell-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell-tests:
+    permissions:
+      contents: read
+      pull-requests: write # publish-test-summary posts shell coverage on PRs
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    with:
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      job-name: Docker Shell Tests
+      test-path: tests/bats/unit/docker
+      coverage: true
+      # kcov reports 0% for bash via BATS; non-zero fails CI until measurement fixed
+      coverage-threshold: 0
+      upload-coverage: false
+      egress-policy: block
+      egress-preset: github-tooling
+      runner-image: ubuntu-24.04

--- a/scripts/ci/docker/classify_release_bump.sh
+++ b/scripts/ci/docker/classify_release_bump.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# CI wrapper around release_bump_only.sh (#457). Classifies HEAD_SHA against
+# BASE_SHA (or HEAD_SHA's first parent when BASE_SHA is unset/empty) and
+# writes `bump-only=<true|false>` to GITHUB_OUTPUT.
+#
+# Used by docker-build-publish.yml (push: BASE_SHA=github.event.before) and
+# deploy-railway-cloud.yml (workflow_run: parent of head_sha).
+
+set -euo pipefail
+
+: "${HEAD_SHA:?HEAD_SHA is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+base="${BASE_SHA:-}"
+if [[ -z "${base}" ]]; then
+	base="$(git rev-parse "${HEAD_SHA}~1")"
+fi
+
+result="$("${script_dir}/release_bump_only.sh" "${base}" "${HEAD_SHA}")"
+
+echo "bump-only=${result}" >>"${GITHUB_OUTPUT}"
+echo "classified ${base}..${HEAD_SHA}: bump-only=${result}"

--- a/scripts/ci/docker/release_bump_only.sh
+++ b/scripts/ci/docker/release_bump_only.sh
@@ -59,16 +59,21 @@ while IFS= read -r f; do
 	fi
 done <<<"${changed_files}"
 
-# Cargo.toml diff (added/removed lines only) must contain nothing but
-# version stamps.
-toml_diff=$(git diff --unified=0 "${base}" "${head}" -- Cargo.toml |
-	grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true)
-if [[ -n "${toml_diff}" ]]; then
-	bad=$(echo "${toml_diff}" |
-		grep -vE '^[+-]version = "[0-9]+\.[0-9]+\.[0-9]+[^"]*"$' || true)
-	if [[ -n "${bad}" ]]; then
-		echo "not bump-only: non-version change in Cargo.toml:" >&2
-		echo "${bad}" >&2
+# Cargo.toml: a bare version-line diff check is section-blind — a
+# `version = "..."` line under [dependencies.foo] looks identical to the
+# crate's own version stamp. Instead, strip the version line from the
+# [package] / [workspace.package] sections of both revisions and require the
+# remainders to be byte-identical: then the ONLY change is the crate version.
+strip_pkg_version() {
+	git show "$1:Cargo.toml" 2>/dev/null | awk '
+		/^\[/ { in_pkg = ($0 == "[package]" || $0 == "[workspace.package]") }
+		!(in_pkg && /^version = "[0-9]+\.[0-9]+\.[0-9]+[^"]*"$/)
+	'
+}
+
+if ! git diff --quiet "${base}" "${head}" -- Cargo.toml; then
+	if ! diff -q <(strip_pkg_version "${base}") <(strip_pkg_version "${head}") >/dev/null; then
+		echo "not bump-only: Cargo.toml changed outside [package]/[workspace.package] version" >&2
 		echo "false"
 		exit 0
 	fi
@@ -94,27 +99,28 @@ parse_lock() {
 }
 
 if ! git diff --quiet "${base}" "${head}" -- Cargo.lock; then
-	base_lock="$(parse_lock "${base}")"
-	head_lock="$(parse_lock "${head}")"
-	# comm prefixes column-2 (head-only) lines with a tab — strip it before
-	# taking the package-name field, or added packages would be missed.
-	changed_pkgs=$(comm -3 <(sort <<<"${base_lock}") <(sort <<<"${head_lock}") |
-		sed 's/^\t//' | cut -f1 | sort -u)
-	while IFS= read -r pkg; do
-		[[ -z "${pkg}" ]] && continue
-		base_entry=$(grep -m1 "^${pkg}	" <<<"${base_lock}" || true)
-		head_entry=$(grep -m1 "^${pkg}	" <<<"${head_lock}" || true)
-		if [[ -z "${base_entry}" || -z "${head_entry}" ]]; then
-			echo "not bump-only: package added/removed in Cargo.lock: ${pkg}" >&2
-			echo "false"
-			exit 0
-		fi
-		if [[ "${base_entry##*	}" != "0" || "${head_entry##*	}" != "0" ]]; then
-			echo "not bump-only: external package changed in Cargo.lock: ${pkg}" >&2
-			echo "false"
-			exit 0
-		fi
-	done <<<"${changed_pkgs}"
+	base_lock="$(parse_lock "${base}" | sort)"
+	head_lock="$(parse_lock "${head}" | sort)"
+	# Compare full (name, version, has-checksum) rows — a name-keyed lookup
+	# would mis-select when the same crate exists at multiple versions.
+	removed_rows=$(comm -23 <(printf '%s\n' "${base_lock}") <(printf '%s\n' "${head_lock}"))
+	added_rows=$(comm -13 <(printf '%s\n' "${base_lock}") <(printf '%s\n' "${head_lock}"))
+	bad_rows=$(printf '%s\n%s\n' "${removed_rows}" "${added_rows}" |
+		awk -F'\t' 'NF && $3 != 0 { print $1 " " $2 }')
+	if [[ -n "${bad_rows}" ]]; then
+		echo "not bump-only: external package changed in Cargo.lock:" >&2
+		echo "${bad_rows}" >&2
+		echo "false"
+		exit 0
+	fi
+	# The multiset of changed package names must match on both sides — a bump
+	# never adds or removes packages.
+	if ! diff -q <(awk -F'\t' 'NF{print $1}' <<<"${removed_rows}" | sort) \
+		<(awk -F'\t' 'NF{print $1}' <<<"${added_rows}" | sort) >/dev/null; then
+		echo "not bump-only: package set changed in Cargo.lock" >&2
+		echo "false"
+		exit 0
+	fi
 fi
 
 echo "true"

--- a/scripts/ci/docker/release_bump_only.sh
+++ b/scripts/ci/docker/release_bump_only.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Decide whether a commit range is a release-version-bump-only change, so the
+# Docker publish (and the Railway deploy chained on it) can be skipped for
+# commits that only stamp a new version (#457).
+#
+# A range qualifies as bump-only when ALL of the following hold:
+#   1. Changed files are a subset of: CHANGELOG.md, Cargo.toml, Cargo.lock.
+#   2. The Cargo.toml diff touches only `version = "..."` lines.
+#   3. The Cargo.lock diff touches only `version = "..."` lines.
+# CHANGELOG.md content is not inspected (never affects the image).
+#
+# The file allowlist alone is NOT sufficient: dependency updates (Renovate)
+# also touch only Cargo.toml + Cargo.lock and must still build. The
+# version-line-only diff check is what separates the two.
+#
+# Usage: release_bump_only.sh <base-sha> <head-sha>
+# Output: prints "true" or "false" to stdout; always exits 0 unless misused.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+	echo "usage: $0 <base-sha> <head-sha>" >&2
+	exit 2
+fi
+
+base="$1"
+head="$2"
+
+# Force-push / branch-creation pushes have an all-zero before SHA — no
+# meaningful diff, never classify as bump-only.
+if [[ "${base}" =~ ^0+$ ]]; then
+	echo "false"
+	exit 0
+fi
+
+allowed_files=("CHANGELOG.md" "Cargo.toml" "Cargo.lock")
+
+changed_files=$(git diff --name-only "${base}" "${head}")
+
+if [[ -z "${changed_files}" ]]; then
+	echo "false"
+	exit 0
+fi
+
+while IFS= read -r f; do
+	ok=false
+	for a in "${allowed_files[@]}"; do
+		if [[ "${f}" == "${a}" ]]; then
+			ok=true
+			break
+		fi
+	done
+	if [[ "${ok}" == "false" ]]; then
+		echo "not bump-only: ${f} outside allowlist" >&2
+		echo "false"
+		exit 0
+	fi
+done <<<"${changed_files}"
+
+# Diff content lines (added/removed only, no context/headers) must all be
+# version stamps in the two manifest files.
+for manifest in "Cargo.toml" "Cargo.lock"; do
+	diff_lines=$(git diff --unified=0 "${base}" "${head}" -- "${manifest}" |
+		grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true)
+	if [[ -z "${diff_lines}" ]]; then
+		continue
+	fi
+	bad=$(echo "${diff_lines}" |
+		grep -vE '^[+-]version = "[0-9]+\.[0-9]+\.[0-9]+[^"]*"$' || true)
+	if [[ -n "${bad}" ]]; then
+		echo "not bump-only: non-version change in ${manifest}:" >&2
+		echo "${bad}" >&2
+		echo "false"
+		exit 0
+	fi
+done
+
+echo "true"

--- a/scripts/ci/docker/release_bump_only.sh
+++ b/scripts/ci/docker/release_bump_only.sh
@@ -59,22 +59,62 @@ while IFS= read -r f; do
 	fi
 done <<<"${changed_files}"
 
-# Diff content lines (added/removed only, no context/headers) must all be
-# version stamps in the two manifest files.
-for manifest in "Cargo.toml" "Cargo.lock"; do
-	diff_lines=$(git diff --unified=0 "${base}" "${head}" -- "${manifest}" |
-		grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true)
-	if [[ -z "${diff_lines}" ]]; then
-		continue
-	fi
-	bad=$(echo "${diff_lines}" |
+# Cargo.toml diff (added/removed lines only) must contain nothing but
+# version stamps.
+toml_diff=$(git diff --unified=0 "${base}" "${head}" -- Cargo.toml |
+	grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true)
+if [[ -n "${toml_diff}" ]]; then
+	bad=$(echo "${toml_diff}" |
 		grep -vE '^[+-]version = "[0-9]+\.[0-9]+\.[0-9]+[^"]*"$' || true)
 	if [[ -n "${bad}" ]]; then
-		echo "not bump-only: non-version change in ${manifest}:" >&2
+		echo "not bump-only: non-version change in Cargo.toml:" >&2
 		echo "${bad}" >&2
 		echo "false"
 		exit 0
 	fi
-done
+fi
+
+# Cargo.lock: a line-level version check is spoofable — a dependency bump
+# whose diff happens to touch only `version = "..."` lines would pass. So
+# parse both revisions into (name, version, has-checksum) entries and require
+# every changed package to be checksum-less in both revisions: workspace
+# members carry no checksum, external/registry packages always do. Package
+# additions or removals never qualify as a bump.
+parse_lock() {
+	git show "$1:Cargo.lock" 2>/dev/null | awk '
+		/^name = /     { gsub(/"/, ""); name = $3 }
+		/^version = /  { gsub(/"/, ""); ver = $3 }
+		/^checksum = / { ck = 1 }
+		/^$/ {
+			if (name != "") { print name "\t" ver "\t" (ck + 0) }
+			name = ""; ver = ""; ck = 0
+		}
+		END { if (name != "") { print name "\t" ver "\t" ck } }
+	'
+}
+
+if ! git diff --quiet "${base}" "${head}" -- Cargo.lock; then
+	base_lock="$(parse_lock "${base}")"
+	head_lock="$(parse_lock "${head}")"
+	# comm prefixes column-2 (head-only) lines with a tab — strip it before
+	# taking the package-name field, or added packages would be missed.
+	changed_pkgs=$(comm -3 <(sort <<<"${base_lock}") <(sort <<<"${head_lock}") |
+		sed 's/^\t//' | cut -f1 | sort -u)
+	while IFS= read -r pkg; do
+		[[ -z "${pkg}" ]] && continue
+		base_entry=$(grep -m1 "^${pkg}	" <<<"${base_lock}" || true)
+		head_entry=$(grep -m1 "^${pkg}	" <<<"${head_lock}" || true)
+		if [[ -z "${base_entry}" || -z "${head_entry}" ]]; then
+			echo "not bump-only: package added/removed in Cargo.lock: ${pkg}" >&2
+			echo "false"
+			exit 0
+		fi
+		if [[ "${base_entry##*	}" != "0" || "${head_entry##*	}" != "0" ]]; then
+			echo "not bump-only: external package changed in Cargo.lock: ${pkg}" >&2
+			echo "false"
+			exit 0
+		fi
+	done <<<"${changed_pkgs}"
+fi
 
 echo "true"

--- a/tests/bats/unit/docker/test_release_bump_only.bats
+++ b/tests/bats/unit/docker/test_release_bump_only.bats
@@ -112,6 +112,40 @@ commit_all() {
 	[[ "${output}" == *"false"* ]]
 }
 
+@test "dependency-section version change in Cargo.toml classifies false" {
+	# CodeRabbit on #469: [dependencies.foo] version lines must not pass as
+	# the crate's own version stamp.
+	printf '\n[dependencies.foo]\nversion = "1.0.0"\n' >>"${REPO}/Cargo.toml"
+	git -C "${REPO}" add -A && git -C "${REPO}" commit -qm "add dep"
+	BASE="$(git -C "${REPO}" rev-parse HEAD)"
+	sed -i.bak 's/1\.0\.0/1.0.1/' "${REPO}/Cargo.toml"
+	rm -f "${REPO}"/*.bak
+	commit_all "chore(release): version 0.29.1"
+	run run_script "${BASE}" "${HEAD_SHA}"
+	[ "${status}" -eq 0 ]
+	[[ "${output}" == *"false"* ]]
+}
+
+@test "duplicate crate versions: bumping one external copy classifies false" {
+	# CodeRabbit on #469: name-keyed lookup mis-selects when a crate exists at
+	# multiple versions; full-row comparison must catch the changed copy.
+	cat >>"${REPO}/Cargo.lock" <<-'EOF'
+
+		[[package]]
+		name = "serde"
+		version = "2.0.0"
+		checksum = "dddd"
+	EOF
+	git -C "${REPO}" add -A && git -C "${REPO}" commit -qm "dup versions"
+	BASE="$(git -C "${REPO}" rev-parse HEAD)"
+	sed -i.bak -e 's/2\.0\.0/2.0.1/' -e 's/dddd/eeee/' "${REPO}/Cargo.lock"
+	rm -f "${REPO}"/*.bak
+	commit_all "chore(release): version 0.29.1"
+	run run_script "${BASE}" "${HEAD_SHA}"
+	[ "${status}" -eq 0 ]
+	[[ "${output}" == *"false"* ]]
+}
+
 @test "all-zero base sha classifies false" {
 	run run_script "0000000000000000000000000000000000000000" "${BASE}"
 	[ "${status}" -eq 0 ]

--- a/tests/bats/unit/docker/test_release_bump_only.bats
+++ b/tests/bats/unit/docker/test_release_bump_only.bats
@@ -87,6 +87,31 @@ commit_all() {
 	[ "${output}" = "true" ]
 }
 
+@test "external dep version-only change (checksum untouched) classifies false" {
+	# Greptile P1 on #469: a diff touching only version lines must not pass
+	# when the changed package is external (has a checksum).
+	sed -i.bak 's/1\.0\.22/1.0.23/' "${REPO}/Cargo.lock"
+	rm -f "${REPO}"/*.bak
+	commit_all "chore(release): version 0.29.1"
+	run run_script "${BASE}" "${HEAD_SHA}"
+	[ "${status}" -eq 0 ]
+	[[ "${output}" == *"false"* ]]
+}
+
+@test "package added to Cargo.lock classifies false" {
+	cat >>"${REPO}/Cargo.lock" <<-'EOF'
+
+		[[package]]
+		name = "newdep"
+		version = "0.1.0"
+		checksum = "cccc"
+	EOF
+	commit_all "chore(release): version 0.29.1"
+	run run_script "${BASE}" "${HEAD_SHA}"
+	[ "${status}" -eq 0 ]
+	[[ "${output}" == *"false"* ]]
+}
+
 @test "all-zero base sha classifies false" {
 	run run_script "0000000000000000000000000000000000000000" "${BASE}"
 	[ "${status}" -eq 0 ]

--- a/tests/bats/unit/docker/test_release_bump_only.bats
+++ b/tests/bats/unit/docker/test_release_bump_only.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/docker/release_bump_only.sh (#457)
+
+load "../../helpers/common"
+
+SCRIPT="scripts/ci/docker/release_bump_only.sh"
+
+setup() {
+	setup_temp_dir
+	REPO="${BATS_TEST_TMPDIR}/repo"
+	mkdir -p "${REPO}"
+	git -C "${REPO}" init -q
+	git -C "${REPO}" config user.email "test@example.com"
+	git -C "${REPO}" config user.name "test"
+	cat >"${REPO}/Cargo.toml" <<-'EOF'
+		[package]
+		name = "rustume"
+		version = "0.29.0"
+	EOF
+	cat >"${REPO}/Cargo.lock" <<-'EOF'
+		[[package]]
+		name = "rustume"
+		version = "0.29.0"
+
+		[[package]]
+		name = "serde"
+		version = "1.0.22"
+		checksum = "aaaa"
+	EOF
+	echo "# Changelog" >"${REPO}/CHANGELOG.md"
+	echo "fn main() {}" >"${REPO}/main.rs"
+	git -C "${REPO}" add -A
+	git -C "${REPO}" commit -qm "init"
+	BASE="$(git -C "${REPO}" rev-parse HEAD)"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+run_script() {
+	(cd "${REPO}" && bash "${PROJECT_ROOT}/${SCRIPT}" "$@")
+}
+
+commit_all() {
+	git -C "${REPO}" add -A
+	git -C "${REPO}" commit -qm "$1"
+	HEAD_SHA="$(git -C "${REPO}" rev-parse HEAD)"
+}
+
+@test "pure version bump classifies true" {
+	sed -i.bak 's/0\.29\.0/0.29.1/' "${REPO}/Cargo.toml" "${REPO}/Cargo.lock"
+	rm -f "${REPO}"/*.bak
+	echo "## 0.29.1" >>"${REPO}/CHANGELOG.md"
+	commit_all "chore(release): version 0.29.1"
+	run run_script "${BASE}" "${HEAD_SHA}"
+	[ "${status}" -eq 0 ]
+	[ "${output}" = "true" ]
+}
+
+@test "bump that also updates a dependency classifies false" {
+	sed -i.bak 's/0\.29\.0/0.29.1/' "${REPO}/Cargo.toml" "${REPO}/Cargo.lock"
+	sed -i.bak -e 's/1\.0\.22/1.0.23/' -e 's/aaaa/bbbb/' "${REPO}/Cargo.lock"
+	rm -f "${REPO}"/*.bak
+	commit_all "chore(release): version 0.29.1"
+	run run_script "${BASE}" "${HEAD_SHA}"
+	[ "${status}" -eq 0 ]
+	[[ "${output}" == *"false"* ]]
+}
+
+@test "code change outside allowlist classifies false" {
+	sed -i.bak 's/0\.29\.0/0.29.1/' "${REPO}/Cargo.toml" "${REPO}/Cargo.lock"
+	rm -f "${REPO}"/*.bak
+	echo "fn extra() {}" >>"${REPO}/main.rs"
+	commit_all "chore(release): version 0.29.1"
+	run run_script "${BASE}" "${HEAD_SHA}"
+	[ "${status}" -eq 0 ]
+	[[ "${output}" == *"false"* ]]
+}
+
+@test "changelog-only change classifies true" {
+	echo "## notes" >>"${REPO}/CHANGELOG.md"
+	commit_all "chore(release): version 0.29.1"
+	run run_script "${BASE}" "${HEAD_SHA}"
+	[ "${status}" -eq 0 ]
+	[ "${output}" = "true" ]
+}
+
+@test "all-zero base sha classifies false" {
+	run run_script "0000000000000000000000000000000000000000" "${BASE}"
+	[ "${status}" -eq 0 ]
+	[ "${output}" = "false" ]
+}
+
+@test "empty diff classifies false" {
+	run run_script "${BASE}" "${BASE}"
+	[ "${status}" -eq 0 ]
+	[ "${output}" = "false" ]
+}
+
+@test "missing arguments exits 2" {
+	run run_script "${BASE}"
+	[ "${status}" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

Epic #453, sub-issue #457. Every feature currently builds `:main` and deploys to Railway **twice** — once for the feature merge, once for the semantic-release version-bump merge, whose image is byte-identical.

## Changes

- `scripts/ci/docker/release_bump_only.sh` — diff classifier: true only when changed files ⊆ {CHANGELOG.md, Cargo.toml, Cargo.lock} **and** both manifest diffs contain nothing but `version = "…"` lines. A file allowlist alone is insufficient — Renovate dep bumps touch the same files and must build; verified against real history (0.29.0 pure bump → skip; 0.29.1 bump-with-dep-update → build).
- `docker-build-publish.yml` — `classify` gate job (nominated by `chore(release): version` commit message on main pushes only); `docker` job skips when bump-only. Fail-open: classifier error ⇒ build.
- `deploy-railway-cloud.yml` — mirrored classify gate: a skipped build still concludes its run `success`, which would re-trigger the `workflow_run` deploy with an identical image.
- `tests/bats/unit/docker/test_release_bump_only.bats` — 7 cases (pure bump, bump+dep, code change, changelog-only, zero-SHA, empty diff, usage).
- `test-docker-shell.yml` — new BATS workflow for `scripts/ci/docker` (mirrors the railway/backup shell test workflows).

## Safety

- Spoof-resistant: commit message only nominates; the diff decides. A bump-looking commit touching code still builds + deploys.
- Tag-triggered release builds unaffected (classify only runs on branch pushes to main).
- `workflow_dispatch` deploys unaffected (classify skips ⇒ deploy proceeds).

## Testing

- BATS: 7/7 pass locally. Lint clean (yaml, shellcheck, shfmt).
- End-to-end verification on the next release-bump merge: expect classify=true, docker skipped, no Railway deploy.

Closes #457. Epic: #453.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI release-bump classification to detect “bump-only” version changes.
  * Skipped redundant Docker image publishing and deployment for version-bump-only merges.
  * Introduced a Docker shell-script test workflow for PRs and main-branch updates.

* **Bug Fixes**
  * Tightened deployment conditions to ensure deploys only occur for relevant, successful main-branch workflow runs.

* **Tests**
  * Expanded Bats coverage for bump classification, including changelog-only, dependency/Cargo.lock cases, empty diffs, and invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR skips redundant CI work for release-version-only merges. The main changes are:

- Adds a Docker release-bump classifier for `CHANGELOG.md`, `Cargo.toml`, and `Cargo.lock` changes.
- Gates Docker publish and Railway deploy jobs when the classifier reports a bump-only merge.
- Adds a Docker shell-script test workflow for the classifier tests.
- Adds BATS coverage for pure bumps, dependency changes, lockfile changes, and invalid inputs.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/docker/release_bump_only.sh | Adds the release-bump-only classifier and rejects changed checksum-bearing dependency rows in `Cargo.lock`. |
| scripts/ci/docker/classify_release_bump.sh | Adds the CI wrapper that resolves the base revision and writes the classifier result to GitHub Actions output. |
| .github/workflows/docker-build-publish.yml | Adds a classify job and skips Docker publish only when the classifier reports a bump-only change. |
| .github/workflows/deploy-railway-cloud.yml | Adds a matching classify gate so release-version-only workflow runs do not trigger redundant Railway deploys. |
| tests/bats/unit/docker/test_release_bump_only.bats | Adds classifier tests for release bumps, dependency updates, package additions, duplicate crate versions, and invalid inputs. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): section-aware Cargo.toml check ..."](https://github.com/lgtm-hq/rustume/commit/09776fa10198c4b41b099e4c8b24e90e88ef9df0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43837391)</sub>

<!-- /greptile_comment -->