### PR TITLE
chore(ci): bump lgtm-ci pins to v0.54.0 and add infra auto-rerun caller

### DIFF
--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -21,6 +21,7 @@ name: Auto Rerun on Infra Failure
       - Rust Build (workspace)
       - Quality - Lint & Format
     types: [completed]
+    branches: [main]
 
 permissions: {}
 

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Auto Rerun on Infra Failure
+
+# When a listed workflow fails and its failed-job logs match a known
+# GitHub-side outage signature ("Failed to resolve action download info",
+# runner shutdown signals, harden-runner allowed-domain resolution errors),
+# re-run only the failed jobs — once (run-attempt guard upstream). Closes the
+# loop on incidents like 2026-07-13 (runs 29252857248, 29252725585,
+# 29261557105) where pure infra failures needed manual reruns. See #463.
+#
+# workflow_run triggers only run from the definition on the default branch,
+# so changes here take effect after merging to main.
+
+"on":
+  workflow_run:
+    workflows:
+      - Build - Docker Image & Registry
+      - Coverage Reports
+      - Deploy - GitHub Pages
+      - Rust Build (workspace)
+      - Quality - Lint & Format
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  rerun:
+    if: github.event.workflow_run.conclusion == 'failure'
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    permissions:
+      actions: write
+      contents: read
+    with:
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      # run id/attempt are numbers in the event payload; format() passes them
+      # as the strings the reusable workflow inputs expect.
+      run-id: ${{ format('{0}', github.event.workflow_run.id) }}
+      run-attempt: ${{ format('{0}', github.event.workflow_run.run_attempt) }}
+      egress-policy: block
+      egress-preset: github-minimal

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -18,9 +18,9 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: "🏷️ Create Release Tag"
       version-source: cargo
       create-release: false

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -68,7 +68,7 @@ jobs:
         # setup-rust cargo-binstall fix for Windows Git Bash
         # (MINGW64_NT-* was "Unsupported OS", skipping release artifacts).
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@82b57ed22b8ed7c707af41ff8a1b74f4e300997f # v0.53.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -42,12 +42,12 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read # checkout repository sources for lintro analysis
       packages: read # pull the pinned lintro image from GHCR
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: "🛠️ Lintro Code Quality"
       lintro-tool-options: clippy:timeout=300
       timeout-minutes: 30
@@ -65,14 +65,14 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read # read quality job outputs and artifacts
       pull-requests: write # post or update the quality summary comment
     with:
       exit-code: >-
         ${{ needs.quality.outputs.exit-code != '' && needs.quality.outputs.exit-code || '1' }}
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: "🛠️ Lintro Code Quality PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,9 +34,9 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: "🔬 CodeQL Analysis"
       languages: actions,rust
       language-build-modes: '{"rust":"none","actions":"none"}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,12 +36,12 @@ jobs:
   # instrumented, as a superset of the old dedicated job's filter.
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: "🦀 Rust Coverage"
       coverage: true
       setup-script: scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -54,12 +54,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,11 +15,11 @@ concurrency:
 jobs:
   review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       job-name: "🔍 Dependency Review"
       fail-on-severity: high
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
       # github-tooling preset + api.deps.dev: dependency-review-action

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
       actions: write
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       # Explicit space-separated (folded scalar) allowlists: the reusable
       # workflow's newline block-scalar defaults are mis-parsed by the
@@ -74,7 +74,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/deploy-railway-cloud.yml
+++ b/.github/workflows/deploy-railway-cloud.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -92,7 +92,7 @@ jobs:
     if: >-
       always() && needs.classify.outputs.bump-only != 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       packages: write
@@ -100,7 +100,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -40,7 +40,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       packages: write
@@ -48,7 +48,7 @@ jobs:
       package-name: rustume
       min-age-days: ${{ inputs.min_age_days || 7 }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: audit
       runner-image: ubuntu-24.04
     secrets:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -13,11 +13,11 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       job-name: "👤 Auto Assign PR Author"
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,12 +12,12 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       job-name: "🏷️ Auto Label PR"
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -108,7 +108,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,10 +17,11 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       job-name: "🛡️ Scorecard Analysis"
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      # v0.54.0 hard-cut the no-op tooling-ref / egress-preset /
+      # allowed-endpoints-mode inputs on reusable-scorecards (#540).
       # publish_results:true enforces an allowlist of actions that excludes
       # lgtm-ci local composites (checkout-and-harden). That makes every run
       # fail with "job has unallowed step". Keep SARIF upload to the Security
@@ -28,11 +29,6 @@ jobs:
       # uses allowlisted actions.
       publish-results: false
       egress-policy: block
-      egress-preset: scorecard
-      # replace: harden-runner pre reads inputs only (not resolved presets).
-      # Full list = scorecard reusable default + StepSecurity/sigstore/OSSF
-      # hosts used by this job.
-      allowed-endpoints-mode: replace
       allowed-endpoints: >
         github.com:443
         api.github.com:443

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -22,12 +22,12 @@ concurrency:
 jobs:
   security-audit:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       packages: read
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: "Scan dependencies"
       runner-image: ubuntu-24.04
       # yamllint disable-line rule:line-length
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+          ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
           sparse-checkout: |
             scripts/ci/
           sparse-checkout-cone-mode: true
@@ -84,12 +84,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs: security-audit
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       pull-requests: write
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: "💬 Post PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       job-name: "📝 Validate PR Title"
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
       comment-marker: "<!-- semantic-pr-title -->"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -50,12 +50,12 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       ecosystems: rust
       auto-merge: true
       max-bump: minor
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
       # Harden-runner pre reads workflow inputs only (not resolved presets)

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -31,12 +31,12 @@ concurrency:
 jobs:
   site-quality:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       pull-requests: write # required: reusable declares this on internal publish job
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: Build and check documentation site
       test-job-name: Test documentation site
       node-version: '22'

--- a/.github/workflows/test-backup-shell.yml
+++ b/.github/workflows/test-backup-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: Backup Shell Tests
       test-path: tests/bats/unit/backup
       coverage: true

--- a/.github/workflows/test-docker-shell.yml
+++ b/.github/workflows/test-docker-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: Docker Shell Tests
       test-path: tests/bats/unit/docker
       coverage: true

--- a/.github/workflows/test-railway-shell.yml
+++ b/.github/workflows/test-railway-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: Railway Shell Tests
       test-path: tests/bats/unit/railway
       coverage: true

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -29,10 +29,10 @@ jobs:
     # ruleset check name stays rust-build / 🔨 Build Check — an extra nesting
     # hop would prefix build / and break required-status matching.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       job-name: "🔨 Build Check"
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       draft-pr-skip: true
       egress-policy: block
       egress-preset: quality

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -19,10 +19,10 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       job-name: "🔍 Check Vulnerability Suppressions"
-      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block


### PR DESCRIPTION
## Summary

Epic #453, final two sub-issues (#459, #463 — consumer side; upstream shipped in lgtm-ci v0.54.0).

## Changes

- **All lgtm-ci pins → v0.54.0** (`31c25ef2`, 25 workflow files): picks up blocked-egress build diagnostics (failed docker builds now annotate the likely-blocked host instead of hanging silently), the auto-rerun reusable, and the release guard-race fix (root cause of the three-0.29.1-PRs wedge).
- **Breaking-change adaptation:** `reusable-scorecards` hard-cut its no-op `tooling-ref`/`egress-preset`/`allowed-endpoints-mode` inputs (#540) — removed from `scorecards.yml`. Swept all other hard-cut inputs (toolchain, lintro-tools, allow-org-versions, publish-results on e2e): none in use.
- **New `auto-rerun-on-infra-failure.yml`:** watches the five heavy workflows; on failure with a known infra signature (action-download Service Unavailable, runner shutdown, harden-runner DNS), reruns failed jobs exactly once. Would have absorbed all three of yesterday's manual reruns.

## Testing

- `lintro chk` clean across workflows.
- Auto-rerun caller is inert until on main (workflow_run) — first live validation on the next infra blip.

Closes #459. Closes #463. Epic: #453.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the CI workflow integrations and adds automatic reruns for known infra failures.

- Bumps `lgtm-ci` workflow and action pins to v0.54.0.
- Adds an auto-rerun workflow for selected failed main-branch workflows.
- Removes scorecards inputs that are no longer accepted by the reusable workflow.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-rerun-on-infra-failure.yml | Adds the reusable auto-rerun caller with a main-branch workflow-run filter. |
| .github/workflows/scorecards.yml | Updates the reusable workflow pin and removes inputs no longer accepted by scorecards. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): restrict infra auto-rerun to ma..."](https://github.com/lgtm-hq/rustume/commit/edcd358d34c31ee2f9297d0fd969cc3c6f8f15b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43982240)</sub>

<!-- /greptile_comment -->