### PR TITLE
docs(rfc): require recovery-backup nonce storage and freshness

### DIFF
--- a/docs/rfcs/0001-e2e-encryption.md
+++ b/docs/rfcs/0001-e2e-encryption.md
@@ -193,7 +193,7 @@ All E2EE resume payloads use a **versioned JSON envelope** stored in `resumes.da
 | --- | --- |
 | **KDF** | Argon2id (RFC 9106). Default params: `m=19456` KiB, `t=2`, `p=1`. Params and salt live in `users.e2ee_config` (account-level), not per-resume. |
 | **Key derivation** | `MK = Argon2id(passphrase, salt, params)` → 32 bytes. Account `DEK` is a random 32-byte value generated at E2EE enable and wrapped by MK (not derived from MK). |
-| **AEAD** | ChaCha20-Poly1305 (RFC 8439). Key = account DEK. Nonce = 12 random bytes per encryption; **must never repeat** for a given DEK. |
+| **AEAD** | ChaCha20-Poly1305 (RFC 8439). Key = account DEK. Nonce = 12 random bytes per encryption; **must never repeat** for a given DEK. This rule covers DEK-keyed resume envelopes and MK-keyed DEK wraps only — RK-keyed recovery backups have a separate nonce-freshness requirement below. |
 | **Plaintext input** | Canonical JSON serialization of `ResumeData` (same as today). |
 | **Detection** | Payload is an E2EE envelope only when the top-level object contains **only** an `e2ee` key (no `basics`, `sections`, or `metadata`). Server rejects mixed plaintext+ciphertext shapes and malformed envelopes (`e2ee.version`, `e2ee.nonce`, `e2ee.ciphertext` required) with 422. Valid envelopes skip resume-schema checks; byte-size limits still apply. |
 
@@ -211,11 +211,23 @@ All E2EE resume payloads use a **versioned JSON envelope** stored in `resumes.da
 On enable, client generates one-time recovery codes. For each code:
 
 1. Derive `RK = HKDF-SHA256(code, info="rustume-recovery-v1")` → 32 bytes.
-2. Encrypt DEK backup: `wrapped_dek_recovery = ChaCha20-Poly1305(RK, nonce, DEK)`.
-3. Upload `wrapped_dek_recovery` to server; server stores `hash(code)` for verification
-   **and** the ciphertext blob (operator cannot decrypt without the code).
-4. On recovery: user submits code → server verifies hash → returns `wrapped_dek_recovery`
-   → client derives RK, unwraps DEK, prompts new passphrase.
+2. Sample a fresh 12-byte nonce (`nonce_recovery`). Encrypt the DEK backup:
+   `wrapped_dek_recovery = ChaCha20-Poly1305(RK, nonce_recovery, DEK)`.
+3. Upload the recovery backup blob to the server. The stored format **must** include
+   both `nonce_recovery` and the ciphertext (e.g. `{ "nonce": "...", "ciphertext": "..." }`
+   as base64url fields). Server also stores `hash(code)` for verification (operator
+   cannot decrypt without the code).
+4. On recovery: user submits code → server verifies hash → returns the recovery backup
+   blob → client derives RK, unwraps DEK with the stored nonce, prompts new passphrase.
+
+**Nonce freshness (RK-keyed):** each recovery backup is keyed by `RK`, not the account
+DEK. The DEK-envelope nonce rule above does **not** cover these blobs. Reusing
+`nonce_recovery` under the same `RK` (for example when re-encrypting a new DEK for the
+same recovery code during DEK rotation) is catastrophic for Poly1305. Therefore:
+
+- the recovery backup format must persist its nonce alongside the ciphertext; and
+- every rewrite of a recovery backup — including DEK rotation step 4 below — **must**
+  sample a fresh `nonce_recovery`.
 
 ### Where the code lives
 
@@ -321,8 +333,10 @@ Requires explicit user action — not reversible by operator alone.
 1. Generate new DEK.
 2. Re-encrypt every resume envelope with new DEK.
 3. Re-wrap new DEK with current MK, update `e2ee_config`.
-4. Re-encrypt each recovery-code backup so every `wrapped_dek_recovery` unwraps the
-   new DEK, or invalidate and regenerate recovery codes before completing rotation.
+4. Re-encrypt each recovery-code backup with a **fresh** `nonce_recovery` so every
+   stored recovery blob unwraps the new DEK (never reuse a prior recovery nonce under
+   the same `RK`), or invalidate and regenerate recovery codes before completing
+   rotation.
 5. Increment `e2ee_config.key_generation` counter.
 
 ### Existing plaintext rows

--- a/docs/rfcs/0001-e2e-encryption.md
+++ b/docs/rfcs/0001-e2e-encryption.md
@@ -213,12 +213,17 @@ On enable, client generates one-time recovery codes. For each code:
 1. Derive `RK = HKDF-SHA256(code, info="rustume-recovery-v1")` → 32 bytes.
 2. Sample a fresh 12-byte nonce (`nonce_recovery`). Encrypt the DEK backup:
    `wrapped_dek_recovery = ChaCha20-Poly1305(RK, nonce_recovery, DEK)`.
-3. Upload the recovery backup blob to the server. The stored format **must** include
-   both `nonce_recovery` and the ciphertext (e.g. `{ "nonce": "...", "ciphertext": "..." }`
-   as base64url fields). Server also stores `hash(code)` for verification (operator
+3. Upload the recovery backup blob to the server. Each recovery code is stored as one
+   row (or JSON object) that **atomically associates**:
+   - `code_hash` = `hash(code)` (lookup / verification key)
+   - `backup` = `{ "nonce": "<base64url>", "ciphertext": "<base64url>" }` (the
+     `nonce_recovery` + ciphertext pair for that same code)
+   The server must never store a ciphertext without its nonce, and must never return a
+   backup blob that is not the one paired with the matched `code_hash` (operator still
    cannot decrypt without the code).
-4. On recovery: user submits code → server verifies hash → returns the recovery backup
-   blob → client derives RK, unwraps DEK with the stored nonce, prompts new passphrase.
+4. On recovery: user submits code → server finds the row where `code_hash` matches →
+   returns that row's `backup` blob → client derives RK, unwraps DEK with the stored
+   nonce, prompts new passphrase.
 
 **Nonce freshness (RK-keyed):** each recovery backup is keyed by `RK`, not the account
 DEK. The DEK-envelope nonce rule above does **not** cover these blobs. Reusing
@@ -335,8 +340,12 @@ Requires explicit user action — not reversible by operator alone.
 3. Re-wrap new DEK with current MK, update `e2ee_config`.
 4. Re-encrypt each recovery-code backup with a **fresh** `nonce_recovery` so every
    stored recovery blob unwraps the new DEK (never reuse a prior recovery nonce under
-   the same `RK`), or invalidate and regenerate recovery codes before completing
-   rotation.
+   the same `RK`), **or** invalidate and regenerate recovery codes before completing
+   rotation. Invalidation **must** delete (or mark unusable and refuse to return) every
+   prior `code_hash` + `backup` row for the account in the same transaction that
+   writes the new recovery set / new DEK wrap — old codes must be unreachable before
+   rotation is considered complete. Leaving old rows active while adding new ones is
+   forbidden: an old code must not return a stale backup that unwraps the previous DEK.
 5. Increment `e2ee_config.key_generation` counter.
 
 ### Existing plaintext rows

--- a/docs/rfcs/0001-e2e-encryption.md
+++ b/docs/rfcs/0001-e2e-encryption.md
@@ -341,11 +341,15 @@ Requires explicit user action — not reversible by operator alone.
 4. Re-encrypt each recovery-code backup with a **fresh** `nonce_recovery` so every
    stored recovery blob unwraps the new DEK (never reuse a prior recovery nonce under
    the same `RK`), **or** invalidate and regenerate recovery codes before completing
-   rotation. Invalidation **must** delete (or mark unusable and refuse to return) every
-   prior `code_hash` + `backup` row for the account in the same transaction that
-   writes the new recovery set / new DEK wrap — old codes must be unreachable before
-   rotation is considered complete. Leaving old rows active while adding new ones is
-   forbidden: an old code must not return a stale backup that unwraps the previous DEK.
+   rotation. When keeping the same codes, each `code_hash` row's `backup` **must be
+   replaced atomically** (single-row upsert / delete-then-insert in one transaction) so
+   lookup never observes both an old and a new backup for the same hash. Invalidation
+   **must** delete (or mark unusable and refuse to return) every prior `code_hash` +
+   `backup` row for the account in the same transaction that writes the new recovery
+   set / new DEK wrap — old codes must be unreachable before rotation is considered
+   complete. Leaving old rows active while adding new ones is forbidden: an old or
+   stale backup must not unwrap the previous DEK after resumes have moved to the new
+   DEK.
 5. Increment `e2ee_config.key_generation` counter.
 
 ### Existing plaintext rows


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  docs(rfc): require recovery-backup nonce storage and freshness
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Specify that RK-keyed recovery backups must store their nonce and sample a fresh
nonce on every rewrite (including DEK rotation). Clarifies that the DEK-envelope
nonce rule does not cover recovery blobs — closes the unresolved security review
from #394.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #445
- Relates to #44

## Details

Recovery backup format now requires `{ nonce, ciphertext }` persistence and fresh
`nonce_recovery` on DEK rotation re-encrypts to avoid ChaCha20-Poly1305 nonce reuse
under the same RK.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tightens the recovery-backup requirements in the E2EE RFC.

- Clarifies that RK-keyed recovery backups have their own nonce rule.
- Requires recovery backups to persist both nonce and ciphertext.
- Requires each backup to be paired with its matching recovery-code hash.
- Requires fresh recovery nonces and atomic backup replacement during DEK rotation.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/rfcs/0001-e2e-encryption.md | Updates the E2EE RFC recovery-code storage, nonce freshness, and DEK-rotation requirements. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(rfc): require atomic recovery backu..."](https://github.com/lgtm-hq/rustume/commit/dad413e277131ef5c2031841fe5d1f5c1ff8e349) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44192001)</sub>

<!-- /greptile_comment -->