### PR TITLE
fix(ci): use Postgres trust auth in local CI setup

### DIFF
--- a/crates/server/src/middleware/rate_limit.rs
+++ b/crates/server/src/middleware/rate_limit.rs
@@ -440,9 +440,20 @@ mod tests {
         assert!(limits.check(RateLimitGroup::Health, &key).is_ok());
         assert_eq!(limits.key_count(), 1);
 
-        thread::sleep(Duration::from_secs(2));
-        limits.evict_stale();
-        assert_eq!(limits.key_count(), 0);
+        // governor::retain_recent is period-based; allow headroom on busy CI runners
+        // instead of a single fixed sleep that flakes under load.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            thread::sleep(Duration::from_millis(200));
+            limits.evict_stale();
+            if limits.key_count() == 0 {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "stale rate-limit key was not evicted within 5s"
+            );
+        }
     }
 
     #[test]

--- a/scripts/ci/testing/rust/setup-postgres-test-db.sh
+++ b/scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -9,14 +9,14 @@ set -euo pipefail
 
 : "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
 : "${POSTGRES_USER:=postgres}"
-: "${POSTGRES_PASSWORD:=postgres}"
 : "${POSTGRES_DB:=rustume_test}"
 : "${POSTGRES_PORT:=5432}"
 : "${POSTGRES_IMAGE:=postgres:16}"
 : "${POSTGRES_CONTAINER_NAME:=rustume-ci-postgres}"
 : "${POSTGRES_READY_TIMEOUT_SECONDS:=60}"
 
-TEST_DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}"
+# Local CI-only trust auth — no password credential embedded in this script.
+TEST_DATABASE_URL="postgres://${POSTGRES_USER}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}"
 
 wait_for_postgres() {
 	local attempt=0
@@ -44,7 +44,7 @@ start_postgres() {
 	docker run -d \
 		--name "$POSTGRES_CONTAINER_NAME" \
 		-e "POSTGRES_USER=${POSTGRES_USER}" \
-		-e "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+		-e "POSTGRES_HOST_AUTH_METHOD=trust" \
 		-e "POSTGRES_DB=${POSTGRES_DB}" \
 		-p "${POSTGRES_PORT}:5432" \
 		"$POSTGRES_IMAGE" >/dev/null


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): use Postgres trust auth in local CI setup
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Remove the hardcoded `POSTGRES_PASSWORD=postgres` default from
`scripts/ci/testing/rust/setup-postgres-test-db.sh`. GitGuardian flags that
default as a generic password on any PR whose history includes a merge of main
(even when the PR did not introduce it).

The ephemeral CI Postgres container now uses `POSTGRES_HOST_AUTH_METHOD=trust`
and a password-free connection URL. This is local CI only.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Relates to #408

## Details

After this lands on main, rebase #408 so GitGuardian no longer sees the
password string in merge commits pulled from main.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates local CI database setup and a timing-sensitive rate-limit test. The main changes are:

- Local CI Postgres now uses trust authentication.
- The test database URL no longer embeds a default password.
- The stale rate-limit eviction test now waits with bounded polling.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/middleware/rate_limit.rs | Changed the stale-key eviction test to poll with a bounded deadline instead of using one fixed sleep. |
| scripts/ci/testing/rust/setup-postgres-test-db.sh | Changed the local CI Postgres container to trust auth and exported a password-free test database URL. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(server): harden rate-limit eviction..."](https://github.com/lgtm-hq/rustume/commit/9e9810d56143e54fb2d572bfc283e312200c9456) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44191732)</sub>

<!-- /greptile_comment -->