### PR TITLE
feat(web): pan preview when zoomed

### DIFF
--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, Show } from "solid-js";
+import { createSignal, createEffect, onCleanup, untrack, Show } from "solid-js";
 import { toast } from "../ui";
 import { resumeStore } from "../../stores/resume";
 import { uiStore } from "../../stores/ui";
@@ -6,6 +6,7 @@ import { renderPreview } from "../../api/render";
 import { useDebounce } from "../../hooks/useDebounce";
 import { useOnline } from "../../hooks/useOnline";
 import {
+  KEYBOARD_PAN_STEP,
   clampPan,
   isWheelZoomGesture,
   shouldResetPan,
@@ -31,6 +32,7 @@ export function Preview() {
   let dragStartY = 0;
   let panStartX = 0;
   let panStartY = 0;
+  let activePointerId: number | null = null;
 
   const applyPanClamp = (x: number, y: number, zoom = ui.previewZoom) => {
     const viewport = viewportRef;
@@ -43,18 +45,27 @@ export function Preview() {
     setPanY(0);
   };
 
-  createEffect(() => {
-    const zoom = ui.previewZoom;
+  const reclampPan = (zoom = ui.previewZoom) => {
     if (shouldResetPan(zoom)) {
       resetPan();
       return;
     }
-    const clamped = applyPanClamp(panX(), panY(), zoom);
-    if (clamped.x !== panX() || clamped.y !== panY()) {
+    const clamped = applyPanClamp(untrack(panX), untrack(panY), zoom);
+    if (clamped.x !== untrack(panX) || clamped.y !== untrack(panY)) {
       setPanX(clamped.x);
       setPanY(clamped.y);
     }
+  };
+
+  // Re-clamp only when zoom changes; pan updates are already clamped at write.
+  createEffect(() => reclampPan(ui.previewZoom));
+
+  // Viewport resizes can leave a previously valid pan out of bounds.
+  const resizeObserver = new ResizeObserver(() => reclampPan());
+  createEffect(() => {
+    if (viewportRef) resizeObserver.observe(viewportRef);
   });
+  onCleanup(() => resizeObserver.disconnect());
 
   // Request ID to guard against race conditions
   let resumeRequestId = 0;
@@ -103,9 +114,10 @@ export function Preview() {
   };
 
   const handlePointerDown = (event: PointerEvent) => {
-    if (ui.previewZoom <= 1 || event.button !== 0) return;
+    if (ui.previewZoom <= 1 || event.button !== 0 || activePointerId !== null) return;
 
     setIsDragging(true);
+    activePointerId = event.pointerId;
     dragStartX = event.clientX;
     dragStartY = event.clientY;
     panStartX = panX();
@@ -115,7 +127,7 @@ export function Preview() {
   };
 
   const handlePointerMove = (event: PointerEvent) => {
-    if (!isDragging()) return;
+    if (!isDragging() || event.pointerId !== activePointerId) return;
 
     const deltaX = event.clientX - dragStartX;
     const deltaY = event.clientY - dragStartY;
@@ -125,10 +137,14 @@ export function Preview() {
   };
 
   const endDrag = (event: PointerEvent) => {
-    if (!isDragging()) return;
+    if (!isDragging() || event.pointerId !== activePointerId) return;
 
     setIsDragging(false);
-    (event.currentTarget as HTMLDivElement).releasePointerCapture(event.pointerId);
+    activePointerId = null;
+    const el = event.currentTarget as HTMLDivElement;
+    if (el.hasPointerCapture(event.pointerId)) {
+      el.releasePointerCapture(event.pointerId);
+    }
   };
 
   const handleDoubleClick = () => {
@@ -137,6 +153,23 @@ export function Preview() {
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
+    // When zoomed in, arrow keys pan (keyboard equivalent of drag);
+    // at fit zoom, up/down keep navigating pages.
+    if (ui.previewZoom > 1) {
+      const pan: Record<string, [number, number]> = {
+        ArrowUp: [0, KEYBOARD_PAN_STEP],
+        ArrowDown: [0, -KEYBOARD_PAN_STEP],
+        ArrowLeft: [KEYBOARD_PAN_STEP, 0],
+        ArrowRight: [-KEYBOARD_PAN_STEP, 0],
+      };
+      const delta = pan[event.key];
+      if (!delta) return;
+      const clamped = applyPanClamp(panX() + delta[0], panY() + delta[1]);
+      setPanX(clamped.x);
+      setPanY(clamped.y);
+      event.preventDefault();
+      return;
+    }
     if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
     if (!goToPageWithCooldown(ui.previewPage + (event.key === "ArrowDown" ? 1 : -1))) return;
     event.preventDefault();
@@ -368,7 +401,11 @@ export function Preview() {
         }}
         style={{ "touch-action": ui.previewZoom > 1 ? "none" : "auto" }}
         tabIndex={0}
-        title={ui.previewZoom > 1 ? "Drag to pan · Ctrl+scroll to zoom · Double-click to reset" : undefined}
+        title={
+          ui.previewZoom > 1
+            ? "Drag or arrow keys to pan · Ctrl/Cmd+scroll to zoom · Double-click to reset"
+            : undefined
+        }
         onWheel={handleWheel}
         onKeyDown={handleKeyDown}
         onPointerDown={handlePointerDown}

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -353,7 +353,9 @@ export function Preview() {
 
       {/* Preview Area */}
       <div
-        ref={viewportRef}
+        ref={(el) => {
+          viewportRef = el;
+        }}
         class="flex-1 p-6 flex items-start justify-center
           focus:outline-none focus-visible:ring-2 focus-visible:ring-accent
           focus-visible:ring-offset-2 focus-visible:ring-offset-paper"

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -5,10 +5,16 @@ import { uiStore } from "../../stores/ui";
 import { renderPreview } from "../../api/render";
 import { useDebounce } from "../../hooks/useDebounce";
 import { useOnline } from "../../hooks/useOnline";
+import {
+  clampPan,
+  isWheelZoomGesture,
+  shouldResetPan,
+  wheelZoomDelta,
+} from "./previewPan";
 
 export function Preview() {
   const { store } = resumeStore;
-  const { store: ui, setPreviewPage, zoomIn, zoomOut } = uiStore;
+  const { store: ui, setPreviewPage, setPreviewZoom, zoomIn, zoomOut } = uiStore;
   const isOnline = useOnline();
 
   const [previewUrl, setPreviewUrl] = createSignal<string | null>(null);
@@ -16,6 +22,39 @@ export function Preview() {
   const [error, setError] = createSignal<string | null>(null);
   const [lastCachedUrl, setLastCachedUrl] = createSignal<string | null>(null);
   const [totalPages, setTotalPages] = createSignal(1);
+  const [panX, setPanX] = createSignal(0);
+  const [panY, setPanY] = createSignal(0);
+  const [isDragging, setIsDragging] = createSignal(false);
+
+  let viewportRef: HTMLDivElement | undefined;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let panStartX = 0;
+  let panStartY = 0;
+
+  const applyPanClamp = (x: number, y: number, zoom = ui.previewZoom) => {
+    const viewport = viewportRef;
+    if (!viewport) return { x: 0, y: 0 };
+    return clampPan(x, y, zoom, viewport.clientWidth, viewport.clientHeight);
+  };
+
+  const resetPan = () => {
+    setPanX(0);
+    setPanY(0);
+  };
+
+  createEffect(() => {
+    const zoom = ui.previewZoom;
+    if (shouldResetPan(zoom)) {
+      resetPan();
+      return;
+    }
+    const clamped = applyPanClamp(panX(), panY(), zoom);
+    if (clamped.x !== panX() || clamped.y !== panY()) {
+      setPanX(clamped.x);
+      setPanY(clamped.y);
+    }
+  });
 
   // Request ID to guard against race conditions
   let resumeRequestId = 0;
@@ -49,9 +88,52 @@ export function Preview() {
   };
 
   const handleWheel = (event: WheelEvent) => {
+    if (isWheelZoomGesture(event)) {
+      const nextZoom = wheelZoomDelta(event.deltaY, ui.previewZoom);
+      if (nextZoom !== ui.previewZoom) {
+        setPreviewZoom(nextZoom);
+      }
+      event.preventDefault();
+      return;
+    }
+
     if (Math.abs(event.deltaY) < 30) return;
     if (!goToPageWithCooldown(ui.previewPage + (event.deltaY > 0 ? 1 : -1))) return;
     event.preventDefault();
+  };
+
+  const handlePointerDown = (event: PointerEvent) => {
+    if (ui.previewZoom <= 1 || event.button !== 0) return;
+
+    setIsDragging(true);
+    dragStartX = event.clientX;
+    dragStartY = event.clientY;
+    panStartX = panX();
+    panStartY = panY();
+    (event.currentTarget as HTMLDivElement).setPointerCapture(event.pointerId);
+    event.preventDefault();
+  };
+
+  const handlePointerMove = (event: PointerEvent) => {
+    if (!isDragging()) return;
+
+    const deltaX = event.clientX - dragStartX;
+    const deltaY = event.clientY - dragStartY;
+    const clamped = applyPanClamp(panStartX + deltaX, panStartY + deltaY);
+    setPanX(clamped.x);
+    setPanY(clamped.y);
+  };
+
+  const endDrag = (event: PointerEvent) => {
+    if (!isDragging()) return;
+
+    setIsDragging(false);
+    (event.currentTarget as HTMLDivElement).releasePointerCapture(event.pointerId);
+  };
+
+  const handleDoubleClick = () => {
+    setPreviewZoom(1);
+    resetPan();
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -271,18 +353,34 @@ export function Preview() {
 
       {/* Preview Area */}
       <div
-        class="flex-1 overflow-auto p-6 flex items-start justify-center
+        ref={viewportRef}
+        class="flex-1 p-6 flex items-start justify-center
           focus:outline-none focus-visible:ring-2 focus-visible:ring-accent
           focus-visible:ring-offset-2 focus-visible:ring-offset-paper"
+        classList={{
+          "overflow-auto": ui.previewZoom <= 1,
+          "overflow-hidden": ui.previewZoom > 1,
+          "cursor-grab": ui.previewZoom > 1 && !isDragging(),
+          "cursor-grabbing": isDragging(),
+          "select-none": ui.previewZoom > 1,
+        }}
+        style={{ "touch-action": ui.previewZoom > 1 ? "none" : "auto" }}
         tabIndex={0}
+        title={ui.previewZoom > 1 ? "Drag to pan · Ctrl+scroll to zoom · Double-click to reset" : undefined}
         onWheel={handleWheel}
         onKeyDown={handleKeyDown}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onDblClick={handleDoubleClick}
       >
         <div
           class="relative transition-[width,height] duration-200 origin-top"
           style={{
             width: `${595 * ui.previewZoom}px`,
             height: `${842 * ui.previewZoom}px`,
+            transform: `translate(${panX()}px, ${panY()}px)`,
           }}
         >
           {/* Paper Effect */}

--- a/apps/web/src/components/preview/__tests__/previewPan.test.ts
+++ b/apps/web/src/components/preview/__tests__/previewPan.test.ts
@@ -25,8 +25,10 @@ describe("previewPan", () => {
     const viewportWidth = 400;
     const viewportHeight = 500;
     const zoom = 1.5;
+    // Horizontally centered: symmetric range. Top-aligned: content may only
+    // move up, far enough to reveal the bottom edge.
     const maxPanX = (PREVIEW_PAGE_WIDTH * zoom - viewportWidth) / 2;
-    const maxPanY = (PREVIEW_PAGE_HEIGHT * zoom - viewportHeight) / 2;
+    const maxPanY = PREVIEW_PAGE_HEIGHT * zoom - viewportHeight;
 
     it("zeros pan when zoom is at or below 1x", () => {
       expect(clampPan(100, 50, 1, viewportWidth, viewportHeight)).toEqual({ x: 0, y: 0 });
@@ -42,7 +44,7 @@ describe("previewPan", () => {
       expect(clampPan(10, -20, zoom, viewportWidth, viewportHeight)).toEqual({ x: 10, y: -20 });
     });
 
-    it("clamps pan to horizontal and vertical limits", () => {
+    it("clamps horizontal pan symmetrically around the center", () => {
       expect(clampPan(maxPanX + 50, 0, zoom, viewportWidth, viewportHeight)).toEqual({
         x: maxPanX,
         y: 0,
@@ -51,14 +53,26 @@ describe("previewPan", () => {
         x: -maxPanX,
         y: 0,
       });
-      expect(clampPan(0, maxPanY + 80, zoom, viewportWidth, viewportHeight)).toEqual({
-        x: 0,
-        y: maxPanY,
-      });
+    });
+
+    it("only allows panning content up from its top-aligned rest position", () => {
+      // Panning down would reveal empty space above the top-aligned paper.
+      expect(clampPan(0, 80, zoom, viewportWidth, viewportHeight)).toEqual({ x: 0, y: 0 });
+      // Panning up is allowed through the full vertical overflow, so the
+      // bottom edge of the page is reachable.
       expect(clampPan(0, -maxPanY - 80, zoom, viewportWidth, viewportHeight)).toEqual({
         x: 0,
         y: -maxPanY,
       });
+      expect(clampPan(0, -maxPanY, zoom, viewportWidth, viewportHeight)).toEqual({
+        x: 0,
+        y: -maxPanY,
+      });
+    });
+
+    it("clamps vertical pan to zero when content fits vertically", () => {
+      const shortViewport = PREVIEW_PAGE_HEIGHT * zoom + 100;
+      expect(clampPan(0, -50, zoom, viewportWidth, shortViewport)).toEqual({ x: 0, y: 0 });
     });
   });
 

--- a/apps/web/src/components/preview/__tests__/previewPan.test.ts
+++ b/apps/web/src/components/preview/__tests__/previewPan.test.ts
@@ -1,0 +1,81 @@
+import {
+  PREVIEW_PAGE_HEIGHT,
+  PREVIEW_PAGE_WIDTH,
+  clampPan,
+  isWheelZoomGesture,
+  shouldResetPan,
+  wheelZoomDelta,
+} from "../previewPan";
+
+describe("previewPan", () => {
+  describe("shouldResetPan", () => {
+    it("returns true at or below 1x zoom", () => {
+      expect(shouldResetPan(1)).toBe(true);
+      expect(shouldResetPan(0.5)).toBe(true);
+      expect(shouldResetPan(0)).toBe(true);
+    });
+
+    it("returns false above 1x zoom", () => {
+      expect(shouldResetPan(1.1)).toBe(false);
+      expect(shouldResetPan(2)).toBe(false);
+    });
+  });
+
+  describe("clampPan", () => {
+    const viewportWidth = 400;
+    const viewportHeight = 500;
+    const zoom = 1.5;
+    const maxPanX = (PREVIEW_PAGE_WIDTH * zoom - viewportWidth) / 2;
+    const maxPanY = (PREVIEW_PAGE_HEIGHT * zoom - viewportHeight) / 2;
+
+    it("zeros pan when zoom is at or below 1x", () => {
+      expect(clampPan(100, 50, 1, viewportWidth, viewportHeight)).toEqual({ x: 0, y: 0 });
+      expect(clampPan(100, 50, 0.5, viewportWidth, viewportHeight)).toEqual({ x: 0, y: 0 });
+    });
+
+    it("zeros pan when viewport dimensions are invalid", () => {
+      expect(clampPan(100, 50, zoom, 0, viewportHeight)).toEqual({ x: 0, y: 0 });
+      expect(clampPan(100, 50, zoom, viewportWidth, 0)).toEqual({ x: 0, y: 0 });
+    });
+
+    it("passes through pan within bounds", () => {
+      expect(clampPan(10, -20, zoom, viewportWidth, viewportHeight)).toEqual({ x: 10, y: -20 });
+    });
+
+    it("clamps pan to horizontal and vertical limits", () => {
+      expect(clampPan(maxPanX + 50, 0, zoom, viewportWidth, viewportHeight)).toEqual({
+        x: maxPanX,
+        y: 0,
+      });
+      expect(clampPan(-maxPanX - 50, 0, zoom, viewportWidth, viewportHeight)).toEqual({
+        x: -maxPanX,
+        y: 0,
+      });
+      expect(clampPan(0, maxPanY + 80, zoom, viewportWidth, viewportHeight)).toEqual({
+        x: 0,
+        y: maxPanY,
+      });
+      expect(clampPan(0, -maxPanY - 80, zoom, viewportWidth, viewportHeight)).toEqual({
+        x: 0,
+        y: -maxPanY,
+      });
+    });
+  });
+
+  describe("isWheelZoomGesture", () => {
+    it("detects ctrl or meta modifier", () => {
+      expect(isWheelZoomGesture({ ctrlKey: true, metaKey: false })).toBe(true);
+      expect(isWheelZoomGesture({ ctrlKey: false, metaKey: true })).toBe(true);
+      expect(isWheelZoomGesture({ ctrlKey: false, metaKey: false })).toBe(false);
+    });
+  });
+
+  describe("wheelZoomDelta", () => {
+    it("steps zoom by 0.1 and clamps to 0.5–2", () => {
+      expect(wheelZoomDelta(-100, 1)).toBe(1.1);
+      expect(wheelZoomDelta(100, 1)).toBe(0.9);
+      expect(wheelZoomDelta(-100, 2)).toBe(2);
+      expect(wheelZoomDelta(100, 0.5)).toBe(0.5);
+    });
+  });
+});

--- a/apps/web/src/components/preview/previewPan.ts
+++ b/apps/web/src/components/preview/previewPan.ts
@@ -9,7 +9,9 @@ export function shouldResetPan(zoom: number): boolean {
 
 /**
  * Clamp pan offset so the paper stays within the viewport when zoomed in.
- * Content is centered at rest; translate moves it relative to that center.
+ * The paper is horizontally centered but top-aligned at rest (`items-start
+ * justify-center`), so x pans symmetrically around the center while y may
+ * only move content up — just far enough to reveal the bottom edge.
  */
 export function clampPan(
   panX: number,
@@ -26,13 +28,17 @@ export function clampPan(
   const contentHeight = PREVIEW_PAGE_HEIGHT * zoom;
 
   const maxPanX = Math.max(0, (contentWidth - viewportWidth) / 2);
-  const maxPanY = Math.max(0, (contentHeight - viewportHeight) / 2);
+  const maxPanY = Math.max(0, contentHeight - viewportHeight);
 
   return {
     x: Math.max(-maxPanX, Math.min(maxPanX, panX)),
-    y: Math.max(-maxPanY, Math.min(maxPanY, panY)),
+    // `|| 0` normalizes the -0 that Math.max(-0, ...) can produce.
+    y: Math.max(-maxPanY, Math.min(0, panY)) || 0,
   };
 }
+
+/** Keyboard pan step in CSS pixels per arrow-key press. */
+export const KEYBOARD_PAN_STEP = 48;
 
 /** Ctrl/Meta + wheel zooms; plain wheel keeps page navigation. */
 export function isWheelZoomGesture(event: { ctrlKey: boolean; metaKey: boolean }): boolean {

--- a/apps/web/src/components/preview/previewPan.ts
+++ b/apps/web/src/components/preview/previewPan.ts
@@ -1,0 +1,47 @@
+/** A4 preview dimensions at 1x zoom (CSS pixels). */
+export const PREVIEW_PAGE_WIDTH = 595;
+export const PREVIEW_PAGE_HEIGHT = 842;
+
+/** Pan is only meaningful when zoomed beyond fit (1x). */
+export function shouldResetPan(zoom: number): boolean {
+  return zoom <= 1;
+}
+
+/**
+ * Clamp pan offset so the paper stays within the viewport when zoomed in.
+ * Content is centered at rest; translate moves it relative to that center.
+ */
+export function clampPan(
+  panX: number,
+  panY: number,
+  zoom: number,
+  viewportWidth: number,
+  viewportHeight: number,
+): { x: number; y: number } {
+  if (shouldResetPan(zoom) || viewportWidth <= 0 || viewportHeight <= 0) {
+    return { x: 0, y: 0 };
+  }
+
+  const contentWidth = PREVIEW_PAGE_WIDTH * zoom;
+  const contentHeight = PREVIEW_PAGE_HEIGHT * zoom;
+
+  const maxPanX = Math.max(0, (contentWidth - viewportWidth) / 2);
+  const maxPanY = Math.max(0, (contentHeight - viewportHeight) / 2);
+
+  return {
+    x: Math.max(-maxPanX, Math.min(maxPanX, panX)),
+    y: Math.max(-maxPanY, Math.min(maxPanY, panY)),
+  };
+}
+
+/** Ctrl/Meta + wheel zooms; plain wheel keeps page navigation. */
+export function isWheelZoomGesture(event: { ctrlKey: boolean; metaKey: boolean }): boolean {
+  return event.ctrlKey || event.metaKey;
+}
+
+/** Compute next zoom level from a wheel delta (matches button step of 0.1). */
+export function wheelZoomDelta(deltaY: number, currentZoom: number): number {
+  const step = 0.1;
+  const delta = deltaY > 0 ? -step : step;
+  return Math.max(0.5, Math.min(2, Math.round((currentZoom + delta) * 10) / 10));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): pan preview when zoomed
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Makes zoomed resume previews usable by adding click-and-drag panning when zoom is above 1x, Ctrl/Meta+wheel zoom, and double-click to reset zoom/pan. Cursor switches between `grab` and `grabbing` while dragging.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Related Issues

Closes #70

## Details

### Web (`apps/web`)
- Pan offset applied via CSS `translate` on the preview paper
- Ctrl/Meta+wheel zooms (plain wheel still navigates pages)
- Pan resets automatically when zoom returns to ≤1x
- Double-click resets zoom to 100% and clears pan
- `previewPan.ts` helpers with unit tests for clamp/reset/wheel gestures

### Testing
- `bun run test` — `previewPan.test.ts` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds click-and-drag panning, Ctrl/Meta+wheel zoom, and double-click reset to the resume preview when zoomed above 1×. The pan-clamping logic in `previewPan.ts` is cleanly separated, correctly uses an asymmetric vertical range for the top-aligned layout, and is well-covered by unit tests.

- `previewPan.ts` introduces `clampPan`, `wheelZoomDelta`, and `isWheelZoomGesture` helpers with correct boundary math and good test coverage.
- `Preview.tsx` wires up pointer-capture-based dragging, a `ResizeObserver` to re-clamp after viewport resizes, and reactive zoom integration — but calling `event.preventDefault()` on every `pointerdown` when zoomed suppresses the compatibility `click` events the browser needs to synthesize `dblclick`, breaking the \"double-click to reset\" feature.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the double-click reset, which is silently broken due to pointerdown.preventDefault() suppressing dblclick.

The pan-clamp math, reactive wiring, and ResizeObserver teardown are all correct. The one concrete defect is that calling event.preventDefault() on every left pointerdown when zoomed suppresses the browser's compatibility click events, so the dblclick event (and therefore handleDoubleClick / zoom reset) never fires. This is an advertised feature in the PR description that doesn't work as implemented.

Preview.tsx — specifically the handlePointerDown function where event.preventDefault() should be removed (selection and touch-scroll defaults are already covered by the select-none class and touch-action:none style).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/preview/Preview.tsx | Adds pointer/wheel/keyboard pan interaction; calling event.preventDefault() on pointerdown suppresses dblclick, breaking the double-click-to-reset feature when zoomed. |
| apps/web/src/components/preview/previewPan.ts | New helper module with correct asymmetric vertical clamp (top-aligned) and symmetric horizontal clamp; well-commented and clean. |
| apps/web/src/components/preview/__tests__/previewPan.test.ts | New unit tests with good coverage of clamp edge cases, including the asymmetric vertical boundary; assertions match the updated implementation. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Viewport as Viewport DIV
    participant Signals as SolidJS Signals
    participant clampPan as clampPan()
    participant uiStore

    Note over User,uiStore: Ctrl/Meta + Wheel → Zoom
    User->>Viewport: wheel (ctrlKey/metaKey)
    Viewport->>uiStore: setPreviewZoom(nextZoom)
    uiStore-->>Signals: ui.previewZoom changes
    Signals->>clampPan: createEffect → reclampPan(zoom)
    clampPan-->>Signals: setPanX / setPanY (clamped)

    Note over User,uiStore: Pointer Drag → Pan
    User->>Viewport: "pointerdown (zoom > 1)"
    Viewport->>Viewport: setPointerCapture + preventDefault ⚠️
    Viewport-->>Signals: setIsDragging(true)
    User->>Viewport: pointermove
    Viewport->>clampPan: applyPanClamp(panStartX+Δx, panStartY+Δy)
    clampPan-->>Signals: setPanX / setPanY
    User->>Viewport: pointerup
    Viewport-->>Signals: setIsDragging(false)

    Note over User,uiStore: Double-click → Reset (broken when zoomed)
    User->>Viewport: "dblclick (zoom > 1)"
    Note over Viewport: dblclick suppressed by pointerdown.preventDefault()
    Viewport--xuiStore: handleDoubleClick never fires

    Note over User,uiStore: Arrow Keys → Keyboard Pan
    User->>Viewport: keydown ArrowUp/Down/Left/Right
    Viewport->>clampPan: applyPanClamp(panX±step, panY±step)
    clampPan-->>Signals: setPanX / setPanY

    Note over User,uiStore: Viewport Resize → Re-clamp
    Viewport->>Signals: ResizeObserver fires
    Signals->>clampPan: reclampPan() with new clientWidth/Height
    clampPan-->>Signals: setPanX / setPanY (adjusted)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Viewport as Viewport DIV
    participant Signals as SolidJS Signals
    participant clampPan as clampPan()
    participant uiStore

    Note over User,uiStore: Ctrl/Meta + Wheel → Zoom
    User->>Viewport: wheel (ctrlKey/metaKey)
    Viewport->>uiStore: setPreviewZoom(nextZoom)
    uiStore-->>Signals: ui.previewZoom changes
    Signals->>clampPan: createEffect → reclampPan(zoom)
    clampPan-->>Signals: setPanX / setPanY (clamped)

    Note over User,uiStore: Pointer Drag → Pan
    User->>Viewport: "pointerdown (zoom > 1)"
    Viewport->>Viewport: setPointerCapture + preventDefault ⚠️
    Viewport-->>Signals: setIsDragging(true)
    User->>Viewport: pointermove
    Viewport->>clampPan: applyPanClamp(panStartX+Δx, panStartY+Δy)
    clampPan-->>Signals: setPanX / setPanY
    User->>Viewport: pointerup
    Viewport-->>Signals: setIsDragging(false)

    Note over User,uiStore: Double-click → Reset (broken when zoomed)
    User->>Viewport: "dblclick (zoom > 1)"
    Note over Viewport: dblclick suppressed by pointerdown.preventDefault()
    Viewport--xuiStore: handleDoubleClick never fires

    Note over User,uiStore: Arrow Keys → Keyboard Pan
    User->>Viewport: keydown ArrowUp/Down/Left/Right
    Viewport->>clampPan: applyPanClamp(panX±step, panY±step)
    clampPan-->>Signals: setPanX / setPanY

    Note over User,uiStore: Viewport Resize → Re-clamp
    Viewport->>Signals: ResizeObserver fires
    Signals->>clampPan: reclampPan() with new clientWidth/Height
    clampPan-->>Signals: setPanX / setPanY (adjusted)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): correct pan clamp for top-alig..."](https://github.com/lgtm-hq/rustume/commit/36780ec2b100c4be12476068da8d77123681bd2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45739870)</sub>

<!-- /greptile_comment -->