### PR TITLE
fix(ci): gate Railway deploy behind RAILWAY_DEPLOY_ENABLED

### DIFF
--- a/.github/workflows/deploy-railway-cloud.yml
+++ b/.github/workflows/deploy-railway-cloud.yml
@@ -5,6 +5,10 @@ name: Deploy - Rustume Cloud (Railway)
 # After a successful GHCR publish on main, deploy to Railway via GraphQL API.
 # Requires repository secret: RAILWAY_API_TOKEN (or RAILWAY_TOKEN).
 #
+# Ops toggle: set repository variable RAILWAY_DEPLOY_ENABLED=false to skip
+# the deploy job (e.g. while Railway billing is unresolved — see #492).
+# Unset or any other value means enabled.
+#
 # Environment IDs target the current single Railway service (production).
 # If a dedicated staging environment is created later, update the IDs below.
 
@@ -73,6 +77,7 @@ jobs:
     needs: classify
     if: >-
       always() &&
+      vars.RAILWAY_DEPLOY_ENABLED != 'false' &&
       needs.classify.outputs.bump-only != 'true' &&
       ((github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main') ||


### PR DESCRIPTION
## Summary
- Gate the Railway `deploy` job on `vars.RAILWAY_DEPLOY_ENABLED != 'false'`
- Default remains enabled (unset / any other value still deploys)
- Lets owners disable the job while an expired Railway trial (or similar ops outage) would otherwise fail every `main` run

Closes #492

## Test plan
- [ ] Confirm workflow YAML validates in GitHub Actions
- [ ] With variable unset: deploy job still eligible (same as today)
- [ ] With `RAILWAY_DEPLOY_ENABLED=false`: deploy job is skipped (not failed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a runtime switch to enable or disable Railway deployments.
  * Deployments are skipped when the repository setting is explicitly set to `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-out ops toggle for the Railway deploy job by gating it on the repository variable `RAILWAY_DEPLOY_ENABLED != 'false'`, allowing owners to skip deployments during Railway outages or billing issues without editing the workflow. The change is minimal and correctly placed after `always()` so it applies for both `workflow_run` and `workflow_dispatch` triggers.

- Adds `vars.RAILWAY_DEPLOY_ENABLED != 'false'` as the second condition in the `deploy` job's `if` expression, preserving existing default-enabled behavior when the variable is unset.
- Documents the toggle in the file header comment with clear instructions linking to issue #492.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the one-line change has no risk of breaking existing deploys and the fallback (variable unset) is identical to today's behavior.

The toggle comparison != 'false' is case-sensitive, so operators who set the variable to False or FALSE would find the deploy still running against their intent. This is unlikely given the documentation, but worth noting. All other logic — placement after always(), interaction with the bump-only gate, and workflow_dispatch path — is correct.

.github/workflows/deploy-railway-cloud.yml — the only changed file; deserves a quick look at the case-sensitivity behavior of the new variable gate.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-railway-cloud.yml | Adds RAILWAY_DEPLOY_ENABLED variable gate to the deploy job's if condition; one-line addition is logically correct but the comparison is case-sensitive to 'false', so non-lowercase values like 'False' or 'FALSE' would not trigger the skip. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Trigger: workflow_run or workflow_dispatch]) --> B{event_name == workflow_run?}
    B -- Yes --> C[classify job\nChecks commit message]
    B -- No --> D{RAILWAY_DEPLOY_ENABLED != 'false'?}
    C -- bump-only=true --> E[classify skipped / bump-only]
    C -- bump-only=false --> D
    D -- false\nvar = 'false' --> F([Deploy job SKIPPED])
    D -- true\nvar unset or other --> G{Other conditions:\nworkflow_run.conclusion == success\nor workflow_dispatch on main}
    G -- Fail --> F
    G -- Pass --> H([deploy job RUNS])
    H --> I[Create GitHub Deployment]
    H --> J[Deploy GHCR image to Railway]
    H --> K[Poll deployment status]
    K -- success --> L[Update Deployment: success]
    K -- failure/cancelled --> M[Update Deployment: failure]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([Trigger: workflow_run or workflow_dispatch]) --> B{event_name == workflow_run?}
    B -- Yes --> C[classify job\nChecks commit message]
    B -- No --> D{RAILWAY_DEPLOY_ENABLED != 'false'?}
    C -- bump-only=true --> E[classify skipped / bump-only]
    C -- bump-only=false --> D
    D -- false\nvar = 'false' --> F([Deploy job SKIPPED])
    D -- true\nvar unset or other --> G{Other conditions:\nworkflow_run.conclusion == success\nor workflow_dispatch on main}
    G -- Fail --> F
    G -- Pass --> H([deploy job RUNS])
    H --> I[Create GitHub Deployment]
    H --> J[Deploy GHCR image to Railway]
    H --> K[Poll deployment status]
    K -- success --> L[Update Deployment: success]
    K -- failure/cancelled --> M[Update Deployment: failure]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdeploy-railway-cloud.yml%3A80%0AThe%20%60vars.RAILWAY_DEPLOY_ENABLED%20!%3D%20'false'%60%20comparison%20is%20case-sensitive.%20If%20an%20operator%20sets%20the%20variable%20to%20%60False%60%20or%20%60FALSE%60%2C%20the%20condition%20evaluates%20to%20%60true%60%20and%20the%20deploy%20job%20still%20runs%2C%20contradicting%20the%20intent.%20GitHub%20Actions%20%60vars%60%20context%20always%20returns%20strings%2C%20so%20a%20case-folded%20comparison%20would%20make%20the%20gate%20more%20robust%20against%20operator%20typos.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%28vars.RAILWAY_DEPLOY_ENABLED%20%3D%3D%20''%20%7C%7C%20vars.RAILWAY_DEPLOY_ENABLED%20!%3D%20'false'%29%20%26%26%0A%60%60%60%0A%0A&pr=494&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdeploy-railway-cloud.yml%3A80%0AThe%20%60vars.RAILWAY_DEPLOY_ENABLED%20!%3D%20'false'%60%20comparison%20is%20case-sensitive.%20If%20an%20operator%20sets%20the%20variable%20to%20%60False%60%20or%20%60FALSE%60%2C%20the%20condition%20evaluates%20to%20%60true%60%20and%20the%20deploy%20job%20still%20runs%2C%20contradicting%20the%20intent.%20GitHub%20Actions%20%60vars%60%20context%20always%20returns%20strings%2C%20so%20a%20case-folded%20comparison%20would%20make%20the%20gate%20more%20robust%20against%20operator%20typos.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%28vars.RAILWAY_DEPLOY_ENABLED%20%3D%3D%20''%20%7C%7C%20vars.RAILWAY_DEPLOY_ENABLED%20!%3D%20'false'%29%20%26%26%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=494&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F492-gate-railway-deploy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F492-gate-railway-deploy%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdeploy-railway-cloud.yml%3A80%0AThe%20%60vars.RAILWAY_DEPLOY_ENABLED%20!%3D%20'false'%60%20comparison%20is%20case-sensitive.%20If%20an%20operator%20sets%20the%20variable%20to%20%60False%60%20or%20%60FALSE%60%2C%20the%20condition%20evaluates%20to%20%60true%60%20and%20the%20deploy%20job%20still%20runs%2C%20contradicting%20the%20intent.%20GitHub%20Actions%20%60vars%60%20context%20always%20returns%20strings%2C%20so%20a%20case-folded%20comparison%20would%20make%20the%20gate%20more%20robust%20against%20operator%20typos.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%28vars.RAILWAY_DEPLOY_ENABLED%20%3D%3D%20''%20%7C%7C%20vars.RAILWAY_DEPLOY_ENABLED%20!%3D%20'false'%29%20%26%26%0A%60%60%60%0A%0A&repo=lgtm-hq%2Frustume&pr=494&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): gate Railway deploy behind RAIL..."](https://github.com/lgtm-hq/rustume/commit/f1deae54144ba2a3520c94e29d445fc90fd7ece2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45294933)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->