### PR TITLE
test(shell): commit curl mocks for deploy-ghcr bats as fixtures

### DIFF
--- a/tests/bats/fixtures/railway/mock-curl-ghcr.sh
+++ b/tests/bats/fixtures/railway/mock-curl-ghcr.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Parameterized mock curl for deploy-ghcr.bats error-path tests.
+#
+# Required:
+#   MOCK_CURL_MODE=update_error|deploy_error|predeploy_error|poll_error
+#
+# For poll_error, also set COUNTER_FILE to a writable path (call counter).
+
+set -euo pipefail
+
+payload=""
+while (($# > 0)); do
+	if [[ "$1" == "-d" && $# -ge 2 ]]; then
+		payload="$2"
+		shift 2
+	else
+		shift
+	fi
+done
+
+mode="${MOCK_CURL_MODE:-}"
+case "${mode}" in
+update_error)
+	if [[ "${payload}" == *"deployments"* ]]; then
+		echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
+	elif [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
+		echo '{"errors":[{"message":"update failed"}]}'
+	else
+		echo '{"data":{}}'
+	fi
+	;;
+deploy_error)
+	if [[ "${payload}" == *"deployments"* ]]; then
+		echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
+	elif [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
+		echo '{"data":{"serviceInstanceUpdate":true}}'
+	elif [[ "${payload}" == *"serviceInstanceDeployV2"* ]]; then
+		echo '{"errors":[{"message":"deploy failed"}]}'
+	else
+		echo '{"data":{}}'
+	fi
+	;;
+predeploy_error)
+	if [[ "${payload}" == *"deployments"* ]]; then
+		echo '{"errors":[{"message":"deployments query failed"}]}'
+	else
+		echo '{"data":{}}'
+	fi
+	;;
+poll_error)
+	if [[ -z "${COUNTER_FILE:-}" ]]; then
+		echo "COUNTER_FILE must be set" >&2
+		exit 1
+	fi
+	count="$(cat "${COUNTER_FILE}")"
+	count=$((count + 1))
+	echo "${count}" >"${COUNTER_FILE}"
+	if [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
+		echo '{"data":{"serviceInstanceUpdate":true}}'
+	elif [[ "${payload}" == *"serviceInstanceDeployV2"* ]]; then
+		echo '{"data":{"serviceInstanceDeployV2":true}}'
+	elif [[ "${payload}" == *"deployments"* ]]; then
+		if [[ "${count}" -le 1 ]]; then
+			echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
+		else
+			echo '{"errors":[{"message":"polling query failed"}]}'
+		fi
+	else
+		echo '{"data":{}}'
+	fi
+	;;
+*)
+	echo "MOCK_CURL_MODE must be one of: update_error, deploy_error, predeploy_error, poll_error" >&2
+	exit 1
+	;;
+esac

--- a/tests/bats/unit/railway/test_deploy_ghcr.bats
+++ b/tests/bats/unit/railway/test_deploy_ghcr.bats
@@ -65,33 +65,20 @@ teardown() {
 	assert_equal "new-deploy" "$(get_github_output deployment_id)"
 }
 
+install_ghcr_curl_mock() {
+	local mock_bin="$1"
+	mkdir -p "${mock_bin}"
+	cp "${PROJECT_ROOT}/tests/bats/fixtures/railway/mock-curl-ghcr.sh" "${mock_bin}/curl"
+	chmod +x "${mock_bin}/curl"
+}
+
 @test "deploy-ghcr: graphql-only fails when serviceInstanceUpdate returns errors" {
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
-	mkdir -p "${mock_bin}"
-
-	cat >"${mock_bin}/curl" <<'EOF'
-#!/usr/bin/env bash
-payload=""
-while (($# > 0)); do
-	if [[ "$1" == "-d" && $# -ge 2 ]]; then
-		payload="$2"
-		shift 2
-	else
-		shift
-	fi
-done
-if [[ "${payload}" == *"deployments"* ]]; then
-	echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
-elif [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
-	echo '{"errors":[{"message":"update failed"}]}'
-else
-	echo '{"data":{}}'
-fi
-EOF
-	chmod +x "${mock_bin}/curl"
+	install_ghcr_curl_mock "${mock_bin}"
 
 	run bash -c "
 		PATH='${mock_bin}:'\"\${PATH}\" \
+		MOCK_CURL_MODE='update_error' \
 		RAILWAY_TOKEN='test-token' \
 		bash '${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh' --graphql-only
 	"
@@ -102,33 +89,11 @@ EOF
 
 @test "deploy-ghcr: graphql-only fails when serviceInstanceDeployV2 returns errors" {
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
-	mkdir -p "${mock_bin}"
-
-	cat >"${mock_bin}/curl" <<'EOF'
-#!/usr/bin/env bash
-payload=""
-while (($# > 0)); do
-	if [[ "$1" == "-d" && $# -ge 2 ]]; then
-		payload="$2"
-		shift 2
-	else
-		shift
-	fi
-done
-if [[ "${payload}" == *"deployments"* ]]; then
-	echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
-elif [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
-	echo '{"data":{"serviceInstanceUpdate":true}}'
-elif [[ "${payload}" == *"serviceInstanceDeployV2"* ]]; then
-	echo '{"errors":[{"message":"deploy failed"}]}'
-else
-	echo '{"data":{}}'
-fi
-EOF
-	chmod +x "${mock_bin}/curl"
+	install_ghcr_curl_mock "${mock_bin}"
 
 	run bash -c "
 		PATH='${mock_bin}:'\"\${PATH}\" \
+		MOCK_CURL_MODE='deploy_error' \
 		RAILWAY_TOKEN='test-token' \
 		bash '${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh' --graphql-only
 	"
@@ -139,29 +104,11 @@ EOF
 
 @test "deploy-ghcr: graphql-only fails when pre-deploy deployment query returns errors" {
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
-	mkdir -p "${mock_bin}"
-
-	cat >"${mock_bin}/curl" <<'EOF'
-#!/usr/bin/env bash
-payload=""
-while (($# > 0)); do
-	if [[ "$1" == "-d" && $# -ge 2 ]]; then
-		payload="$2"
-		shift 2
-	else
-		shift
-	fi
-done
-if [[ "${payload}" == *"deployments"* ]]; then
-	echo '{"errors":[{"message":"deployments query failed"}]}'
-else
-	echo '{"data":{}}'
-fi
-EOF
-	chmod +x "${mock_bin}/curl"
+	install_ghcr_curl_mock "${mock_bin}"
 
 	run bash -c "
 		PATH='${mock_bin}:'\"\${PATH}\" \
+		MOCK_CURL_MODE='predeploy_error' \
 		RAILWAY_TOKEN='test-token' \
 		bash '${RAILWAY_SCRIPTS_DIR}/deploy-ghcr.sh' --graphql-only
 	"
@@ -173,45 +120,12 @@ EOF
 @test "deploy-ghcr: graphql-only fails when polling deployment query returns errors" {
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
 	local counter_file="${BATS_TEST_TMPDIR}/curl_calls"
-	mkdir -p "${mock_bin}"
+	install_ghcr_curl_mock "${mock_bin}"
 	echo "0" >"${counter_file}"
-
-	cat >"${mock_bin}/curl" <<'EOF'
-#!/usr/bin/env bash
-payload=""
-while (($# > 0)); do
-	if [[ "$1" == "-d" && $# -ge 2 ]]; then
-		payload="$2"
-		shift 2
-	else
-		shift
-	fi
-done
-if [[ -z "${COUNTER_FILE:-}" ]]; then
-	echo "COUNTER_FILE must be set" >&2
-	exit 1
-fi
-count="$(cat "${COUNTER_FILE}")"
-count=$((count + 1))
-echo "${count}" >"${COUNTER_FILE}"
-if [[ "${payload}" == *"serviceInstanceUpdate"* ]]; then
-	echo '{"data":{"serviceInstanceUpdate":true}}'
-elif [[ "${payload}" == *"serviceInstanceDeployV2"* ]]; then
-	echo '{"data":{"serviceInstanceDeployV2":true}}'
-elif [[ "${payload}" == *"deployments"* ]]; then
-	if [[ "${count}" -le 1 ]]; then
-		echo '{"data":{"deployments":{"edges":[{"node":{"id":"old-deploy","status":"SUCCESS"}}]}}}'
-	else
-		echo '{"errors":[{"message":"polling query failed"}]}'
-	fi
-else
-	echo '{"data":{}}'
-fi
-EOF
-	chmod +x "${mock_bin}/curl"
 
 	run bash -c "
 		PATH='${mock_bin}:'\"\${PATH}\" \
+		MOCK_CURL_MODE='poll_error' \
 		COUNTER_FILE='${counter_file}' \
 		RAILWAY_TOKEN='test-token' \
 		DEPLOY_ID_REGISTER_TIMEOUT='5' \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(shell): commit curl mocks for deploy-ghcr bats as fixtures
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Replace runtime heredoc curl mocks in `test_deploy_ghcr.bats` with a committed
parameterized fixture (`mock-curl-ghcr.sh`) selected via `MOCK_CURL_MODE`, matching
the existing railway/backup fixture convention.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #448

## Details

Assertions unchanged; railway deploy-ghcr BATS suite passes locally (8/8).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves deploy-ghcr curl mocks into a shared Bats fixture. The main changes are:

- Adds a parameterized `mock-curl-ghcr.sh` fixture for GraphQL error paths.
- Replaces per-test heredoc mocks with `install_ghcr_curl_mock`.
- Selects each mock scenario with `MOCK_CURL_MODE`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/bats/fixtures/railway/mock-curl-ghcr.sh | Adds the shared curl fixture with modes for update, deploy, predeploy, and polling error responses. |
| tests/bats/unit/railway/test_deploy_ghcr.bats | Updates the deploy-ghcr Bats tests to copy the shared fixture and set the desired mock mode per test. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(shell): commit curl mocks for deplo..."](https://github.com/lgtm-hq/rustume/commit/643da4d6a7a2ddc29cf19c0040b891d5ee58fe52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44192018)</sub>

<!-- /greptile_comment -->