### PR TITLE
fix(ci): gate Railway deploy behind RAILWAY_DEPLOY_ENABLED repo variable

### DIFF
--- a/.github/workflows/deploy-railway-cloud.yml
+++ b/.github/workflows/deploy-railway-cloud.yml
@@ -5,6 +5,10 @@ name: Deploy - Rustume Cloud (Railway)
 # After a successful GHCR publish on main, deploy to Railway via GraphQL API.
 # Requires repository secret: RAILWAY_API_TOKEN (or RAILWAY_TOKEN).
 #
+# Ops toggle: set repository variable RAILWAY_DEPLOY_ENABLED=false to skip
+# the deploy job (e.g. while Railway billing is unresolved — see #492).
+# Unset or any other value means enabled.
+#
 # Environment IDs target the current single Railway service (production).
 # If a dedicated staging environment is created later, update the IDs below.
 
@@ -73,6 +77,7 @@ jobs:
     needs: classify
     if: >-
       always() &&
+      vars.RAILWAY_DEPLOY_ENABLED != 'false' &&
       needs.classify.outputs.bump-only != 'true' &&
       ((github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main') ||


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): gate Railway deploy behind RAILWAY_DEPLOY_ENABLED repo variable`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The Railway trial has expired, so every push to `main` ends with a failed **Deploy - Rustume Cloud (Railway)** run (`serviceInstanceDeployV2` → "Your trial has expired"). CI cannot fix billing; until an owner selects a plan, the deterministic deploy failure turns every `main` run red.

This adds an explicit, reversible ops toggle: the `deploy` job is skipped when the repository variable `RAILWAY_DEPLOY_ENABLED` is set to `false`. Unset or any other value keeps deploys enabled, so current behavior is unchanged until the variable is set.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (workflow-condition-only change)
- [x] Docs updated if user-facing (workflow header comment documents the toggle)
- [x] Local CI passed (`uv run lintro chk`)

## Closes

- Closes #492

## Details

- Adds `vars.RAILWAY_DEPLOY_ENABLED != 'false'` to the `deploy` job `if:` condition in `.github/workflows/deploy-railway-cloud.yml`.
- After merge, set repo variable `RAILWAY_DEPLOY_ENABLED=false` to silence deploy failures; delete the variable (or set any other value) once Railway billing is restored.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR gates the Railway deploy job behind a new repository variable `RAILWAY_DEPLOY_ENABLED`, giving operators a reversible way to silence the deterministic deploy failure caused by an expired Railway trial without touching secrets or disabling the workflow file.

- Adds `vars.RAILWAY_DEPLOY_ENABLED != 'false'` as the first real condition inside the `deploy` job's multi-clause `if:`, preserving default enabled behaviour when the variable is absent.
- Adds a matching header comment documenting the toggle, the exact value to use, and the issue reference.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single boolean condition added to an existing multi-clause `if:` expression, with no effect on any other job or step.

The toggle logic is correct: when `RAILWAY_DEPLOY_ENABLED` is unset, `vars.RAILWAY_DEPLOY_ENABLED` resolves to an empty string and deploys continue as before. The case-sensitive string comparison is a minor ops ergonomics consideration, not a functional regression.

No files require special attention; the one changed file is a small, self-contained workflow condition addition.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-railway-cloud.yml | Adds `vars.RAILWAY_DEPLOY_ENABLED != 'false'` guard to the deploy job's `if:` condition and a matching header comment; logic is correct and default behavior (unset variable → deploy runs) is preserved. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Push to main / workflow_dispatch]) --> B[classify job]
    B --> C{deploy job if: condition}
    C -->|"vars.RAILWAY_DEPLOY_ENABLED == 'false'"| D[Deploy skipped]
    C -->|"bump-only == 'true'"| D
    C -->|"wrong event / branch"| D
    C -->|all checks pass| E[Deploy to Railway]
    E --> F[Create GitHub Deployment]
    F --> G[Deploy GHCR image]
    G --> H[Poll deployment status]
    H -->|success| I[Update Deployment success]
    H -->|failure / cancelled| J[Update Deployment failure]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([Push to main / workflow_dispatch]) --> B[classify job]
    B --> C{deploy job if: condition}
    C -->|"vars.RAILWAY_DEPLOY_ENABLED == 'false'"| D[Deploy skipped]
    C -->|"bump-only == 'true'"| D
    C -->|"wrong event / branch"| D
    C -->|all checks pass| E[Deploy to Railway]
    E --> F[Create GitHub Deployment]
    F --> G[Deploy GHCR image]
    G --> H[Poll deployment status]
    H -->|success| I[Update Deployment success]
    H -->|failure / cancelled| J[Update Deployment failure]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/deploy-railway-cloud.yml`, line 45-50 ([link](https://github.com/lgtm-hq/rustume/blob/f1deae54144ba2a3520c94e29d445fc90fd7ece2/.github/workflows/deploy-railway-cloud.yml#L45-L50)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`classify` job still runs when deploy is disabled**

   The `classify` job has its own independent `if:` condition and is not gated by `RAILWAY_DEPLOY_ENABLED`. When the variable is set to `false`, `classify` will still spin up (check out the repo, run the diff classifier script) even though its output is never consumed by the skipped `deploy` job. This is a minor inefficiency, not a bug, but adding the same guard to `classify` would save a runner minute on every push during the billing outage period.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fdeploy-railway-cloud.yml%0ALine%3A%2045-50%0A%0AComment%3A%0A**%60classify%60%20job%20still%20runs%20when%20deploy%20is%20disabled**%0A%0AThe%20%60classify%60%20job%20has%20its%20own%20independent%20%60if%3A%60%20condition%20and%20is%20not%20gated%20by%20%60RAILWAY_DEPLOY_ENABLED%60.%20When%20the%20variable%20is%20set%20to%20%60false%60%2C%20%60classify%60%20will%20still%20spin%20up%20%28check%20out%20the%20repo%2C%20run%20the%20diff%20classifier%20script%29%20even%20though%20its%20output%20is%20never%20consumed%20by%20the%20skipped%20%60deploy%60%20job.%20This%20is%20a%20minor%20inefficiency%2C%20not%20a%20bug%2C%20but%20adding%20the%20same%20guard%20to%20%60classify%60%20would%20save%20a%20runner%20minute%20on%20every%20push%20during%20the%20billing%20outage%20period.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fdeploy-railway-cloud.yml%0ALine%3A%2045-50%0A%0AComment%3A%0A**%60classify%60%20job%20still%20runs%20when%20deploy%20is%20disabled**%0A%0AThe%20%60classify%60%20job%20has%20its%20own%20independent%20%60if%3A%60%20condition%20and%20is%20not%20gated%20by%20%60RAILWAY_DEPLOY_ENABLED%60.%20When%20the%20variable%20is%20set%20to%20%60false%60%2C%20%60classify%60%20will%20still%20spin%20up%20%28check%20out%20the%20repo%2C%20run%20the%20diff%20classifier%20script%29%20even%20though%20its%20output%20is%20never%20consumed%20by%20the%20skipped%20%60deploy%60%20job.%20This%20is%20a%20minor%20inefficiency%2C%20not%20a%20bug%2C%20but%20adding%20the%20same%20guard%20to%20%60classify%60%20would%20save%20a%20runner%20minute%20on%20every%20push%20during%20the%20billing%20outage%20period.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F492-gate-railway-deploy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F492-gate-railway-deploy%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fdeploy-railway-cloud.yml%0ALine%3A%2045-50%0A%0AComment%3A%0A**%60classify%60%20job%20still%20runs%20when%20deploy%20is%20disabled**%0A%0AThe%20%60classify%60%20job%20has%20its%20own%20independent%20%60if%3A%60%20condition%20and%20is%20not%20gated%20by%20%60RAILWAY_DEPLOY_ENABLED%60.%20When%20the%20variable%20is%20set%20to%20%60false%60%2C%20%60classify%60%20will%20still%20spin%20up%20%28check%20out%20the%20repo%2C%20run%20the%20diff%20classifier%20script%29%20even%20though%20its%20output%20is%20never%20consumed%20by%20the%20skipped%20%60deploy%60%20job.%20This%20is%20a%20minor%20inefficiency%2C%20not%20a%20bug%2C%20but%20adding%20the%20same%20guard%20to%20%60classify%60%20would%20save%20a%20runner%20minute%20on%20every%20push%20during%20the%20billing%20outage%20period.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fdeploy-railway-cloud.yml%3A80%0A**Case-sensitive%20toggle%20may%20surprise%20operators**%0A%0AThe%20comparison%20%60vars.RAILWAY_DEPLOY_ENABLED%20!%3D%20'false'%60%20is%20case-sensitive%20in%20GitHub%20Actions%20expression%20evaluation.%20Setting%20the%20variable%20to%20%60False%60%2C%20%60FALSE%60%2C%20or%20%60FALSE%60%20will%20not%20match%20%60'false'%60%2C%20so%20the%20deploy%20job%20will%20still%20run%20despite%20an%20operator's%20intent%20to%20disable%20it.%20The%20header%20comment%20does%20specify%20the%20exact%20value%2C%20but%20a%20case-mismatch%20error%20would%20be%20silent%20and%20hard%20to%20debug%20from%20a%20failed%20deploy%20log.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20toLower%28vars.RAILWAY_DEPLOY_ENABLED%29%20!%3D%20'false'%20%26%26%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fdeploy-railway-cloud.yml%3A45-50%0A**%60classify%60%20job%20still%20runs%20when%20deploy%20is%20disabled**%0A%0AThe%20%60classify%60%20job%20has%20its%20own%20independent%20%60if%3A%60%20condition%20and%20is%20not%20gated%20by%20%60RAILWAY_DEPLOY_ENABLED%60.%20When%20the%20variable%20is%20set%20to%20%60false%60%2C%20%60classify%60%20will%20still%20spin%20up%20%28check%20out%20the%20repo%2C%20run%20the%20diff%20classifier%20script%29%20even%20though%20its%20output%20is%20never%20consumed%20by%20the%20skipped%20%60deploy%60%20job.%20This%20is%20a%20minor%20inefficiency%2C%20not%20a%20bug%2C%20but%20adding%20the%20same%20guard%20to%20%60classify%60%20would%20save%20a%20runner%20minute%20on%20every%20push%20during%20the%20billing%20outage%20period.%0A%0A&pr=493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fdeploy-railway-cloud.yml%3A80%0A**Case-sensitive%20toggle%20may%20surprise%20operators**%0A%0AThe%20comparison%20%60vars.RAILWAY_DEPLOY_ENABLED%20!%3D%20'false'%60%20is%20case-sensitive%20in%20GitHub%20Actions%20expression%20evaluation.%20Setting%20the%20variable%20to%20%60False%60%2C%20%60FALSE%60%2C%20or%20%60FALSE%60%20will%20not%20match%20%60'false'%60%2C%20so%20the%20deploy%20job%20will%20still%20run%20despite%20an%20operator's%20intent%20to%20disable%20it.%20The%20header%20comment%20does%20specify%20the%20exact%20value%2C%20but%20a%20case-mismatch%20error%20would%20be%20silent%20and%20hard%20to%20debug%20from%20a%20failed%20deploy%20log.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20toLower%28vars.RAILWAY_DEPLOY_ENABLED%29%20!%3D%20'false'%20%26%26%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fdeploy-railway-cloud.yml%3A45-50%0A**%60classify%60%20job%20still%20runs%20when%20deploy%20is%20disabled**%0A%0AThe%20%60classify%60%20job%20has%20its%20own%20independent%20%60if%3A%60%20condition%20and%20is%20not%20gated%20by%20%60RAILWAY_DEPLOY_ENABLED%60.%20When%20the%20variable%20is%20set%20to%20%60false%60%2C%20%60classify%60%20will%20still%20spin%20up%20%28check%20out%20the%20repo%2C%20run%20the%20diff%20classifier%20script%29%20even%20though%20its%20output%20is%20never%20consumed%20by%20the%20skipped%20%60deploy%60%20job.%20This%20is%20a%20minor%20inefficiency%2C%20not%20a%20bug%2C%20but%20adding%20the%20same%20guard%20to%20%60classify%60%20would%20save%20a%20runner%20minute%20on%20every%20push%20during%20the%20billing%20outage%20period.%0A%0A&repo=lgtm-hq%2Frustume&pr=493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F492-gate-railway-deploy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F492-gate-railway-deploy%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fdeploy-railway-cloud.yml%3A80%0A**Case-sensitive%20toggle%20may%20surprise%20operators**%0A%0AThe%20comparison%20%60vars.RAILWAY_DEPLOY_ENABLED%20!%3D%20'false'%60%20is%20case-sensitive%20in%20GitHub%20Actions%20expression%20evaluation.%20Setting%20the%20variable%20to%20%60False%60%2C%20%60FALSE%60%2C%20or%20%60FALSE%60%20will%20not%20match%20%60'false'%60%2C%20so%20the%20deploy%20job%20will%20still%20run%20despite%20an%20operator's%20intent%20to%20disable%20it.%20The%20header%20comment%20does%20specify%20the%20exact%20value%2C%20but%20a%20case-mismatch%20error%20would%20be%20silent%20and%20hard%20to%20debug%20from%20a%20failed%20deploy%20log.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20toLower%28vars.RAILWAY_DEPLOY_ENABLED%29%20!%3D%20'false'%20%26%26%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fdeploy-railway-cloud.yml%3A45-50%0A**%60classify%60%20job%20still%20runs%20when%20deploy%20is%20disabled**%0A%0AThe%20%60classify%60%20job%20has%20its%20own%20independent%20%60if%3A%60%20condition%20and%20is%20not%20gated%20by%20%60RAILWAY_DEPLOY_ENABLED%60.%20When%20the%20variable%20is%20set%20to%20%60false%60%2C%20%60classify%60%20will%20still%20spin%20up%20%28check%20out%20the%20repo%2C%20run%20the%20diff%20classifier%20script%29%20even%20though%20its%20output%20is%20never%20consumed%20by%20the%20skipped%20%60deploy%60%20job.%20This%20is%20a%20minor%20inefficiency%2C%20not%20a%20bug%2C%20but%20adding%20the%20same%20guard%20to%20%60classify%60%20would%20save%20a%20runner%20minute%20on%20every%20push%20during%20the%20billing%20outage%20period.%0A%0A&repo=lgtm-hq%2Frustume&pr=493&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): gate Railway deploy behind RAIL..."](https://github.com/lgtm-hq/rustume/commit/f1deae54144ba2a3520c94e29d445fc90fd7ece2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45294044)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->