### PR TITLE
feat(storage): persistent server-side storage for self-hosted mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,24 @@
 # Enable cloud mode (auth, Postgres resume storage)
 RUSTUME_CLOUD=true
 
-# PostgreSQL (Neon in production; docker compose --profile cloud for local)
-# Required for the cloud compose profile — set in .env (not committed).
+# PostgreSQL (Neon in production; the compose postgres service for local).
+# Compose defaults to rustume/rustume/rustume and
+# DATABASE_URL=postgres://rustume:rustume@postgres:5432/rustume when unset —
+# fine for LAN/Docker-network isolation; override for exposed deployments.
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DB=
 DATABASE_URL=
+
+# Encryption at rest (self-hosted default: true; cloud default: false).
+# When enabled, resume payloads are AES-256-GCM encrypted before hitting
+# Postgres. The key is read from RUSTUME_ENCRYPTION_KEY (hex, 32 bytes —
+# generate: openssl rand -hex 32), else from RUSTUME_ENCRYPTION_KEY_FILE
+# (default /data/.encryption_key), else auto-generated and persisted there.
+# BACK UP THE KEY — without it, encrypted resume data is unrecoverable.
+# RUSTUME_ENCRYPT_AT_REST=true
+# RUSTUME_ENCRYPTION_KEY=
+# RUSTUME_ENCRYPTION_KEY_FILE=/data/.encryption_key
 
 # WorkOS AuthKit
 WORKOS_CLIENT_ID=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.6",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +615,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.6",
+ "inout",
+]
+
+[[package]]
 name = "citationberg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -929,6 +975,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1546,6 +1601,16 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -2312,6 +2377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3071,6 +3145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,6 +3405,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3665,6 +3757,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -4215,6 +4310,7 @@ dependencies = [
 name = "rustume-server"
 version = "0.29.1"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "axum",
  "axum-extra",
@@ -4223,6 +4319,7 @@ dependencies = [
  "cookie",
  "dashmap",
  "governor",
+ "hex",
  "hmac",
  "http-body-util",
  "lru",
@@ -6128,6 +6225,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.6",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,10 @@ sqlx = { version = "0.9", default-features = false, features = [
 ] }
 uuid = { version = "1", features = ["v4", "serde"] }
 
+# Encryption at rest (self-hosted resume storage)
+aes-gcm = "0.10"
+hex = "0.4"
+
 # HTTP client (WorkOS)
 reqwest = { version = "0.13", default-features = false, features = [
   "json",

--- a/apps/web/src/api/__tests__/auth.test.ts
+++ b/apps/web/src/api/__tests__/auth.test.ts
@@ -61,6 +61,29 @@ describe("probeAuth", () => {
     });
   });
 
+  it("returns local mode when /auth/me reports server-side storage", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        mode: "local",
+        id: "00000000-0000-0000-0000-000000000001",
+        plan: "self-hosted",
+        require_auth: false,
+      }),
+    });
+
+    const result = await probeAuth();
+
+    expect(result).toEqual({
+      mode: "local",
+      user: {
+        id: "00000000-0000-0000-0000-000000000001",
+        plan: "self-hosted",
+      },
+    });
+  });
+
   it("maps subscription info from /auth/me", async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/apps/web/src/api/auth.ts
+++ b/apps/web/src/api/auth.ts
@@ -13,7 +13,10 @@ export interface AuthUser {
 }
 
 export type AuthProbeResult =
+  /** Legacy stateless server (no DATABASE_URL): resumes stay in the browser. */
   | { mode: "self-hosted" }
+  /** Self-hosted with persistent server storage: implicit user, no auth. */
+  | { mode: "local"; user: AuthUser }
   | { mode: "cloud"; user: AuthUser | null; requireAuth: boolean };
 
 function parseRequireAuth(payload: unknown): boolean {
@@ -99,6 +102,13 @@ export async function probeAuth(): Promise<AuthProbeResult> {
 
   const payload = await response.json();
   const { user, requireAuth } = parseAuthUserPayload(payload);
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    (payload as { mode?: unknown }).mode === "local"
+  ) {
+    return { mode: "local", user };
+  }
   return {
     mode: "cloud",
     user,

--- a/apps/web/src/components/Auth/AuthMenu.tsx
+++ b/apps/web/src/components/Auth/AuthMenu.tsx
@@ -21,7 +21,7 @@ export function AuthMenu() {
       when={!state.loading}
       fallback={<Spinner class="w-4 h-4 text-stone" ariaLabel="Loading authentication" />}
     >
-      <Show when={state.cloudEnabled} fallback={null}>
+      <Show when={state.cloudEnabled && !state.localMode} fallback={null}>
         <Show
           when={state.user}
           fallback={

--- a/apps/web/src/components/Auth/CloudImportPrompt.tsx
+++ b/apps/web/src/components/Auth/CloudImportPrompt.tsx
@@ -114,13 +114,18 @@ export function CloudImportPrompt() {
             else setOpen(value);
           }}
           title="Import local resumes?"
-          description="We found resumes saved on this device. Import them to your Rustume Cloud account?"
+          description={
+            authStore.state.localMode
+              ? "We found resumes saved in this browser. Import them to the server so they persist outside this device?"
+              : "We found resumes saved on this device. Import them to your Rustume Cloud account?"
+          }
           size="md"
         >
           <div class="px-6 py-5 space-y-4">
             <p class="text-sm text-stone">
-              {count()} local resume{count() === 1 ? "" : "s"} can be copied to cloud storage. Your
-              local copies will remain on this device.
+              {count()} local resume{count() === 1 ? "" : "s"} can be copied to{" "}
+              {authStore.state.localMode ? "server storage" : "cloud storage"}. Your local copies
+              will remain on this device.
             </p>
             <div class="flex justify-end gap-3">
               <Button variant="ghost" onClick={() => dismiss(userId())} disabled={importing()}>
@@ -132,7 +137,7 @@ export function CloudImportPrompt() {
                 disabled={importing()}
               >
                 <Show when={!importing()} fallback="Importing...">
-                  Import to cloud
+                  {authStore.state.localMode ? "Import to server" : "Import to cloud"}
                 </Show>
               </Button>
             </div>

--- a/apps/web/src/components/Auth/__tests__/AuthMenu.test.tsx
+++ b/apps/web/src/components/Auth/__tests__/AuthMenu.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@solidjs/testing-library";
+import { Route, Router } from "@solidjs/router";
+import { AuthMenu } from "../AuthMenu";
+
+const { mockAuthState } = vi.hoisted(() => ({
+  mockAuthState: {
+    loading: false,
+    cloudEnabled: true,
+    localMode: false,
+    requireAuth: false,
+    user: null as { id: string; plan: string } | null,
+  },
+}));
+
+vi.mock("../../../stores/auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    displayName: () => "Ada Lovelace",
+  },
+}));
+
+function renderMenu() {
+  return render(() => (
+    <Router>
+      <Route path="*" component={() => <AuthMenu />} />
+    </Router>
+  ));
+}
+
+describe("AuthMenu", () => {
+  it("shows the sign-in button for signed-out cloud visitors", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.localMode = false;
+    mockAuthState.requireAuth = false;
+    mockAuthState.user = null;
+
+    const { getByText, unmount } = renderMenu();
+    expect(getByText("Sign in to sync")).toBeTruthy();
+    unmount();
+  });
+
+  it("shows the account menu for signed-in cloud users", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.localMode = false;
+    mockAuthState.requireAuth = false;
+    mockAuthState.user = { id: "user-1", plan: "pro" };
+
+    const { getByLabelText, unmount } = renderMenu();
+    expect(getByLabelText("Account menu")).toBeTruthy();
+    unmount();
+  });
+
+  it("hides all auth UI in local mode", () => {
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.localMode = true;
+    mockAuthState.requireAuth = false;
+    mockAuthState.user = {
+      id: "00000000-0000-0000-0000-000000000001",
+      plan: "self-hosted",
+    };
+
+    const { container, queryByText, queryByLabelText, unmount } = renderMenu();
+    expect(queryByText("Sign in to sync")).toBeNull();
+    expect(queryByLabelText("Account menu")).toBeNull();
+    expect(container.textContent).toBe("");
+    unmount();
+  });
+});

--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -142,7 +142,7 @@ export default function Account() {
           }
         >
           <Show
-            when={state.cloudEnabled}
+            when={state.cloudEnabled && !state.localMode}
             fallback={
               <div class="text-center py-16">
                 <h1 class="font-display text-2xl font-semibold text-ink mb-3">Account</h1>

--- a/apps/web/src/stores/__tests__/auth.test.ts
+++ b/apps/web/src/stores/__tests__/auth.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { probeAuthMock, logoutMock } = vi.hoisted(() => ({
+  probeAuthMock: vi.fn(),
+  logoutMock: vi.fn(),
+}));
+
+vi.mock("../../api/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/auth")>();
+  return {
+    ...actual,
+    probeAuth: probeAuthMock,
+    logout: logoutMock,
+  };
+});
+
+import { authStore } from "../auth";
+
+const localUser = {
+  id: "00000000-0000-0000-0000-000000000001",
+  plan: "self-hosted",
+};
+
+describe("authStore", () => {
+  beforeEach(() => {
+    probeAuthMock.mockReset();
+    logoutMock.mockReset();
+  });
+
+  it("enables server storage without auth UI in local mode", async () => {
+    probeAuthMock.mockResolvedValue({ mode: "local", user: localUser });
+
+    await authStore.refresh();
+
+    expect(authStore.state.localMode).toBe(true);
+    expect(authStore.state.cloudEnabled).toBe(true);
+    expect(authStore.state.requireAuth).toBe(false);
+    expect(authStore.state.user).toEqual(localUser);
+    expect(authStore.state.loading).toBe(false);
+  });
+
+  it("treats signOut as a no-op in local mode", async () => {
+    probeAuthMock.mockResolvedValue({ mode: "local", user: localUser });
+    await authStore.refresh();
+
+    await authStore.signOut();
+
+    expect(logoutMock).not.toHaveBeenCalled();
+    expect(authStore.state.user).toEqual(localUser);
+  });
+
+  it("clears localMode when a cloud probe follows", async () => {
+    probeAuthMock.mockResolvedValue({ mode: "local", user: localUser });
+    await authStore.refresh();
+
+    probeAuthMock.mockResolvedValue({ mode: "cloud", user: null, requireAuth: true });
+    await authStore.refresh();
+
+    expect(authStore.state.localMode).toBe(false);
+    expect(authStore.state.cloudEnabled).toBe(true);
+    expect(authStore.state.requireAuth).toBe(true);
+    expect(authStore.state.user).toBeNull();
+  });
+
+  it("disables server storage in stateless self-hosted mode", async () => {
+    probeAuthMock.mockResolvedValue({ mode: "self-hosted" });
+
+    await authStore.refresh();
+
+    expect(authStore.state.localMode).toBe(false);
+    expect(authStore.state.cloudEnabled).toBe(false);
+    expect(authStore.state.user).toBeNull();
+  });
+});

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -11,7 +11,10 @@ import {
 
 interface AuthState {
   loading: boolean;
+  /** True when the server API is used for resume storage (local or cloud mode). */
   cloudEnabled: boolean;
+  /** True in self-hosted local mode: server storage without auth UI. */
+  localMode: boolean;
   requireAuth: boolean;
   user: AuthUser | null;
 }
@@ -20,18 +23,37 @@ function createAuthStore() {
   const [state, setState] = createStore<AuthState>({
     loading: true,
     cloudEnabled: false,
+    localMode: false,
     requireAuth: false,
     user: null,
   });
 
   function applyProbe(result: AuthProbeResult) {
     if (result.mode === "self-hosted") {
-      setState({ cloudEnabled: false, requireAuth: false, user: null, loading: false });
+      setState({
+        cloudEnabled: false,
+        localMode: false,
+        requireAuth: false,
+        user: null,
+        loading: false,
+      });
+      return;
+    }
+
+    if (result.mode === "local") {
+      setState({
+        cloudEnabled: true,
+        localMode: true,
+        requireAuth: false,
+        user: result.user,
+        loading: false,
+      });
       return;
     }
 
     setState({
       cloudEnabled: true,
+      localMode: false,
       requireAuth: result.requireAuth,
       user: result.user,
       loading: false,
@@ -44,12 +66,19 @@ function createAuthStore() {
       applyProbe(await probeAuth());
     } catch (error) {
       console.error("Failed to probe auth:", error);
-      setState({ cloudEnabled: false, requireAuth: false, user: null, loading: false });
+      setState({
+        cloudEnabled: false,
+        localMode: false,
+        requireAuth: false,
+        user: null,
+        loading: false,
+      });
     }
   }
 
   async function signOut() {
-    if (!state.cloudEnabled) return;
+    // Local mode has no session to sign out of.
+    if (!state.cloudEnabled || state.localMode) return;
     try {
       await logout();
     } finally {

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -50,6 +50,10 @@ lru.workspace = true
 utoipa.workspace = true
 utoipa-swagger-ui = { version = "9", features = ["axum", "reqwest"] }
 
+# Encryption at rest (self-hosted resume storage)
+aes-gcm.workspace = true
+hex.workspace = true
+
 # Cloud mode
 sqlx.workspace = true
 uuid.workspace = true

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -34,17 +34,20 @@ use crate::routes::{
 };
 use crate::state::AppState;
 
-/// Build the default router in self-hosted (stateless) mode.
+/// Build the default router in stateless fallback mode (no storage, no cloud).
 pub fn create_router() -> Router {
-    create_router_with_state(AppState::new(Arc::new(static_dir()), None))
+    create_router_with_state(AppState::new(Arc::new(static_dir()), None, None))
 }
 
 /// Build a router with a custom static asset directory (used in tests).
 pub fn create_router_with_static_dir(dir: PathBuf) -> Router {
-    create_router_with_state(AppState::new(Arc::new(dir), None))
+    create_router_with_state(AppState::new(Arc::new(dir), None, None))
 }
 
-/// Build the full Axum router, registering cloud routes when `state.cloud` is set.
+/// Build the full Axum router.
+///
+/// Resume CRUD routes are registered whenever `state.storage` is set
+/// (self-hosted and cloud); WorkOS auth and account routes are cloud-only.
 pub fn create_router_with_state(state: AppState) -> Router {
     let cors = build_cors_layer();
     let cloud_rate_limits = state.rate_limits.is_some();
@@ -140,6 +143,21 @@ pub fn create_router_with_state(state: AppState) -> Router {
                 rate_limit_auth,
             ));
 
+        let account_routes = Router::new()
+            .route("/api/account", delete(delete_account))
+            .route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_auth_when_enabled,
+            ));
+
+        router = router.merge(auth_routes).merge(account_routes);
+    } else {
+        // Self-hosted: mode probe stays available so the web app can detect
+        // local (server storage) vs stateless (browser storage) mode.
+        router = router.route("/auth/me", get(me));
+    }
+
+    if state.storage.is_some() {
         let mut resume_routes = Router::new()
             .route("/api/resumes", get(list_resumes).post(create_resume))
             .route(
@@ -170,13 +188,6 @@ pub fn create_router_with_state(state: AppState) -> Router {
             ));
         }
 
-        let account_routes = Router::new()
-            .route("/api/account", delete(delete_account))
-            .route_layer(middleware::from_fn_with_state(
-                state.clone(),
-                require_auth_when_enabled,
-            ));
-
         let mut export_json_routes = Router::new()
             .route("/api/resumes/export", get(export_resumes_json))
             .route_layer(middleware::from_fn_with_state(
@@ -204,12 +215,10 @@ pub fn create_router_with_state(state: AppState) -> Router {
         }
 
         router = router
-            .merge(auth_routes)
             .merge(resume_routes)
             .merge(import_routes)
             .merge(export_json_routes)
-            .merge(export_pdf_routes)
-            .merge(account_routes);
+            .merge(export_pdf_routes);
     }
 
     let router = router

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -1,10 +1,11 @@
-//! Rustume Cloud bootstrap: PostgreSQL pool, WorkOS client, and session service.
+//! Rustume Cloud bootstrap: WorkOS client, session service, and email.
+//!
+//! The PostgreSQL pool itself is owned by [`crate::storage`]; cloud mode
+//! layers auth services on top of that shared pool.
 
-use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use std::env::VarError;
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::info;
 
 use crate::auth::session::SessionService;
@@ -14,8 +15,6 @@ use crate::email::EmailService;
 /// Cloud-specific configuration loaded from environment variables.
 #[derive(Clone)]
 pub struct CloudConfig {
-    /// PostgreSQL connection string (`DATABASE_URL`).
-    pub database_url: String,
     /// WorkOS AuthKit client ID.
     pub workos_client_id: String,
     /// WorkOS API key (server-side secret).
@@ -24,10 +23,6 @@ pub struct CloudConfig {
     pub workos_redirect_uri: String,
     /// Secret used to sign session cookies.
     pub session_secret: String,
-    /// Maximum PostgreSQL pool connections (`DB_MAX_CONNECTIONS`, default 10).
-    pub db_max_connections: u32,
-    /// Pool acquire timeout in seconds (`DB_ACQUIRE_TIMEOUT_SECS`, default 5).
-    pub db_acquire_timeout_secs: u64,
     /// Resend API key when transactional email is enabled (`RESEND_API_KEY`).
     pub resend_api_key: Option<String>,
     /// Sender address when transactional email is enabled (`EMAIL_FROM`).
@@ -37,21 +32,16 @@ pub struct CloudConfig {
 impl CloudConfig {
     /// Load required cloud settings from the process environment.
     pub fn from_env() -> anyhow::Result<Self> {
-        let database_url = required_non_empty_env("DATABASE_URL")?;
-
         let session_secret = required_non_empty_env("SESSION_SECRET")?;
         if session_secret.len() < 32 {
             anyhow::bail!("SESSION_SECRET must be at least 32 characters");
         }
 
         Ok(Self {
-            database_url,
             workos_client_id: required_non_empty_env("WORKOS_CLIENT_ID")?,
             workos_api_key: required_non_empty_env("WORKOS_API_KEY")?,
             workos_redirect_uri: required_non_empty_env("WORKOS_REDIRECT_URI")?,
             session_secret,
-            db_max_connections: optional_env_u32("DB_MAX_CONNECTIONS", 10)?,
-            db_acquire_timeout_secs: optional_env_u64("DB_ACQUIRE_TIMEOUT_SECS", 5)?,
             resend_api_key: optional_non_empty_env("RESEND_API_KEY")?,
             email_from: optional_non_empty_env("EMAIL_FROM")?,
         })
@@ -61,13 +51,10 @@ impl CloudConfig {
 impl std::fmt::Debug for CloudConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CloudConfig")
-            .field("database_url", &"<redacted>")
             .field("workos_client_id", &self.workos_client_id)
             .field("workos_api_key", &"<redacted>")
             .field("workos_redirect_uri", &self.workos_redirect_uri)
             .field("session_secret", &"<redacted>")
-            .field("db_max_connections", &self.db_max_connections)
-            .field("db_acquire_timeout_secs", &self.db_acquire_timeout_secs)
             .field(
                 "resend_api_key",
                 &self.resend_api_key.as_ref().map(|_| "<redacted>"),
@@ -96,11 +83,11 @@ where
     }
 }
 
-fn optional_env_u32(key: &str, default: u32) -> anyhow::Result<u32> {
+pub(crate) fn optional_env_u32(key: &str, default: u32) -> anyhow::Result<u32> {
     optional_env(key, default)
 }
 
-fn optional_env_u64(key: &str, default: u64) -> anyhow::Result<u64> {
+pub(crate) fn optional_env_u64(key: &str, default: u64) -> anyhow::Result<u64> {
     optional_env(key, default)
 }
 
@@ -197,18 +184,8 @@ pub struct CloudState {
     pub email: Option<EmailService>,
 }
 
-/// Connect to PostgreSQL, run migrations, and wire cloud auth services.
-pub async fn init_cloud(config: CloudConfig) -> anyhow::Result<Arc<CloudState>> {
-    let db = PgPoolOptions::new()
-        .max_connections(config.db_max_connections)
-        .acquire_timeout(Duration::from_secs(config.db_acquire_timeout_secs))
-        .connect(&config.database_url)
-        .await?;
-
-    sqlx::migrate!("./src/db/migrations").run(&db).await?;
-
-    info!("PostgreSQL migrations applied");
-
+/// Wire cloud auth services (WorkOS, sessions, email) on top of the shared pool.
+pub fn init_cloud(config: CloudConfig, db: PgPool) -> anyhow::Result<Arc<CloudState>> {
     let email = match email_service_from_config(&config)? {
         Some(service) => {
             info!("Transactional email enabled");
@@ -253,13 +230,10 @@ mod tests {
     #[test]
     fn email_service_from_config_requires_both_vars() {
         let config = CloudConfig {
-            database_url: "postgres://localhost/rustume".to_string(),
             workos_client_id: "client".to_string(),
             workos_api_key: "key".to_string(),
             workos_redirect_uri: "http://localhost/auth/callback".to_string(),
             session_secret: "test-session-secret-at-least-32-chars".to_string(),
-            db_max_connections: 10,
-            db_acquire_timeout_secs: 5,
             resend_api_key: Some("re_test".to_string()),
             email_from: None,
         };

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -150,9 +150,15 @@ fn email_service_from_config(config: &CloudConfig) -> anyhow::Result<Option<Emai
     }
 }
 
+/// Returns `true` when the `RUSTUME_CLOUD` flag itself is set, regardless of
+/// whether `DATABASE_URL` is configured.
+pub fn cloud_flag_enabled() -> bool {
+    matches!(std::env::var("RUSTUME_CLOUD").as_deref(), Ok("true" | "1"))
+}
+
 /// Returns `true` when `RUSTUME_CLOUD` is enabled and `DATABASE_URL` is set.
 pub fn cloud_enabled() -> bool {
-    matches!(std::env::var("RUSTUME_CLOUD").as_deref(), Ok("true" | "1"))
+    cloud_flag_enabled()
         && std::env::var("DATABASE_URL")
             .ok()
             .is_some_and(|url| !url.trim().is_empty())

--- a/crates/server/src/db/migrations/007_encrypt_at_rest.sql
+++ b/crates/server/src/db/migrations/007_encrypt_at_rest.sql
@@ -1,0 +1,25 @@
+-- Application-level encryption at rest (#254).
+-- Resume payloads are stored in exactly one of:
+--   data           JSONB  — plaintext (cloud default)
+--   data_encrypted BYTEA  — AES-256-GCM nonce || ciphertext (self-hosted default)
+
+-- Allow the implicit self-hosted user plan alongside cloud billing plans.
+ALTER TABLE users DROP CONSTRAINT users_plan_check;
+ALTER TABLE users
+ADD CONSTRAINT users_plan_check CHECK (plan IN ('free', 'pro', 'team', 'self-hosted'));
+
+ALTER TABLE resumes ADD COLUMN data_encrypted BYTEA;
+ALTER TABLE resumes ALTER COLUMN data DROP NOT NULL;
+
+ALTER TABLE resume_versions ADD COLUMN data_encrypted BYTEA;
+ALTER TABLE resume_versions ALTER COLUMN data DROP NOT NULL;
+
+-- Enforce exactly one of data / data_encrypted is set.
+ALTER TABLE resumes ADD CONSTRAINT resumes_data_xor CHECK (
+    (data IS NOT NULL AND data_encrypted IS NULL)
+    OR (data IS NULL AND data_encrypted IS NOT NULL)
+);
+ALTER TABLE resume_versions ADD CONSTRAINT resume_versions_data_xor CHECK (
+    (data IS NOT NULL AND data_encrypted IS NULL)
+    OR (data IS NULL AND data_encrypted IS NOT NULL)
+);

--- a/crates/server/src/db/migrations/007_encrypt_at_rest.sql
+++ b/crates/server/src/db/migrations/007_encrypt_at_rest.sql
@@ -2,11 +2,16 @@
 -- Resume payloads are stored in exactly one of:
 --   data           JSONB  — plaintext (cloud default)
 --   data_encrypted BYTEA  — AES-256-GCM nonce || ciphertext (self-hosted default)
+--
+-- Check constraints are added NOT VALID so populated tables are not scanned
+-- under this migration's locks; migration 008 validates them with the less
+-- restrictive SHARE UPDATE EXCLUSIVE lock.
 
 -- Allow the implicit self-hosted user plan alongside cloud billing plans.
 ALTER TABLE users DROP CONSTRAINT users_plan_check;
 ALTER TABLE users
-ADD CONSTRAINT users_plan_check CHECK (plan IN ('free', 'pro', 'team', 'self-hosted'));
+ADD CONSTRAINT users_plan_check
+CHECK (plan IN ('free', 'pro', 'team', 'self-hosted')) NOT VALID;
 
 ALTER TABLE resumes ADD COLUMN data_encrypted BYTEA;
 ALTER TABLE resumes ALTER COLUMN data DROP NOT NULL;
@@ -18,8 +23,8 @@ ALTER TABLE resume_versions ALTER COLUMN data DROP NOT NULL;
 ALTER TABLE resumes ADD CONSTRAINT resumes_data_xor CHECK (
     (data IS NOT NULL AND data_encrypted IS NULL)
     OR (data IS NULL AND data_encrypted IS NOT NULL)
-);
+) NOT VALID;
 ALTER TABLE resume_versions ADD CONSTRAINT resume_versions_data_xor CHECK (
     (data IS NOT NULL AND data_encrypted IS NULL)
     OR (data IS NULL AND data_encrypted IS NOT NULL)
-);
+) NOT VALID;

--- a/crates/server/src/db/migrations/008_validate_encrypt_constraints.sql
+++ b/crates/server/src/db/migrations/008_validate_encrypt_constraints.sql
@@ -1,0 +1,7 @@
+-- Validate the constraints added NOT VALID in migration 007.
+-- VALIDATE CONSTRAINT scans with SHARE UPDATE EXCLUSIVE, so concurrent
+-- reads and writes are not blocked while existing rows are checked.
+
+ALTER TABLE users VALIDATE CONSTRAINT users_plan_check;
+ALTER TABLE resumes VALIDATE CONSTRAINT resumes_data_xor;
+ALTER TABLE resume_versions VALIDATE CONSTRAINT resume_versions_data_xor;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -121,6 +121,26 @@ pub struct ResumeRow {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Raw resume row with both payload columns, prior to decryption.
+///
+/// Exactly one of `data` / `data_encrypted` is set (enforced by a check
+/// constraint). Use [`crate::storage::StorageState::decode_resume_row`] to
+/// produce an API-facing [`ResumeRow`].
+#[derive(Debug, Clone, FromRow)]
+pub struct StoredResumeRow {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub title: String,
+    pub data: Option<serde_json::Value>,
+    pub data_encrypted: Option<Vec<u8>>,
+    pub is_public: bool,
+    pub public_slug: Option<String>,
+    pub password_hash: Option<String>,
+    pub version: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 /// Lightweight resume summary for list endpoints.
 #[derive(Debug, Clone, FromRow, Serialize, ToSchema)]
 pub struct ResumeSummary {
@@ -194,6 +214,8 @@ pub struct SubscriptionInfo {
 /// WorkOS. Resume content is not included.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct AuthUserResponse {
+    /// Deployment identity mode: `local` (self-hosted, implicit user) or `cloud`.
+    pub mode: &'static str,
     #[schema(value_type = String, format = "uuid")]
     pub id: Uuid,
     /// Hosted-service subscription status for billing.
@@ -254,13 +276,28 @@ pub struct DeleteAccountResponse {
 }
 
 impl AuthUserResponse {
-    /// Build a profile response with the hosted require-auth flag.
+    /// Build a cloud-mode profile response with the hosted require-auth flag.
     pub fn from_user(
         user: User,
         require_auth: bool,
         subscription: Option<SubscriptionInfo>,
     ) -> Self {
+        Self::with_mode("cloud", user, require_auth, subscription)
+    }
+
+    /// Build a local-mode (self-hosted) profile response.
+    pub fn from_local_user(user: User) -> Self {
+        Self::with_mode("local", user, false, None)
+    }
+
+    fn with_mode(
+        mode: &'static str,
+        user: User,
+        require_auth: bool,
+        subscription: Option<SubscriptionInfo>,
+    ) -> Self {
         Self {
+            mode,
             id: user.id,
             plan: user.plan,
             email: user.email,
@@ -294,6 +331,7 @@ mod tests {
         let response = AuthUserResponse::from_user(user, true, None);
         let json = serde_json::to_value(&response).unwrap();
 
+        assert_eq!(json["mode"], "cloud");
         assert_eq!(json["id"], Uuid::nil().to_string());
         assert_eq!(json["plan"], "free");
         assert_eq!(json["email"], "dev@example.com");
@@ -322,6 +360,28 @@ mod tests {
         assert!(json.get("email").is_none());
         assert!(json.get("first_name").is_none());
         assert!(json.get("last_name").is_none());
+    }
+
+    #[test]
+    fn auth_user_response_local_mode_disables_require_auth() {
+        let user = User {
+            id: crate::storage::LOCAL_USER_ID,
+            workos_id: "local".to_string(),
+            plan: "self-hosted".to_string(),
+            paddle_customer_id: None,
+            email: None,
+            first_name: None,
+            last_name: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let json = serde_json::to_value(AuthUserResponse::from_local_user(user)).unwrap();
+
+        assert_eq!(json["mode"], "local");
+        assert_eq!(json["plan"], "self-hosted");
+        assert_eq!(json["require_auth"], false);
+        assert!(json.get("subscription").is_none());
     }
 
     #[test]

--- a/crates/server/src/encryption.rs
+++ b/crates/server/src/encryption.rs
@@ -222,12 +222,32 @@ fn write_key_file(path: &Path, key: &[u8; KEY_LEN]) -> anyhow::Result<bool> {
     let publish = std::fs::hard_link(&tmp_path, path);
     let _ = std::fs::remove_file(&tmp_path);
     match publish {
-        Ok(()) => Ok(true),
+        Ok(()) => {
+            sync_dir(parent)?;
+            Ok(true)
+        }
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
         Err(err) => Err(anyhow::anyhow!(
             "failed to publish encryption key file {path:?}: {err}"
         )),
     }
+}
+
+/// Fsync a directory so a freshly published key's directory entry is durable.
+fn sync_dir(dir: &Path) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        std::fs::File::open(dir)
+            .and_then(|handle| handle.sync_all())
+            .map_err(|err| {
+                anyhow::anyhow!("failed to sync encryption key directory {dir:?}: {err}")
+            })?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = dir;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/server/src/encryption.rs
+++ b/crates/server/src/encryption.rs
@@ -1,0 +1,297 @@
+//! Application-level AES-256-GCM encryption for resume data at rest.
+//!
+//! The encryption key is resolved in priority order:
+//!
+//! 1. `RUSTUME_ENCRYPTION_KEY` environment variable (hex-encoded 32 bytes)
+//! 2. Key file (`RUSTUME_ENCRYPTION_KEY_FILE`, default `/data/.encryption_key`)
+//! 3. Auto-generated random key persisted to the key file (with a warning)
+//!
+//! Encrypted blobs are laid out as `nonce (12 bytes) || ciphertext`.
+
+use aes_gcm::aead::{Aead, OsRng};
+use aes_gcm::{AeadCore, Aes256Gcm, Key, KeyInit};
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
+
+/// AES-256-GCM nonce length in bytes.
+const NONCE_LEN: usize = 12;
+
+/// AES-256 key length in bytes.
+const KEY_LEN: usize = 32;
+
+/// Default on-disk location for the auto-generated encryption key.
+pub const DEFAULT_KEY_FILE: &str = "/data/.encryption_key";
+
+/// Environment variable holding a hex-encoded 32-byte encryption key.
+pub const KEY_ENV: &str = "RUSTUME_ENCRYPTION_KEY";
+
+/// Environment variable overriding the key file path.
+pub const KEY_FILE_ENV: &str = "RUSTUME_ENCRYPTION_KEY_FILE";
+
+/// Symmetric encryption service for resume JSON blobs.
+#[derive(Clone)]
+pub struct EncryptionService {
+    cipher: Aes256Gcm,
+}
+
+impl std::fmt::Debug for EncryptionService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionService")
+            .field("cipher", &"<aes-256-gcm>")
+            .finish()
+    }
+}
+
+impl EncryptionService {
+    /// Build a service from raw key bytes (tests and callers with managed keys).
+    #[must_use]
+    pub fn from_key(key: &[u8; KEY_LEN]) -> Self {
+        let key = Key::<Aes256Gcm>::from(*key);
+        Self {
+            cipher: Aes256Gcm::new(&key),
+        }
+    }
+
+    /// Load the key from the environment or key file, generating one if needed.
+    pub fn init() -> anyhow::Result<Self> {
+        let env_key = std::env::var(KEY_ENV)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        Self::init_with(env_key.as_deref(), &key_file_path())
+    }
+
+    /// Returns `true` when key material is already configured (env var or key file).
+    ///
+    /// Used to decide whether decryption support should be wired up even when
+    /// encryption of new writes is disabled.
+    #[must_use]
+    pub fn key_configured() -> bool {
+        std::env::var(KEY_ENV).is_ok_and(|value| !value.trim().is_empty())
+            || key_file_path().exists()
+    }
+
+    /// Resolve the key from an optional hex env value or a key file path.
+    ///
+    /// Generates and persists a new key to `key_file` when neither source
+    /// provides one.
+    pub fn init_with(env_key: Option<&str>, key_file: &Path) -> anyhow::Result<Self> {
+        if let Some(hex_key) = env_key {
+            let key = decode_hex_key(hex_key)?;
+            info!("Encryption key loaded from {KEY_ENV}");
+            return Ok(Self::from_key(&key));
+        }
+
+        if key_file.exists() {
+            let key = read_key_file(key_file)?;
+            info!(path = %key_file.display(), "Encryption key loaded from key file");
+            return Ok(Self::from_key(&key));
+        }
+
+        let key: [u8; KEY_LEN] = Aes256Gcm::generate_key(OsRng).into();
+        write_key_file(key_file, &key)?;
+        warn!(
+            path = %key_file.display(),
+            "Auto-generated encryption key at {} — back up this file. If lost, encrypted \
+             resume data is unrecoverable.",
+            key_file.display()
+        );
+        Ok(Self::from_key(&key))
+    }
+
+    /// Encrypt resume JSON into a `nonce || ciphertext` blob.
+    pub fn encrypt(&self, data: &serde_json::Value) -> anyhow::Result<Vec<u8>> {
+        let plaintext = serde_json::to_vec(data)?;
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let ciphertext = self
+            .cipher
+            .encrypt(&nonce, plaintext.as_slice())
+            .map_err(|_| anyhow::anyhow!("encryption failed"))?;
+
+        let mut blob = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+        blob.extend_from_slice(&nonce);
+        blob.extend_from_slice(&ciphertext);
+        Ok(blob)
+    }
+
+    /// Decrypt a `nonce || ciphertext` blob back into resume JSON.
+    pub fn decrypt(&self, blob: &[u8]) -> anyhow::Result<serde_json::Value> {
+        if blob.len() <= NONCE_LEN {
+            anyhow::bail!("encrypted blob is too short");
+        }
+        let (nonce, ciphertext) = blob.split_at(NONCE_LEN);
+        let plaintext = self
+            .cipher
+            .decrypt(nonce.into(), ciphertext)
+            .map_err(|_| anyhow::anyhow!("decryption failed: wrong key or corrupted data"))?;
+        Ok(serde_json::from_slice(&plaintext)?)
+    }
+}
+
+/// Resolve the key file path from the environment, defaulting to `/data/.encryption_key`.
+fn key_file_path() -> PathBuf {
+    std::env::var(KEY_FILE_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map_or_else(|| PathBuf::from(DEFAULT_KEY_FILE), PathBuf::from)
+}
+
+fn decode_hex_key(hex_key: &str) -> anyhow::Result<[u8; KEY_LEN]> {
+    let bytes = hex::decode(hex_key.trim())
+        .map_err(|_| anyhow::anyhow!("{KEY_ENV} must be hex-encoded"))?;
+    <[u8; KEY_LEN]>::try_from(bytes.as_slice())
+        .map_err(|_| anyhow::anyhow!("{KEY_ENV} must decode to exactly {KEY_LEN} bytes"))
+}
+
+fn read_key_file(path: &Path) -> anyhow::Result<[u8; KEY_LEN]> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|err| anyhow::anyhow!("failed to read encryption key file {path:?}: {err}"))?;
+    decode_hex_key(&contents)
+        .map_err(|err| anyhow::anyhow!("invalid encryption key file {path:?}: {err}"))
+}
+
+fn write_key_file(path: &Path, key: &[u8; KEY_LEN]) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            anyhow::anyhow!("failed to create encryption key directory {parent:?}: {err}")
+        })?;
+    }
+    std::fs::write(path, hex::encode(key))
+        .map_err(|err| anyhow::anyhow!("failed to write encryption key file {path:?}: {err}"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|err| {
+            anyhow::anyhow!("failed to restrict encryption key file permissions: {err}")
+        })?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key(seed: u8) -> [u8; KEY_LEN] {
+        [seed; KEY_LEN]
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let service = EncryptionService::from_key(&test_key(1));
+        let data = serde_json::json!({"basics": {"name": "Ada Lovelace"}, "n": 42});
+
+        let blob = service.encrypt(&data).expect("encrypt");
+        assert_ne!(blob, serde_json::to_vec(&data).expect("serialize"));
+
+        let decrypted = service.decrypt(&blob).expect("decrypt");
+        assert_eq!(decrypted, data);
+    }
+
+    #[test]
+    fn encrypt_produces_unique_blobs_per_call() {
+        let service = EncryptionService::from_key(&test_key(1));
+        let data = serde_json::json!({"a": 1});
+
+        let first = service.encrypt(&data).expect("encrypt");
+        let second = service.encrypt(&data).expect("encrypt");
+        assert_ne!(first, second, "nonces must be random per encryption");
+    }
+
+    #[test]
+    fn decrypt_with_wrong_key_fails() {
+        let encryptor = EncryptionService::from_key(&test_key(1));
+        let attacker = EncryptionService::from_key(&test_key(2));
+        let blob = encryptor
+            .encrypt(&serde_json::json!({"secret": true}))
+            .expect("encrypt");
+
+        let err = attacker.decrypt(&blob).expect_err("wrong key must fail");
+        assert!(err.to_string().contains("decryption failed"));
+    }
+
+    #[test]
+    fn decrypt_rejects_tampered_ciphertext() {
+        let service = EncryptionService::from_key(&test_key(1));
+        let mut blob = service
+            .encrypt(&serde_json::json!({"secret": true}))
+            .expect("encrypt");
+        let last = blob.len() - 1;
+        blob[last] ^= 0xff;
+
+        assert!(service.decrypt(&blob).is_err());
+    }
+
+    #[test]
+    fn decrypt_rejects_truncated_blob() {
+        let service = EncryptionService::from_key(&test_key(1));
+        assert!(service.decrypt(&[0u8; NONCE_LEN]).is_err());
+    }
+
+    #[test]
+    fn init_with_env_key_takes_priority() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key_file = dir.path().join(".encryption_key");
+        let hex_key = hex::encode(test_key(7));
+
+        let service =
+            EncryptionService::init_with(Some(&hex_key), &key_file).expect("init from env");
+        let expected = EncryptionService::from_key(&test_key(7));
+
+        let blob = service
+            .encrypt(&serde_json::json!({"x": 1}))
+            .expect("encrypt");
+        assert_eq!(
+            expected.decrypt(&blob).expect("decrypt with same key"),
+            serde_json::json!({"x": 1})
+        );
+        assert!(!key_file.exists(), "env key must not touch the key file");
+    }
+
+    #[test]
+    fn init_with_rejects_invalid_env_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key_file = dir.path().join(".encryption_key");
+
+        assert!(EncryptionService::init_with(Some("not-hex"), &key_file).is_err());
+        assert!(EncryptionService::init_with(Some("abcd"), &key_file).is_err());
+    }
+
+    #[test]
+    fn init_with_generates_and_persists_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key_file = dir.path().join("nested").join(".encryption_key");
+
+        let first = EncryptionService::init_with(None, &key_file).expect("generate key");
+        assert!(key_file.exists(), "generated key must be persisted");
+
+        let second = EncryptionService::init_with(None, &key_file).expect("reload key");
+        let blob = first
+            .encrypt(&serde_json::json!({"persisted": true}))
+            .expect("encrypt");
+        assert_eq!(
+            second.decrypt(&blob).expect("decrypt with reloaded key"),
+            serde_json::json!({"persisted": true}),
+            "reloaded key must match the generated key"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generated_key_file_is_owner_read_write_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key_file = dir.path().join(".encryption_key");
+        EncryptionService::init_with(None, &key_file).expect("generate key");
+
+        let mode = std::fs::metadata(&key_file)
+            .expect("metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+}

--- a/crates/server/src/encryption.rs
+++ b/crates/server/src/encryption.rs
@@ -175,19 +175,27 @@ fn read_key_file(path: &Path) -> anyhow::Result<[u8; KEY_LEN]> {
         .map_err(|err| anyhow::anyhow!("invalid encryption key file {path:?}: {err}"))
 }
 
-/// Atomically create the key file with owner-only permissions.
+/// Atomically publish the key file with owner-only permissions.
+///
+/// The key is written and fsynced to a mode-0600 temporary sibling first, then
+/// hard-linked into place — the final path only ever holds a complete key, and
+/// linking fails (without overwriting) if another process published first.
 ///
 /// Returns `Ok(false)` when the file already exists (a concurrent process
 /// persisted a key first); the caller should reload it instead.
 fn write_key_file(path: &Path, key: &[u8; KEY_LEN]) -> anyhow::Result<bool> {
     use std::io::Write;
 
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|err| {
-            anyhow::anyhow!("failed to create encryption key directory {parent:?}: {err}")
-        })?;
+    if path.exists() {
+        return Ok(false);
     }
 
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).map_err(|err| {
+        anyhow::anyhow!("failed to create encryption key directory {parent:?}: {err}")
+    })?;
+
+    let tmp_path = path.with_extension(format!("tmp.{}", std::process::id()));
     let mut options = std::fs::OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
@@ -198,20 +206,28 @@ fn write_key_file(path: &Path, key: &[u8; KEY_LEN]) -> anyhow::Result<bool> {
         options.mode(0o600);
     }
 
-    let mut file = match options.open(path) {
-        Ok(file) => file,
-        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
-        Err(err) => {
-            return Err(anyhow::anyhow!(
-                "failed to create encryption key file {path:?}: {err}"
-            ))
-        }
-    };
-    file.write_all(hex::encode(key).as_bytes())
-        .and_then(|()| file.sync_all())
-        .map_err(|err| anyhow::anyhow!("failed to write encryption key file {path:?}: {err}"))?;
+    let write_result = options
+        .open(&tmp_path)
+        .and_then(|mut file| {
+            file.write_all(hex::encode(key).as_bytes())?;
+            file.sync_all()
+        })
+        .map_err(|err| anyhow::anyhow!("failed to write encryption key file {tmp_path:?}: {err}"));
+    if let Err(err) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(err);
+    }
 
-    Ok(true)
+    // Hard-link is atomic and never overwrites: exactly one process wins.
+    let publish = std::fs::hard_link(&tmp_path, path);
+    let _ = std::fs::remove_file(&tmp_path);
+    match publish {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(err) => Err(anyhow::anyhow!(
+            "failed to publish encryption key file {path:?}: {err}"
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/encryption.rs
+++ b/crates/server/src/encryption.rs
@@ -8,7 +8,7 @@
 //!
 //! Encrypted blobs are laid out as `nonce (12 bytes) || ciphertext`.
 
-use aes_gcm::aead::{Aead, OsRng};
+use aes_gcm::aead::{Aead, OsRng, Payload};
 use aes_gcm::{AeadCore, Aes256Gcm, Key, KeyInit};
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
@@ -89,23 +89,39 @@ impl EncryptionService {
         }
 
         let key: [u8; KEY_LEN] = Aes256Gcm::generate_key(OsRng).into();
-        write_key_file(key_file, &key)?;
-        warn!(
-            path = %key_file.display(),
-            "Auto-generated encryption key at {} — back up this file. If lost, encrypted \
-             resume data is unrecoverable.",
-            key_file.display()
-        );
+        if write_key_file(key_file, &key)? {
+            warn!(
+                path = %key_file.display(),
+                "Auto-generated encryption key at {} — back up this file. If lost, encrypted \
+                 resume data is unrecoverable.",
+                key_file.display()
+            );
+            return Ok(Self::from_key(&key));
+        }
+
+        // Lost a concurrent-startup race: another process persisted a key
+        // first. Discard ours and use the on-disk key so all instances agree.
+        let key = read_key_file(key_file)?;
+        info!(path = %key_file.display(), "Encryption key loaded from key file");
         Ok(Self::from_key(&key))
     }
 
     /// Encrypt resume JSON into a `nonce || ciphertext` blob.
-    pub fn encrypt(&self, data: &serde_json::Value) -> anyhow::Result<Vec<u8>> {
+    ///
+    /// `aad` (associated data, e.g. the resume ID) is authenticated but not
+    /// encrypted: decryption fails if the blob is moved to a different row.
+    pub fn encrypt(&self, data: &serde_json::Value, aad: &[u8]) -> anyhow::Result<Vec<u8>> {
         let plaintext = serde_json::to_vec(data)?;
         let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
         let ciphertext = self
             .cipher
-            .encrypt(&nonce, plaintext.as_slice())
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: plaintext.as_slice(),
+                    aad,
+                },
+            )
             .map_err(|_| anyhow::anyhow!("encryption failed"))?;
 
         let mut blob = Vec::with_capacity(NONCE_LEN + ciphertext.len());
@@ -115,14 +131,22 @@ impl EncryptionService {
     }
 
     /// Decrypt a `nonce || ciphertext` blob back into resume JSON.
-    pub fn decrypt(&self, blob: &[u8]) -> anyhow::Result<serde_json::Value> {
+    ///
+    /// `aad` must match the associated data supplied at encryption time.
+    pub fn decrypt(&self, blob: &[u8], aad: &[u8]) -> anyhow::Result<serde_json::Value> {
         if blob.len() <= NONCE_LEN {
             anyhow::bail!("encrypted blob is too short");
         }
         let (nonce, ciphertext) = blob.split_at(NONCE_LEN);
         let plaintext = self
             .cipher
-            .decrypt(nonce.into(), ciphertext)
+            .decrypt(
+                nonce.into(),
+                Payload {
+                    msg: ciphertext,
+                    aad,
+                },
+            )
             .map_err(|_| anyhow::anyhow!("decryption failed: wrong key or corrupted data"))?;
         Ok(serde_json::from_slice(&plaintext)?)
     }
@@ -151,24 +175,43 @@ fn read_key_file(path: &Path) -> anyhow::Result<[u8; KEY_LEN]> {
         .map_err(|err| anyhow::anyhow!("invalid encryption key file {path:?}: {err}"))
 }
 
-fn write_key_file(path: &Path, key: &[u8; KEY_LEN]) -> anyhow::Result<()> {
+/// Atomically create the key file with owner-only permissions.
+///
+/// Returns `Ok(false)` when the file already exists (a concurrent process
+/// persisted a key first); the caller should reload it instead.
+fn write_key_file(path: &Path, key: &[u8; KEY_LEN]) -> anyhow::Result<bool> {
+    use std::io::Write;
+
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|err| {
             anyhow::anyhow!("failed to create encryption key directory {parent:?}: {err}")
         })?;
     }
-    std::fs::write(path, hex::encode(key))
-        .map_err(|err| anyhow::anyhow!("failed to write encryption key file {path:?}: {err}"))?;
 
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|err| {
-            anyhow::anyhow!("failed to restrict encryption key file permissions: {err}")
-        })?;
+        use std::os::unix::fs::OpenOptionsExt;
+        // 0600 from the very first syscall — no umask-dependent window where
+        // the key is readable by other users.
+        options.mode(0o600);
     }
 
-    Ok(())
+    let mut file = match options.open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "failed to create encryption key file {path:?}: {err}"
+            ))
+        }
+    };
+    file.write_all(hex::encode(key).as_bytes())
+        .and_then(|()| file.sync_all())
+        .map_err(|err| anyhow::anyhow!("failed to write encryption key file {path:?}: {err}"))?;
+
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -179,16 +222,31 @@ mod tests {
         [seed; KEY_LEN]
     }
 
+    const AAD: &[u8] = b"resume-1";
+
     #[test]
     fn encrypt_decrypt_roundtrip() {
         let service = EncryptionService::from_key(&test_key(1));
         let data = serde_json::json!({"basics": {"name": "Ada Lovelace"}, "n": 42});
 
-        let blob = service.encrypt(&data).expect("encrypt");
+        let blob = service.encrypt(&data, AAD).expect("encrypt");
         assert_ne!(blob, serde_json::to_vec(&data).expect("serialize"));
 
-        let decrypted = service.decrypt(&blob).expect("decrypt");
+        let decrypted = service.decrypt(&blob, AAD).expect("decrypt");
         assert_eq!(decrypted, data);
+    }
+
+    #[test]
+    fn decrypt_with_wrong_aad_fails() {
+        let service = EncryptionService::from_key(&test_key(1));
+        let blob = service
+            .encrypt(&serde_json::json!({"secret": true}), AAD)
+            .expect("encrypt");
+
+        assert!(
+            service.decrypt(&blob, b"resume-2").is_err(),
+            "a blob moved to another row must not decrypt"
+        );
     }
 
     #[test]
@@ -196,8 +254,8 @@ mod tests {
         let service = EncryptionService::from_key(&test_key(1));
         let data = serde_json::json!({"a": 1});
 
-        let first = service.encrypt(&data).expect("encrypt");
-        let second = service.encrypt(&data).expect("encrypt");
+        let first = service.encrypt(&data, AAD).expect("encrypt");
+        let second = service.encrypt(&data, AAD).expect("encrypt");
         assert_ne!(first, second, "nonces must be random per encryption");
     }
 
@@ -206,10 +264,12 @@ mod tests {
         let encryptor = EncryptionService::from_key(&test_key(1));
         let attacker = EncryptionService::from_key(&test_key(2));
         let blob = encryptor
-            .encrypt(&serde_json::json!({"secret": true}))
+            .encrypt(&serde_json::json!({"secret": true}), AAD)
             .expect("encrypt");
 
-        let err = attacker.decrypt(&blob).expect_err("wrong key must fail");
+        let err = attacker
+            .decrypt(&blob, AAD)
+            .expect_err("wrong key must fail");
         assert!(err.to_string().contains("decryption failed"));
     }
 
@@ -217,18 +277,18 @@ mod tests {
     fn decrypt_rejects_tampered_ciphertext() {
         let service = EncryptionService::from_key(&test_key(1));
         let mut blob = service
-            .encrypt(&serde_json::json!({"secret": true}))
+            .encrypt(&serde_json::json!({"secret": true}), AAD)
             .expect("encrypt");
         let last = blob.len() - 1;
         blob[last] ^= 0xff;
 
-        assert!(service.decrypt(&blob).is_err());
+        assert!(service.decrypt(&blob, AAD).is_err());
     }
 
     #[test]
     fn decrypt_rejects_truncated_blob() {
         let service = EncryptionService::from_key(&test_key(1));
-        assert!(service.decrypt(&[0u8; NONCE_LEN]).is_err());
+        assert!(service.decrypt(&[0u8; NONCE_LEN], AAD).is_err());
     }
 
     #[test]
@@ -242,10 +302,10 @@ mod tests {
         let expected = EncryptionService::from_key(&test_key(7));
 
         let blob = service
-            .encrypt(&serde_json::json!({"x": 1}))
+            .encrypt(&serde_json::json!({"x": 1}), AAD)
             .expect("encrypt");
         assert_eq!(
-            expected.decrypt(&blob).expect("decrypt with same key"),
+            expected.decrypt(&blob, AAD).expect("decrypt with same key"),
             serde_json::json!({"x": 1})
         );
         assert!(!key_file.exists(), "env key must not touch the key file");
@@ -270,10 +330,12 @@ mod tests {
 
         let second = EncryptionService::init_with(None, &key_file).expect("reload key");
         let blob = first
-            .encrypt(&serde_json::json!({"persisted": true}))
+            .encrypt(&serde_json::json!({"persisted": true}), AAD)
             .expect("encrypt");
         assert_eq!(
-            second.decrypt(&blob).expect("decrypt with reloaded key"),
+            second
+                .decrypt(&blob, AAD)
+                .expect("decrypt with reloaded key"),
             serde_json::json!({"persisted": true}),
             "reloaded key must match the generated key"
         );

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -749,11 +749,11 @@ mod tests {
         let pool = PgPoolOptions::new()
             .connect_lazy("postgres://localhost/rustume_test")
             .expect("lazy pool");
-        std::sync::Arc::new(storage::StorageState {
-            db: pool,
-            encryption: Some(encryption::EncryptionService::from_key(&[7u8; 32])),
-            encrypt_at_rest: false,
-        })
+        std::sync::Arc::new(storage::StorageState::new(
+            pool,
+            Some(encryption::EncryptionService::from_key(&[7u8; 32])),
+            false,
+        ))
     }
 
     fn test_cloud_state() -> std::sync::Arc<cloud::CloudState> {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -12,17 +12,20 @@
 //! - `POST /api/validate` - Validate resume data
 //! - `GET /swagger-ui` - Swagger UI documentation
 //!
-//! # Cloud endpoints (when `RUSTUME_CLOUD=true`)
+//! # Storage endpoints (when `DATABASE_URL` is set — self-hosted and cloud)
 //!
-//! - `GET /auth/login` - Redirect to WorkOS AuthKit
-//! - `GET /auth/callback` - OAuth callback
-//! - `POST /auth/logout` - Clear session
-//! - `GET /auth/me` - Current user profile
+//! - `GET /auth/me` - Current identity (`mode: "local"` or `mode: "cloud"`)
 //! - `GET/POST /api/resumes` - List and create resumes
 //! - `GET/PUT/DELETE /api/resumes/{id}` - Resume CRUD
 //! - `POST /api/resumes/import` - Bulk import from local storage
 //! - `GET /api/resumes/export` - Bulk JSON export
 //! - `GET /api/resumes/export/pdf` - Bulk PDF export (ZIP)
+//!
+//! # Cloud endpoints (when `RUSTUME_CLOUD=true`)
+//!
+//! - `GET /auth/login` - Redirect to WorkOS AuthKit
+//! - `GET /auth/callback` - OAuth callback
+//! - `POST /auth/logout` - Clear session
 //! - `DELETE /api/account` - Permanently delete account and all data
 //! - `GET /metrics` - Prometheus metrics
 
@@ -34,6 +37,7 @@ pub mod config;
 pub mod db;
 pub mod dto;
 pub mod email;
+pub mod encryption;
 pub mod error;
 pub mod middleware;
 pub mod net;
@@ -43,7 +47,10 @@ pub mod routes;
 pub mod run;
 pub mod shutdown;
 pub mod state;
+pub mod storage;
 pub mod subscription;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod validation;
 
 pub use app::{create_router, create_router_with_state, create_router_with_static_dir};
@@ -736,6 +743,19 @@ mod tests {
         );
     }
 
+    fn test_storage_state() -> std::sync::Arc<storage::StorageState> {
+        use sqlx::postgres::PgPoolOptions;
+
+        let pool = PgPoolOptions::new()
+            .connect_lazy("postgres://localhost/rustume_test")
+            .expect("lazy pool");
+        std::sync::Arc::new(storage::StorageState {
+            db: pool,
+            encryption: Some(encryption::EncryptionService::from_key(&[7u8; 32])),
+            encrypt_at_rest: false,
+        })
+    }
+
     fn test_cloud_state() -> std::sync::Arc<cloud::CloudState> {
         use auth::{session::SessionService, workos::WorkOsClient};
         use email::EmailService;
@@ -771,6 +791,7 @@ mod tests {
     async fn test_render_pdf_anonymous_ok_when_require_auth_disabled() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
+            Some(test_storage_state()),
             Some(test_cloud_state()),
             false,
         );
@@ -797,6 +818,7 @@ mod tests {
     async fn test_render_pdf_anonymous_401_when_require_auth_enabled() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
+            Some(test_storage_state()),
             Some(test_cloud_state()),
             true,
         );
@@ -823,6 +845,7 @@ mod tests {
     async fn test_templates_anonymous_401_when_require_auth_enabled() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
+            Some(test_storage_state()),
             Some(test_cloud_state()),
             true,
         );
@@ -845,6 +868,7 @@ mod tests {
     async fn test_resumes_anonymous_401_when_require_auth_enabled() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
+            Some(test_storage_state()),
             Some(test_cloud_state()),
             true,
         );
@@ -867,6 +891,7 @@ mod tests {
     async fn test_auth_me_includes_require_auth_when_signed_out() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
+            Some(test_storage_state()),
             Some(test_cloud_state()),
             true,
         );
@@ -923,6 +948,7 @@ mod tests {
 
         let state = state::AppState::with_options(
             std::sync::Arc::new(routes::static_dir()),
+            Some(test_storage_state()),
             Some(test_cloud_state()),
             false,
             config,
@@ -988,6 +1014,7 @@ mod tests {
     async fn test_delete_account_unauthenticated_401() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
+            Some(test_storage_state()),
             Some(test_cloud_state()),
             true,
         );

--- a/crates/server/src/middleware/auth.rs
+++ b/crates/server/src/middleware/auth.rs
@@ -1,4 +1,5 @@
-//! Session cookie authentication extractor for cloud routes.
+//! Authenticated-user extractor: session cookies in cloud mode, the implicit
+//! local user in self-hosted mode.
 
 use axum::{
     extract::{FromRequestParts, Request, State},
@@ -24,7 +25,11 @@ impl FromRequestParts<AppState> for AuthUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let cloud = state.cloud()?;
+        let Some(cloud) = state.cloud.as_deref() else {
+            // Self-hosted mode: no auth — resolve the implicit local user.
+            let user = state.storage()?.local_user().await?;
+            return Ok(AuthUser(user));
+        };
         let jar = CookieJar::from_request_parts(parts, state)
             .await
             .map_err(|_| unauthorized("Missing session cookie"))?;

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -1,4 +1,4 @@
-//! WorkOS AuthKit login, callback, logout, and session probe routes.
+//! WorkOS AuthKit login, callback, logout, and the mode-aware identity probe.
 
 use axum::{
     extract::{Query, State},
@@ -216,20 +216,25 @@ pub async fn logout(
     Ok(response)
 }
 
-/// Return the currently authenticated user (requires session cookie).
+/// Return the current identity: the implicit local user in self-hosted mode,
+/// or the session-cookie user in cloud mode.
 #[utoipa::path(
     get,
     path = "/auth/me",
     tag = "Auth",
     responses(
-        (status = 200, description = "Authenticated user", body = AuthUserResponse),
-        (status = 401, description = "Not authenticated", body = AuthMeUnauthorizedResponse),
-        (status = 404, description = "Cloud auth not enabled", body = ApiError),
+        (status = 200, description = "Current identity (mode: local or cloud)", body = AuthUserResponse),
+        (status = 401, description = "Not authenticated (cloud mode)", body = AuthMeUnauthorizedResponse),
+        (status = 404, description = "No persistent storage configured", body = ApiError),
     ),
     security(("cookieAuth" = []))
 )]
 pub async fn me(State(state): State<AppState>, jar: CookieJar) -> Result<Response, ApiError> {
-    let cloud = state.cloud()?;
+    let Some(cloud) = state.cloud.as_deref() else {
+        // Self-hosted: no sessions — report the implicit local user.
+        let user = state.storage()?.local_user().await?;
+        return Ok(Json(AuthUserResponse::from_local_user(user)).into_response());
+    };
     let require_auth = state.require_auth;
 
     if let Some(cookie) = jar.get(SESSION_COOKIE) {

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -227,7 +227,7 @@ pub async fn logout(
         (status = 401, description = "Not authenticated (cloud mode)", body = AuthMeUnauthorizedResponse),
         (status = 404, description = "No persistent storage configured", body = ApiError),
     ),
-    security(("cookieAuth" = []))
+    security((), ("cookieAuth" = []))
 )]
 pub async fn me(State(state): State<AppState>, jar: CookieJar) -> Result<Response, ApiError> {
     let Some(cloud) = state.cloud.as_deref() else {

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -63,7 +63,7 @@ pub async fn export_resumes_json(
     let resumes = rows
         .into_iter()
         .map(|row| {
-            let data = storage.decode_resume_data(row.data, row.data_encrypted)?;
+            let data = storage.decode_resume_data(row.data, row.data_encrypted, row.id)?;
             Ok(ResumeExportItem {
                 id: row.id,
                 title: row.title,
@@ -107,7 +107,7 @@ pub async fn export_resumes_pdf(
     for row in rows {
         let data = state
             .storage()?
-            .decode_resume_data(row.data, row.data_encrypted)?;
+            .decode_resume_data(row.data, row.data_encrypted, row.id)?;
         let resume: ResumeData = serde_json::from_value(data)
             .map_err(|_| ApiError::new("Invalid resume data format"))?;
         let file_name = export_pdf_filename(&row.id, &row.title);
@@ -333,11 +333,7 @@ mod tests {
 
     fn test_app_state(pool: sqlx::PgPool) -> AppState {
         let sessions_pool = pool.clone();
-        let storage = Arc::new(crate::storage::StorageState {
-            db: pool.clone(),
-            encryption: None,
-            encrypt_at_rest: false,
-        });
+        let storage = Arc::new(crate::storage::StorageState::new(pool.clone(), None, false));
         AppState::with_require_auth(
             Arc::new(crate::routes::static_dir()),
             Some(storage),

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -1,4 +1,4 @@
-//! Bulk resume export routes for Rustume Cloud data portability.
+//! Bulk resume export routes for data portability (self-hosted and cloud).
 
 use axum::{
     extract::State,
@@ -29,12 +29,13 @@ fn reject_export_over_resume_cap() -> ApiError {
     ))
 }
 
-/// Resume fields required for bulk export.
+/// Resume fields required for bulk export, prior to decryption.
 #[derive(Debug, sqlx::FromRow)]
 struct ExportResumeRow {
     id: Uuid,
     title: String,
-    data: serde_json::Value,
+    data: Option<serde_json::Value>,
+    data_encrypted: Option<Vec<u8>>,
 }
 
 /// Export all resumes for the authenticated user as JSON.
@@ -54,19 +55,22 @@ pub async fn export_resumes_json(
     AuthUser(user): AuthUser,
     State(state): State<AppState>,
 ) -> Result<Json<ResumeBulkExport>, ApiError> {
-    let cloud = state.cloud()?;
-    let access = subscription::load_access(&cloud.db, user.id).await?;
+    let storage = state.storage()?;
+    let access = subscription::load_access(&storage.db, user.id).await?;
     access.ensure_export()?;
 
-    let rows = fetch_all_resumes(&cloud.db, user.id).await?;
+    let rows = fetch_all_resumes(&storage.db, user.id).await?;
     let resumes = rows
         .into_iter()
-        .map(|row| ResumeExportItem {
-            id: row.id,
-            title: row.title,
-            data: row.data,
+        .map(|row| {
+            let data = storage.decode_resume_data(row.data, row.data_encrypted)?;
+            Ok(ResumeExportItem {
+                id: row.id,
+                title: row.title,
+                data,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, ApiError>>()?;
 
     Ok(Json(ResumeBulkExport {
         exported_at: Utc::now(),
@@ -91,17 +95,20 @@ pub async fn export_resumes_pdf(
     AuthUser(user): AuthUser,
     State(state): State<AppState>,
 ) -> Result<Response, ApiError> {
-    let cloud = state.cloud()?;
-    let access = subscription::load_access(&cloud.db, user.id).await?;
+    let storage = state.storage()?;
+    let access = subscription::load_access(&storage.db, user.id).await?;
     access.ensure_export()?;
 
-    let rows = fetch_all_resumes(&cloud.db, user.id).await?;
+    let rows = fetch_all_resumes(&storage.db, user.id).await?;
     let renderer = state.renderer.clone();
     let mut archive = ZipWriter::new(std::io::Cursor::new(Vec::new()));
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
     for row in rows {
-        let resume: ResumeData = serde_json::from_value(row.data)
+        let data = state
+            .storage()?
+            .decode_resume_data(row.data, row.data_encrypted)?;
+        let resume: ResumeData = serde_json::from_value(data)
             .map_err(|_| ApiError::new("Invalid resume data format"))?;
         let file_name = export_pdf_filename(&row.id, &row.title);
         let pdf = tokio::task::spawn_blocking({
@@ -154,7 +161,7 @@ async fn fetch_all_resumes(
     let fetch_limit = MAX_EXPORT_RESUMES + 1;
     let rows = sqlx::query_as::<_, ExportResumeRow>(
         r#"
-        SELECT id, title, data
+        SELECT id, title, data, data_encrypted
         FROM resumes
         WHERE user_id = $1
         ORDER BY updated_at DESC
@@ -326,8 +333,14 @@ mod tests {
 
     fn test_app_state(pool: sqlx::PgPool) -> AppState {
         let sessions_pool = pool.clone();
+        let storage = Arc::new(crate::storage::StorageState {
+            db: pool.clone(),
+            encryption: None,
+            encrypt_at_rest: false,
+        });
         AppState::with_require_auth(
             Arc::new(crate::routes::static_dir()),
+            Some(storage),
             Some(Arc::new(CloudState {
                 db: pool,
                 workos: WorkOsClient::new("client_test".into(), "api_key_test".into()),

--- a/crates/server/src/routes/export.rs
+++ b/crates/server/src/routes/export.rs
@@ -443,6 +443,81 @@ mod tests {
         );
     }
 
+    async fn seed_encrypted_resume(
+        pool: &sqlx::PgPool,
+        encryption: &crate::encryption::EncryptionService,
+        user_id: Uuid,
+        data: &serde_json::Value,
+    ) -> Uuid {
+        let resume_id = Uuid::new_v4();
+        let blob = encryption
+            .encrypt(data, resume_id.as_bytes())
+            .expect("encrypt seed payload");
+        sqlx::query(
+            "INSERT INTO resumes (id, user_id, title, data, data_encrypted) \
+             VALUES ($1, $2, $3, NULL, $4)",
+        )
+        .bind(resume_id)
+        .bind(user_id)
+        .bind("Encrypted resume")
+        .bind(blob)
+        .execute(pool)
+        .await
+        .expect("insert encrypted resume");
+        resume_id
+    }
+
+    fn encrypted_app_state(
+        pool: sqlx::PgPool,
+        encryption: crate::encryption::EncryptionService,
+    ) -> AppState {
+        let mut state = test_app_state(pool.clone());
+        state.storage = Some(Arc::new(crate::storage::StorageState::new(
+            pool,
+            Some(encryption),
+            true,
+        )));
+        state
+    }
+
+    #[tokio::test]
+    async fn export_resumes_json_decrypts_encrypted_rows() {
+        let Some(database_url) = database_url_for_tests() else {
+            return;
+        };
+        let pool = connect_test_pool(&database_url).await;
+        let encryption = crate::encryption::EncryptionService::from_key(&[9u8; 32]);
+        let user = seed_user_with_resumes(&pool, 0).await;
+        let data = serde_json::json!({"basics": {"name": "Cipher Person"}});
+        seed_encrypted_resume(&pool, &encryption, user.id, &data).await;
+        let state = encrypted_app_state(pool.clone(), encryption);
+
+        let result = export_resumes_json(AuthUser(user.clone()), State(state)).await;
+        cleanup_user(&pool, user.id).await;
+
+        let payload = result.expect("encrypted rows must export as plaintext JSON");
+        assert_eq!(payload.resumes.len(), 1);
+        assert_eq!(payload.resumes[0].data, data);
+    }
+
+    #[tokio::test]
+    async fn export_resumes_pdf_decrypts_encrypted_rows() {
+        let Some(database_url) = database_url_for_tests() else {
+            return;
+        };
+        let pool = connect_test_pool(&database_url).await;
+        let encryption = crate::encryption::EncryptionService::from_key(&[9u8; 32]);
+        let user = seed_user_with_resumes(&pool, 0).await;
+        seed_encrypted_resume(&pool, &encryption, user.id, &serde_json::json!({})).await;
+        let state = encrypted_app_state(pool.clone(), encryption);
+
+        let result = export_resumes_pdf(AuthUser(user.clone()), State(state)).await;
+        cleanup_user(&pool, user.id).await;
+
+        let response = result.expect("encrypted rows must export as PDF ZIP");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
     #[test]
     fn export_pdf_filename_sanitizes_title() {
         let id = Uuid::nil();

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -132,7 +132,7 @@ pub async fn create_resume(
     validate_title(title.as_str())?;
     validate_resume_json(&body.data)?;
     let resume_id = body.id.unwrap_or_else(Uuid::new_v4);
-    let payload = storage.encode_resume_data(body.data)?;
+    let payload = storage.encode_resume_data(body.data, resume_id)?;
 
     let row = sqlx::query_as::<_, StoredResumeRow>(
         r#"
@@ -189,7 +189,7 @@ pub async fn update_resume(
     }
     let payload = body
         .data
-        .map(|data| storage.encode_resume_data(data))
+        .map(|data| storage.encode_resume_data(data, id))
         .transpose()?;
 
     let row = apply_resume_update(storage, user.id, id, &title, payload, body.version).await?;
@@ -331,7 +331,7 @@ async fn import_single_resume(
 ) -> Result<ResumeRow, ApiError> {
     let title = item.title.unwrap_or_else(|| "Untitled".to_string());
     let resume_id = item.id.unwrap_or_else(Uuid::new_v4);
-    let payload = storage.encode_resume_data(item.data)?;
+    let payload = storage.encode_resume_data(item.data, resume_id)?;
 
     let row = sqlx::query_as::<_, StoredResumeRow>(
         r#"

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -1,4 +1,8 @@
-//! Authenticated resume CRUD routes for Rustume Cloud.
+//! Resume CRUD routes backed by persistent server-side storage.
+//!
+//! Available in both self-hosted mode (implicit local user, no auth) and
+//! cloud mode (session-cookie auth). Payloads are encrypted at rest when
+//! `RUSTUME_ENCRYPT_AT_REST` is enabled.
 
 use axum::{
     extract::{Path, Query, State},
@@ -12,12 +16,13 @@ use crate::audit::{record_event, AuditEvent};
 use crate::db::{
     CreateResumeRequest, ImportFailure, ImportResumeItem, ImportResumesRequest,
     ImportResumesResponse, PaginatedResumeSummaries, ResumeListQuery, ResumeRow, ResumeSummary,
-    UpdateResumeRequest,
+    StoredResumeRow, UpdateResumeRequest,
 };
 use crate::error::ApiError;
 use crate::middleware::auth::AuthUser;
 use crate::net::{self, trusted_client_ip};
 use crate::state::AppState;
+use crate::storage::{EncodedResumeData, StorageState};
 use crate::subscription;
 use crate::validation::{validate_resume_json, validate_title};
 
@@ -38,8 +43,8 @@ pub async fn list_resumes(
     State(state): State<AppState>,
     Query(query): Query<ResumeListQuery>,
 ) -> Result<Json<PaginatedResumeSummaries>, ApiError> {
-    let cloud = state.cloud()?;
-    let access = subscription::load_access(&cloud.db, user.id).await?;
+    let storage = state.storage()?;
+    let access = subscription::load_access(&storage.db, user.id).await?;
     access.ensure_read()?;
     let (page, per_page, offset) = query.normalized();
 
@@ -51,7 +56,7 @@ pub async fn list_resumes(
         "#,
     )
     .bind(user.id)
-    .fetch_one(&cloud.db)
+    .fetch_one(&storage.db)
     .await
     .map_err(internal_db_error)?;
 
@@ -67,7 +72,7 @@ pub async fn list_resumes(
     .bind(user.id)
     .bind(i64::from(per_page))
     .bind(offset)
-    .fetch_all(&cloud.db)
+    .fetch_all(&storage.db)
     .await
     .map_err(internal_db_error)?;
 
@@ -97,10 +102,10 @@ pub async fn get_resume(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ResumeRow>, ApiError> {
-    let cloud = state.cloud()?;
-    let access = subscription::load_access(&cloud.db, user.id).await?;
+    let storage = state.storage()?;
+    let access = subscription::load_access(&storage.db, user.id).await?;
     access.ensure_read()?;
-    fetch_owned_resume(&state, user.id, id).await.map(Json)
+    fetch_owned_resume(storage, user.id, id).await.map(Json)
 }
 
 /// Create a resume for the authenticated user.
@@ -120,30 +125,32 @@ pub async fn create_resume(
     State(state): State<AppState>,
     Json(body): Json<CreateResumeRequest>,
 ) -> Result<(StatusCode, Json<ResumeRow>), ApiError> {
-    let cloud = state.cloud()?;
-    let access = subscription::load_access(&cloud.db, user.id).await?;
+    let storage = state.storage()?;
+    let access = subscription::load_access(&storage.db, user.id).await?;
     access.ensure_write()?;
     let title = body.title.unwrap_or_else(|| "Untitled".to_string());
     validate_title(title.as_str())?;
     validate_resume_json(&body.data)?;
     let resume_id = body.id.unwrap_or_else(Uuid::new_v4);
+    let payload = storage.encode_resume_data(body.data)?;
 
-    let row = sqlx::query_as::<_, ResumeRow>(
+    let row = sqlx::query_as::<_, StoredResumeRow>(
         r#"
-        INSERT INTO resumes (id, user_id, title, data)
-        VALUES ($1, $2, $3, $4)
-        RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+        INSERT INTO resumes (id, user_id, title, data, data_encrypted)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING id, user_id, title, data, data_encrypted, is_public, public_slug, password_hash, version, created_at, updated_at
         "#,
     )
     .bind(resume_id)
     .bind(user.id)
     .bind(title)
-    .bind(body.data)
-    .fetch_one(&cloud.db)
+    .bind(payload.data)
+    .bind(payload.data_encrypted)
+    .fetch_one(&storage.db)
     .await
     .map_err(map_resume_db_error)?;
 
-    Ok((StatusCode::CREATED, Json(row)))
+    Ok((StatusCode::CREATED, Json(storage.decode_resume_row(row)?)))
 }
 
 /// Update a resume owned by the authenticated user.
@@ -171,17 +178,21 @@ pub async fn update_resume(
         return Err(ApiError::new("At least one of title or data is required"));
     }
 
-    let cloud = state.cloud()?;
-    let access = subscription::load_access(&cloud.db, user.id).await?;
+    let storage = state.storage()?;
+    let access = subscription::load_access(&storage.db, user.id).await?;
     access.ensure_write()?;
-    let existing = fetch_owned_resume(&state, user.id, id).await?;
+    let existing = fetch_owned_resume(storage, user.id, id).await?;
     let title = body.title.unwrap_or(existing.title);
     validate_title(title.as_str())?;
     if let Some(data) = &body.data {
         validate_resume_json(data)?;
     }
+    let payload = body
+        .data
+        .map(|data| storage.encode_resume_data(data))
+        .transpose()?;
 
-    let row = apply_resume_update(&cloud.db, user.id, id, &title, body.data, body.version).await?;
+    let row = apply_resume_update(storage, user.id, id, &title, payload, body.version).await?;
 
     Ok(Json(row))
 }
@@ -205,13 +216,13 @@ pub async fn delete_resume(
     Path(id): Path<Uuid>,
     headers: HeaderMap,
 ) -> Result<StatusCode, ApiError> {
-    let cloud = state.cloud()?;
-    let access = subscription::load_access(&cloud.db, user.id).await?;
+    let storage = state.storage()?;
+    let access = subscription::load_access(&storage.db, user.id).await?;
     access.ensure_delete()?;
     let result = sqlx::query("DELETE FROM resumes WHERE id = $1 AND user_id = $2")
         .bind(id)
         .bind(user.id)
-        .execute(&cloud.db)
+        .execute(&storage.db)
         .await
         .map_err(internal_db_error)?;
 
@@ -220,7 +231,7 @@ pub async fn delete_resume(
     }
 
     record_event(
-        &cloud.db,
+        &storage.db,
         AuditEvent {
             event_type: "resume.delete",
             actor_user_id: Some(user.id),
@@ -237,7 +248,7 @@ pub async fn delete_resume(
 
 const MAX_IMPORT_BATCH: usize = 100;
 
-/// Import local resumes into the authenticated user's cloud account.
+/// Import browser-stored resumes into the authenticated user's server storage.
 #[utoipa::path(
     post,
     path = "/api/resumes/import",
@@ -261,8 +272,8 @@ pub async fn import_resumes(
         )));
     }
 
-    let cloud = state.cloud()?;
-    let access = subscription::load_access(&cloud.db, user.id).await?;
+    let storage = state.storage()?;
+    let access = subscription::load_access(&storage.db, user.id).await?;
     access.ensure_write()?;
     let requested_count = body.resumes.len();
     let mut imported = Vec::new();
@@ -284,7 +295,7 @@ pub async fn import_resumes(
             });
             continue;
         }
-        match import_single_resume(&cloud.db, user.id, item).await {
+        match import_single_resume(storage, user.id, item).await {
             Ok(row) => imported.push(ResumeSummary::from(row)),
             Err(err) => failed.push(ImportFailure {
                 id: resume_id,
@@ -294,7 +305,7 @@ pub async fn import_resumes(
     }
 
     record_event(
-        &cloud.db,
+        &storage.db,
         AuditEvent {
             event_type: "resume.import.batch",
             actor_user_id: Some(user.id),
@@ -314,32 +325,37 @@ pub async fn import_resumes(
 }
 
 async fn import_single_resume(
-    db: &sqlx::PgPool,
+    storage: &StorageState,
     user_id: Uuid,
     item: ImportResumeItem,
 ) -> Result<ResumeRow, ApiError> {
     let title = item.title.unwrap_or_else(|| "Untitled".to_string());
     let resume_id = item.id.unwrap_or_else(Uuid::new_v4);
+    let payload = storage.encode_resume_data(item.data)?;
 
-    sqlx::query_as::<_, ResumeRow>(
+    let row = sqlx::query_as::<_, StoredResumeRow>(
         r#"
-        INSERT INTO resumes (id, user_id, title, data)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO resumes (id, user_id, title, data, data_encrypted)
+        VALUES ($1, $2, $3, $4, $5)
         ON CONFLICT (id) DO UPDATE SET
             title = EXCLUDED.title,
             data = EXCLUDED.data,
+            data_encrypted = EXCLUDED.data_encrypted,
             updated_at = now()
         WHERE resumes.user_id = EXCLUDED.user_id
-        RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+        RETURNING id, user_id, title, data, data_encrypted, is_public, public_slug, password_hash, version, created_at, updated_at
         "#,
     )
     .bind(resume_id)
     .bind(user_id)
     .bind(title)
-    .bind(item.data)
-    .fetch_one(db)
+    .bind(payload.data)
+    .bind(payload.data_encrypted)
+    .fetch_one(&storage.db)
     .await
-    .map_err(|err| map_import_db_error(err, resume_id))
+    .map_err(|err| map_import_db_error(err, resume_id))?;
+
+    storage.decode_resume_row(row)
 }
 
 fn internal_db_error(err: impl std::fmt::Display + Send + Sync + 'static) -> ApiError {
@@ -369,94 +385,98 @@ fn map_resume_db_error(err: sqlx::Error) -> ApiError {
 }
 
 async fn apply_resume_update(
-    db: &sqlx::PgPool,
+    storage: &StorageState,
     user_id: Uuid,
     resume_id: Uuid,
     title: &str,
-    data: Option<serde_json::Value>,
+    payload: Option<EncodedResumeData>,
     expected_version: Option<i32>,
 ) -> Result<ResumeRow, ApiError> {
-    let row = match (data, expected_version) {
-        (Some(data), Some(version)) => {
-            sqlx::query_as::<_, ResumeRow>(
+    let row = match (payload, expected_version) {
+        (Some(payload), Some(version)) => {
+            sqlx::query_as::<_, StoredResumeRow>(
                 r#"
                 UPDATE resumes
                 SET title = $1,
                     data = $2,
+                    data_encrypted = $3,
                     version = version + 1,
                     updated_at = now()
-                WHERE id = $3 AND user_id = $4 AND version = $5
-                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+                WHERE id = $4 AND user_id = $5 AND version = $6
+                RETURNING id, user_id, title, data, data_encrypted, is_public, public_slug, password_hash, version, created_at, updated_at
                 "#,
             )
             .bind(title)
-            .bind(data)
+            .bind(payload.data)
+            .bind(payload.data_encrypted)
             .bind(resume_id)
             .bind(user_id)
             .bind(version)
-            .fetch_optional(db)
+            .fetch_optional(&storage.db)
             .await
         }
-        (Some(data), None) => {
-            sqlx::query_as::<_, ResumeRow>(
+        (Some(payload), None) => {
+            sqlx::query_as::<_, StoredResumeRow>(
                 r#"
                 UPDATE resumes
                 SET title = $1,
                     data = $2,
+                    data_encrypted = $3,
                     version = version + 1,
                     updated_at = now()
-                WHERE id = $3 AND user_id = $4
-                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+                WHERE id = $4 AND user_id = $5
+                RETURNING id, user_id, title, data, data_encrypted, is_public, public_slug, password_hash, version, created_at, updated_at
                 "#,
             )
             .bind(title)
-            .bind(data)
+            .bind(payload.data)
+            .bind(payload.data_encrypted)
             .bind(resume_id)
             .bind(user_id)
-            .fetch_optional(db)
+            .fetch_optional(&storage.db)
             .await
         }
         (None, Some(version)) => {
-            sqlx::query_as::<_, ResumeRow>(
+            sqlx::query_as::<_, StoredResumeRow>(
                 r#"
                 UPDATE resumes
                 SET title = $1,
                     version = version + 1,
                     updated_at = now()
                 WHERE id = $2 AND user_id = $3 AND version = $4
-                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+                RETURNING id, user_id, title, data, data_encrypted, is_public, public_slug, password_hash, version, created_at, updated_at
                 "#,
             )
             .bind(title)
             .bind(resume_id)
             .bind(user_id)
             .bind(version)
-            .fetch_optional(db)
+            .fetch_optional(&storage.db)
             .await
         }
         (None, None) => {
-            sqlx::query_as::<_, ResumeRow>(
+            sqlx::query_as::<_, StoredResumeRow>(
                 r#"
                 UPDATE resumes
                 SET title = $1,
                     version = version + 1,
                     updated_at = now()
                 WHERE id = $2 AND user_id = $3
-                RETURNING id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+                RETURNING id, user_id, title, data, data_encrypted, is_public, public_slug, password_hash, version, created_at, updated_at
                 "#,
             )
             .bind(title)
             .bind(resume_id)
             .bind(user_id)
-            .fetch_optional(db)
+            .fetch_optional(&storage.db)
             .await
         }
     }
     .map_err(map_resume_db_error)?;
 
     match row {
-        Some(row) => Ok(row),
-        None => map_update_miss(db, user_id, resume_id, expected_version).await,
+        Some(row) => storage.decode_resume_row(row),
+        None => map_update_miss(&storage.db, user_id, resume_id, expected_version).await,
     }
 }
 
@@ -489,22 +509,255 @@ async fn map_update_miss(
 }
 
 async fn fetch_owned_resume(
-    state: &AppState,
+    storage: &StorageState,
     user_id: Uuid,
     resume_id: Uuid,
 ) -> Result<ResumeRow, ApiError> {
-    let cloud = state.cloud()?;
-    sqlx::query_as::<_, ResumeRow>(
+    let row = sqlx::query_as::<_, StoredResumeRow>(
         r#"
-        SELECT id, user_id, title, data, is_public, public_slug, password_hash, version, created_at, updated_at
+        SELECT id, user_id, title, data, data_encrypted, is_public, public_slug, password_hash, version, created_at, updated_at
         FROM resumes
         WHERE id = $1 AND user_id = $2
         "#,
     )
     .bind(resume_id)
     .bind(user_id)
-    .fetch_optional(&cloud.db)
+    .fetch_optional(&storage.db)
     .await
     .map_err(internal_db_error)?
-    .ok_or_else(|| ApiError::not_found("Resume not found"))
+    .ok_or_else(|| ApiError::not_found("Resume not found"))?;
+
+    storage.decode_resume_row(row)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use crate::storage::LOCAL_USER_ID;
+    use crate::test_support::{connect_test_pool, database_url_for_tests, storage_state};
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    async fn cleanup_local_resume(pool: &sqlx::PgPool, id: Uuid) {
+        sqlx::query("DELETE FROM resumes WHERE id = $1")
+            .bind(id)
+            .execute(pool)
+            .await
+            .expect("cleanup resume");
+    }
+
+    fn local_state(pool: sqlx::PgPool, encrypt_at_rest: bool) -> AppState {
+        AppState::with_require_auth(
+            std::sync::Arc::new(crate::routes::static_dir()),
+            Some(storage_state(pool, encrypt_at_rest)),
+            None,
+            false,
+        )
+    }
+
+    fn sample_resume_data() -> serde_json::Value {
+        serde_json::json!({"basics": {"name": "Ada Lovelace"}})
+    }
+
+    #[tokio::test]
+    async fn create_resume_encrypts_payload_at_rest() {
+        let Some(database_url) = database_url_for_tests() else {
+            return;
+        };
+        let pool = connect_test_pool(&database_url).await;
+        let state = local_state(pool.clone(), true);
+        let user = state
+            .storage()
+            .expect("storage")
+            .local_user()
+            .await
+            .expect("local user");
+        let resume_id = Uuid::new_v4();
+
+        let (status, Json(row)) = create_resume(
+            AuthUser(user.clone()),
+            State(state.clone()),
+            Json(CreateResumeRequest {
+                id: Some(resume_id),
+                title: Some("Encrypted".to_string()),
+                data: sample_resume_data(),
+            }),
+        )
+        .await
+        .expect("create resume");
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(row.data, sample_resume_data());
+
+        let (data, data_encrypted) =
+            sqlx::query_as::<_, (Option<serde_json::Value>, Option<Vec<u8>>)>(
+                "SELECT data, data_encrypted FROM resumes WHERE id = $1",
+            )
+            .bind(resume_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch raw row");
+
+        assert!(data.is_none(), "plaintext column must be NULL");
+        let blob = data_encrypted.expect("encrypted column must be set");
+        assert!(
+            !blob.windows(3).any(|w| w == b"Ada"),
+            "blob must not leak plaintext"
+        );
+
+        let fetched = get_resume(AuthUser(user), State(state), Path(resume_id))
+            .await
+            .expect("get resume");
+        assert_eq!(fetched.0.data, sample_resume_data());
+
+        cleanup_local_resume(&pool, resume_id).await;
+    }
+
+    #[tokio::test]
+    async fn update_resume_reencrypts_payload() {
+        let Some(database_url) = database_url_for_tests() else {
+            return;
+        };
+        let pool = connect_test_pool(&database_url).await;
+        let state = local_state(pool.clone(), true);
+        let user = state
+            .storage()
+            .expect("storage")
+            .local_user()
+            .await
+            .expect("local user");
+        let resume_id = Uuid::new_v4();
+
+        let (created_status, _created) = create_resume(
+            AuthUser(user.clone()),
+            State(state.clone()),
+            Json(CreateResumeRequest {
+                id: Some(resume_id),
+                title: Some("Original".to_string()),
+                data: sample_resume_data(),
+            }),
+        )
+        .await
+        .expect("create resume");
+        assert_eq!(created_status, StatusCode::CREATED);
+
+        let updated_data = serde_json::json!({"basics": {"name": "Grace Hopper"}});
+        let updated = update_resume(
+            AuthUser(user),
+            State(state),
+            Path(resume_id),
+            Json(UpdateResumeRequest {
+                title: Some("Updated".to_string()),
+                data: Some(updated_data.clone()),
+                version: Some(1),
+            }),
+        )
+        .await
+        .expect("update resume");
+
+        assert_eq!(updated.0.data, updated_data);
+        assert_eq!(updated.0.version, 2);
+
+        cleanup_local_resume(&pool, resume_id).await;
+    }
+
+    #[tokio::test]
+    async fn local_mode_resume_crud_without_cookies() {
+        let Some(database_url) = database_url_for_tests() else {
+            return;
+        };
+        let pool = connect_test_pool(&database_url).await;
+        let app = crate::app::create_router_with_state(local_state(pool.clone(), true));
+        let resume_id = Uuid::new_v4();
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/resumes")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "id": resume_id,
+                            "title": "Local resume",
+                            "data": sample_resume_data(),
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::CREATED,
+            "local mode create must not require auth"
+        );
+
+        let owner = sqlx::query_scalar::<_, Uuid>("SELECT user_id FROM resumes WHERE id = $1")
+            .bind(resume_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch owner");
+        assert_eq!(
+            owner, LOCAL_USER_ID,
+            "resume must belong to the seeded local user"
+        );
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/resumes/{resume_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/resumes/{resume_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn auth_me_reports_local_mode() {
+        let Some(database_url) = database_url_for_tests() else {
+            return;
+        };
+        let pool = connect_test_pool(&database_url).await;
+        let app = crate::app::create_router_with_state(local_state(pool, true));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/auth/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["mode"], "local");
+        assert_eq!(payload["id"], LOCAL_USER_ID.to_string());
+        assert_eq!(payload["plan"], "self-hosted");
+        assert_eq!(payload["require_auth"], false);
+    }
 }

--- a/crates/server/src/routes/resumes.rs
+++ b/crates/server/src/routes/resumes.rs
@@ -341,6 +341,7 @@ async fn import_single_resume(
             title = EXCLUDED.title,
             data = EXCLUDED.data,
             data_encrypted = EXCLUDED.data_encrypted,
+            version = resumes.version + 1,
             updated_at = now()
         WHERE resumes.user_id = EXCLUDED.user_id
         RETURNING id, user_id, title, data, data_encrypted, is_public, public_slug, password_hash, version, created_at, updated_at
@@ -659,6 +660,20 @@ mod tests {
 
         assert_eq!(updated.0.data, updated_data);
         assert_eq!(updated.0.version, 2);
+
+        let (data, data_encrypted) =
+            sqlx::query_as::<_, (Option<serde_json::Value>, Option<Vec<u8>>)>(
+                "SELECT data, data_encrypted FROM resumes WHERE id = $1",
+            )
+            .bind(resume_id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch raw row after update");
+        assert!(data.is_none(), "update must not write plaintext");
+        assert!(
+            data_encrypted.is_some(),
+            "update must re-encrypt the payload"
+        );
 
         cleanup_local_resume(&pool, resume_id).await;
     }

--- a/crates/server/src/run.rs
+++ b/crates/server/src/run.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::app::create_router_with_state;
 use crate::cloud::{cloud_enabled, init_cloud, CloudConfig};
@@ -11,8 +11,10 @@ use crate::observability::init_sentry;
 use crate::routes::{init_metrics, static_dir};
 use crate::shutdown::{health_probe, shutdown_signal};
 use crate::state::AppState;
+use crate::storage::{init_storage, seed_local_user, StorageConfig};
 
-/// Start the HTTP server, optionally initializing Rustume Cloud when configured.
+/// Start the HTTP server: always initialize storage when `DATABASE_URL` is
+/// set, and layer Rustume Cloud auth on top when `RUSTUME_CLOUD` is enabled.
 pub async fn run() -> anyhow::Result<()> {
     if std::env::args().any(|a| a == "--health") {
         std::process::exit(health_probe());
@@ -30,16 +32,34 @@ pub async fn run() -> anyhow::Result<()> {
     init_metrics();
 
     let static_root = Arc::new(static_dir());
-    let cloud = if cloud_enabled() {
-        let config = CloudConfig::from_env()?;
-        info!("Rustume Cloud mode enabled");
-        Some(init_cloud(config).await?)
-    } else {
-        info!("Running in self-hosted stateless mode");
-        None
+    let cloud_mode = cloud_enabled();
+
+    let storage = match StorageConfig::from_env(cloud_mode)? {
+        Some(config) => Some(init_storage(config).await?),
+        None => {
+            warn!(
+                "DATABASE_URL is not set — running in stateless fallback mode; resume data \
+                 stays in the browser and is not persisted server-side"
+            );
+            None
+        }
     };
 
-    let app_state = AppState::new(static_root.clone(), cloud);
+    let cloud = match (&storage, cloud_mode) {
+        (Some(storage), true) => {
+            let config = CloudConfig::from_env()?;
+            info!("Rustume Cloud mode enabled");
+            Some(init_cloud(config, storage.db.clone())?)
+        }
+        (Some(storage), false) => {
+            seed_local_user(&storage.db).await?;
+            info!("Running in self-hosted mode with persistent server-side storage");
+            None
+        }
+        (None, _) => None,
+    };
+
+    let app_state = AppState::new(static_root.clone(), storage, cloud);
     if let Some(rate_limits) = app_state.rate_limits.clone() {
         RateLimitState::spawn_eviction_task(rate_limits);
     }

--- a/crates/server/src/run.rs
+++ b/crates/server/src/run.rs
@@ -37,6 +37,9 @@ pub async fn run() -> anyhow::Result<()> {
     let storage = match StorageConfig::from_env(cloud_mode)? {
         Some(config) => Some(init_storage(config).await?),
         None => {
+            if crate::cloud::cloud_flag_enabled() {
+                anyhow::bail!("DATABASE_URL must be set when RUSTUME_CLOUD is enabled");
+            }
             warn!(
                 "DATABASE_URL is not set — running in stateless fallback mode; resume data \
                  stays in the browser and is not persisted server-side"

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -1,16 +1,23 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use sqlx::PgPool;
+
 use rustume_render::TypstRenderer;
 
 use crate::cloud::CloudState;
 use crate::config::RateLimitConfig;
 use crate::middleware::rate_limit::RateLimitState;
+use crate::storage::StorageState;
 
 /// Shared router state for all handlers.
 #[derive(Clone)]
 pub struct AppState {
     pub static_dir: Arc<PathBuf>,
+    /// Persistent resume storage (PostgreSQL + encryption). `None` only in
+    /// stateless fallback mode when `DATABASE_URL` is not configured.
+    pub storage: Option<Arc<StorageState>>,
+    /// Cloud auth services (WorkOS, sessions). `None` in self-hosted mode.
     pub cloud: Option<Arc<CloudState>>,
     pub renderer: Arc<TypstRenderer>,
     /// When true, billable API routes require a valid session (hosted Rustume Cloud).
@@ -21,12 +28,17 @@ pub struct AppState {
 
 impl AppState {
     /// Build application state with a shared Typst renderer instance.
-    pub fn new(static_dir: Arc<PathBuf>, cloud: Option<Arc<CloudState>>) -> Self {
+    pub fn new(
+        static_dir: Arc<PathBuf>,
+        storage: Option<Arc<StorageState>>,
+        cloud: Option<Arc<CloudState>>,
+    ) -> Self {
         let rate_limits = cloud
             .as_ref()
             .map(|_| Arc::new(RateLimitState::new(RateLimitConfig::from_env())));
         Self {
             static_dir,
+            storage,
             cloud,
             renderer: Arc::new(TypstRenderer::new()),
             require_auth: crate::cloud::require_auth_enabled(),
@@ -38,16 +50,24 @@ impl AppState {
     #[cfg(test)]
     pub fn with_require_auth(
         static_dir: Arc<PathBuf>,
+        storage: Option<Arc<StorageState>>,
         cloud: Option<Arc<CloudState>>,
         require_auth: bool,
     ) -> Self {
-        Self::with_options(static_dir, cloud, require_auth, RateLimitConfig::from_env())
+        Self::with_options(
+            static_dir,
+            storage,
+            cloud,
+            require_auth,
+            RateLimitConfig::from_env(),
+        )
     }
 
     /// Build application state with explicit cloud and rate limit settings (tests).
     #[cfg(test)]
     pub fn with_options(
         static_dir: Arc<PathBuf>,
+        storage: Option<Arc<StorageState>>,
         cloud: Option<Arc<CloudState>>,
         require_auth: bool,
         rate_limit_config: RateLimitConfig,
@@ -57,6 +77,7 @@ impl AppState {
             .map(|_| Arc::new(RateLimitState::new(rate_limit_config)));
         Self {
             static_dir,
+            storage,
             cloud,
             renderer: Arc::new(TypstRenderer::new()),
             require_auth,
@@ -69,5 +90,19 @@ impl AppState {
         self.cloud.as_deref().ok_or_else(|| {
             crate::error::ApiError::not_found("Cloud features are not enabled on this server")
         })
+    }
+
+    /// Return the storage layer or a 404 when persistent storage is disabled.
+    pub fn storage(&self) -> Result<&StorageState, crate::error::ApiError> {
+        self.storage.as_deref().ok_or_else(|| {
+            crate::error::ApiError::not_found(
+                "Persistent storage is not enabled on this server (DATABASE_URL is not set)",
+            )
+        })
+    }
+
+    /// Return the shared PostgreSQL pool or a 404 when storage is disabled.
+    pub fn db(&self) -> Result<&PgPool, crate::error::ApiError> {
+        self.storage().map(|storage| &storage.db)
     }
 }

--- a/crates/server/src/storage.rs
+++ b/crates/server/src/storage.rs
@@ -9,6 +9,7 @@ use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::OnceCell;
 use tracing::{error, info};
 use uuid::Uuid;
 
@@ -68,7 +69,7 @@ impl StorageConfig {
             database_url,
             db_max_connections: crate::cloud::optional_env_u32("DB_MAX_CONNECTIONS", 10)?,
             db_acquire_timeout_secs: crate::cloud::optional_env_u64("DB_ACQUIRE_TIMEOUT_SECS", 5)?,
-            encrypt_at_rest: encrypt_at_rest_enabled(cloud),
+            encrypt_at_rest: encrypt_at_rest_enabled(cloud)?,
         }))
     }
 }
@@ -76,16 +77,20 @@ impl StorageConfig {
 /// Resolve the `RUSTUME_ENCRYPT_AT_REST` toggle.
 ///
 /// Defaults to `true` for self-hosted deployments and `false` for cloud.
-#[must_use]
-pub fn encrypt_at_rest_enabled(cloud: bool) -> bool {
+/// Fails fast on unrecognized values so a typo cannot silently change how
+/// resume data is persisted.
+pub fn encrypt_at_rest_enabled(cloud: bool) -> anyhow::Result<bool> {
     encrypt_at_rest_from_env(cloud, std::env::var("RUSTUME_ENCRYPT_AT_REST").ok())
 }
 
-fn encrypt_at_rest_from_env(cloud: bool, value: Option<String>) -> bool {
+fn encrypt_at_rest_from_env(cloud: bool, value: Option<String>) -> anyhow::Result<bool> {
     match value.as_deref().map(str::trim) {
-        Some("true" | "1") => true,
-        Some("false" | "0") => false,
-        _ => !cloud,
+        Some("true" | "1") => Ok(true),
+        Some("false" | "0") => Ok(false),
+        Some("") | None => Ok(!cloud),
+        Some(other) => {
+            anyhow::bail!("RUSTUME_ENCRYPT_AT_REST must be one of true, false, 1, 0; got {other:?}")
+        }
     }
 }
 
@@ -107,13 +112,31 @@ pub struct StorageState {
     pub encryption: Option<EncryptionService>,
     /// Whether new resume writes are encrypted.
     pub encrypt_at_rest: bool,
+    /// Lazily cached implicit local user (self-hosted mode), shared across
+    /// clones so the per-request `AuthUser` extraction skips the database.
+    local_user_cell: Arc<OnceCell<User>>,
 }
 
 impl StorageState {
+    /// Build a storage state around an existing pool.
+    #[must_use]
+    pub fn new(db: PgPool, encryption: Option<EncryptionService>, encrypt_at_rest: bool) -> Self {
+        Self {
+            db,
+            encryption,
+            encrypt_at_rest,
+            local_user_cell: Arc::new(OnceCell::new()),
+        }
+    }
+
     /// Encode resume JSON for persistence, encrypting when enabled.
+    ///
+    /// The resume ID is bound as associated data so an encrypted blob copied
+    /// into a different row fails to decrypt.
     pub fn encode_resume_data(
         &self,
         data: serde_json::Value,
+        resume_id: Uuid,
     ) -> Result<EncodedResumeData, ApiError> {
         if !self.encrypt_at_rest {
             return Ok(EncodedResumeData {
@@ -126,10 +149,12 @@ impl StorageState {
             error!("encrypt-at-rest enabled but no encryption key is configured");
             ApiError::internal("internal server error")
         })?;
-        let blob = encryption.encrypt(&data).map_err(|err| {
-            error!("resume encryption failed: {err}");
-            ApiError::internal("internal server error")
-        })?;
+        let blob = encryption
+            .encrypt(&data, resume_id.as_bytes())
+            .map_err(|err| {
+                error!("resume encryption failed: {err}");
+                ApiError::internal("internal server error")
+            })?;
         Ok(EncodedResumeData {
             data: None,
             data_encrypted: Some(blob),
@@ -141,6 +166,7 @@ impl StorageState {
         &self,
         data: Option<serde_json::Value>,
         data_encrypted: Option<Vec<u8>>,
+        resume_id: Uuid,
     ) -> Result<serde_json::Value, ApiError> {
         if let Some(data) = data {
             return Ok(data);
@@ -154,10 +180,12 @@ impl StorageState {
             error!("encrypted resume data present but no encryption key is configured");
             ApiError::internal("internal server error")
         })?;
-        encryption.decrypt(&blob).map_err(|err| {
-            error!("resume decryption failed: {err}");
-            ApiError::internal("internal server error")
-        })
+        encryption
+            .decrypt(&blob, resume_id.as_bytes())
+            .map_err(|err| {
+                error!("resume decryption failed: {err}");
+                ApiError::internal("internal server error")
+            })
     }
 
     /// Convert a stored row into the API row, decrypting the payload as needed.
@@ -175,7 +203,7 @@ impl StorageState {
             created_at,
             updated_at,
         } = row;
-        let data = self.decode_resume_data(data, data_encrypted)?;
+        let data = self.decode_resume_data(data, data_encrypted, id)?;
         Ok(ResumeRow {
             id,
             user_id,
@@ -191,20 +219,30 @@ impl StorageState {
     }
 
     /// Fetch the implicit self-hosted user, seeding it if missing.
+    ///
+    /// The row is immutable after seeding (until future cloud linking), so it
+    /// is cached after the first lookup to avoid a per-request query.
     pub async fn local_user(&self) -> Result<User, ApiError> {
-        if let Some(user) = fetch_local_user(&self.db).await? {
-            return Ok(user);
-        }
-
-        seed_local_user(&self.db).await.map_err(|err| {
-            error!("local user seed failed: {err}");
-            ApiError::internal("internal server error")
-        })?;
-        fetch_local_user(&self.db).await?.ok_or_else(|| {
-            error!("local user missing after seed");
-            ApiError::internal("internal server error")
-        })
+        self.local_user_cell
+            .get_or_try_init(|| fetch_or_seed_local_user(&self.db))
+            .await
+            .cloned()
     }
+}
+
+async fn fetch_or_seed_local_user(db: &PgPool) -> Result<User, ApiError> {
+    if let Some(user) = fetch_local_user(db).await? {
+        return Ok(user);
+    }
+
+    seed_local_user(db).await.map_err(|err| {
+        error!("local user seed failed: {err}");
+        ApiError::internal("internal server error")
+    })?;
+    fetch_local_user(db).await?.ok_or_else(|| {
+        error!("local user missing after seed");
+        ApiError::internal("internal server error")
+    })
 }
 
 async fn fetch_local_user(db: &PgPool) -> Result<Option<User>, ApiError> {
@@ -256,11 +294,11 @@ pub async fn init_storage(config: StorageConfig) -> anyhow::Result<Arc<StorageSt
         "Resume storage initialized"
     );
 
-    Ok(Arc::new(StorageState {
+    Ok(Arc::new(StorageState::new(
         db,
         encryption,
-        encrypt_at_rest: config.encrypt_at_rest,
-    }))
+        config.encrypt_at_rest,
+    )))
 }
 
 #[cfg(test)]
@@ -269,17 +307,24 @@ mod tests {
 
     #[test]
     fn encrypt_at_rest_defaults_on_for_self_hosted() {
-        assert!(encrypt_at_rest_from_env(false, None));
-        assert!(!encrypt_at_rest_from_env(true, None));
+        assert!(encrypt_at_rest_from_env(false, None).unwrap());
+        assert!(!encrypt_at_rest_from_env(true, None).unwrap());
+        assert!(encrypt_at_rest_from_env(false, Some(String::new())).unwrap());
     }
 
     #[test]
     fn encrypt_at_rest_env_overrides_defaults() {
-        assert!(!encrypt_at_rest_from_env(false, Some("false".to_string())));
-        assert!(!encrypt_at_rest_from_env(false, Some("0".to_string())));
-        assert!(encrypt_at_rest_from_env(true, Some("true".to_string())));
-        assert!(encrypt_at_rest_from_env(true, Some("1".to_string())));
-        assert!(encrypt_at_rest_from_env(false, Some("garbage".to_string())));
+        assert!(!encrypt_at_rest_from_env(false, Some("false".to_string())).unwrap());
+        assert!(!encrypt_at_rest_from_env(false, Some("0".to_string())).unwrap());
+        assert!(encrypt_at_rest_from_env(true, Some("true".to_string())).unwrap());
+        assert!(encrypt_at_rest_from_env(true, Some("1".to_string())).unwrap());
+    }
+
+    #[test]
+    fn encrypt_at_rest_rejects_unrecognized_values() {
+        let err = encrypt_at_rest_from_env(false, Some("garbage".to_string()))
+            .expect_err("typo must fail fast");
+        assert!(err.to_string().contains("RUSTUME_ENCRYPT_AT_REST"));
     }
 
     #[test]

--- a/crates/server/src/storage.rs
+++ b/crates/server/src/storage.rs
@@ -311,8 +311,16 @@ async fn verify_encryption_key(
     db: &PgPool,
     encryption: Option<&EncryptionService>,
 ) -> anyhow::Result<()> {
+    // Version rows bind their parent resume ID as associated data, so both
+    // samples decrypt against the returned UUID.
     let sample = sqlx::query_as::<_, (Uuid, Vec<u8>)>(
-        "SELECT id, data_encrypted FROM resumes WHERE data_encrypted IS NOT NULL LIMIT 1",
+        r#"
+        SELECT id, data_encrypted FROM resumes WHERE data_encrypted IS NOT NULL
+        UNION ALL
+        SELECT resume_id, data_encrypted FROM resume_versions
+        WHERE data_encrypted IS NOT NULL
+        LIMIT 1
+        "#,
     )
     .fetch_optional(db)
     .await?;

--- a/crates/server/src/storage.rs
+++ b/crates/server/src/storage.rs
@@ -1,0 +1,292 @@
+//! Always-on PostgreSQL storage: pool bootstrap, migrations, encryption at
+//! rest, and the implicit local user for self-hosted deployments.
+//!
+//! Cloud mode ([`crate::cloud`]) layers WorkOS auth and sessions on top of
+//! this storage layer; self-hosted mode uses it directly with a seeded local
+//! user and no authentication.
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::db::{ResumeRow, StoredResumeRow, User};
+use crate::encryption::EncryptionService;
+use crate::error::ApiError;
+
+/// Fixed UUID of the implicit self-hosted user (`00000000-0000-0000-0000-000000000001`).
+pub const LOCAL_USER_ID: Uuid = Uuid::from_u128(1);
+
+/// Sentinel `workos_id` marking the implicit self-hosted user.
+///
+/// A future local-to-cloud linking flow replaces this with a real WorkOS ID.
+pub const LOCAL_WORKOS_ID: &str = "local";
+
+/// Plan label for the implicit self-hosted user.
+pub const LOCAL_USER_PLAN: &str = "self-hosted";
+
+/// Storage settings loaded from environment variables.
+#[derive(Clone)]
+pub struct StorageConfig {
+    /// PostgreSQL connection string (`DATABASE_URL`).
+    pub database_url: String,
+    /// Maximum PostgreSQL pool connections (`DB_MAX_CONNECTIONS`, default 10).
+    pub db_max_connections: u32,
+    /// Pool acquire timeout in seconds (`DB_ACQUIRE_TIMEOUT_SECS`, default 5).
+    pub db_acquire_timeout_secs: u64,
+    /// Whether new resume writes are encrypted (`RUSTUME_ENCRYPT_AT_REST`).
+    pub encrypt_at_rest: bool,
+}
+
+impl std::fmt::Debug for StorageConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageConfig")
+            .field("database_url", &"<redacted>")
+            .field("db_max_connections", &self.db_max_connections)
+            .field("db_acquire_timeout_secs", &self.db_acquire_timeout_secs)
+            .field("encrypt_at_rest", &self.encrypt_at_rest)
+            .finish()
+    }
+}
+
+impl StorageConfig {
+    /// Load storage settings from the environment.
+    ///
+    /// Returns `Ok(None)` when `DATABASE_URL` is not set (stateless fallback).
+    pub fn from_env(cloud: bool) -> anyhow::Result<Option<Self>> {
+        let Some(database_url) = std::env::var("DATABASE_URL")
+            .ok()
+            .map(|url| url.trim().to_string())
+            .filter(|url| !url.is_empty())
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self {
+            database_url,
+            db_max_connections: crate::cloud::optional_env_u32("DB_MAX_CONNECTIONS", 10)?,
+            db_acquire_timeout_secs: crate::cloud::optional_env_u64("DB_ACQUIRE_TIMEOUT_SECS", 5)?,
+            encrypt_at_rest: encrypt_at_rest_enabled(cloud),
+        }))
+    }
+}
+
+/// Resolve the `RUSTUME_ENCRYPT_AT_REST` toggle.
+///
+/// Defaults to `true` for self-hosted deployments and `false` for cloud.
+#[must_use]
+pub fn encrypt_at_rest_enabled(cloud: bool) -> bool {
+    encrypt_at_rest_from_env(cloud, std::env::var("RUSTUME_ENCRYPT_AT_REST").ok())
+}
+
+fn encrypt_at_rest_from_env(cloud: bool, value: Option<String>) -> bool {
+    match value.as_deref().map(str::trim) {
+        Some("true" | "1") => true,
+        Some("false" | "0") => false,
+        _ => !cloud,
+    }
+}
+
+/// Resume data ready to be bound to the `data` / `data_encrypted` columns.
+#[derive(Debug)]
+pub struct EncodedResumeData {
+    /// Plaintext JSONB payload (`data` column), when encryption is off.
+    pub data: Option<serde_json::Value>,
+    /// AES-256-GCM blob (`data_encrypted` column), when encryption is on.
+    pub data_encrypted: Option<Vec<u8>>,
+}
+
+/// Shared storage services: PostgreSQL pool and encryption at rest.
+#[derive(Clone)]
+pub struct StorageState {
+    /// PostgreSQL connection pool.
+    pub db: PgPool,
+    /// Encryption service, present when a key is configured or generated.
+    pub encryption: Option<EncryptionService>,
+    /// Whether new resume writes are encrypted.
+    pub encrypt_at_rest: bool,
+}
+
+impl StorageState {
+    /// Encode resume JSON for persistence, encrypting when enabled.
+    pub fn encode_resume_data(
+        &self,
+        data: serde_json::Value,
+    ) -> Result<EncodedResumeData, ApiError> {
+        if !self.encrypt_at_rest {
+            return Ok(EncodedResumeData {
+                data: Some(data),
+                data_encrypted: None,
+            });
+        }
+
+        let encryption = self.encryption.as_ref().ok_or_else(|| {
+            error!("encrypt-at-rest enabled but no encryption key is configured");
+            ApiError::internal("internal server error")
+        })?;
+        let blob = encryption.encrypt(&data).map_err(|err| {
+            error!("resume encryption failed: {err}");
+            ApiError::internal("internal server error")
+        })?;
+        Ok(EncodedResumeData {
+            data: None,
+            data_encrypted: Some(blob),
+        })
+    }
+
+    /// Decode a stored resume payload, decrypting when necessary.
+    pub fn decode_resume_data(
+        &self,
+        data: Option<serde_json::Value>,
+        data_encrypted: Option<Vec<u8>>,
+    ) -> Result<serde_json::Value, ApiError> {
+        if let Some(data) = data {
+            return Ok(data);
+        }
+
+        let Some(blob) = data_encrypted else {
+            error!("resume row has neither data nor data_encrypted");
+            return Err(ApiError::internal("internal server error"));
+        };
+        let encryption = self.encryption.as_ref().ok_or_else(|| {
+            error!("encrypted resume data present but no encryption key is configured");
+            ApiError::internal("internal server error")
+        })?;
+        encryption.decrypt(&blob).map_err(|err| {
+            error!("resume decryption failed: {err}");
+            ApiError::internal("internal server error")
+        })
+    }
+
+    /// Convert a stored row into the API row, decrypting the payload as needed.
+    pub fn decode_resume_row(&self, row: StoredResumeRow) -> Result<ResumeRow, ApiError> {
+        let StoredResumeRow {
+            id,
+            user_id,
+            title,
+            data,
+            data_encrypted,
+            is_public,
+            public_slug,
+            password_hash,
+            version,
+            created_at,
+            updated_at,
+        } = row;
+        let data = self.decode_resume_data(data, data_encrypted)?;
+        Ok(ResumeRow {
+            id,
+            user_id,
+            title,
+            data,
+            is_public,
+            public_slug,
+            password_hash,
+            version,
+            created_at,
+            updated_at,
+        })
+    }
+
+    /// Fetch the implicit self-hosted user, seeding it if missing.
+    pub async fn local_user(&self) -> Result<User, ApiError> {
+        if let Some(user) = fetch_local_user(&self.db).await? {
+            return Ok(user);
+        }
+
+        seed_local_user(&self.db).await.map_err(|err| {
+            error!("local user seed failed: {err}");
+            ApiError::internal("internal server error")
+        })?;
+        fetch_local_user(&self.db).await?.ok_or_else(|| {
+            error!("local user missing after seed");
+            ApiError::internal("internal server error")
+        })
+    }
+}
+
+async fn fetch_local_user(db: &PgPool) -> Result<Option<User>, ApiError> {
+    sqlx::query_as::<_, User>("SELECT * FROM users WHERE id = $1")
+        .bind(LOCAL_USER_ID)
+        .fetch_optional(db)
+        .await
+        .map_err(|err| {
+            error!("local user lookup failed: {err}");
+            ApiError::internal("internal server error")
+        })
+}
+
+/// Insert the implicit self-hosted user row if it does not exist yet.
+pub async fn seed_local_user(db: &PgPool) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        INSERT INTO users (id, workos_id, plan)
+        VALUES ($1, $2, $3)
+        ON CONFLICT DO NOTHING
+        "#,
+    )
+    .bind(LOCAL_USER_ID)
+    .bind(LOCAL_WORKOS_ID)
+    .bind(LOCAL_USER_PLAN)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Connect to PostgreSQL, run migrations, and wire the encryption service.
+pub async fn init_storage(config: StorageConfig) -> anyhow::Result<Arc<StorageState>> {
+    let db = PgPoolOptions::new()
+        .max_connections(config.db_max_connections)
+        .acquire_timeout(Duration::from_secs(config.db_acquire_timeout_secs))
+        .connect(&config.database_url)
+        .await?;
+
+    sqlx::migrate!("./src/db/migrations").run(&db).await?;
+    info!("PostgreSQL migrations applied");
+
+    let encryption = if config.encrypt_at_rest || EncryptionService::key_configured() {
+        Some(EncryptionService::init()?)
+    } else {
+        None
+    };
+    info!(
+        encrypt_at_rest = config.encrypt_at_rest,
+        "Resume storage initialized"
+    );
+
+    Ok(Arc::new(StorageState {
+        db,
+        encryption,
+        encrypt_at_rest: config.encrypt_at_rest,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encrypt_at_rest_defaults_on_for_self_hosted() {
+        assert!(encrypt_at_rest_from_env(false, None));
+        assert!(!encrypt_at_rest_from_env(true, None));
+    }
+
+    #[test]
+    fn encrypt_at_rest_env_overrides_defaults() {
+        assert!(!encrypt_at_rest_from_env(false, Some("false".to_string())));
+        assert!(!encrypt_at_rest_from_env(false, Some("0".to_string())));
+        assert!(encrypt_at_rest_from_env(true, Some("true".to_string())));
+        assert!(encrypt_at_rest_from_env(true, Some("1".to_string())));
+        assert!(encrypt_at_rest_from_env(false, Some("garbage".to_string())));
+    }
+
+    #[test]
+    fn local_user_id_is_fixed_sentinel() {
+        assert_eq!(
+            LOCAL_USER_ID.to_string(),
+            "00000000-0000-0000-0000-000000000001"
+        );
+    }
+}

--- a/crates/server/src/storage.rs
+++ b/crates/server/src/storage.rs
@@ -289,6 +289,7 @@ pub async fn init_storage(config: StorageConfig) -> anyhow::Result<Arc<StorageSt
     } else {
         None
     };
+    verify_encryption_key(&db, encryption.as_ref()).await?;
     info!(
         encrypt_at_rest = config.encrypt_at_rest,
         "Resume storage initialized"
@@ -299,6 +300,40 @@ pub async fn init_storage(config: StorageConfig) -> anyhow::Result<Arc<StorageSt
         encryption,
         config.encrypt_at_rest,
     )))
+}
+
+/// Guard against silent key loss or mismatch at startup.
+///
+/// If encrypted rows already exist, the configured key must decrypt them —
+/// otherwise a regenerated key file or a wrong `RUSTUME_ENCRYPTION_KEY` would
+/// quietly split the dataset across two keys.
+async fn verify_encryption_key(
+    db: &PgPool,
+    encryption: Option<&EncryptionService>,
+) -> anyhow::Result<()> {
+    let sample = sqlx::query_as::<_, (Uuid, Vec<u8>)>(
+        "SELECT id, data_encrypted FROM resumes WHERE data_encrypted IS NOT NULL LIMIT 1",
+    )
+    .fetch_optional(db)
+    .await?;
+    let Some((id, blob)) = sample else {
+        return Ok(());
+    };
+
+    let Some(encryption) = encryption else {
+        anyhow::bail!(
+            "encrypted resume data exists but no encryption key is configured — restore \
+             RUSTUME_ENCRYPTION_KEY or the key file before starting"
+        );
+    };
+    encryption.decrypt(&blob, id.as_bytes()).map_err(|_| {
+        anyhow::anyhow!(
+            "encrypted resume data exists but the configured encryption key cannot decrypt it \
+             — the key file may have been regenerated or RUSTUME_ENCRYPTION_KEY is wrong; \
+             restore the original key before starting"
+        )
+    })?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/server/src/test_support.rs
+++ b/crates/server/src/test_support.rs
@@ -1,0 +1,68 @@
+//! Shared helpers for database-backed integration tests.
+//!
+//! Tests are skipped unless `TEST_DATABASE_URL` (or `DATABASE_URL`) points at
+//! a database whose name contains `_test`, matching the CI setup script.
+
+use sqlx::postgres::PgPoolOptions;
+use std::sync::Arc;
+
+use crate::encryption::EncryptionService;
+use crate::storage::StorageState;
+
+/// Return the test database URL, or `None` (with a skip notice) when unset.
+pub(crate) fn database_url_for_tests() -> Option<String> {
+    let url = std::env::var("TEST_DATABASE_URL")
+        .ok()
+        .map(|url| url.trim().to_owned())
+        .filter(|url| !url.is_empty())
+        .or_else(|| {
+            std::env::var("DATABASE_URL")
+                .ok()
+                .map(|url| url.trim().to_owned())
+                .filter(|url| !url.is_empty())
+        })?;
+
+    if looks_like_test_database_url(&url) {
+        Some(url)
+    } else {
+        eprintln!(
+            "SKIP DB integration tests: set TEST_DATABASE_URL (or DATABASE_URL) to a database \
+             whose name contains _test"
+        );
+        None
+    }
+}
+
+fn looks_like_test_database_url(url: &str) -> bool {
+    let db_name = url
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(url)
+        .rsplit('/')
+        .next()
+        .unwrap_or("");
+    db_name.contains("_test")
+}
+
+/// Connect a small pool to the test database and apply migrations.
+pub(crate) async fn connect_test_pool(database_url: &str) -> sqlx::PgPool {
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(database_url)
+        .await
+        .expect("connect to test database");
+    sqlx::migrate!("./src/db/migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations for integration tests");
+    pool
+}
+
+/// Build a storage state around an existing pool with a fixed test key.
+pub(crate) fn storage_state(pool: sqlx::PgPool, encrypt_at_rest: bool) -> Arc<StorageState> {
+    Arc::new(StorageState {
+        db: pool,
+        encryption: Some(EncryptionService::from_key(&[42u8; 32])),
+        encrypt_at_rest,
+    })
+}

--- a/crates/server/src/test_support.rs
+++ b/crates/server/src/test_support.rs
@@ -60,9 +60,9 @@ pub(crate) async fn connect_test_pool(database_url: &str) -> sqlx::PgPool {
 
 /// Build a storage state around an existing pool with a fixed test key.
 pub(crate) fn storage_state(pool: sqlx::PgPool, encrypt_at_rest: bool) -> Arc<StorageState> {
-    Arc::new(StorageState {
-        db: pool,
-        encryption: Some(EncryptionService::from_key(&[42u8; 32])),
+    Arc::new(StorageState::new(
+        pool,
+        Some(EncryptionService::from_key(&[42u8; 32])),
         encrypt_at_rest,
-    })
+    ))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-rustume}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-rustume}
       POSTGRES_DB: ${POSTGRES_DB:-rustume}
-    ports:
-      # Loopback-only: never expose default-credential Postgres beyond the host.
-      - "127.0.0.1:5432:5432"
+    # No host port mapping by default: the database runs with default
+    # credentials and is only reachable on the compose network. For direct
+    # psql access, add a compose override that maps 127.0.0.1:5432:5432.
     volumes:
       - rustume_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,16 @@
 #
 # Self-hosted (default):
 #   docker compose up
+#   Postgres always starts; resume data persists in the rustume_pgdata volume,
+#   encrypted at rest with a key auto-generated in the rustume_data volume
+#   (/data/.encryption_key). Back up that file — without it, encrypted resume
+#   data is unrecoverable. `docker compose down -v` DESTROYS both volumes.
 #
 # Rustume Cloud local dev:
-#   cp .env.example .env   # required: POSTGRES_PASSWORD, DATABASE_URL,
-#                          # SESSION_SECRET (32+ chars), WORKOS_CLIENT_ID, WORKOS_API_KEY
+#   cp .env.example .env   # required: SESSION_SECRET (32+ chars),
+#                          # WORKOS_CLIENT_ID, WORKOS_API_KEY
 #                          # optional: RESEND_API_KEY + EMAIL_FROM (transactional email)
-#   docker compose --profile cloud up
+#   RUSTUME_CLOUD=true docker compose up
 ---
 services:
   rustume:
@@ -24,7 +28,8 @@ services:
       PORT: "3000"
       CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
       RUSTUME_CLOUD: ${RUSTUME_CLOUD:-false}
-      DATABASE_URL: ${DATABASE_URL:-}
+      DATABASE_URL: ${DATABASE_URL:-postgres://rustume:rustume@postgres:5432/rustume}
+      RUSTUME_ENCRYPT_AT_REST: ${RUSTUME_ENCRYPT_AT_REST:-true}
       WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID:-}
       WORKOS_API_KEY: ${WORKOS_API_KEY:-}
       WORKOS_REDIRECT_URI: ${WORKOS_REDIRECT_URI:-http://localhost:3000/auth/callback}
@@ -32,10 +37,11 @@ services:
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       EMAIL_FROM: ${EMAIL_FROM:-}
     restart: unless-stopped
+    volumes:
+      - rustume_data:/data
     depends_on:
       postgres:
         condition: service_healthy
-        required: false
     healthcheck:
       test: ["CMD", "/app/rustume-server", "--health"]
       interval: 30s
@@ -44,13 +50,14 @@ services:
       retries: 3
 
   postgres:
-    profiles: [cloud]
     image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
     container_name: rustume-postgres
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+      # Defaults are fine for LAN/Docker-network isolation; change them for
+      # deployments exposed beyond a trusted network.
+      POSTGRES_USER: ${POSTGRES_USER:-rustume}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-rustume}
+      POSTGRES_DB: ${POSTGRES_DB:-rustume}
     ports:
       - "5432:5432"
     volumes:
@@ -63,3 +70,4 @@ services:
 
 volumes:
   rustume_pgdata:
+  rustume_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,11 @@ services:
       PORT: "3000"
       CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
       RUSTUME_CLOUD: ${RUSTUME_CLOUD:-false}
-      DATABASE_URL: ${DATABASE_URL:-postgres://rustume:rustume@postgres:5432/rustume}
+      # Defaults stay aligned with the postgres service credentials below.
+      # yamllint disable-line rule:line-length
+      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-rustume}:${POSTGRES_PASSWORD:-rustume}@postgres:5432/${POSTGRES_DB:-rustume}}
+      # Compose defaults encryption ON. For cloud dev (RUSTUME_CLOUD=true) set
+      # RUSTUME_ENCRYPT_AT_REST=false explicitly to match the cloud default.
       RUSTUME_ENCRYPT_AT_REST: ${RUSTUME_ENCRYPT_AT_REST:-true}
       WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID:-}
       WORKOS_API_KEY: ${WORKOS_API_KEY:-}
@@ -59,7 +63,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-rustume}
       POSTGRES_DB: ${POSTGRES_DB:-rustume}
     ports:
-      - "5432:5432"
+      # Loopback-only: never expose default-credential Postgres beyond the host.
+      - "127.0.0.1:5432:5432"
     volumes:
       - rustume_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TA
     --mount=type=cache,target=/app/target,id=rustume-target-${TARGETARCH} \
     RUST_TARGET="$(cat /tmp/rust_target)" && \
     cargo build --release --target "${RUST_TARGET}" -p rustume-server && \
-    cp "target/${RUST_TARGET}/release/rustume-server" /app/rustume-server
+    cp "target/${RUST_TARGET}/release/rustume-server" /app/rustume-server && \
+    mkdir -p /out/data
 
 # =============================================================================
 # Stage 4: Web builder (WASM bindings + Vite static bundle)
@@ -144,6 +145,10 @@ COPY --from=builder /usr/share/fonts/dejavu /usr/share/fonts/truetype/dejavu
 
 # License texts (AGPL distribution compliance for self-hosted images)
 COPY LICENSE NOTICE THIRD_PARTY_NOTICES /app/legal/
+
+# Writable data directory for the auto-generated encryption key
+# (mounted as the rustume_data volume by docker-compose)
+COPY --from=builder --chown=65532:65532 /out/data /data
 
 # Environment variables
 ENV RUST_LOG=info

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -109,6 +109,10 @@ the image instead of compiling from GitHub source. Staging tracks `:main` (or a 
 | `RUST_LOG` | `info` | Rust tracing filter. Use `debug` for more server logs. |
 | `CORS_ORIGIN` | `*` | Comma-separated allowed origins for API requests. Set explicitly in production (e.g. `https://your-domain.com`). |
 | `RUSTUME_STATIC_DIR` | `/app/web` | Directory containing the built web app. |
+| `DATABASE_URL` | compose: local postgres | PostgreSQL connection string for persistent resume storage. When unset, the server falls back to stateless mode (browser-only storage). |
+| `RUSTUME_ENCRYPT_AT_REST` | `true` (self-hosted) / `false` (cloud) | Encrypt resume payloads with AES-256-GCM before writing to Postgres. |
+| `RUSTUME_ENCRYPTION_KEY` | unset | Hex-encoded 32-byte key (`openssl rand -hex 32`). Takes priority over the key file. |
+| `RUSTUME_ENCRYPTION_KEY_FILE` | `/data/.encryption_key` | Key file location; a random key is auto-generated here on first start if no key is configured. |
 
 The root `docker-compose.yml` sets `CORS_ORIGIN` to `http://localhost:3000`.
 The server binary defaults to `*` when unset.
@@ -129,6 +133,37 @@ rustume.example.com {
 
 ## Persistence
 
-The server is stateless. Resume data is stored in the browser by the web app and
-sent to the API only when parsing, previewing, or exporting. Back up browser data
-by exporting resumes from the UI.
+`docker compose up` runs Postgres alongside the server. Resume data is stored
+server-side in the `rustume_pgdata` volume and encrypted at rest by default,
+so it survives browser wipes, reinstalls, and device switches. On first start
+the server seeds an implicit local user (no login required) and auto-generates
+an encryption key at `/data/.encryption_key` (the `rustume_data` volume).
+
+If `DATABASE_URL` is not set (for example when running the bare binary), the
+server falls back to the legacy stateless mode: resume data stays in the
+browser and is sent to the API only for parsing, previewing, or exporting.
+
+Self-hosted mode trusts the local network: the resume API requires no
+authentication, so anyone who can reach the server can read and write resumes.
+Keep it on a trusted LAN or add access control at a reverse proxy. Change the
+default Postgres credentials if the database port is exposed.
+
+## Backup
+
+Two artifacts are needed for full recovery — the database dump alone is
+encrypted garbage without the key, and the key alone has nothing to decrypt:
+
+```bash
+# 1. Encryption key (once — it never changes)
+docker compose cp rustume:/data/.encryption_key ./rustume-encryption.key.backup
+
+# 2. Postgres data (regularly)
+docker compose exec postgres pg_dump -U rustume rustume > rustume-backup.sql
+```
+
+Restore by placing the key back at `/data/.encryption_key` (or setting
+`RUSTUME_ENCRYPTION_KEY` to its hex contents) and restoring the SQL dump.
+
+`docker compose down` preserves the named volumes (`rustume_pgdata`,
+`rustume_data`). **`docker compose down -v` destroys all resume data and the
+encryption key.**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -154,15 +154,19 @@ Two artifacts are needed for full recovery — the database dump alone is
 encrypted garbage without the key, and the key alone has nothing to decrypt:
 
 ```bash
-# 1. Encryption key (once — it never changes)
+# 1. Encryption key (once — it never changes). If you set
+#    RUSTUME_ENCRYPTION_KEY_FILE, copy that path instead.
 docker compose cp rustume:/data/.encryption_key ./rustume-encryption.key.backup
 
-# 2. Postgres data (regularly)
-docker compose exec postgres pg_dump -U rustume rustume > rustume-backup.sql
+# 2. Postgres data (regularly) — uses the credentials the container runs with
+docker compose exec postgres sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"'   > rustume-backup.sql
 ```
 
-Restore by placing the key back at `/data/.encryption_key` (or setting
-`RUSTUME_ENCRYPTION_KEY` to its hex contents) and restoring the SQL dump.
+To restore, stop the server first (`docker compose stop rustume`), place the
+key back at the configured key file path (or set `RUSTUME_ENCRYPTION_KEY` to
+its hex contents), restore the SQL dump, then start the server again. The
+server refuses to start if encrypted rows exist that the configured key
+cannot decrypt.
 
 `docker compose down` preserves the named volumes (`rustume_pgdata`,
 `rustume_data`). **`docker compose down -v` destroys all resume data and the


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `feat(storage): persistent server-side storage for self-hosted mode`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`docker compose up` now ships a complete, persistent resume builder: Postgres
is always on, resume data lives server-side encrypted at rest, and the web app
uses the server API through an implicit local user — no login, no browser-only
storage loss.

### Server

- **Storage layer** (`crates/server/src/storage.rs`, new): Postgres pool +
  migrations + encryption service, initialized whenever `DATABASE_URL` is set.
  `cloud.rs` now only wires WorkOS/session/email services on top of the shared
  pool (`init_cloud(config, db)`).
- **Implicit local user**: self-hosted startup seeds
  `id 00000000-0000-0000-0000-000000000001, workos_id='local',
  plan='self-hosted'`. The `AuthUser` extractor returns it when `state.cloud`
  is `None`, so resume CRUD works with zero auth.
- **Routes**: resume CRUD/import/export are mounted whenever storage exists
  (self-hosted + cloud); `/auth/login|callback|logout` and `/api/account`
  remain cloud-only. `/auth/me` is always mounted and mode-aware:
  `200 {mode:"local", ...}` self-hosted, existing `200/401` behavior (now with
  `mode:"cloud"`) in cloud mode.
- **Encryption at rest** (`crates/server/src/encryption.rs`, new):
  AES-256-GCM over resume JSON (`nonce || ciphertext`). Key resolution:
  `RUSTUME_ENCRYPTION_KEY` (hex) → key file
  (`RUSTUME_ENCRYPTION_KEY_FILE`, default `/data/.encryption_key`) →
  auto-generate + persist (0600) with a loud backup warning. Toggled by
  `RUSTUME_ENCRYPT_AT_REST` (default: on self-hosted, off cloud).
- **Migration 007**: `data_encrypted BYTEA` on `resumes` and
  `resume_versions`, `data` nullable, XOR check constraints (exactly one of
  `data`/`data_encrypted` set), and `users_plan_check` extended with
  `'self-hosted'`. Reads decrypt whichever column is populated, so toggling
  encryption later is safe.

### Web

- `AuthProbeResult` gains `{ mode: "local"; user }`; auth store gains
  `localMode`. In local mode the server API backs all resume storage
  (`cloudEnabled: true`), `signOut` is a no-op, and auth UI (AuthMenu,
  Account page cloud content) is hidden.

### Infra / docs

- `docker-compose.yml`: postgres always on (cloud profile removed), default
  credentials/`DATABASE_URL`, `RUSTUME_ENCRYPT_AT_REST=true`, new
  `rustume_data` volume mounted at `/data`.
- `docker/Dockerfile`: `/data` directory owned by the nonroot runtime user.
- `docs/deployment.md`: persistence model, backup runbook (key + pg_dump),
  `down -v` destruction warning, network-trust note. `.env.example` updated.

### Deviations from the issue spec (code drift / pragmatics)

- `AppState` holds `storage: Option<Arc<StorageState>>` rather than a bare
  `PgPool` + `EncryptionService`: when `DATABASE_URL` is unset (bare binary,
  router unit tests) the server falls back to the previous stateless mode with
  a warning instead of failing startup. In the compose/runtime path storage is
  always initialized, matching the spec's intent.
- `StorageState.encryption` is `Option`: it is only materialized when
  encryption is enabled or key material exists, so cloud deployments (Railway,
  no `/data`) don't auto-generate keys they never use.
- The migration number is 007 (spec said 003 — 004–006 landed since) and it
  also widens `users_plan_check` (added in 002 after the spec was written) to
  allow `plan='self-hosted'`.
- `CloudImportPrompt` is **kept** (spec suggested hiding it in local mode) with
  mode-aware wording: existing self-hosted users upgrading to this release
  still have browser-stored resumes, and the prompt is the migration path into
  server storage. Hiding it would strand that data invisibly.
- No `docker/Dockerfile.railway` exists anymore, so only `docker/Dockerfile`
  was touched.
- Addendum items intentionally deferred: web first-run key-backup banner,
  `GET /api/admin/encryption-key`, subscription caching for linked instances,
  and API version headers (the addenda scope them to later phases).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`cargo test --workspace`, `bun run test`, `uv run lintro chk`)

## Closes

- Closes #254

## Details

Testing:

- Unit: `EncryptionService` roundtrip, uniqueness, wrong-key/tamper/truncation
  failures, env-key priority, key generation + persistence + 0600 perms;
  encrypt-at-rest defaults; local `/auth/me` response shape.
- DB integration (gated on `TEST_DATABASE_URL`, same pattern as the export
  tests / CI setup script): create encrypts (`data IS NULL`, blob has no
  plaintext), get/update decrypt + re-encrypt, full local-mode CRUD through
  the router without cookies, `/auth/me` reports `mode:"local"`.
- Web: probe parsing for `mode:"local"`, auth store local-mode behavior,
  AuthMenu hidden in local mode (292 tests green).
- Manual e2e against a scratch Postgres: fresh boot auto-generates the key
  (warning logged), `/auth/me` → local, unauthenticated create/get/delete,
  `data_encrypted` populated in the DB, data still decryptable after restart.

Ops notes:

- Migration 007 is additive and safe on existing cloud data (all rows keep
  plaintext `data`; the XOR constraint allows it). No sqlx macros are used, so
  no `.sqlx` offline data changes.
- `docker compose down -v` now destroys resume data **and** the encryption
  key — documented in compose comments and `docs/deployment.md`.

Pre-push AI review: Greptile run included; CodeRabbit was rate-limited
(proceeded per workflow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent self-hosted resume storage backed by PostgreSQL.
  * Added optional encryption at rest for stored resume data, with configurable or automatically generated keys.
  * Added local authentication mode with server-side storage, without requiring sign-in.
  * Resume import, export, and management now work across self-hosted and cloud modes.

* **Documentation**
  * Expanded deployment and configuration guidance, including encryption, backups, storage volumes, and stateless fallback behavior.

* **Bug Fixes**
  * Improved authentication and account UI handling across local, cloud, and stateless modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds persistent server-side resume storage for self-hosted deployments: a Postgres-backed storage layer with AES-256-GCM encryption at rest, an implicit local user for zero-auth CRUD, and web-layer detection of the new `local` mode. Previous issues flagged by review (Postgres port exposure and key-file TOCTOU race) are both addressed.

- **Encryption layer** (`encryption.rs`): correct nonce-per-encrypt, AAD bound to resume UUID, atomic key-file publication, full unit-test coverage.
- **Storage/migration** (`storage.rs`, migrations 007/008): XOR check constraints added `NOT VALID` then validated in a separate migration; startup key verification blocks startup on key mismatch.
- **Web auth store** (`api/auth.ts`, `stores/auth.ts`): three-way probe result with backward-compatible 404 fallback; `signOut` no-ops in local mode.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — no defects on the primary read/write paths; the two findings are low-impact edge cases that do not affect correctness for typical usage.

The encryption, storage, and auth changes are well-structured and thoroughly tested. The two findings are bounded to unusual inputs (very long resume titles causing ZIP extraction failures) and a dead code branch with an undocumented AAD assumption that only matters if encrypted version rows are added in a future PR.

crates/server/src/routes/export.rs (filename length cap) and crates/server/src/storage.rs (verify_encryption_key version-row branch) warrant a quick look before adding version-history encryption in a follow-on PR.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/encryption.rs | New AES-256-GCM encryption service with atomic key-file write, correct nonce-per-encrypt, AAD binding, and comprehensive unit tests. |
| crates/server/src/storage.rs | New storage layer with Postgres pool, migrations, local-user seeding, and a startup key-verification check that includes a dead resume_versions branch with an implicit AAD contract. |
| crates/server/src/routes/resumes.rs | Resume CRUD routes updated to handle encrypted payloads; XOR constraint maintained at all write sites. |
| crates/server/src/routes/export.rs | Export routes decrypt rows before serializing; export_pdf_filename can produce filenames exceeding the 255-byte filesystem limit for maximum-length titles. |
| crates/server/src/middleware/auth.rs | AuthUser extractor falls back to the implicit local user in self-hosted mode — intentional by design. |
| crates/server/src/db/migrations/007_encrypt_at_rest.sql | Adds nullable data_encrypted BYTEA, makes data nullable, adds XOR check constraints as NOT VALID, and extends users_plan_check for self-hosted. Safe on existing cloud data. |
| apps/web/src/stores/auth.ts | Auth store gains localMode state and a third probe-result branch for mode: local. signOut correctly no-ops in local mode. |
| crates/server/src/run.rs | Startup initialises storage before cloud, seeds the local user in self-hosted mode, and fails fast when RUSTUME_CLOUD is set without DATABASE_URL. |
| docker-compose.yml | Postgres service no longer publishes a host port; encryption-at-rest default set to true; new rustume_data volume for key persistence. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Web as Web App
    participant API as Rustume Server
    participant PG as PostgreSQL
    participant Key as Key File / Env

    Web->>API: GET /auth/me
    alt self-hosted (DATABASE_URL set, no cloud)
        API->>PG: fetch local user
        PG-->>API: User
        API-->>Web: 200 mode local
    else stateless no DATABASE_URL
        API-->>Web: 404
    else cloud WorkOS
        API->>PG: session lookup
        PG-->>API: User or null
        API-->>Web: 200 or 401
    end

    Web->>API: POST /api/resumes
    API->>API: AuthUser extractor
    API->>API: subscription load_access
    alt encrypt_at_rest true
        API->>Key: encrypt data with nonce and AAD
        Key-->>API: nonce ciphertext blob
        API->>PG: INSERT data NULL data_encrypted blob
    else encrypt_at_rest false
        API->>PG: INSERT data json data_encrypted NULL
    end
    PG-->>API: StoredResumeRow
    API->>API: decode and decrypt
    API-->>Web: 201 ResumeRow
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Web as Web App
    participant API as Rustume Server
    participant PG as PostgreSQL
    participant Key as Key File / Env

    Web->>API: GET /auth/me
    alt self-hosted (DATABASE_URL set, no cloud)
        API->>PG: fetch local user
        PG-->>API: User
        API-->>Web: 200 mode local
    else stateless no DATABASE_URL
        API-->>Web: 404
    else cloud WorkOS
        API->>PG: session lookup
        PG-->>API: User or null
        API-->>Web: 200 or 401
    end

    Web->>API: POST /api/resumes
    API->>API: AuthUser extractor
    API->>API: subscription load_access
    alt encrypt_at_rest true
        API->>Key: encrypt data with nonce and AAD
        Key-->>API: nonce ciphertext blob
        API->>PG: INSERT data NULL data_encrypted blob
    else encrypt_at_rest false
        API->>PG: INSERT data json data_encrypted NULL
    end
    PG-->>API: StoredResumeRow
    API->>API: decode and decrypt
    API-->>Web: 201 ResumeRow
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(server): address CodeRabbit review t..."](https://github.com/lgtm-hq/rustume/commit/d5696431bffb0b1e2cc6f7aeae95a24165f6a461) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45055173)</sub>

<!-- /greptile_comment -->