### PR TITLE
test(server): assert single policy.accept audit event on duplicate acceptance

### DIFF
--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -430,16 +430,22 @@ mod policy_acceptance_tests {
             .expect("count policy acceptances")
     }
 
-    async fn count_policy_accept_audit_events(pool: &sqlx::PgPool, user_id: Uuid) -> i64 {
+    async fn count_policy_accept_audit_events(
+        pool: &sqlx::PgPool,
+        user_id: Uuid,
+        policy: &str,
+    ) -> i64 {
         sqlx::query_scalar(
             r#"
             SELECT COUNT(*)::bigint
             FROM audit_events
             WHERE event_type = 'policy.accept'
               AND actor_user_id = $1
+              AND (metadata->>'policy') = $2
             "#,
         )
         .bind(user_id)
+        .bind(policy)
         .fetch_one(pool)
         .await
         .expect("count policy.accept audit events")
@@ -521,7 +527,10 @@ mod policy_acceptance_tests {
             .expect("second acceptance");
 
         assert_eq!(count_policy_acceptances(&pool, user_id).await, 1);
-        assert_eq!(count_policy_accept_audit_events(&pool, user_id).await, 1);
+        assert_eq!(
+            count_policy_accept_audit_events(&pool, user_id, "terms").await,
+            1
+        );
 
         cleanup_user(&pool, user_id).await;
     }
@@ -539,16 +548,26 @@ mod policy_acceptance_tests {
         let upserted = upsert_user(&pool, &workos_user).await.expect("upsert");
         let user_id = upserted.user.id;
 
-        // Spawn both acceptances on a multi-threaded runtime so the inserts are
-        // genuinely in flight at the same time, not merely interleaved.
-        let spawn_acceptance = |pool: sqlx::PgPool| {
-            tokio::spawn(async move {
-                record_policy_acceptance(&pool, user_id, "privacy", config::PRIVACY_VERSION, None)
+        // Spawn both acceptances on a multi-threaded runtime and gate them on a
+        // shared barrier so the inserts are genuinely in flight at the same
+        // time, not merely interleaved.
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let spawn_acceptance =
+            |pool: sqlx::PgPool, barrier: std::sync::Arc<tokio::sync::Barrier>| {
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    record_policy_acceptance(
+                        &pool,
+                        user_id,
+                        "privacy",
+                        config::PRIVACY_VERSION,
+                        None,
+                    )
                     .await
-            })
-        };
-        let first_task = spawn_acceptance(pool.clone());
-        let second_task = spawn_acceptance(pool.clone());
+                })
+            };
+        let first_task = spawn_acceptance(pool.clone(), barrier.clone());
+        let second_task = spawn_acceptance(pool.clone(), barrier.clone());
         let (first, second) = tokio::join!(first_task, second_task);
         first
             .expect("first acceptance task")
@@ -558,7 +577,10 @@ mod policy_acceptance_tests {
             .expect("second concurrent acceptance");
 
         assert_eq!(count_policy_acceptances(&pool, user_id).await, 1);
-        assert_eq!(count_policy_accept_audit_events(&pool, user_id).await, 1);
+        assert_eq!(
+            count_policy_accept_audit_events(&pool, user_id, "privacy").await,
+            1
+        );
 
         cleanup_user(&pool, user_id).await;
     }

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -363,7 +363,7 @@ mod policy_acceptance_tests {
 
     use crate::auth::workos::{upsert_user, WorkOsUser};
     use crate::config;
-    use crate::policy::record_signup_policy_acceptances;
+    use crate::policy::{record_policy_acceptance, record_signup_policy_acceptances};
     use sqlx::postgres::PgPoolOptions;
     use sqlx::Row;
     use uuid::Uuid;
@@ -430,6 +430,21 @@ mod policy_acceptance_tests {
             .expect("count policy acceptances")
     }
 
+    async fn count_policy_accept_audit_events(pool: &sqlx::PgPool, user_id: Uuid) -> i64 {
+        sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)::bigint
+            FROM audit_events
+            WHERE event_type = 'policy.accept'
+              AND actor_user_id = $1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .expect("count policy.accept audit events")
+    }
+
     fn sample_workos_user(suffix: &str) -> WorkOsUser {
         WorkOsUser {
             id: format!("workos_policy_{suffix}"),
@@ -483,6 +498,69 @@ mod policy_acceptance_tests {
         assert_eq!(count_policy_acceptances(&pool, first.user.id).await, 2);
 
         cleanup_user(&pool, first.user.id).await;
+    }
+
+    #[tokio::test]
+    async fn repeated_policy_acceptance_emits_single_audit_event() {
+        let Some(database_url) = database_url_for_tests() else {
+            return;
+        };
+
+        let pool = connect_test_pool(&database_url).await;
+        let suffix = Uuid::new_v4().to_string();
+        let workos_user = sample_workos_user(&suffix);
+
+        let upserted = upsert_user(&pool, &workos_user).await.expect("upsert");
+        let user_id = upserted.user.id;
+
+        record_policy_acceptance(&pool, user_id, "terms", config::TERMS_VERSION, None)
+            .await
+            .expect("first acceptance");
+        record_policy_acceptance(&pool, user_id, "terms", config::TERMS_VERSION, None)
+            .await
+            .expect("second acceptance");
+
+        assert_eq!(count_policy_acceptances(&pool, user_id).await, 1);
+        assert_eq!(count_policy_accept_audit_events(&pool, user_id).await, 1);
+
+        cleanup_user(&pool, user_id).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_policy_acceptance_emits_single_audit_event() {
+        let Some(database_url) = database_url_for_tests() else {
+            return;
+        };
+
+        let pool = connect_test_pool(&database_url).await;
+        let suffix = Uuid::new_v4().to_string();
+        let workos_user = sample_workos_user(&suffix);
+
+        let upserted = upsert_user(&pool, &workos_user).await.expect("upsert");
+        let user_id = upserted.user.id;
+
+        // Spawn both acceptances on a multi-threaded runtime so the inserts are
+        // genuinely in flight at the same time, not merely interleaved.
+        let spawn_acceptance = |pool: sqlx::PgPool| {
+            tokio::spawn(async move {
+                record_policy_acceptance(&pool, user_id, "privacy", config::PRIVACY_VERSION, None)
+                    .await
+            })
+        };
+        let first_task = spawn_acceptance(pool.clone());
+        let second_task = spawn_acceptance(pool.clone());
+        let (first, second) = tokio::join!(first_task, second_task);
+        first
+            .expect("first acceptance task")
+            .expect("first concurrent acceptance");
+        second
+            .expect("second acceptance task")
+            .expect("second concurrent acceptance");
+
+        assert_eq!(count_policy_acceptances(&pool, user_id).await, 1);
+        assert_eq!(count_policy_accept_audit_events(&pool, user_id).await, 1);
+
+        cleanup_user(&pool, user_id).await;
     }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

> [!NOTE]
> **Stacked PR** — this branch is stacked on `feat/354-tos-privacy-pages` (#430) and targets that branch, not `main`. Merge #430 first (or fold this in before #430 merges). The diff below shows only this branch's commits.

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(server): assert single policy.accept audit event on duplicate acceptance
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Issue #446 tracked duplicate `policy.accept` audit events: the audit write ran unconditionally after an `ON CONFLICT DO NOTHING` insert, so concurrent first-time OAuth callbacks each emitted an event. The production fix (gating the audit write on `rows_affected() > 0` in `crates/server/src/policy/mod.rs`) already landed on #430 in `95d2cd6`; this PR adds the regression tests the issue asked for so the gate cannot silently regress:

- `repeated_policy_acceptance_emits_single_audit_event` — calls `record_policy_acceptance` twice for the same user/policy/version and asserts exactly one `policy_acceptances` row and exactly one `policy.accept` audit event.
- `concurrent_policy_acceptance_emits_single_audit_event` — races two acceptances via `tokio::join!` and asserts the same invariants.

Both live in the existing DB-gated `policy_acceptance_tests` harness (skip unless `TEST_DATABASE_URL`/`DATABASE_URL` names a `_test` database). No cleanup of `audit_events` is attempted — the table is append-only by trigger — so assertions filter by the per-test random user UUID.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Part of #446 (close it once this lands on `main` via #430)
- Relates to #430
- Relates to #354

## Details

- Verified against an ephemeral dockerized Postgres 16 (`rustume_test`): all 4 policy acceptance tests pass, full `rustume-server` suite green (86 passed).
- An initial draft deleted audit rows during cleanup and was rejected by the `audit_events_immutable()` trigger — cleanup was dropped in favor of per-user filtering, which also exercises the append-only guarantee.
- `cargo clippy -D warnings`, `cargo fmt --check`, and `uv run lintro chk` all pass.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds two regression tests for issue #446, guarding the `rows_affected() > 0` gate in `record_policy_acceptance` that prevents duplicate `policy.accept` audit events when multiple callers race on an already-accepted policy.

- `repeated_policy_acceptance_emits_single_audit_event` calls `record_policy_acceptance` twice sequentially for the same user/policy/version and asserts exactly one `policy_acceptances` row and one audit event.
- `concurrent_policy_acceptance_emits_single_audit_event` races two tasks behind a `tokio::sync::Barrier` on a multi-thread runtime and asserts the same idempotency invariants; a new `count_policy_accept_audit_events` helper scopes the count by both `actor_user_id` and `metadata->>'policy'`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is test-only, isolated to the existing DB-gated harness, and exercises the production fix without touching any production code paths.

Both tests are cleanly scoped to fresh per-user UUIDs, the barrier correctly synchronizes the concurrent DB writes, and the audit-event helper is now filtered by both user and policy name. No production code is modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/routes/auth.rs | Adds two DB-gated regression tests plus a `count_policy_accept_audit_events` helper; barrier-based synchronization and per-user UUID isolation are implemented correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T1 as Task 1
    participant T2 as Task 2
    participant B as Barrier(2)
    participant DB as PostgreSQL

    T1->>B: wait()
    T2->>B: wait()
    B-->>T1: released
    B-->>T2: released
    par Concurrent inserts
        T1->>DB: INSERT ON CONFLICT DO NOTHING
        T2->>DB: INSERT ON CONFLICT DO NOTHING
    end
    DB-->>T1: "rows_affected = 1"
    DB-->>T2: "rows_affected = 0"
    T1->>DB: INSERT audit_event (policy.accept)
    Note over T2: rows_affected == 0, skip audit write
    Note over DB: Exactly 1 audit event written
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T1 as Task 1
    participant T2 as Task 2
    participant B as Barrier(2)
    participant DB as PostgreSQL

    T1->>B: wait()
    T2->>B: wait()
    B-->>T1: released
    B-->>T2: released
    par Concurrent inserts
        T1->>DB: INSERT ON CONFLICT DO NOTHING
        T2->>DB: INSERT ON CONFLICT DO NOTHING
    end
    DB-->>T1: "rows_affected = 1"
    DB-->>T2: "rows_affected = 0"
    T1->>DB: INSERT audit_event (policy.accept)
    Note over T2: rows_affected == 0, skip audit write
    Note over DB: Exactly 1 audit event written
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(server): gate concurrent acceptance..."](https://github.com/lgtm-hq/rustume/commit/c973aae8c4356e451306c2cf01ea3902b2c90545) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45049369)</sub>

<!-- /greptile_comment -->