### PR TITLE
ci: align checkout pin comment with pinned v7.0.0 SHA

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
         # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `ci: align checkout pin comment with pinned v7.0.0 SHA`

- Type:
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The floating `v7` tag of `actions/checkout` moved to a new commit upstream, so the action-pinning validator now rejects the `# v7` comment on the SHA pinned in `build-binary.yml` (`9c091bb…` no longer resolves to `v7`). This currently fails the `validate / Validate Action Pinning` check on every PR.

Comment-only change: `# v7` → `# v7.0.0`, which is exactly what `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` is tagged as, consistent with the three other workflows pinning the same commit. No behavior change to what runs in CI.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (not applicable — CI pin comment only)
- [ ] Docs updated if user-facing (not applicable)
- [x] Local CI passed (`uv run lintro chk` — zero errors; remaining warnings are untracked local scratch files)

## Related Issues

None — unblocks PR #517 and any other open PRs failing the pinning check.

## Details

Verified via `git ls-remote https://github.com/actions/checkout 'refs/tags/v7.0.0'` → `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` (matches the pin), while `refs/tags/v7` now points at `3d3c42e5aac5ba805825da76410c181273ba90b1`. Renovate can bump the actual SHA in its normal cycle; this PR only restores validator consistency.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates a stale version comment on a pinned `actions/checkout` SHA in `.github/workflows/build-binary.yml` from `# v7` to `# v7.0.0`. This is a comment-only change with no runtime impact.

- The pinned SHA `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` corresponds to the `v7.0.0` tag; the floating `v7` tag has since moved to a different commit, causing the action-pinning validator to reject the old comment on every PR.
- The corrected comment now matches the three other workflow files in this repo that pin the same SHA, restoring consistency across the CI configuration.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is a comment correction with no effect on which code runs in CI.

The diff touches a single comment in one workflow file. The pinned SHA is unchanged, so the actual action fetched by GitHub Actions is identical before and after. The updated comment now correctly names the exact tag (`v7.0.0`) that the SHA resolves to, matching the convention already used in the three other workflows that pin the same commit.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-binary.yml | Comment-only change: `# v7` → `# v7.0.0` on the pinned `actions/checkout` SHA, aligning the annotation with the exact tag the SHA resolves to. No behavior change. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PR as Pull Request
    participant Validator as Pinning Validator
    participant Workflow as build-binary.yml
    participant GitHub as actions/checkout (GitHub)

    PR->>Validator: trigger validate/Validate Action Pinning
    Validator->>Workflow: read SHA + comment
    Note over Workflow: SHA: 9c091bb…
    Workflow-->>Validator: "comment was "# v7""
    Validator->>GitHub: resolve refs/tags/v7
    GitHub-->>Validator: 3d3c42e… (≠ 9c091bb…)
    Validator--xPR: ❌ mismatch — check fails

    Note over Workflow: After this PR: comment is "# v7.0.0"

    PR->>Validator: trigger validate/Validate Action Pinning
    Validator->>Workflow: read SHA + comment
    Workflow-->>Validator: "comment is "# v7.0.0""
    Validator->>GitHub: resolve refs/tags/v7.0.0
    GitHub-->>Validator: "9c091bb… (= 9c091bb…)"
    Validator-->>PR: ✅ match — check passes
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PR as Pull Request
    participant Validator as Pinning Validator
    participant Workflow as build-binary.yml
    participant GitHub as actions/checkout (GitHub)

    PR->>Validator: trigger validate/Validate Action Pinning
    Validator->>Workflow: read SHA + comment
    Note over Workflow: SHA: 9c091bb…
    Workflow-->>Validator: "comment was "# v7""
    Validator->>GitHub: resolve refs/tags/v7
    GitHub-->>Validator: 3d3c42e… (≠ 9c091bb…)
    Validator--xPR: ❌ mismatch — check fails

    Note over Workflow: After this PR: comment is "# v7.0.0"

    PR->>Validator: trigger validate/Validate Action Pinning
    Validator->>Workflow: read SHA + comment
    Workflow-->>Validator: "comment is "# v7.0.0""
    Validator->>GitHub: resolve refs/tags/v7.0.0
    GitHub-->>Validator: "9c091bb… (= 9c091bb…)"
    Validator-->>PR: ✅ match — check passes
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: align checkout pin comment with pinn..."](https://github.com/lgtm-hq/rustume/commit/ca43feb80b91790f59c82a7b23bf086ceb1776c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45709653)</sub>

<!-- /greptile_comment -->