### PR TITLE
fix(web): improve ARIA semantics, accessible names, and color contrast across app and site chrome

### DIFF
--- a/apps/site/src/components/NavDropdown.astro
+++ b/apps/site/src/components/NavDropdown.astro
@@ -103,7 +103,12 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
 
       dropdown.addEventListener("mouseenter", open);
       dropdown.addEventListener("mouseleave", scheduleClose);
-      dropdown.addEventListener("focusin", open);
+      dropdown.addEventListener("focusin", () => {
+        // Ignore the synthetic focusin fired by trigger.focus() during an
+        // Escape-close, which would otherwise reopen the panel immediately.
+        if (dropdown.classList.contains("is-escaped")) return;
+        open();
+      });
       dropdown.addEventListener("focusout", (event) => {
         const next = event.relatedTarget;
         if (next instanceof Node && dropdown.contains(next)) return;

--- a/apps/site/src/components/NavDropdown.astro
+++ b/apps/site/src/components/NavDropdown.astro
@@ -13,7 +13,6 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
   <a
     href={href}
     class="nav-link nav-dropdown-trigger"
-    aria-haspopup={groups.length > 0 ? "true" : undefined}
     aria-expanded={groups.length > 0 ? "false" : undefined}
     aria-controls={groups.length > 0 ? menuId : undefined}
   >
@@ -119,7 +118,9 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
         dropdown.classList.add("is-escaped");
         dropdown.querySelector<HTMLElement>(".nav-dropdown-trigger")?.focus();
       });
-      dropdown.addEventListener("focusout", () => {
+      dropdown.addEventListener("focusout", (event) => {
+        const next = event.relatedTarget;
+        if (next instanceof Node && dropdown.contains(next)) return;
         dropdown.classList.remove("is-escaped");
       });
     }

--- a/apps/site/src/components/NavDropdown.astro
+++ b/apps/site/src/components/NavDropdown.astro
@@ -10,7 +10,13 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
 ---
 
 <div class="nav-dropdown" data-nav-dropdown>
-  <a href={href} class="nav-link nav-dropdown-trigger">
+  <a
+    href={href}
+    class="nav-link nav-dropdown-trigger"
+    aria-haspopup={groups.length > 0 ? "true" : undefined}
+    aria-expanded={groups.length > 0 ? "false" : undefined}
+    aria-controls={groups.length > 0 ? menuId : undefined}
+  >
     {label}
     <svg class="nav-dropdown-chevron" width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
       <path d="M2.5 4.5 6 8l3.5-3.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
@@ -18,7 +24,7 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
   </a>
   {
     groups.length > 0 && (
-      <div class="nav-dropdown-panel" id={menuId} role="navigation" aria-label={`${label} pages`}>
+      <div class="nav-dropdown-panel" id={menuId} role="group" aria-label={`${label} pages`}>
         <div class="nav-dropdown-panel-inner">
           {
             groups.map((group) => (
@@ -52,9 +58,17 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
     }
   }
 
+  function setExpanded(dropdown: HTMLElement, expanded: boolean): void {
+    const trigger = dropdown.querySelector<HTMLElement>(".nav-dropdown-trigger");
+    if (trigger?.hasAttribute("aria-expanded")) {
+      trigger.setAttribute("aria-expanded", String(expanded));
+    }
+  }
+
   function closeDropdown(dropdown: HTMLElement): void {
     clearCloseTimer(dropdown);
     dropdown.classList.remove("is-open");
+    setExpanded(dropdown, false);
   }
 
   function closeOtherDropdowns(active: HTMLElement): void {
@@ -71,7 +85,9 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
       const open = (): void => {
         closeOtherDropdowns(dropdown);
         clearCloseTimer(dropdown);
+        dropdown.classList.remove("is-escaped");
         dropdown.classList.add("is-open");
+        setExpanded(dropdown, true);
       };
 
       const scheduleClose = (): void => {
@@ -80,6 +96,7 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
           dropdown,
           setTimeout(() => {
             dropdown.classList.remove("is-open");
+            setExpanded(dropdown, false);
             closeTimers.delete(dropdown);
           }, CLOSE_DELAY_MS),
         );
@@ -92,6 +109,28 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
         const next = event.relatedTarget;
         if (next instanceof Node && dropdown.contains(next)) return;
         scheduleClose();
+      });
+      dropdown.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape" || !dropdown.classList.contains("is-open")) return;
+        event.stopPropagation();
+        closeDropdown(dropdown);
+        // Suppress the :focus-within fallback until focus moves or the
+        // dropdown is reopened, so Escape visually closes the panel.
+        dropdown.classList.add("is-escaped");
+        dropdown.querySelector<HTMLElement>(".nav-dropdown-trigger")?.focus();
+      });
+      dropdown.addEventListener("focusout", () => {
+        dropdown.classList.remove("is-escaped");
+      });
+    }
+
+    if (document.body.dataset.navDropdownOutsideBound !== "true") {
+      document.body.dataset.navDropdownOutsideBound = "true";
+      document.addEventListener("click", (event) => {
+        for (const dropdown of document.querySelectorAll<HTMLElement>("[data-nav-dropdown]")) {
+          if (event.target instanceof Node && dropdown.contains(event.target)) continue;
+          closeDropdown(dropdown);
+        }
       });
     }
   }
@@ -145,6 +184,14 @@ const menuId = `nav-menu-${label.toLowerCase().replace(/\s+/g, "-")}`;
 
   .nav-dropdown:not(.is-open):not(:focus-within) .nav-dropdown-panel {
     transition: none;
+  }
+
+  /* Escape closes the panel even while the trigger keeps focus */
+  .nav-dropdown.is-escaped .nav-dropdown-panel {
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-4px);
+    pointer-events: none;
   }
 
   .nav-dropdown-panel-inner {

--- a/apps/site/src/components/SearchDropdown.astro
+++ b/apps/site/src/components/SearchDropdown.astro
@@ -13,8 +13,23 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
   <div class="search-bar-inner" id="search-trigger">
     <span class="search-bar-placeholder">What are you looking for?</span>
     <span class="search-bar-shortcut"><span class="search-bar-shortcut-mod" data-mod="⌘"></span>K</span>
-    <button class="search-bar-btn" type="button" aria-label="Search">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+    <button
+      class="search-bar-btn"
+      type="button"
+      aria-label="Search"
+      aria-haspopup="dialog"
+      aria-expanded="false"
+      aria-controls="search-menu"
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        aria-hidden="true"
+      >
         <circle cx="11" cy="11" r="8"></circle>
         <path d="M21 21l-4.35-4.35"></path>
       </svg>
@@ -38,6 +53,7 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
     var baseUrl = searchBar.getAttribute('data-base-url') || '';
     var searchInitialized = false;
     var shortcutMod = searchBar.querySelector('.search-bar-shortcut-mod');
+    var triggerBtn = searchBar.querySelector('.search-bar-btn');
 
     if (shortcutMod) {
       var isMac = /Mac|iPhone|iPod|iPad/i.test(navigator.platform) ||
@@ -47,6 +63,7 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
 
     async function openSearch() {
       searchBar.classList.add('open');
+      if (triggerBtn) triggerBtn.setAttribute('aria-expanded', 'true');
       await initSearch();
       if (!searchBar.classList.contains('open')) return;
       var input = searchBar.querySelector('.pagefind-ui__search-input');
@@ -57,7 +74,13 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
     }
 
     function closeSearch() {
+      var hadFocusInside = menu.contains(document.activeElement);
       searchBar.classList.remove('open');
+      if (triggerBtn) {
+        triggerBtn.setAttribute('aria-expanded', 'false');
+        // Return focus to the trigger when the dialog held focus.
+        if (hadFocusInside) triggerBtn.focus();
+      }
     }
 
     function toggleSearch() {

--- a/apps/site/src/components/docs/DocsSidebar.astro
+++ b/apps/site/src/components/docs/DocsSidebar.astro
@@ -20,8 +20,9 @@ const grouped = CORE_DOC_CATEGORIES.map((key) => ({
 ---
 
 <aside class="docs-sidebar" data-pagefind-ignore>
-  {
-    grouped.map(({ label, docs }) => (
+  <nav aria-label="Documentation">
+    {
+      grouped.map(({ label, docs }) => (
       <div class="sidebar-section">
         <div class="sidebar-section-title">{label}</div>
         {
@@ -36,6 +37,7 @@ const grouped = CORE_DOC_CATEGORIES.map((key) => ({
           ))
         }
       </div>
-    ))
-  }
+      ))
+    }
+  </nav>
 </aside>

--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -97,7 +97,7 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
   <body>
     <a href="#main-content" class="skip-link">Skip to content</a>
     <Header />
-    <main class="main" id="main-content">
+    <main class="main" id="main-content" tabindex="-1">
       <slot />
     </main>
     <Footer />

--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -95,8 +95,9 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
     </script>
   </head>
   <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
     <Header />
-    <main class="main">
+    <main class="main" id="main-content">
       <slot />
     </main>
     <Footer />

--- a/apps/site/src/layouts/DocsLayout.astro
+++ b/apps/site/src/layouts/DocsLayout.astro
@@ -21,7 +21,8 @@ const formattedDescription = sanitizeDocDescription(formatDocDescription(descrip
 <BaseLayout title={title} description={metaDescription}>
   <div class="docs-layout">
     <DocsSidebar currentSlug={slug} />
-    <main class="docs-main">
+    {/* BaseLayout already renders the page's <main> landmark */}
+    <div class="docs-main">
       <article class="docs-content" data-pagefind-body>
         <header class="docs-header">
           <h1 class="docs-title">{title}</h1>
@@ -32,6 +33,6 @@ const formattedDescription = sanitizeDocDescription(formatDocDescription(descrip
         </div>
         <DocsResources resources={resources ?? []} />
       </article>
-    </main>
+    </div>
   </div>
 </BaseLayout>

--- a/apps/site/src/layouts/DocsStandaloneLayout.astro
+++ b/apps/site/src/layouts/DocsStandaloneLayout.astro
@@ -35,7 +35,8 @@ const formattedDescription = sanitizeDocDescription(formatDocDescription(descrip
   <div class="docs-standalone">
     {showSectionNav && category && <DocsSectionNav category={category} currentSlug={slug} />}
     <div class="docs-standalone-body">
-      <main class="docs-standalone-main">
+      {/* BaseLayout already renders the page's <main> landmark */}
+      <div class="docs-standalone-main">
         <article class="docs-content" data-pagefind-body>
           <header class="docs-header">
             <h1 class="docs-title">{title}</h1>
@@ -46,7 +47,7 @@ const formattedDescription = sanitizeDocDescription(formatDocDescription(descrip
           </div>
           <DocsResources resources={resources ?? []} />
         </article>
-      </main>
+      </div>
       <DocsOnThisPage enabled={toc} />
     </div>
   </div>

--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -33,10 +33,23 @@
   --shadow-xl: var(--rust-warm-shadow);
   --shadow-glow-sm: 0 0 0 3px color-mix(in srgb, var(--rust-forge) 30%, transparent);
 
+  /*
+   * WCAG AA derived token: some turbo theme palettes ship a secondary text
+   * color below the 4.5:1 AA contrast ratio on base/surface backgrounds
+   * (e.g. solarized-light #657b83 on #eee8d5 is 3.64:1). Mixing it toward
+   * the theme's primary text color keeps the hue while guaranteeing more
+   * contrast in every theme; craft (default) already passes and only gains.
+   */
+  --a11y-text-secondary: color-mix(
+    in srgb,
+    var(--turbo-text-secondary) 75%,
+    var(--turbo-text-primary)
+  );
+
   /* Aliases for legacy token names */
-  --turbo-text-muted: var(--turbo-text-secondary);
+  --turbo-text-muted: var(--a11y-text-secondary);
   --turbo-text-default: var(--turbo-text-primary);
-  --turbo-text-tertiary: var(--turbo-text-secondary);
+  --turbo-text-tertiary: var(--a11y-text-secondary);
 }
 
 /* Turbo theme accent bridge (craft sets these in craft-theme.css) */
@@ -98,6 +111,27 @@ body::after {
 .site-footer {
   position: relative;
   z-index: 1;
+}
+
+/* Skip-to-content link: visually hidden until keyboard-focused */
+.skip-link {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 2000;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--turbo-border-default);
+  background: var(--turbo-bg-surface);
+  color: var(--turbo-text-primary);
+  font-weight: 600;
+  transform: translateY(calc(-100% - 1.5rem));
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+  text-decoration: none;
+  color: var(--turbo-text-primary);
 }
 
 h1, h2, h3, h4 {
@@ -497,7 +531,7 @@ th {
 .sidebar-link {
   display: block;
   padding: 0.4rem 1.25rem;
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
   font-size: 0.9rem;
   text-decoration: none;
   border-left: 2px solid transparent;
@@ -687,7 +721,7 @@ th {
   padding: 0.32rem 0.7rem;
   border: 1px solid var(--turbo-border-default);
   border-radius: var(--radius-full);
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
   font-size: 0.84rem;
   text-decoration: none;
   background: var(--turbo-bg-surface);
@@ -767,7 +801,7 @@ th {
 .cloud-doc-figure figcaption {
   margin-top: 0.65rem;
   font-size: 0.875rem;
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
   text-align: center;
 }
 
@@ -794,7 +828,7 @@ th {
   font-family: var(--font-body, var(--turbo-font-sans));
   font-size: 0.85rem;
   font-weight: 500;
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
 }
 
 .plans-table .plan-unlimited {
@@ -1031,7 +1065,7 @@ th {
   background: color-mix(in srgb, var(--turbo-bg-surface) 85%, transparent);
   border: 1px solid var(--turbo-border-default);
   font-size: 0.92rem;
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
 }
 
 .craft-privacy-num {
@@ -1156,7 +1190,7 @@ th {
 }
 
 .feature-tile-description {
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
   margin: 0;
   font-size: 0.8125rem;
   line-height: 1.45;
@@ -1174,12 +1208,12 @@ th {
 .tag-outline {
   background: transparent;
   border: 1px solid var(--turbo-border-default);
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
 }
 
 .feature-tile-tag {
   background: var(--turbo-bg-surface);
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
   padding: 0.125rem 0.5rem;
   border-radius: var(--radius-full, 9999px);
   font-size: 0.6875rem;
@@ -1240,7 +1274,7 @@ th {
 }
 
 .card.card-feature .card-body > p {
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
   font-size: 0.92rem;
   line-height: 1.55;
   margin: 0;
@@ -1370,7 +1404,7 @@ th {
 
 .callout-banner p,
 .callout-banner ul {
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
   line-height: 1.65;
 }
 
@@ -1417,7 +1451,7 @@ th {
 
 .link-card span {
   font-size: 0.82rem;
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
 }
 
 .doc-categories {
@@ -1453,7 +1487,7 @@ th {
 }
 
 .doc-category span {
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
   font-size: 0.88rem;
 }
 
@@ -1609,7 +1643,7 @@ th {
   font-size: 0.62rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--site-accent-light, var(--turbo-text-secondary));
+  color: var(--site-accent-light, var(--a11y-text-secondary));
 }
 
 .theme-picker-options {
@@ -1661,7 +1695,7 @@ th {
   font-size: 0.58rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--turbo-text-secondary);
+  color: var(--a11y-text-secondary);
   opacity: 0.85;
 }
 

--- a/apps/web/src/components/builder/BasicsForm.tsx
+++ b/apps/web/src/components/builder/BasicsForm.tsx
@@ -16,7 +16,13 @@ export function BasicsForm() {
       {/* Header */}
       <div class="flex items-center gap-3 pb-4 border-b border-border">
         <div class="w-10 h-10 bg-accent/10 rounded-lg flex items-center justify-center">
-          <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg
+            class="w-5 h-5 text-accent"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
             <path
               stroke-linecap="round"
               stroke-linejoin="round"

--- a/apps/web/src/components/builder/ImageUpload.tsx
+++ b/apps/web/src/components/builder/ImageUpload.tsx
@@ -225,8 +225,13 @@ export function ImageUpload(props: ImageUploadProps) {
               <Show
                 when={!isProcessing()}
                 fallback={
-                  <div class="flex flex-col items-center gap-2">
-                    <svg class="w-8 h-8 text-accent animate-spin" fill="none" viewBox="0 0 24 24">
+                  <div role="status" aria-live="polite" class="flex flex-col items-center gap-2">
+                    <svg
+                      class="w-8 h-8 text-accent animate-spin"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
                       <circle
                         class="opacity-25"
                         cx="12"
@@ -252,6 +257,7 @@ export function ImageUpload(props: ImageUploadProps) {
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
+                    aria-hidden="true"
                   >
                     <path
                       stroke-linecap="round"

--- a/apps/web/src/components/builder/SectionList.tsx
+++ b/apps/web/src/components/builder/SectionList.tsx
@@ -37,7 +37,13 @@ export function SectionList() {
       {/* Header */}
       <div class="flex items-center gap-3 pb-4 border-b border-border">
         <div class="w-10 h-10 bg-accent/10 rounded-lg flex items-center justify-center">
-          <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg
+            class="w-5 h-5 text-accent"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -89,6 +95,7 @@ export function SectionList() {
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
                 >
                   <path
                     stroke-linecap="round"
@@ -108,6 +115,7 @@ export function SectionList() {
               <div
                 role="switch"
                 aria-checked={isVisible(section.key)}
+                aria-label={`Show ${section.name} section`}
                 tabIndex={0}
                 class={`w-8 h-5 rounded-full transition-colors relative cursor-pointer ${
                   isVisible(section.key) ? "bg-accent" : "bg-border"

--- a/apps/web/src/components/builder/SummaryEditor.tsx
+++ b/apps/web/src/components/builder/SummaryEditor.tsx
@@ -10,7 +10,13 @@ export function SummaryEditor() {
       {/* Header */}
       <div class="flex items-center gap-3 pb-4 border-b border-border">
         <div class="w-10 h-10 bg-accent/10 rounded-lg flex items-center justify-center">
-          <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg
+            class="w-5 h-5 text-accent"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
             <path
               stroke-linecap="round"
               stroke-linejoin="round"

--- a/apps/web/src/components/export/ExportModal.tsx
+++ b/apps/web/src/components/export/ExportModal.tsx
@@ -90,13 +90,20 @@ export function ExportModal() {
         <div class="space-y-3">
           {/* PDF */}
           <button
+            type="button"
             class="w-full p-4 flex items-center gap-4 border border-border rounded-xl
               hover:border-accent hover:bg-accent/5 transition-colors text-left group"
             onClick={handleExportPdf}
             disabled={isExporting()}
+            aria-busy={isExporting()}
           >
             <div class="w-12 h-12 bg-red-100 rounded-xl flex items-center justify-center flex-shrink-0">
-              <svg class="w-6 h-6 text-red-600" viewBox="0 0 24 24" fill="currentColor">
+              <svg
+                class="w-6 h-6 text-red-600"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 2l5 5h-5V4zM8.5 13.5a1 1 0 1 1 0 2h-1a.5.5 0 0 0-.5.5v1.5h-.5a.5.5 0 0 1 0-1H7v-1a1.5 1.5 0 0 1 1.5-1.5zm6.5 0a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-1.5a.5.5 0 0 1-.5-.5v-3a.5.5 0 0 1 .5-.5H15zm-2.5 0a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-1 0v-1h-.5a.5.5 0 0 1 0-1h.5v-1a.5.5 0 0 1 .5-.5z" />
               </svg>
             </div>
@@ -109,7 +116,11 @@ export function ExportModal() {
             <Show
               when={!isExporting()}
               fallback={
-                <svg class="w-5 h-5 animate-spin text-accent" viewBox="0 0 24 24">
+                <svg
+                  class="w-5 h-5 animate-spin text-accent"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
                   <circle
                     class="opacity-25"
                     cx="12"
@@ -132,6 +143,7 @@ export function ExportModal() {
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path
                   stroke-linecap="round"
@@ -145,12 +157,18 @@ export function ExportModal() {
 
           {/* JSON */}
           <button
+            type="button"
             class="w-full p-4 flex items-center gap-4 border border-border rounded-xl
               hover:border-accent hover:bg-accent/5 transition-colors text-left group"
             onClick={handleExportJson}
           >
             <div class="w-12 h-12 bg-amber-100 rounded-xl flex items-center justify-center flex-shrink-0">
-              <svg class="w-6 h-6 text-amber-600" viewBox="0 0 24 24" fill="currentColor">
+              <svg
+                class="w-6 h-6 text-amber-600"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
                 <path d="M5 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2H5zm4.5 5a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-1 0v-3a.5.5 0 0 1 .5-.5zm5 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 .5.5h.5a.5.5 0 0 1 0 1H15a1.5 1.5 0 0 1-1.5-1.5v-2a.5.5 0 0 1 .5-.5zM8 14a.5.5 0 0 1 .5.5v1a.5.5 0 0 0 .5.5h.5a.5.5 0 0 1 0 1H9a1.5 1.5 0 0 1-1.5-1.5v-1A.5.5 0 0 1 8 14z" />
               </svg>
             </div>
@@ -165,6 +183,7 @@ export function ExportModal() {
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path
                 stroke-linecap="round"
@@ -178,7 +197,10 @@ export function ExportModal() {
 
         {/* Error */}
         <Show when={error()}>
-          <div class="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          <div
+            role="alert"
+            class="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700"
+          >
             {error()}
           </div>
         </Show>

--- a/apps/web/src/components/import/ImportModal.tsx
+++ b/apps/web/src/components/import/ImportModal.tsx
@@ -210,12 +210,19 @@ export function ImportModal() {
             type="file"
             accept=".json,.zip"
             onChange={handleFileInput}
+            aria-label="Choose a resume file to import"
             class="absolute inset-0 opacity-0 cursor-pointer"
           />
 
           <div class="space-y-3">
             <div class="w-12 h-12 mx-auto bg-surface rounded-xl flex items-center justify-center">
-              <svg class="w-6 h-6 text-stone" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg
+                class="w-6 h-6 text-stone"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
@@ -238,8 +245,12 @@ export function ImportModal() {
 
         {/* Loading */}
         <Show when={isLoading()}>
-          <div class="flex items-center justify-center gap-2 py-2 text-stone">
-            <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24">
+          <div
+            role="status"
+            aria-live="polite"
+            class="flex items-center justify-center gap-2 py-2 text-stone"
+          >
+            <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" aria-hidden="true">
               <circle
                 class="opacity-25"
                 cx="12"
@@ -261,7 +272,10 @@ export function ImportModal() {
 
         {/* Error */}
         <Show when={error()}>
-          <div class="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          <div
+            role="alert"
+            class="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700"
+          >
             {error()}
           </div>
         </Show>

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -17,17 +17,22 @@ export const AppShell: ParentComponent = (props) => {
       <header class="h-14 border-b border-border bg-paper/80 backdrop-blur-sm sticky top-0 z-30">
         <div class="h-full px-4 flex items-center justify-between">
           {/* Logo */}
-          <A href="/" class="flex items-center gap-2 group">
-            <div class="w-8 h-8 bg-ink rounded flex items-center justify-center">
-              <span class="text-paper font-display font-bold text-lg">R</span>
-            </div>
-            <span
-              class="font-display text-xl font-semibold text-ink
-              group-hover:text-accent transition-colors"
-            >
-              Rustume
-            </span>
-          </A>
+          <nav aria-label="Primary">
+            <A href="/" class="flex items-center gap-2 group">
+              <div
+                class="w-8 h-8 bg-ink rounded flex items-center justify-center"
+                aria-hidden="true"
+              >
+                <span class="text-paper font-display font-bold text-lg">R</span>
+              </div>
+              <span
+                class="font-display text-xl font-semibold text-ink
+                group-hover:text-accent transition-colors"
+              >
+                Rustume
+              </span>
+            </A>
+          </nav>
 
           {/* Status Indicators */}
           <div class="flex items-center gap-4">
@@ -62,10 +67,14 @@ function SaveIndicator() {
   const { store } = resumeStore;
 
   return (
-    <div class="flex items-center gap-2 text-xs font-mono text-stone">
+    <div
+      role="status"
+      aria-live="polite"
+      class="flex items-center gap-2 text-xs font-mono text-stone"
+    >
       <Show when={store.isSaving}>
         <div class="flex items-center gap-1.5">
-          <svg class="w-3 h-3 animate-spin" viewBox="0 0 24 24">
+          <svg class="w-3 h-3 animate-spin" viewBox="0 0 24 24" aria-hidden="true">
             <circle
               class="opacity-25"
               cx="12"
@@ -87,14 +96,20 @@ function SaveIndicator() {
 
       <Show when={!store.isSaving && store.isDirty}>
         <div class="flex items-center gap-1.5">
-          <div class="w-1.5 h-1.5 bg-accent rounded-full" />
+          <div class="w-1.5 h-1.5 bg-accent rounded-full" aria-hidden="true" />
           <span>Unsaved</span>
         </div>
       </Show>
 
       <Show when={!store.isSaving && !store.isDirty && store.lastSaved}>
         <div class="flex items-center gap-1.5">
-          <svg class="w-3 h-3 text-green-600" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg
+            class="w-3 h-3 text-green-600"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
             <path
               stroke-linecap="round"
               stroke-linejoin="round"

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -62,7 +62,7 @@ export function Sidebar(props: SidebarProps) {
   };
 
   const renderIcon = (icon: string, className = "w-5 h-5") => (
-    <svg class={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg class={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d={icon} />
     </svg>
   );
@@ -92,6 +92,7 @@ export function Sidebar(props: SidebarProps) {
             fill={isPinned() ? "currentColor" : "none"}
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
             <path
               stroke-linecap="round"
@@ -110,7 +111,7 @@ export function Sidebar(props: SidebarProps) {
       <div class="h-px bg-border mx-2 mb-2" />
 
       {/* Navigation Items */}
-      <nav class="flex-1 overflow-auto px-2">
+      <nav aria-label="Resume sections" class="flex-1 overflow-auto px-2">
         <For each={props.items}>
           {(item, index) => (
             <div class={startsGroup(index()) ? "mt-3 first:mt-0" : "mt-1"}>

--- a/apps/web/src/components/layout/SplitPane.tsx
+++ b/apps/web/src/components/layout/SplitPane.tsx
@@ -73,6 +73,10 @@ export const SplitPane: ParentComponent<SplitPaneProps> = (props) => {
         <div
           role="separator"
           aria-orientation="vertical"
+          aria-label="Resize editor and preview panels"
+          aria-valuenow={Math.round(ratio() * 100)}
+          aria-valuemin={0}
+          aria-valuemax={100}
           class="w-1 bg-border hover:bg-accent cursor-col-resize
             transition-colors duration-150 flex-shrink-0 relative group"
           classList={{ "bg-accent": isDragging() }}

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -187,7 +187,13 @@ export function Preview() {
             onClick={() => goToPage(ui.previewPage - 1)}
             disabled={ui.previewPage === 0}
           >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -208,7 +214,13 @@ export function Preview() {
             onClick={() => goToPage(ui.previewPage + 1)}
             disabled={ui.previewPage >= totalPages() - 1}
           >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -229,7 +241,13 @@ export function Preview() {
               }}
               title={`Content spans ${totalPages()} pages`}
             >
-              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg
+                class="w-3 h-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
@@ -241,11 +259,19 @@ export function Preview() {
             </span>
           </Show>
           <button
+            type="button"
             class="p-1.5 text-stone hover:text-ink hover:bg-surface rounded transition-colors"
             onClick={zoomOut}
+            aria-label="Zoom out"
             title="Zoom out"
           >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" />
             </svg>
           </button>
@@ -253,11 +279,19 @@ export function Preview() {
             {Math.round(ui.previewZoom * 100)}%
           </span>
           <button
+            type="button"
             class="p-1.5 text-stone hover:text-ink hover:bg-surface rounded transition-colors"
             onClick={zoomIn}
+            aria-label="Zoom in"
             title="Zoom in"
           >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -305,7 +339,9 @@ export function Preview() {
                     fallback={
                       <div class="text-center text-stone">
                         <Show when={error()}>
-                          <p class="text-sm mb-2">{error()}</p>
+                          <p role="alert" class="text-sm mb-2">
+                            {error()}
+                          </p>
                         </Show>
                         <Show when={!isOnline()}>
                           <div class="flex items-center justify-center gap-2 text-offline">
@@ -314,6 +350,7 @@ export function Preview() {
                               fill="none"
                               stroke="currentColor"
                               viewBox="0 0 24 24"
+                              aria-hidden="true"
                             >
                               <path
                                 stroke-linecap="round"
@@ -331,8 +368,12 @@ export function Preview() {
                       </div>
                     }
                   >
-                    <div class="flex flex-col items-center gap-3">
-                      <svg class="w-8 h-8 animate-spin text-accent" viewBox="0 0 24 24">
+                    <div role="status" aria-live="polite" class="flex flex-col items-center gap-3">
+                      <svg
+                        class="w-8 h-8 animate-spin text-accent"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
                         <circle
                           class="opacity-25"
                           cx="12"
@@ -365,8 +406,12 @@ export function Preview() {
 
           {/* Loading overlay */}
           <Show when={isLoading() && previewUrl()}>
-            <div class="absolute inset-0 flex items-center justify-center bg-white/50">
-              <svg class="w-6 h-6 animate-spin text-accent" viewBox="0 0 24 24">
+            <div
+              role="status"
+              aria-label="Updating preview"
+              class="absolute inset-0 flex items-center justify-center bg-white/50"
+            >
+              <svg class="w-6 h-6 animate-spin text-accent" viewBox="0 0 24 24" aria-hidden="true">
                 <circle
                   class="opacity-25"
                   cx="12"

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -408,9 +408,9 @@ export function Preview() {
           <Show when={isLoading() && previewUrl()}>
             <div
               role="status"
-              aria-label="Updating preview"
               class="absolute inset-0 flex items-center justify-center bg-white/50"
             >
+              <span class="sr-only">Updating preview</span>
               <svg class="w-6 h-6 animate-spin text-accent" viewBox="0 0 24 24" aria-hidden="true">
                 <circle
                   class="opacity-25"

--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -178,10 +178,12 @@ interface PresetCardProps {
 function PresetCard(props: PresetCardProps) {
   return (
     <button
+      type="button"
       onClick={props.onSelect}
       class={`relative p-2 rounded-lg border-2 transition-all hover:scale-105 ${
         props.isSelected ? "border-accent shadow-md" : "border-border hover:border-accent/50"
       }`}
+      aria-pressed={props.isSelected}
       title={props.preset.name}
     >
       {/* Color Preview */}

--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -29,7 +29,13 @@ export function ThemeEditor() {
       {/* Header */}
       <div class="flex items-center gap-3 pb-4 border-b border-border">
         <div class="w-10 h-10 bg-accent/10 rounded-lg flex items-center justify-center">
-          <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg
+            class="w-5 h-5 text-accent"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -201,7 +207,13 @@ function PresetCard(props: PresetCardProps) {
       {/* Selected indicator */}
       <Show when={props.isSelected}>
         <div class="absolute -top-1 -right-1 w-4 h-4 bg-accent rounded-full flex items-center justify-center">
-          <svg class="w-2.5 h-2.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg
+            class="w-2.5 h-2.5 text-white"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -255,6 +267,7 @@ function ColorInput(props: ColorInputProps) {
           transition-all hover:border-accent hover:scale-[1.02] hover:shadow-lg
           focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent/20"
         style={{ background: props.value }}
+        aria-label={`Pick ${props.label.toLowerCase()} color`}
         title="Click to pick a color"
       >
         {/* Hidden native color input */}
@@ -263,6 +276,7 @@ function ColorInput(props: ColorInputProps) {
           type="color"
           value={props.value}
           onInput={(e) => props.onChange(e.currentTarget.value)}
+          aria-label={`${props.label} color`}
           class="sr-only"
         />
       </button>
@@ -272,6 +286,7 @@ function ColorInput(props: ColorInputProps) {
         type="text"
         value={props.value}
         onInput={(e) => handleTextInput(e.currentTarget.value)}
+        aria-label={`${props.label} hex value`}
         class="w-full px-2 py-1.5 text-xs font-mono text-center bg-surface border border-border
           rounded-lg focus:outline-none focus:border-accent uppercase"
         maxLength={7}

--- a/apps/web/src/components/ui/Accordion.tsx
+++ b/apps/web/src/components/ui/Accordion.tsx
@@ -53,6 +53,7 @@ export const Accordion: ParentComponent<AccordionProps> = (props) => {
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
                 >
                   <path
                     stroke-linecap="round"

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -52,6 +52,7 @@ export const Button: ParentComponent<ButtonProps> = (props) => {
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <circle
             class="opacity-25"

--- a/apps/web/src/hooks/__tests__/usePageTitle.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageTitle.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { createRoot, createSignal } from "solid-js";
+import { usePageTitle } from "../usePageTitle";
+
+/** Effects flush after the synchronous createRoot body completes. */
+const flushEffects = () => Promise.resolve();
+
+describe("usePageTitle", () => {
+  it("sets a static title with the base suffix", async () => {
+    const dispose = createRoot((d) => {
+      usePageTitle("Account");
+      return d;
+    });
+    await flushEffects();
+    expect(document.title).toBe("Account — Rustume");
+    dispose();
+  });
+
+  it("tracks a reactive title accessor", async () => {
+    const [name, setName] = createSignal<string | undefined>("Ada Lovelace");
+    const dispose = createRoot((d) => {
+      usePageTitle(() => name());
+      return d;
+    });
+    await flushEffects();
+    expect(document.title).toBe("Ada Lovelace — Rustume");
+
+    setName("Grace Hopper");
+    await flushEffects();
+    expect(document.title).toBe("Grace Hopper — Rustume");
+
+    dispose();
+  });
+
+  it("falls back to the base title for empty values", async () => {
+    const dispose = createRoot((d) => {
+      usePageTitle(() => undefined);
+      return d;
+    });
+    await flushEffects();
+    expect(document.title).toBe("Rustume");
+    dispose();
+  });
+});

--- a/apps/web/src/hooks/usePageTitle.ts
+++ b/apps/web/src/hooks/usePageTitle.ts
@@ -1,4 +1,4 @@
-import { createEffect, onCleanup } from "solid-js";
+import { createEffect } from "solid-js";
 
 const BASE_TITLE = "Rustume";
 
@@ -6,16 +6,13 @@ const BASE_TITLE = "Rustume";
  * Keep `document.title` in sync with the current route (WCAG 2.4.2).
  *
  * Accepts a static string or an accessor so titles can track reactive
- * state (e.g. the resume name in the editor). Restores the base title
- * when the owning page is disposed.
+ * state (e.g. the resume name in the editor). No cleanup reset: the next
+ * route's effect overwrites the title, and resetting on disposal would
+ * flash the base title between pages.
  */
 export function usePageTitle(title: string | (() => string | undefined)): void {
   createEffect(() => {
     const value = typeof title === "function" ? title() : title;
     document.title = value ? `${value} — ${BASE_TITLE}` : BASE_TITLE;
-  });
-
-  onCleanup(() => {
-    document.title = BASE_TITLE;
   });
 }

--- a/apps/web/src/hooks/usePageTitle.ts
+++ b/apps/web/src/hooks/usePageTitle.ts
@@ -1,0 +1,21 @@
+import { createEffect, onCleanup } from "solid-js";
+
+const BASE_TITLE = "Rustume";
+
+/**
+ * Keep `document.title` in sync with the current route (WCAG 2.4.2).
+ *
+ * Accepts a static string or an accessor so titles can track reactive
+ * state (e.g. the resume name in the editor). Restores the base title
+ * when the owning page is disposed.
+ */
+export function usePageTitle(title: string | (() => string | undefined)): void {
+  createEffect(() => {
+    const value = typeof title === "function" ? title() : title;
+    document.title = value ? `${value} — ${BASE_TITLE}` : BASE_TITLE;
+  });
+
+  onCleanup(() => {
+    document.title = BASE_TITLE;
+  });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -17,17 +17,39 @@
   --turbo-state-danger: #f38ba8;
   --turbo-border-default: #6c7086;
   --turbo-selection-bg: #7f849c;
+
+  /*
+   * WCAG AA derived tokens.
+   *
+   * Several turbo-themes palettes ship secondary-text, accent, and border
+   * tokens that fall short of WCAG AA when used on the base/surface
+   * backgrounds (e.g. catppuccin-latte text.secondary #6c6f85 on #e6e9ef is
+   * 4.06:1, brand.primary #1e66f5 on #e6e9ef is 4.04:1, border #9ca0b0 on
+   * #eff1f5 is 2.30:1). Nudging each token toward the theme's primary text
+   * color raises contrast in every theme while preserving its hue:
+   *   - stone (muted text):  latte 4.06:1 -> 4.56:1 (>= 4.5:1 AA text)
+   *   - accent (link text):  latte 4.04:1 -> 4.65:1 (>= 4.5:1 AA text)
+   *   - border (UI/inputs):  latte 2.14:1 -> 3.41:1 (>= 3:1 AA non-text)
+   * Dark defaults (catppuccin-mocha) already pass and only gain contrast.
+   */
+  --a11y-text-secondary: color-mix(
+    in srgb,
+    var(--turbo-text-secondary) 75%,
+    var(--turbo-text-primary)
+  );
+  --a11y-accent: color-mix(in srgb, var(--turbo-brand-primary) 75%, var(--turbo-text-primary));
+  --a11y-border: color-mix(in srgb, var(--turbo-border-default) 55%, var(--turbo-text-primary));
 }
 
 @theme {
-  /* Colors - mapped from turbo-themes */
+  /* Colors - mapped from turbo-themes (via WCAG AA derived tokens above) */
   --color-ink: var(--turbo-text-primary);
   --color-paper: var(--turbo-bg-base);
-  --color-stone: var(--turbo-text-secondary);
-  --color-accent: var(--turbo-brand-primary);
+  --color-stone: var(--a11y-text-secondary);
+  --color-accent: var(--a11y-accent);
   --color-accent-light: var(--turbo-bg-overlay);
   --color-surface: var(--turbo-bg-surface);
-  --color-border: var(--turbo-border-default);
+  --color-border: var(--a11y-border);
   --color-shadow: rgba(0, 0, 0, 0.15);
   --color-offline: var(--turbo-state-warning);
 

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -5,6 +5,7 @@ import { downloadResumesJson, downloadResumesPdf } from "../api/export";
 import { listCloudResumesPage } from "../api/resumes";
 import { authStore } from "../stores/auth";
 import { Button, Input, Modal, Spinner, toast } from "../components/ui";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 function ProfileAvatar(props: { label: string }) {
   return (
@@ -36,6 +37,7 @@ function ComingSoonRow(props: { title: string; description: string }) {
 }
 
 export default function Account() {
+  usePageTitle("Account");
   const { state, signIn, signOut, clearUser, displayName } = authStore;
   const navigate = useNavigate();
   const [signingOut, setSigningOut] = createSignal(false);

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -2,6 +2,7 @@ import { createMemo, createSignal, lazy, onMount, Show, Suspense } from "solid-j
 import { useParams, useNavigate } from "@solidjs/router";
 import { Button, toast, ShortcutsModal, Spinner } from "../components/ui";
 import { useHotkeys, type Shortcut } from "../hooks/useHotkeys";
+import { usePageTitle } from "../hooks/usePageTitle";
 import { useNavigationGuard } from "../hooks/useNavigationGuard";
 import { SplitPane } from "../components/layout/SplitPane";
 import { Sidebar, type SidebarItem } from "../components/layout/Sidebar";
@@ -212,6 +213,11 @@ export default function Editor() {
   const navigate = useNavigate();
   const { store, loadResume, createNewResume } = resumeStore;
   const { store: ui, openModal, closeModal, setPanel } = uiStore;
+
+  usePageTitle(() => {
+    const name = store.resume?.basics.name.trim();
+    return name ? `${name} · Editor` : "Editor";
+  });
 
   const [activeTab, setActiveTab] = createSignal<EditorTab>("basics");
   const [isLoading, setIsLoading] = createSignal(true);
@@ -496,8 +502,12 @@ export default function Editor() {
               <Show
                 when={loadError()}
                 fallback={
-                  <div class="text-center">
-                    <svg class="w-8 h-8 animate-spin text-accent mx-auto mb-4" viewBox="0 0 24 24">
+                  <div role="status" aria-live="polite" class="text-center">
+                    <svg
+                      class="w-8 h-8 animate-spin text-accent mx-auto mb-4"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
                       <circle
                         class="opacity-25"
                         cx="12"

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { For, Show, createSignal } from "solid-js";
 import { A, useNavigate } from "@solidjs/router";
 import { Button, Spinner, toast } from "../components/ui";
+import { usePageTitle } from "../hooks/usePageTitle";
 import { useResumeList } from "../stores/persistence";
 import { authStore } from "../stores/auth";
 import { generateId } from "../wasm/types";
@@ -33,6 +34,7 @@ function formatUpdatedAt(date: Date): string {
 }
 
 export default function Home() {
+  usePageTitle("Your resumes");
   const navigate = useNavigate();
   const { state: authState, signIn } = authStore;
   const { resumes, loading, deleteResume, duplicateResume, renameResume, refresh } =

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from "@solidjs/router";
 import { StatusPage } from "../components/errors/StatusPage";
+import { usePageTitle } from "../hooks/usePageTitle";
 
 function MissingPageIcon() {
   return (
@@ -22,6 +23,7 @@ function MissingPageIcon() {
 }
 
 export default function NotFound() {
+  usePageTitle("Page not found");
   const navigate = useNavigate();
   const location = useLocation();
 

--- a/apps/web/src/pages/Unauthorized.tsx
+++ b/apps/web/src/pages/Unauthorized.tsx
@@ -1,5 +1,6 @@
 import { createSignal } from "solid-js";
 import { StatusPage } from "../components/errors/StatusPage";
+import { usePageTitle } from "../hooks/usePageTitle";
 import { authStore } from "../stores/auth";
 
 function LockIcon() {
@@ -23,6 +24,7 @@ function LockIcon() {
 
 /** Shown when hosted Rustume Cloud requires sign-in before using the app. */
 export default function Unauthorized() {
+  usePageTitle("Sign in required");
   const { signIn } = authStore;
   const [signingIn, setSigningIn] = createSignal(false);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(web): improve ARIA semantics, accessible names, and color contrast across app and site chrome
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Accessibility pass over the web app chrome and the marketing site per #368: accessible names, explicit label association, landmark structure, per-route page titles, live-region announcements, dropdown keyboard/ARIA correctness, and a WCAG AA contrast audit of the turbo-themes tokens as used by both apps.

Editor keyboard/focus behavior is intentionally untouched — that is #367 (PR #450); this PR avoids the files/hunks that PR changes (LayoutEditor, SectionEditor, CustomSectionEditor, RichTextEditor, Modal close button, EditorThemeSelector trigger, AppShell skip link).

### apps/web

- **Page titles (WCAG 2.4.2)**: new `usePageTitle` hook (with lifecycle tests); every route (`Home`, `Editor`, `Account`, `NotFound`, `Unauthorized`) now sets `document.title`, with the editor tracking the resume name reactively.
- **Live regions (WCAG 4.1.3)**:
  - `AppShell` `SaveIndicator` ("Saving… / Unsaved / Saved") is now `role="status" aria-live="polite"`.
  - Preview "Rendering…" state and update overlay announce via `role="status"`; the inline preview error is `role="alert"`.
  - Import/export/image-upload progress announce via `role="status"`; inline error boxes are `role="alert"`; the PDF export button carries `aria-busy`.
  - Verified `ToastRegion` needs no change: Kobalte renders `role="region"` + per-toast `role="status"`/`aria-live` with `aria-atomic`, so terminal success/error toasts already announce.
- **Accessible names / label association (WCAG 1.1.1, 4.1.2)**:
  - Import modal file input, ThemeEditor color picker / swatch button / hex input, theme preset buttons (`aria-pressed`), SectionList visibility switches, Preview zoom buttons, and the SplitPane separator (plus `aria-valuenow/min/max`) are now named.
  - Sidebar `<nav>` labeled "Resume sections"; AppShell logo wrapped in `<nav aria-label="Primary">` (header/nav/main landmark structure).
- **Decorative SVG sweep (WCAG 1.1.1)**: `aria-hidden="true"` added to remaining decorative icons/spinners in builder, preview, import, export, layout, and ui components.

### apps/site

- **NavDropdown**: trigger now exposes `aria-expanded`/`aria-controls`; Escape closes and returns focus to the trigger (with a `relatedTarget`-guarded reset so the panel does not reopen); click-outside closes; the panel's nested `role="navigation"` landmark demoted to `role="group"`.
- **SearchDropdown**: trigger button exposes `aria-haspopup="dialog"`/`aria-expanded`/`aria-controls`; focus returns to the trigger when the dialog closes while holding focus; search icon marked decorative. (ThemeDropdown already implemented the full pattern; Header/Footer audit found no gaps.)
- **Landmarks**: skip-to-content link added to `BaseLayout` (with `tabindex="-1"` on `#main-content`); nested `<main>` elements in `DocsLayout`/`DocsStandaloneLayout` demoted to `<div>` (one `main` per page); docs sidebar links wrapped in `<nav aria-label="Documentation">`. `SEOHead` already provides unique per-page `<title>`s.

### Contrast audit (WCAG 1.4.3 / 1.4.11)

Tokens audited programmatically (WCAG relative-luminance formula) across the turbo-themes flavors as mapped in `apps/web/src/index.css` and `apps/site/src/styles/global.css`, in the default light (catppuccin-latte) and dark (catppuccin-mocha) themes. Failing tokens are now derived via `color-mix` toward the theme's `text.primary`, preserving hue while raising contrast in **every** flavor.

Before/after ratios, default themes (`fg on bg.base` / `fg on bg.surface`):

| Token usage | Requirement | Latte before | Latte after | Mocha before | Mocha after |
| --- | --- | --- | --- | --- | --- |
| `text.primary` body text | 4.5:1 | 7.06 / 6.57 ✅ | unchanged | 11.34 / 12.14 ✅ | unchanged |
| `text.secondary` muted text (`stone`) | 4.5:1 | **4.37 / 4.06 ❌** | 4.91 / 4.56 ✅ | 7.37 / 7.89 ✅ | 8.26 / 8.84 ✅ |
| `brand.primary` accent/link text | 4.5:1 | **4.34 / 4.04 ❌** | 5.01 / 4.65 ✅ | 7.79 / 8.34 ✅ | 8.57 / 9.17 ✅ |
| `border.default` input/UI borders | 3:1 | **2.30 / 2.14 ❌** | 3.67 / 3.41 ✅ | 3.36 / 3.59 ✅ | 6.17 / 6.60 ✅ |
| Focus ring (accent, UI) | 3:1 | 4.34 ✅ | 5.01 ✅ | 7.79 ✅ | 8.57 ✅ |

Marketing site (default `craft` dark theme): secondary text 8.28 / 7.92 ✅ before → 9.88 / 9.45 ✅ after; link `#e8622a` on `#14110e` is 4.71:1 ✅ (unchanged). The site's `--turbo-text-muted`/`--turbo-text-tertiary` aliases and all direct secondary-text usages now use the same derived token, which also lifts weaker palettes (e.g. github-light muted text 6.11 → 7.81).

Notes:

- Toast variant icons/stripes (`--turbo-state-*`) are left as-is: each toast carries an explicit title/description, so the colored icon is redundant decoration exempt from 1.4.11 (and it is `aria-hidden`).
- A handful of non-default upstream palettes (e.g. solarized) ship a `text.primary` that itself falls below 4.5:1 on `bg.surface`; that is a turbo-themes token issue that cannot be fixed by usage-level overrides and is out of scope here.
- Keyboard operability of the SplitPane resize divider is editor keyboard behavior and belongs with #367; this PR only gives the separator a name and value semantics.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (`usePageTitle` lifecycle tests; existing 287 web + 139 site tests pass, including axe-based a11y tests)
- [x] Docs updated if user-facing (n/a — no user-facing docs impact)
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #368

## Details

- Verification: `bun run test` (apps/web, 287 pass), `bun run test` + `astro check` + `bun run build` (apps/site, 139 pass, 0 errors), `uv run lintro chk` clean on both apps.
- Pre-push AI review: Greptile (1 run) and CodeRabbit (1 run) both reviewed the branch; all findings addressed (NavDropdown Escape/`focusout` guard, `aria-haspopup` mismatch, skip-link focus target, title-flash on route change, `aria-pressed` on preset buttons, hook tests).
- Contrast measurements were computed with the WCAG 2.x relative-luminance formula over the actual token hex values shipped by `@lgtm-hq/turbo-themes@0.21` and the site's `craft-theme.css`, matching what axe/devtools report.
- The `color-mix` derivations live next to the token mappings (`apps/web/src/index.css`, `apps/site/src/styles/global.css`) with comments recording the failing ratios, so future theme bumps keep the guarantee without hardcoding per-theme values.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers a broad accessibility pass covering ARIA semantics, accessible names, live-region announcements, landmark structure, per-route page titles, keyboard/focus fixes for `NavDropdown` and `SearchDropdown`, and a WCAG AA contrast derivation via `color-mix` for the shared token layer.

- **apps/web**: New `usePageTitle` hook wires `document.title` reactively on every route; `SaveIndicator`, preview, import/export, and image-upload spinners gain `role=\"status\"`/`role=\"alert\"` live regions with text content; decorative SVGs are uniformly marked `aria-hidden`; contrast tokens (`--a11y-text-secondary`, `--a11y-accent`, `--a11y-border`) are derived from the upstream turbo-themes values via `color-mix`.
- **apps/site**: `NavDropdown` gains `aria-expanded`/`aria-controls`, an Escape-close handler with an `is-escaped` guard that prevents the synthetic `focusin` from re-opening the panel, and click-outside detection; `SearchDropdown` gains `aria-haspopup=\"dialog\"`/`aria-expanded` with focus return; landmark structure is corrected (`DocsLayout`/`DocsStandaloneLayout` nested `<main>` demoted to `<div>`, docs sidebar wrapped in `<nav aria-label=\"Documentation\">`, skip-to-content link added to `BaseLayout`).
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive ARIA attribute and landmark additions with no logic changes outside accessibility concerns.

All 28 changed files add or correct ARIA attributes, live-region roles, landmark structure, and CSS contrast derivations. No application logic, data paths, or API surfaces are modified. The NavDropdown Escape regression noted in the prior review has been correctly addressed via the `is-escaped` guard; the loading overlay live-region text content concern has been resolved with `sr-only` text. The `color-mix` contrast approach is well-documented and browser support is appropriate for the target audience. The one area worth revisiting (export progress feedback) is a minor AT experience gap, not a functional defect.

No files require special attention. The `ExportModal.tsx` export-progress feedback gap is minor and non-blocking.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/site/src/components/NavDropdown.astro | Adds aria-expanded/aria-controls to the link trigger, demotes panel from role="navigation" to role="group", adds Escape-close with is-escaped guard correctly preventing the synthetic focusin from re-opening the panel, and adds click-outside handling with a body-level deduplication guard. |
| apps/site/src/components/SearchDropdown.astro | Button gains aria-haspopup="dialog", aria-expanded, and aria-controls="search-menu"; the search panel already has id="search-menu" and role="dialog", so the pairing is correct; focus returns to triggerBtn only when the dialog held focus (hadFocusInside guard). |
| apps/site/src/layouts/BaseLayout.astro | Adds skip-to-content link and tabindex="-1" on #main-content; DocsLayout and DocsStandaloneLayout correctly demote their inner <main> to <div> so there is only one <main> per page. |
| apps/site/src/styles/global.css | Derives --a11y-text-secondary via color-mix(in srgb, secondary 75%, primary); skip-link styles added; ~12 secondary-text usage sites updated to the derived token. color-mix browser support is adequate for the target audience. |
| apps/web/src/hooks/usePageTitle.ts | Clean SolidJS effect that keeps document.title in sync with a static string or reactive accessor; deliberately omits disposal reset to avoid base-title flash between routes. |
| apps/web/src/hooks/__tests__/usePageTitle.test.ts | Covers static title, reactive title tracking, and undefined fallback; correctly uses createRoot to run the hook inside a reactive context and awaits a microtask to flush effects. |
| apps/web/src/components/preview/Preview.tsx | Loading overlay now has a sr-only text span addressing the previous live-region comment; Rendering spinner has visible "Rendering..." text inside role="status"; inline error is role="alert"; decorative SVGs marked aria-hidden. |
| apps/web/src/components/export/ExportModal.tsx | PDF export button gains type="button" and aria-busy; error div gains role="alert"; decorative icons marked aria-hidden. aria-busy on a disabled button has inconsistent AT support — no companion live region announces "Exporting..." as ImportModal's role="status" does. |
| apps/web/src/components/import/ImportModal.tsx | File input gains aria-label; loading state wrapped in role="status" aria-live="polite" with visible "Loading..." text; error div gains role="alert"; decorative SVGs marked aria-hidden. |
| apps/web/src/components/layout/AppShell.tsx | SaveIndicator wrapped in role="status" aria-live="polite"; logo wrapped in nav[aria-label="Primary"]; decorative SVGs marked aria-hidden. |
| apps/web/src/components/layout/SplitPane.tsx | Separator gains aria-label, aria-valuenow/min/max; keyboard operability intentionally deferred to #367. The ARIA value attributes are present even though the separator is not yet focusable, which is harmless. |
| apps/web/src/index.css | Derives --a11y-text-secondary, --a11y-accent, --a11y-border via color-mix; maps stone/accent/border Tailwind aliases through the derived tokens. Well-documented with before/after ratios. |
| apps/web/src/components/templates/ThemeEditor.tsx | PresetCard gets type="button" and aria-pressed; color swatch button and hex input get aria-label; hidden native color input gets aria-label; decorative SVGs marked aria-hidden. |
| apps/web/src/components/builder/SectionList.tsx | Visibility switch div gains aria-label="Show {section.name} section"; decorative SVGs marked aria-hidden. Correct accessible name for the custom switch role. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant NavDropdown
    participant CSS

    User->>NavDropdown: hover / focusin
    NavDropdown->>CSS: add .is-open
    NavDropdown->>NavDropdown: setExpanded(true)
    Note over NavDropdown,CSS: panel visible

    User->>NavDropdown: press Escape (panel open)
    NavDropdown->>NavDropdown: closeDropdown() → setExpanded(false)
    NavDropdown->>CSS: remove .is-open
    NavDropdown->>CSS: add .is-escaped
    NavDropdown->>NavDropdown: trigger.focus()
    NavDropdown-->>NavDropdown: focusin fires (synthetic)
    NavDropdown->>NavDropdown: guard: is-escaped → return early
    Note over NavDropdown,CSS: panel stays closed ✓

    User->>NavDropdown: Tab away (focusout, next outside dropdown)
    NavDropdown->>CSS: remove .is-escaped
    Note over NavDropdown,CSS: state reset for next visit

    User->>NavDropdown: click outside (document click)
    NavDropdown->>NavDropdown: closeDropdown() → setExpanded(false)
    NavDropdown->>CSS: remove .is-open
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant NavDropdown
    participant CSS

    User->>NavDropdown: hover / focusin
    NavDropdown->>CSS: add .is-open
    NavDropdown->>NavDropdown: setExpanded(true)
    Note over NavDropdown,CSS: panel visible

    User->>NavDropdown: press Escape (panel open)
    NavDropdown->>NavDropdown: closeDropdown() → setExpanded(false)
    NavDropdown->>CSS: remove .is-open
    NavDropdown->>CSS: add .is-escaped
    NavDropdown->>NavDropdown: trigger.focus()
    NavDropdown-->>NavDropdown: focusin fires (synthetic)
    NavDropdown->>NavDropdown: guard: is-escaped → return early
    Note over NavDropdown,CSS: panel stays closed ✓

    User->>NavDropdown: Tab away (focusout, next outside dropdown)
    NavDropdown->>CSS: remove .is-escaped
    Note over NavDropdown,CSS: state reset for next visit

    User->>NavDropdown: click outside (document click)
    NavDropdown->>NavDropdown: closeDropdown() → setExpanded(false)
    NavDropdown->>CSS: remove .is-open
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/site/src/components/NavDropdown.astro`, line 107-125 ([link](https://github.com/lgtm-hq/rustume/blob/4304997e1941525b9de2b25dd3800d8babd6a4d4/apps/site/src/components/NavDropdown.astro#L107-L125)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Duplicate `focusout` listeners with identical guards**

   Two separate `focusout` listeners are attached to each dropdown, both guarded by `if (next instanceof Node && dropdown.contains(next)) return`. They could be merged into a single handler that calls both `scheduleClose()` and `classList.remove("is-escaped")`, which would also make the fix for the Escape regression above simpler to reason about.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fsite%2Fsrc%2Fcomponents%2FNavDropdown.astro%0ALine%3A%20107-125%0A%0AComment%3A%0A**Duplicate%20%60focusout%60%20listeners%20with%20identical%20guards**%0A%0ATwo%20separate%20%60focusout%60%20listeners%20are%20attached%20to%20each%20dropdown%2C%20both%20guarded%20by%20%60if%20%28next%20instanceof%20Node%20%26%26%20dropdown.contains%28next%29%29%20return%60.%20They%20could%20be%20merged%20into%20a%20single%20handler%20that%20calls%20both%20%60scheduleClose%28%29%60%20and%20%60classList.remove%28%22is-escaped%22%29%60%2C%20which%20would%20also%20make%20the%20fix%20for%20the%20Escape%20regression%20above%20simpler%20to%20reason%20about.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=485&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fsite%2Fsrc%2Fcomponents%2FNavDropdown.astro%0ALine%3A%20107-125%0A%0AComment%3A%0A**Duplicate%20%60focusout%60%20listeners%20with%20identical%20guards**%0A%0ATwo%20separate%20%60focusout%60%20listeners%20are%20attached%20to%20each%20dropdown%2C%20both%20guarded%20by%20%60if%20%28next%20instanceof%20Node%20%26%26%20dropdown.contains%28next%29%29%20return%60.%20They%20could%20be%20merged%20into%20a%20single%20handler%20that%20calls%20both%20%60scheduleClose%28%29%60%20and%20%60classList.remove%28%22is-escaped%22%29%60%2C%20which%20would%20also%20make%20the%20fix%20for%20the%20Escape%20regression%20above%20simpler%20to%20reason%20about.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=485&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F368-aria-contrast%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F368-aria-contrast%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fsite%2Fsrc%2Fcomponents%2FNavDropdown.astro%0ALine%3A%20107-125%0A%0AComment%3A%0A**Duplicate%20%60focusout%60%20listeners%20with%20identical%20guards**%0A%0ATwo%20separate%20%60focusout%60%20listeners%20are%20attached%20to%20each%20dropdown%2C%20both%20guarded%20by%20%60if%20%28next%20instanceof%20Node%20%26%26%20dropdown.contains%28next%29%29%20return%60.%20They%20could%20be%20merged%20into%20a%20single%20handler%20that%20calls%20both%20%60scheduleClose%28%29%60%20and%20%60classList.remove%28%22is-escaped%22%29%60%2C%20which%20would%20also%20make%20the%20fix%20for%20the%20Escape%20regression%20above%20simpler%20to%20reason%20about.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=485&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(web): make escape-close guard and pr..."](https://github.com/lgtm-hq/rustume/commit/d0124d5dc1ad1e853c91d919e4930348b2d9f0d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45053219)</sub>

<!-- /greptile_comment -->