### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Rustume is a Rust + SolidJS monorepo (privacy-first, offline-first resume builder).
+Standard commands live in the `Makefile`, `README.md`, and `CONTRIBUTING.md`; prefer
+those. Notes below capture only non-obvious environment caveats for cloud agents.
+
+### Toolchain / dependencies
+
+- Requires **Rust >= 1.85** (a transitive dependency needs the `edition2024`
+  Cargo feature). The default stable toolchain in this environment is already
+  updated (1.97). If Rust is somehow older, run `rustup update stable && rustup
+  default stable`, then `rustup target add wasm32-unknown-unknown`.
+- Polyglot tooling installed outside the update script (persisted in the VM
+  snapshot; PATH is wired via `~/.bashrc`): `bun` (`~/.bun/bin`), `uv`
+  (`~/.local/bin`), and `wasm-pack` + `rustup` targets. If any is missing on a
+  fresh machine, reinstall per `CONTRIBUTING.md` (bun.sh, astral.sh/uv,
+  rustwasm wasm-pack installer). The update script only refreshes deps
+  (`rustup target add`, `cargo fetch`, `bun install` in `apps/web`).
+
+### Building / running
+
+- The web app depends on a generated WASM package at `apps/web/wasm` (not
+  committed; it IS captured in the VM snapshot). It is built by `make setup` /
+  `make wasm`, NOT by `make dev`. If `apps/web/wasm` is missing (e.g. after
+  `make clean`) or you changed `bindings/wasm` or any core crate, rebuild it with
+  `make wasm` before starting the web dev server, or `bun run dev` will fail to
+  resolve the wasm import.
+- `make dev` runs the API server (http://localhost:3000) and the Vite web dev
+  server (http://localhost:5173) together; the Vite server proxies `/api` and
+  `/auth` to `:3000`. Open the web app at :5173. Health check:
+  `curl -sf http://localhost:3000/health`.
+- Default run is "self-hosted stateless mode" — no database or auth needed.
+  Resume editing, import, live preview, and PDF export all work with only
+  `make dev`. Cloud mode (`RUSTUME_CLOUD=true`) additionally needs Postgres +
+  external WorkOS/Resend credentials (see `.env.example`); those external
+  services are not available by default and are not required to test the core
+  product.
+- PDF/PNG rendering is server-side only (Typst). The API render endpoint is
+  `POST /api/render/pdf` and expects a body shaped like
+  `{"resume": <resume-json>, "template": "onyx"}` (not a bare resume object).
+- The CLI binary is named `rustume` (crate `rustume-cli`), e.g.
+  `cargo run -p rustume-cli -- render resume.json -o out.pdf`. It is fully local
+  and needs no running services.
+
+### Lint / test
+
+- Rust: `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`.
+- Web (`apps/web`): `bun run test` (vitest), `bun run lint` (oxlint),
+  `bun run typecheck` (tsc). `make test` / `make lint` run both stacks.
+- Cross-language lint/format: `uv run lintro chk` / `uv run lintro fmt`.
+- Server DB integration tests need Postgres via `TEST_DATABASE_URL`
+  (`scripts/ci/testing/rust/setup-postgres-test-db.sh`); optional otherwise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,14 @@ those. Notes below capture only non-obvious environment caveats for cloud agents
 
 - Requires **Rust >= 1.85** (a transitive dependency needs the `edition2024`
   Cargo feature). The default stable toolchain in this environment is already
-  updated (1.97). If Rust is somehow older, run `rustup update stable && rustup
-  default stable`, then `rustup target add wasm32-unknown-unknown`.
+  updated (check with `rustc --version`). If Rust is somehow older, run
+  `rustup update stable && rustup default stable`, then
+  `rustup target add wasm32-unknown-unknown`.
 - Polyglot tooling installed outside the update script (persisted in the VM
   snapshot; PATH is wired via `~/.bashrc`): `bun` (`~/.bun/bin`), `uv`
   (`~/.local/bin`), and `wasm-pack` + `rustup` targets. If any is missing on a
   fresh machine, reinstall per `CONTRIBUTING.md` (bun.sh, astral.sh/uv,
-  rustwasm wasm-pack installer). The update script only refreshes deps
+  `cargo install wasm-pack`). The update script only refreshes deps
   (`rustup target add`, `cargo fetch`, `bun install` in `apps/web`).
 
 ### Building / running
@@ -27,8 +28,8 @@ those. Notes below capture only non-obvious environment caveats for cloud agents
   `make clean`) or you changed `bindings/wasm` or any core crate, rebuild it with
   `make wasm` before starting the web dev server, or `bun run dev` will fail to
   resolve the wasm import.
-- `make dev` runs the API server (http://localhost:3000) and the Vite web dev
-  server (http://localhost:5173) together; the Vite server proxies `/api` and
+- `make dev` runs the API server (`http://localhost:3000`) and the Vite web dev
+  server (`http://localhost:5173`) together; the Vite server proxies `/api` and
   `/auth` to `:3000`. Open the web app at :5173. Health check:
   `curl -sf http://localhost:3000/health`.
 - Default run is "self-hosted stateless mode" — no database or auth needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Rustume development environment for Cursor Cloud agents and documents durable, non-obvious setup caveats in a new `AGENTS.md`.

This repo is a Rust + SolidJS monorepo (offline-first resume builder) with a Rust API server, a SolidJS web app, a `rustume` CLI, and WASM bindings.

## Environment setup performed

- Updated the Rust toolchain to stable **1.97** (default 1.83 was too old — a transitive dep requires the `edition2024` Cargo feature, needing Rust >= 1.85) and added the `wasm32-unknown-unknown` target.
- Installed `bun`, `uv`, and `wasm-pack`.
- Ran `make setup` (cargo fetch + `bun install` for `apps/web` + WASM build).

### Update script (registered separately)
```
rustup target add wasm32-unknown-unknown
cargo fetch
cd apps/web
bun install
```
Kept minimal/idempotent — the polyglot tools + toolchain + generated WASM persist via the VM snapshot; `AGENTS.md` documents how to recover them if missing.

## Verification

| Surface | Command | Result |
|---|---|---|
| Rust build | `cargo build --bin rustume-server` | pass |
| Rust tests | `cargo test --workspace` | pass |
| Rust lint | `cargo clippy --workspace` | pass |
| Web tests | `bun run test` (apps/web) | 304 passed / 35 files |
| Web lint | `bun run lint` (oxlint) | pass |
| Web typecheck | `bun run typecheck` (tsc) | pass |
| CLI | `rustume init` + `render` | valid PDF generated |
| API | `POST /api/render/pdf` | 200, valid PDF |
| Web app | `make dev` → create resume + export PDF | works end-to-end |

Hello-world task: created a resume for "Ada Lovelace / First Programmer" in the web UI with live preview and exported a PDF successfully.

## Changes
- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section (toolchain requirement, WASM build caveat, self-hosted default run, render endpoint payload shape, CLI/lint/test pointers). No application code changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d9f186d-93a6-45f5-a6db-de48ec1ebb0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d9f186d-93a6-45f5-a6db-de48ec1ebb0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `AGENTS.md` to document non-obvious Cursor Cloud environment setup caveats for this Rust + SolidJS monorepo, with no changes to application code.

- Cross-referencing against `CONTRIBUTING.md` and the `Makefile` confirms that every command, port, tool installation path, and WASM build caveat in the document is accurate and internally consistent.
- Both previously raised review concerns — the `wasm-pack` installation method and the pinned Rust version string — are resolved in this revision (`cargo install wasm-pack` and `rustc --version` respectively).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only addition with no application code changes.

The change is a single new documentation file. Every claim in the file — ports, commands, installation paths, WASM build caveats, and test/lint invocations — was verified against CONTRIBUTING.md and the Makefile and found to be accurate. Both concerns from the previous review round were addressed before this revision arrived.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | New documentation file capturing non-obvious Cursor Cloud dev environment caveats; content cross-checks accurately against CONTRIBUTING.md and the Makefile (ports, commands, installation methods, WASM build caveat, test/lint invocations all match). Previously flagged issues (wasm-pack install path and pinned Rust version) are both resolved in this revision. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Fresh Cursor Cloud VM] --> B{Toolchain OK?\nrustc --version >= 1.85}
    B -- No --> C[rustup update stable\nrustup default stable\nrustup target add wasm32-unknown-unknown]
    B -- Yes --> D{polyglot tools present?\nbun / uv / wasm-pack}
    C --> D
    D -- Missing --> E[Reinstall per CONTRIBUTING.md\nbun.sh / astral.sh/uv\ncargo install wasm-pack]
    D -- OK --> F[make setup\ncheck-deps + cargo fetch\nbun install + make wasm]
    E --> F
    F --> G{apps/web/wasm present?}
    G -- No --> H[make wasm]
    G -- Yes --> I[make dev]
    H --> I
    I --> J[API: localhost:3000\nWeb: localhost:5173]
    J --> K[make test / make lint\nuv run lintro chk]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Fresh Cursor Cloud VM] --> B{Toolchain OK?\nrustc --version >= 1.85}
    B -- No --> C[rustup update stable\nrustup default stable\nrustup target add wasm32-unknown-unknown]
    B -- Yes --> D{polyglot tools present?\nbun / uv / wasm-pack}
    C --> D
    D -- Missing --> E[Reinstall per CONTRIBUTING.md\nbun.sh / astral.sh/uv\ncargo install wasm-pack]
    D -- OK --> F[make setup\ncheck-deps + cargo fetch\nbun install + make wasm]
    E --> F
    F --> G{apps/web/wasm present?}
    G -- No --> H[make wasm]
    G -- Yes --> I[make dev]
    H --> I
    I --> J[API: localhost:3000\nWeb: localhost:5173]
    J --> K[make test / make lint\nuv run lintro chk]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/setup-de..."](https://github.com/lgtm-hq/rustume/commit/94a396f9001ac5f4bfa661b825e0264550730ded) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45709692)</sub>

<!-- /greptile_comment -->