### PR TITLE
refactor(ci): deny-by-default docker path filtering with drift test

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -9,6 +9,13 @@ name: Build - Docker Image & Registry
 #   image a second time — see #454. Tag pushes always fire: GitHub does not
 #   evaluate `paths` filters for tag pushes.)
 #
+# Path filtering (#476): required-check-safe deny-by-default. There is no
+# on.<event>.paths allow-list (those rot when new top-level dirs appear).
+# Instead the `classify` job resolves pipeline=false only when EVERY changed
+# file matches the skip-list (markdown / docs/**); anything else — including
+# brand-new directories — runs Docker. Classification failures fail open.
+# Release bump-only merges still skip via classify_release_bump.sh (#457).
+#
 # Rustume Cloud deploy tags (reusable-docker metadata-action):
 #   main push  -> ghcr.io/lgtm-hq/rustume:main, :sha-<commit>
 #   v*.*.* tag -> ghcr.io/lgtm-hq/rustume:<semver>, :latest, :sha-<commit>
@@ -20,19 +27,8 @@ name: Build - Docker Image & Registry
   push:
     branches: [main]
     tags: ["v*.*.*"]
-    paths: &docker-paths
-      - "docker/**"
-      - "apps/web/**"
-      - "crates/**"
-      - "bindings/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".dockerignore"
-      - ".github/workflows/docker-build-publish.yml"
-      - "scripts/ci/docker/**"
   pull_request:
     branches: [main]
-    paths: *docker-paths
   workflow_dispatch:
 
 permissions:
@@ -47,26 +43,19 @@ concurrency:
     ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Skip the publish for release-version-bump-only merges (#457): the bump
-  # commit changes nothing that reaches the image, and the tag build that
-  # follows produces the release image anyway. The commit-message check only
-  # nominates candidates; the diff classifier decides (a bump PR that also
-  # carries dependency updates, or a hand-crafted bump-looking commit that
-  # touches code, still builds). Note: on a skipped build this run still
-  # concludes "success" (classify ran), so deploy-railway-cloud.yml carries
-  # its own matching classify gate to skip the redundant redeploy.
+  # Path relevance (#476) + release bump-only (#457). Always runs so required
+  # docker contexts are never absent. Downstream compares != 'false' /
+  # != 'true' with always() so a failed classify job fails open (runs docker).
   classify:
-    name: 🔎 Classify Release Bump
-    if: >-
-      github.event_name == 'push'
-      && github.ref == 'refs/heads/main'
-      && startsWith(github.event.head_commit.message, 'chore(release): version')
+    name: 🔎 Classify Docker Relevance
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
     outputs:
-      bump-only: ${{ steps.check.outputs.bump-only }}
+      pipeline: ${{ steps.paths.outputs.pipeline }}
+      bump-only: ${{ steps.bump.outputs.bump-only }}
+      skip-reason: ${{ steps.paths.outputs.skip-reason }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -79,8 +68,19 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Classify diff
-        id: check
+      - name: Classify path relevance
+        id: paths
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/ci/docker/resolve_docker_relevance.sh
+      - name: Classify release bump
+        id: bump
+        if: >-
+          github.event_name == 'push'
+          && github.ref == 'refs/heads/main'
+          && startsWith(github.event.head_commit.message, 'chore(release): version')
         env:
           BASE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
@@ -90,7 +90,9 @@ jobs:
     name: 🐳 Docker Build & Publish
     needs: classify
     if: >-
-      always() && needs.classify.outputs.bump-only != 'true'
+      always()
+      && needs.classify.outputs.pipeline != 'false'
+      && needs.classify.outputs.bump-only != 'true'
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:

--- a/scripts/ci/docker/resolve_docker_relevance.sh
+++ b/scripts/ci/docker/resolve_docker_relevance.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# resolve_docker_relevance.sh
+#
+# Deny-by-default path classification for docker-build-publish.yml (#476).
+# Writes `pipeline=true|false` and `skip-reason` to GITHUB_OUTPUT.
+#
+# Pipeline=false only when EVERY changed file matches the skip-list:
+#   - '*.md' / '**/*.md'  markdown prose
+#   - 'docs/**'           documentation tree
+#
+# Everything else — including brand-new top-level directories — runs Docker.
+# Classification failures and empty/unavailable diffs fail open (pipeline=true).
+#
+# Non-pull_request events always resolve pipeline=true (push/tag/dispatch
+# still run; bump-only skipping is handled separately by classify_release_bump.sh).
+#
+# Usage:
+#   EVENT_NAME=pull_request BASE_SHA=... HEAD_SHA=... \
+#     bash scripts/ci/docker/resolve_docker_relevance.sh
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Resolve Docker pipeline path relevance for GitHub Actions.
+
+Usage:
+  EVENT_NAME=<event> [BASE_SHA=...] [HEAD_SHA=...] \
+    bash scripts/ci/docker/resolve_docker_relevance.sh
+
+Environment:
+  EVENT_NAME  github.event_name
+  BASE_SHA    Diff base (required for pull_request classification overrides)
+  HEAD_SHA    Diff head
+  GITHUB_OUTPUT  When set, appends pipeline / skip-reason outputs
+
+Behavior:
+  - Non-pull_request events always resolve pipeline=true.
+  - pull_request events resolve pipeline=false only when EVERY changed file
+    matches the skip-list ('*.md', 'docs/*'). Fail open otherwise.
+EOF
+	exit 0
+fi
+
+event_name="${EVENT_NAME:-}"
+pipeline="true"
+skip_reason=""
+
+# A changed file may skip Docker only when this returns 0.
+is_skippable_path() {
+	local path="$1"
+	case "$path" in
+	*.md) return 0 ;;
+	docs | docs/*) return 0 ;;
+	esac
+	return 1
+}
+
+resolve_changed_files() {
+	local base="${BASE_SHA:-}"
+	local head="${HEAD_SHA:-}"
+	if [[ -z "$base" || -z "$head" ]]; then
+		if ! git rev-parse --verify --quiet 'HEAD^2' >/dev/null 2>&1; then
+			return 1
+		fi
+		base="$(git rev-parse 'HEAD^1')"
+		head="$(git rev-parse HEAD)"
+	fi
+	git diff --name-only --no-renames "$base" "$head"
+}
+
+if [[ "$event_name" == "pull_request" ]]; then
+	if changed_files="$(resolve_changed_files 2>/dev/null)" &&
+		[[ -n "$changed_files" ]]; then
+		pipeline="false"
+		while IFS= read -r changed_file; do
+			[[ -z "$changed_file" ]] && continue
+			if ! is_skippable_path "$changed_file"; then
+				pipeline="true"
+				break
+			fi
+		done <<<"$changed_files"
+	else
+		echo "::warning::changed-file list unavailable (non-merge HEAD," \
+			"failed or empty diff); failing open (pipeline=true)"
+		pipeline="true"
+	fi
+fi
+
+if [[ "$pipeline" == "false" ]]; then
+	skip_reason="docs-only change"
+fi
+
+echo "event=${event_name:-<unset>} pipeline=${pipeline}" \
+	"skip-reason=${skip_reason:-<none>}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	{
+		echo "pipeline=${pipeline}"
+		echo "skip-reason=${skip_reason}"
+	} >>"$GITHUB_OUTPUT"
+else
+	echo "pipeline=${pipeline}"
+	echo "skip-reason=${skip_reason}"
+fi

--- a/tests/bats/unit/docker/test_resolve_docker_relevance.bats
+++ b/tests/bats/unit/docker/test_resolve_docker_relevance.bats
@@ -64,8 +64,10 @@ is_listed() {
 
 	local missing=()
 	local entry
+	# Use the committed tree (not the working directory) so local build artifacts
+	# like `target/` or `.venv/` cannot fail the drift check.
 	while IFS= read -r entry; do
-		[[ -z "${entry}" || "${entry}" == "." || "${entry}" == ".." ]] && continue
+		[[ -z "${entry}" ]] && continue
 		if [[ "${entry}" == .* && "${entry}" != ".github" ]]; then
 			continue
 		fi
@@ -75,7 +77,7 @@ is_listed() {
 			continue
 		fi
 		missing+=("${entry}")
-	done < <(cd "${PROJECT_ROOT}" && ls -A)
+	done < <(cd "${PROJECT_ROOT}" && git ls-tree --name-only HEAD)
 
 	[[ "${#missing[@]}" -eq 0 ]] || {
 		echo "# Uncategorized top-level paths: ${missing[*]}" >&2

--- a/tests/bats/unit/docker/test_resolve_docker_relevance.bats
+++ b/tests/bats/unit/docker/test_resolve_docker_relevance.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/docker/resolve_docker_relevance.sh (#476)
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/docker/resolve_docker_relevance.sh"
+
+setup() {
+	setup_temp_dir
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	: >"${GITHUB_OUTPUT}"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+is_listed() {
+	local needle="$1"
+	shift
+	local item
+	for item in "$@"; do
+		if [[ "${item}" == "${needle}" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Every top-level path must be explicitly categorized as skip or must-build so
+# new directories cannot silently fall through without a decision (#476 drift).
+@test "resolve_docker_relevance: every top-level path is categorized" {
+	local skip_roots=(docs)
+	local skip_files=(
+		CHANGELOG.md
+		CONTRIBUTING.md
+		README.md
+		SECURITY.md
+	)
+	local must_build=(
+		.github
+		apps
+		bindings
+		crates
+		docker
+		infra
+		scripts
+		tests
+		Cargo.lock
+		Cargo.toml
+		LICENSE
+		Makefile
+		NOTICE
+		THIRD_PARTY_NOTICES
+		clippy.toml
+		docker-compose.yml
+		pyproject.toml
+		renovate.json
+		rustfmt.toml
+		uv.lock
+	)
+
+	local missing=()
+	local entry
+	while IFS= read -r entry; do
+		[[ -z "${entry}" || "${entry}" == "." || "${entry}" == ".." ]] && continue
+		if [[ "${entry}" == .* && "${entry}" != ".github" ]]; then
+			continue
+		fi
+		if is_listed "${entry}" "${skip_roots[@]}" ||
+			is_listed "${entry}" "${skip_files[@]}" ||
+			is_listed "${entry}" "${must_build[@]}"; then
+			continue
+		fi
+		missing+=("${entry}")
+	done < <(cd "${PROJECT_ROOT}" && ls -A)
+
+	[[ "${#missing[@]}" -eq 0 ]] || {
+		echo "# Uncategorized top-level paths: ${missing[*]}" >&2
+		echo "# Add each to skip_roots, skip_files, or must_build in this test." >&2
+		return 1
+	}
+}
+
+@test "resolve_docker_relevance: --help exits successfully" {
+	run bash "${SCRIPT}" --help
+
+	assert_success
+	assert_output --partial "Resolve Docker pipeline path relevance"
+}
+
+@test "resolve_docker_relevance: non-PR events always pipeline=true" {
+	run env \
+		EVENT_NAME="push" \
+		GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
+		bash "${SCRIPT}"
+
+	assert_success
+	assert_equal "true" "$(get_github_output pipeline)"
+}
+
+@test "resolve_docker_relevance: docs-only PR skips pipeline" {
+	run env \
+		EVENT_NAME="pull_request" \
+		BASE_SHA="deadbeef" \
+		HEAD_SHA="cafebabe" \
+		GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
+		bash -c '
+			git() {
+				if [[ "$1" == "diff" ]]; then
+					printf "%s\n" "docs/rfcs/0001-e2e-encryption.md" "README.md"
+					return 0
+				fi
+				command git "$@"
+			}
+			export -f git
+			bash "'"${SCRIPT}"'"
+		'
+
+	assert_success
+	assert_equal "false" "$(get_github_output pipeline)"
+	assert_equal "docs-only change" "$(get_github_output skip-reason)"
+}
+
+@test "resolve_docker_relevance: code change keeps pipeline=true" {
+	run env \
+		EVENT_NAME="pull_request" \
+		BASE_SHA="deadbeef" \
+		HEAD_SHA="cafebabe" \
+		GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
+		bash -c '
+			git() {
+				if [[ "$1" == "diff" ]]; then
+					printf "%s\n" "docs/README.md" "crates/server/src/lib.rs"
+					return 0
+				fi
+				command git "$@"
+			}
+			export -f git
+			bash "'"${SCRIPT}"'"
+		'
+
+	assert_success
+	assert_equal "true" "$(get_github_output pipeline)"
+}
+
+@test "resolve_docker_relevance: unavailable diff fails open" {
+	run env \
+		EVENT_NAME="pull_request" \
+		GITHUB_OUTPUT="${GITHUB_OUTPUT}" \
+		bash -c '
+			git() {
+				if [[ "$1" == "rev-parse" ]]; then
+					return 1
+				fi
+				command git "$@"
+			}
+			export -f git
+			bash "'"${SCRIPT}"'"
+		'
+
+	assert_success
+	assert_equal "true" "$(get_github_output pipeline)"
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(ci): deny-by-default docker path filtering with drift test
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required).

## What's Changing

Removes the rot-prone `on.*.paths` allow-list from `docker-build-publish.yml`.
A classify job now deny-by-default skips Docker only when every changed file is
markdown/`docs/**` (fail-open otherwise), while preserving #457 bump-only skip.
Adds BATS coverage including a top-level path drift test.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #476

## Details

Mirrors py-lintro deny-by-default docker CI. Required-check-safe: workflow runs
on every PR; heavy docker job early-exits green for docs-only diffs.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes Docker CI path filtering to run through an in-workflow classifier.

- Removes the workflow-level Docker path allow-list.
- Adds a Docker relevance script that skips only docs and markdown PR diffs.
- Keeps non-PR Docker builds enabled and preserves release bump-only skipping.
- Adds BATS coverage for path relevance and top-level path drift.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-build-publish.yml | Moves Docker path filtering from event triggers into an always-running classify job. |
| scripts/ci/docker/resolve_docker_relevance.sh | Adds PR diff classification that skips Docker only for docs and markdown-only changes. |
| tests/bats/unit/docker/test_resolve_docker_relevance.bats | Adds unit coverage for Docker relevance decisions and top-level path drift. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): categorize docker path drift a..."](https://github.com/lgtm-hq/rustume/commit/56821a4d9992a29243d8ae9a9827b3c8313e7c92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44193933)</sub>

<!-- /greptile_comment -->