### PR TITLE
fix(ci): fix db-backup apt install and extract inline scripts

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -41,9 +41,13 @@ jobs:
             api.github.com:443
             codeload.github.com:443
             archive.ubuntu.com:80
+            archive.ubuntu.com:443
             azure.archive.ubuntu.com:80
+            azure.archive.ubuntu.com:443
             security.ubuntu.com:80
             security.ubuntu.com:443
+            esm.ubuntu.com:443
+            packages.microsoft.com:443
             awscli.amazonaws.com:443
             *.aws.neon.tech:5432
             ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com:443
@@ -62,27 +66,11 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BACKUP_BUCKET: ${{ secrets.R2_BACKUP_BUCKET }}
-        run: |
-          missing=()
-          for name in BACKUP_DATABASE_URL R2_ACCOUNT_ID R2_ACCESS_KEY_ID \
-            R2_SECRET_ACCESS_KEY R2_BACKUP_BUCKET; do
-            if [[ -z "${!name}" ]]; then
-              missing+=("${name}")
-            fi
-          done
-          if ((${#missing[@]} > 0)); then
-            echo "skip=true" >>"${GITHUB_OUTPUT}"
-            echo "Backup secrets not configured (${missing[*]})."
-            echo "Skipping until provider setup in #334."
-            exit 0
-          fi
-          echo "skip=false" >>"${GITHUB_OUTPUT}"
-          echo "All backup secrets present."
+        run: bash scripts/ci/backup/verify-backup-secrets.sh
 
       - name: Install PostgreSQL client
         if: steps.secrets.outputs.skip != 'true'
-        run: |
-          sudo apt-get install -y --no-update postgresql-client
+        run: bash scripts/ci/backup/install-postgresql-client.sh
 
       - name: Install AWS CLI
         if: steps.secrets.outputs.skip != 'true'
@@ -111,19 +99,7 @@ jobs:
           (inputs.dry_run == true || inputs.dry_run == 'true')
         env:
           BACKUP_DATABASE_URL: ${{ secrets.BACKUP_DATABASE_URL }}
-        run: |
-          echo "Dry run: validating pg_dump only (no upload)."
-          dump_path="$(mktemp "${TMPDIR:-/tmp}/rustume-backup-dry-run.XXXXXXXXXX")"
-          if ! pg_dump -Fc "${BACKUP_DATABASE_URL}" >"${dump_path}"; then
-            echo "pg_dump failed during dry run" >&2
-            exit 1
-          fi
-          if [[ ! -s "${dump_path}" ]]; then
-            echo "pg_dump produced an empty file during dry run" >&2
-            exit 1
-          fi
-          rm -f "${dump_path}"
-          echo "Dry run pg_dump succeeded."
+        run: bash scripts/ci/backup/dry-run-backup.sh
 
       - name: Prune old backups
         if: >-

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -42,12 +42,20 @@ jobs:
             codeload.github.com:443
             archive.ubuntu.com:80
             archive.ubuntu.com:443
+            *.archive.ubuntu.com:80
+            *.archive.ubuntu.com:443
             azure.archive.ubuntu.com:80
             azure.archive.ubuntu.com:443
             security.ubuntu.com:80
             security.ubuntu.com:443
+            *.security.ubuntu.com:80
+            *.security.ubuntu.com:443
             esm.ubuntu.com:443
+            *.esm.ubuntu.com:443
             packages.microsoft.com:443
+            *.packages.microsoft.com:443
+            apt.postgresql.org:80
+            apt.postgresql.org:443
             awscli.amazonaws.com:443
             *.aws.neon.tech:5432
             ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com:443

--- a/scripts/ci/backup/dry-run-backup.sh
+++ b/scripts/ci/backup/dry-run-backup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# Dry-run backup: validate pg_dump only (no upload, no prune).
+#
+# Required:
+#   BACKUP_DATABASE_URL
+
+while (($# > 0)); do
+	case "$1" in
+	--help | -h)
+		sed -n '1,15p' "$0"
+		exit 0
+		;;
+	*)
+		echo "Unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+if [[ -z "${BACKUP_DATABASE_URL:-}" ]]; then
+	echo "BACKUP_DATABASE_URL is required" >&2
+	exit 1
+fi
+
+echo "Dry run: validating pg_dump only (no upload)."
+dump_path="$(mktemp "${TMPDIR:-/tmp}/rustume-backup-dry-run.XXXXXXXXXX")"
+cleanup() {
+	rm -f "${dump_path}"
+}
+trap cleanup EXIT
+
+if ! pg_dump -Fc "${BACKUP_DATABASE_URL}" >"${dump_path}"; then
+	echo "pg_dump failed during dry run" >&2
+	exit 1
+fi
+if [[ ! -s "${dump_path}" ]]; then
+	echo "pg_dump produced an empty file during dry run" >&2
+	exit 1
+fi
+
+echo "Dry run pg_dump succeeded."

--- a/scripts/ci/backup/install-postgresql-client.sh
+++ b/scripts/ci/backup/install-postgresql-client.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# Install postgresql-client on Ubuntu runners for pg_dump.
+
+while (($# > 0)); do
+	case "$1" in
+	--help | -h)
+		sed -n '1,12p' "$0"
+		exit 0
+		;;
+	*)
+		echo "Unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+sudo apt-get update
+sudo apt-get install -y postgresql-client

--- a/scripts/ci/backup/verify-backup-secrets.sh
+++ b/scripts/ci/backup/verify-backup-secrets.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# Verify required backup secrets are present. When any are missing, write
+# skip=true to GITHUB_OUTPUT and exit 0 so the workflow can take the skip path
+# until provider setup in #334 lands.
+#
+# Required env (values may be empty — emptiness is the failure mode):
+#   BACKUP_DATABASE_URL
+#   R2_ACCOUNT_ID
+#   R2_ACCESS_KEY_ID
+#   R2_SECRET_ACCESS_KEY
+#   R2_BACKUP_BUCKET
+#
+# Optional:
+#   GITHUB_OUTPUT  When set, writes skip=true|false
+
+while (($# > 0)); do
+	case "$1" in
+	--help | -h)
+		sed -n '1,20p' "$0"
+		exit 0
+		;;
+	*)
+		echo "Unknown argument: $1" >&2
+		exit 2
+		;;
+	esac
+done
+
+missing=()
+for name in BACKUP_DATABASE_URL R2_ACCOUNT_ID R2_ACCESS_KEY_ID \
+	R2_SECRET_ACCESS_KEY R2_BACKUP_BUCKET; do
+	if [[ -z "${!name:-}" ]]; then
+		missing+=("${name}")
+	fi
+done
+
+if ((${#missing[@]} > 0)); then
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		echo "skip=true" >>"${GITHUB_OUTPUT}"
+	fi
+	echo "Backup secrets not configured (${missing[*]})."
+	echo "Skipping until provider setup in #334."
+	exit 0
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "skip=false" >>"${GITHUB_OUTPUT}"
+fi
+echo "All backup secrets present."

--- a/tests/bats/unit/backup/test_dry_run_backup.bats
+++ b/tests/bats/unit/backup/test_dry_run_backup.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/backup/dry-run-backup.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+setup_pg_dump_mock() {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+	cp "${PROJECT_ROOT}/tests/bats/fixtures/backup/mock-pg-dump.sh" "${mock_bin}/pg_dump"
+	chmod +x "${mock_bin}/pg_dump"
+	export PATH="${mock_bin}:${PATH}"
+}
+
+@test "dry-run-backup: --help exits successfully" {
+	run bash "${BACKUP_SCRIPTS_DIR}/dry-run-backup.sh" --help
+
+	assert_success
+	assert_output --partial "BACKUP_DATABASE_URL"
+}
+
+@test "dry-run-backup: fails when BACKUP_DATABASE_URL is missing" {
+	run bash "${BACKUP_SCRIPTS_DIR}/dry-run-backup.sh"
+
+	assert_failure
+	assert_output --partial "BACKUP_DATABASE_URL is required"
+}
+
+@test "dry-run-backup: succeeds with mocked pg_dump" {
+	setup_pg_dump_mock
+
+	run env \
+		BACKUP_DATABASE_URL="postgresql://example" \
+		bash "${BACKUP_SCRIPTS_DIR}/dry-run-backup.sh"
+
+	assert_success
+	assert_output --partial "Dry run pg_dump succeeded"
+}
+
+@test "dry-run-backup: fails when pg_dump produces empty output" {
+	setup_pg_dump_mock
+
+	run env \
+		BACKUP_DATABASE_URL="postgresql://example" \
+		MOCK_PG_DUMP_EMPTY="1" \
+		bash "${BACKUP_SCRIPTS_DIR}/dry-run-backup.sh"
+
+	assert_failure
+	assert_output --partial "pg_dump produced an empty file during dry run"
+}

--- a/tests/bats/unit/backup/test_verify_backup_secrets.bats
+++ b/tests/bats/unit/backup/test_verify_backup_secrets.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/backup/verify-backup-secrets.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	touch "${GITHUB_OUTPUT}"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "verify-backup-secrets: --help exits successfully" {
+	run bash "${BACKUP_SCRIPTS_DIR}/verify-backup-secrets.sh" --help
+
+	assert_success
+	assert_output --partial "BACKUP_DATABASE_URL"
+}
+
+@test "verify-backup-secrets: skips when secrets are missing" {
+	run env \
+		GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
+		bash "${BACKUP_SCRIPTS_DIR}/verify-backup-secrets.sh"
+
+	assert_success
+	assert_output --partial "Backup secrets not configured"
+	assert_equal "true" "$(get_github_output skip)"
+}
+
+@test "verify-backup-secrets: proceeds when all secrets are present" {
+	run env \
+		BACKUP_DATABASE_URL="postgresql://example" \
+		R2_ACCOUNT_ID="acct" \
+		R2_ACCESS_KEY_ID="key" \
+		R2_SECRET_ACCESS_KEY="secret" \
+		R2_BACKUP_BUCKET="backups" \
+		GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
+		bash "${BACKUP_SCRIPTS_DIR}/verify-backup-secrets.sh"
+
+	assert_success
+	assert_output --partial "All backup secrets present"
+	assert_equal "false" "$(get_github_output skip)"
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): fix db-backup apt install and extract inline scripts
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required).

## What's Changing

Fixes invalid `apt-get --no-update` in `db-backup.yml` (#443) and extracts
inline secret-verification / dry-run / postgresql-client install shell into
`scripts/ci/backup/*.sh` with BATS coverage (#444). Expands harden-runner apt
endpoints for update+install.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #443
- Closes #444

## Details

Bundled because both issues touch `.github/workflows/db-backup.yml`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the db-backup workflow and moves backup helper logic into scripts. The main changes are:

- Expanded harden-runner apt endpoints for update and install traffic.
- Replaced the invalid PostgreSQL client install command.
- Extracted secret verification into a backup script.
- Extracted dry-run `pg_dump` validation into a backup script.
- Added BATS coverage for the extracted backup scripts.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/db-backup.yml | Updates the db-backup workflow to call the extracted scripts and expands the apt endpoint allowlist. |
| scripts/ci/backup/install-postgresql-client.sh | Adds a dedicated script that updates apt metadata before installing `postgresql-client`. |
| scripts/ci/backup/verify-backup-secrets.sh | Adds a dedicated script for backup secret checks and workflow skip output. |
| scripts/ci/backup/dry-run-backup.sh | Adds a dedicated script for dry-run `pg_dump` validation and temp-file cleanup. |
| tests/bats/unit/backup/test_dry_run_backup.bats | Adds unit coverage for the dry-run backup script. |
| tests/bats/unit/backup/test_verify_backup_secrets.bats | Adds unit coverage for the backup secret verification script. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): widen apt egress allowlist for ..."](https://github.com/lgtm-hq/rustume/commit/680c0000fd9c9e5b6b097076700b6758ab02c638) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44193930)</sub>

<!-- /greptile_comment -->