### PR TITLE
feat(web): add command palette

### DIFF
--- a/apps/web/src/components/export/ExportModal.tsx
+++ b/apps/web/src/components/export/ExportModal.tsx
@@ -3,7 +3,7 @@ import { Button, Modal, toast } from "../ui";
 import { uiStore } from "../../stores/ui";
 import { resumeStore } from "../../stores/resume";
 import { downloadPdf } from "../../api/render";
-import { resumeToJson, isWasmReady } from "../../wasm";
+import { downloadResumeJson, resumeFileName } from "./exportJson";
 
 export function ExportModal() {
   const { store: ui, closeModal } = uiStore;
@@ -14,19 +14,6 @@ export function ExportModal() {
 
   const isOpen = () => ui.modal === "export";
 
-  const getFileName = () => {
-    const name = store.resume?.basics.name || "resume";
-    // Remove characters that are problematic in filenames
-    return (
-      name
-        .toLowerCase()
-        .replace(/[<>:"/\\|?*]/g, "")
-        .replace(/\s+/g, "-")
-        .replace(/-+/g, "-")
-        .replace(/^-|-$/g, "") || "resume"
-    );
-  };
-
   const handleExportPdf = async () => {
     if (!store.resume) return;
 
@@ -34,7 +21,7 @@ export function ExportModal() {
     setError(null);
 
     try {
-      await downloadPdf(store.resume, `${getFileName()}.pdf`);
+      await downloadPdf(store.resume, `${resumeFileName(store.resume)}.pdf`);
       toast.success("PDF exported successfully");
       closeModal();
     } catch (e) {
@@ -50,25 +37,7 @@ export function ExportModal() {
     if (!store.resume) return;
 
     try {
-      let json: string;
-
-      if (isWasmReady()) {
-        json = resumeToJson(store.resume);
-      } else {
-        json = JSON.stringify(store.resume, null, 2);
-      }
-
-      const blob = new Blob([json], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `${getFileName()}.json`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-
-      URL.revokeObjectURL(url);
+      downloadResumeJson(store.resume);
       toast.success("JSON exported successfully");
       closeModal();
     } catch (e) {

--- a/apps/web/src/components/export/exportJson.ts
+++ b/apps/web/src/components/export/exportJson.ts
@@ -1,0 +1,24 @@
+import { downloadBlob } from "../../api/export";
+import { isWasmReady, resumeToJson } from "../../wasm";
+import type { ResumeData } from "../../wasm/types";
+
+/** Sanitize a resume name into a safe download filename (without extension). */
+export function resumeFileName(resume: ResumeData | null): string {
+  const name = resume?.basics.name || "resume";
+  // Remove characters that are problematic in filenames
+  return (
+    name
+      .toLowerCase()
+      .replace(/[<>:"/\\|?*]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "resume"
+  );
+}
+
+/** Serialize a resume and trigger a browser download of the JSON file. */
+export function downloadResumeJson(resume: ResumeData): void {
+  const json = isWasmReady() ? resumeToJson(resume) : JSON.stringify(resume, null, 2);
+  const blob = new Blob([json], { type: "application/json" });
+  downloadBlob(blob, `${resumeFileName(resume)}.json`);
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -79,132 +79,132 @@ export function Sidebar(props: SidebarProps) {
         onFocusIn={() => setIsKeyboardFocused(true)}
         onFocusOut={handleFocusOut}
       >
-      {/* Pin Button */}
-      <div class="px-2 mb-2">
-        <button
-          type="button"
-          class={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg transition-colors
+        {/* Pin Button */}
+        <div class="px-2 mb-2">
+          <button
+            type="button"
+            class={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg transition-colors
             ${isPinned() ? "bg-accent/10 text-accent" : "text-stone hover:text-ink hover:bg-paper"}`}
-          onClick={() => setIsPinned(!isPinned())}
-          title={isPinned() ? "Unpin sidebar" : "Pin sidebar"}
-          aria-label={isPinned() ? "Unpin sidebar" : "Pin sidebar"}
-          aria-pressed={isPinned()}
-        >
-          <svg
-            class={`w-4 h-4 flex-shrink-0 transition-transform ${isPinned() ? "" : "rotate-45"}`}
-            fill={isPinned() ? "currentColor" : "none"}
-            stroke="currentColor"
-            viewBox="0 0 24 24"
+            onClick={() => setIsPinned(!isPinned())}
+            title={isPinned() ? "Unpin sidebar" : "Pin sidebar"}
+            aria-label={isPinned() ? "Unpin sidebar" : "Pin sidebar"}
+            aria-pressed={isPinned()}
           >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M5 5a2 2 0 012-2h10a2 2 0 012 2v3a1 1 0 01-1 1h-2l-1 8h-6l-1-8H6a1 1 0 01-1-1V5z"
-            />
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 17v4" />
-          </svg>
-          <Show when={isExpanded()}>
-            <span class="text-xs font-mono truncate">{isPinned() ? "Pinned" : "Pin"}</span>
-          </Show>
-        </button>
-      </div>
+            <svg
+              class={`w-4 h-4 flex-shrink-0 transition-transform ${isPinned() ? "" : "rotate-45"}`}
+              fill={isPinned() ? "currentColor" : "none"}
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M5 5a2 2 0 012-2h10a2 2 0 012 2v3a1 1 0 01-1 1h-2l-1 8h-6l-1-8H6a1 1 0 01-1-1V5z"
+              />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 17v4" />
+            </svg>
+            <Show when={isExpanded()}>
+              <span class="text-xs font-mono truncate">{isPinned() ? "Pinned" : "Pin"}</span>
+            </Show>
+          </button>
+        </div>
 
-      <div class="h-px bg-border mx-2 mb-2" />
+        <div class="h-px bg-border mx-2 mb-2" />
 
-      {/* Navigation Items */}
-      <nav class="flex-1 overflow-auto px-2">
-        <For each={props.items}>
-          {(item, index) => (
-            <div class={startsGroup(index()) ? "mt-3 first:mt-0" : "mt-1"}>
-              <Show when={startsGroup(index())}>
+        {/* Navigation Items */}
+        <nav class="flex-1 overflow-auto px-2">
+          <For each={props.items}>
+            {(item, index) => (
+              <div class={startsGroup(index()) ? "mt-3 first:mt-0" : "mt-1"}>
+                <Show when={startsGroup(index())}>
+                  <Show
+                    when={isExpanded()}
+                    fallback={
+                      <Show when={index() > 0}>
+                        <div class="mx-1 mb-2 h-px bg-border/80" aria-hidden="true" />
+                      </Show>
+                    }
+                  >
+                    <div class="mb-1 px-2 text-[10px] font-mono uppercase tracking-wider text-stone/70">
+                      {item.group}
+                    </div>
+                  </Show>
+                </Show>
+
                 <Show
                   when={isExpanded()}
                   fallback={
-                    <Show when={index() > 0}>
-                      <div class="mx-1 mb-2 h-px bg-border/80" aria-hidden="true" />
-                    </Show>
-                  }
-                >
-                  <div class="mb-1 px-2 text-[10px] font-mono uppercase tracking-wider text-stone/70">
-                    {item.group}
-                  </div>
-                </Show>
-              </Show>
-
-              <Show
-                when={isExpanded()}
-                fallback={
-                  <Tooltip placement="right" openDelay={100} closeDelay={0}>
-                    <Tooltip.Trigger
-                      as="button"
-                      type="button"
-                      aria-label={item.label}
-                      aria-expanded={item.children?.length ? isExpanded() : undefined}
-                      class={`w-full p-2.5 flex items-center justify-center rounded-lg transition-colors
+                    <Tooltip placement="right" openDelay={100} closeDelay={0}>
+                      <Tooltip.Trigger
+                        as="button"
+                        type="button"
+                        aria-label={item.label}
+                        aria-expanded={item.children?.length ? isExpanded() : undefined}
+                        class={`w-full p-2.5 flex items-center justify-center rounded-lg transition-colors
                         ${
                           isItemActive(item)
                             ? "text-accent bg-accent/10"
                             : "text-stone hover:text-ink hover:bg-paper"
                         }`}
-                      onClick={() => props.onSelect(item.id)}
-                    >
-                      {renderIcon(item.icon)}
-                    </Tooltip.Trigger>
-                    <Tooltip.Portal>
-                      <Tooltip.Content class="z-50 px-2.5 py-1.5 bg-ink text-paper text-xs font-medium rounded-lg shadow-lg animate-fade-in">
-                        {item.label}
-                        <Tooltip.Arrow />
-                      </Tooltip.Content>
-                    </Tooltip.Portal>
-                  </Tooltip>
-                }
-              >
-                <div>
-                  <button
-                    type="button"
-                    aria-label={item.label}
-                    aria-expanded={item.children?.length ? isExpanded() : undefined}
-                    class={`w-full px-2.5 py-2 flex items-center gap-3 rounded-lg transition-colors
+                        onClick={() => props.onSelect(item.id)}
+                      >
+                        {renderIcon(item.icon)}
+                      </Tooltip.Trigger>
+                      <Tooltip.Portal>
+                        <Tooltip.Content class="z-50 px-2.5 py-1.5 bg-ink text-paper text-xs font-medium rounded-lg shadow-lg animate-fade-in">
+                          {item.label}
+                          <Tooltip.Arrow />
+                        </Tooltip.Content>
+                      </Tooltip.Portal>
+                    </Tooltip>
+                  }
+                >
+                  <div>
+                    <button
+                      type="button"
+                      aria-label={item.label}
+                      aria-expanded={item.children?.length ? isExpanded() : undefined}
+                      class={`w-full px-2.5 py-2 flex items-center gap-3 rounded-lg transition-colors
                       ${
                         isItemActive(item)
                           ? "text-accent bg-accent/10"
                           : "text-stone hover:text-ink hover:bg-paper"
                       }`}
-                    onClick={() => props.onSelect(item.id)}
-                  >
-                    {renderIcon(item.icon, "w-5 h-5 flex-shrink-0")}
-                    <span class="text-sm font-body truncate">{item.label}</span>
-                  </button>
+                      onClick={() => props.onSelect(item.id)}
+                    >
+                      {renderIcon(item.icon, "w-5 h-5 flex-shrink-0")}
+                      <span class="text-sm font-body truncate">{item.label}</span>
+                    </button>
 
-                  <Show when={item.children?.length}>
-                    <div class="mt-1 ml-4 pl-2 border-l border-border/70 space-y-1">
-                      <For each={item.children}>
-                        {(child) => (
-                          <button
-                            type="button"
-                            aria-label={child.label}
-                            class={`w-full px-2 py-1.5 flex items-center gap-2 rounded-lg transition-colors
+                    <Show when={item.children?.length}>
+                      <div class="mt-1 ml-4 pl-2 border-l border-border/70 space-y-1">
+                        <For each={item.children}>
+                          {(child) => (
+                            <button
+                              type="button"
+                              aria-label={child.label}
+                              class={`w-full px-2 py-1.5 flex items-center gap-2 rounded-lg transition-colors
                               ${
                                 props.activeId === child.id
                                   ? "text-accent bg-accent/10"
                                   : "text-stone hover:text-ink hover:bg-paper"
                               }`}
-                            onClick={() => props.onSelect(child.id)}
-                          >
-                            {renderIcon(child.icon, "w-4 h-4 flex-shrink-0")}
-                            <span class="text-xs font-body truncate">{child.label}</span>
-                          </button>
-                        )}
-                      </For>
-                    </div>
-                  </Show>
-                </div>
-              </Show>
-            </div>
-          )}
-        </For>
-      </nav>
+                              onClick={() => props.onSelect(child.id)}
+                            >
+                              {renderIcon(child.icon, "w-4 h-4 flex-shrink-0")}
+                              <span class="text-xs font-body truncate">{child.label}</span>
+                            </button>
+                          )}
+                        </For>
+                      </div>
+                    </Show>
+                  </div>
+                </Show>
+              </div>
+            )}
+          </For>
+        </nav>
       </div>
     </Show>
   );

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { For, Show, createSignal, createEffect, onCleanup } from "solid-js";
 import { Tooltip } from "@kobalte/core/tooltip";
+import { uiStore } from "../../stores/ui";
 
 export interface SidebarItem {
   id: string;
@@ -16,6 +17,7 @@ interface SidebarProps {
 }
 
 export function Sidebar(props: SidebarProps) {
+  const { store: ui } = uiStore;
   const [isPinned, setIsPinned] = createSignal(false);
   const [isHovered, setIsHovered] = createSignal(false);
   const [isKeyboardFocused, setIsKeyboardFocused] = createSignal(false);
@@ -68,14 +70,15 @@ export function Sidebar(props: SidebarProps) {
   );
 
   return (
-    <div
-      class="h-full bg-surface border-r border-border flex flex-col py-2 transition-all duration-200 ease-out"
-      style={{ width: isExpanded() ? "180px" : "56px" }}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      onFocusIn={() => setIsKeyboardFocused(true)}
-      onFocusOut={handleFocusOut}
-    >
+    <Show when={ui.sidebarOpen}>
+      <div
+        class="h-full bg-surface border-r border-border flex flex-col py-2 transition-all duration-200 ease-out"
+        style={{ width: isExpanded() ? "180px" : "56px" }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onFocusIn={() => setIsKeyboardFocused(true)}
+        onFocusOut={handleFocusOut}
+      >
       {/* Pin Button */}
       <div class="px-2 mb-2">
         <button
@@ -202,6 +205,7 @@ export function Sidebar(props: SidebarProps) {
           )}
         </For>
       </nav>
-    </div>
+      </div>
+    </Show>
   );
 }

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -50,6 +50,15 @@ export function Sidebar(props: SidebarProps) {
     setIsKeyboardFocused(false);
   };
 
+  // The <Show> wrapper hides the DOM without unmounting the component, so a
+  // pending leave-debounce could fire after the sidebar reappears. Reset
+  // hover state whenever the sidebar visibility toggles.
+  createEffect(() => {
+    void ui.sidebarOpen;
+    if (hoverTimeout) clearTimeout(hoverTimeout);
+    setIsHovered(false);
+  });
+
   onCleanup(() => {
     if (hoverTimeout) clearTimeout(hoverTimeout);
   });

--- a/apps/web/src/components/ui/CommandPalette.tsx
+++ b/apps/web/src/components/ui/CommandPalette.tsx
@@ -1,0 +1,239 @@
+import { Dialog } from "@kobalte/core/dialog";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { uiStore } from "../../stores/ui";
+
+const RECENT_STORAGE_KEY = "rustume.commandPalette.recent";
+const MAX_RECENT = 5;
+
+export interface CommandAction {
+  id: string;
+  label: string;
+  keywords?: string;
+  group?: string;
+  handler: () => void;
+}
+
+export interface CommandPaletteProps {
+  actions: CommandAction[];
+}
+
+/** Returns true when query matches text via substring or sequential character match. */
+export function fuzzyMatch(query: string, text: string): boolean {
+  const q = query.toLowerCase().trim();
+  const t = text.toLowerCase();
+  if (!q) return true;
+  if (t.includes(q)) return true;
+
+  let qi = 0;
+  for (let i = 0; i < t.length && qi < q.length; i++) {
+    if (t[i] === q[qi]) qi++;
+  }
+  return qi === q.length;
+}
+
+function getRecentIds(): string[] {
+  try {
+    const raw = sessionStorage.getItem(RECENT_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function pushRecent(id: string) {
+  const recent = getRecentIds().filter((entry) => entry !== id);
+  recent.unshift(id);
+  sessionStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+}
+
+export function CommandPalette(props: CommandPaletteProps) {
+  const { store: ui, closeModal } = uiStore;
+  let inputRef: HTMLInputElement | undefined;
+  let listRef: HTMLDivElement | undefined;
+
+  const [query, setQuery] = createSignal("");
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+  const [recentIds, setRecentIds] = createSignal<string[]>(getRecentIds());
+
+  const isOpen = () => ui.modal === "commandPalette";
+
+  const actionMap = createMemo(() => {
+    const map = new Map<string, CommandAction>();
+    for (const action of props.actions) {
+      map.set(action.id, action);
+    }
+    return map;
+  });
+
+  const filteredActions = createMemo(() => {
+    const q = query().trim();
+    const matches = props.actions.filter((action) => {
+      const haystack = `${action.label} ${action.keywords ?? ""} ${action.group ?? ""}`;
+      return fuzzyMatch(q, haystack);
+    });
+
+    if (!q) {
+      const recentActions = recentIds()
+        .map((id) => actionMap().get(id))
+        .filter((action): action is CommandAction => action !== undefined)
+        .filter((action) => matches.some((match) => match.id === action.id));
+
+      const recentSet = new Set(recentActions.map((action) => action.id));
+      const rest = matches.filter((action) => !recentSet.has(action.id));
+      return [...recentActions, ...rest];
+    }
+
+    return matches;
+  });
+
+  const recentCount = createMemo(() => {
+    if (query().trim()) return 0;
+    const matchIds = new Set(filteredActions().map((action) => action.id));
+    return recentIds().filter((id) => matchIds.has(id)).length;
+  });
+
+  createEffect(() => {
+    filteredActions();
+    setSelectedIndex(0);
+  });
+
+  createEffect(() => {
+    if (!isOpen()) return;
+    setQuery("");
+    setSelectedIndex(0);
+    setRecentIds(getRecentIds());
+    queueMicrotask(() => inputRef?.focus());
+  });
+
+  createEffect(() => {
+    const index = selectedIndex();
+    const list = listRef;
+    if (!list) return;
+    const item = list.querySelector<HTMLElement>(`[data-index="${index}"]`);
+    item?.scrollIntoView?.({ block: "nearest" });
+  });
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) closeModal();
+  };
+
+  const executeAction = (action: CommandAction) => {
+    pushRecent(action.id);
+    setRecentIds(getRecentIds());
+    closeModal();
+    action.handler();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const items = filteredActions();
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSelectedIndex((index) => Math.min(index + 1, Math.max(items.length - 1, 0)));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSelectedIndex((index) => Math.max(index - 1, 0));
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const action = items[selectedIndex()];
+      if (action) executeAction(action);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      closeModal();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen()} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay class="fixed inset-0 bg-ink/40 backdrop-blur-sm z-40 animate-fade-in" />
+        <div class="fixed inset-0 z-50 flex items-start justify-center p-4 pt-[15vh]">
+          <Dialog.Content
+            class="bg-paper rounded-xl shadow-elevated w-full max-w-lg animate-slide-up overflow-hidden"
+            onKeyDown={handleKeyDown}
+          >
+            <div class="flex items-center gap-3 border-b border-border px-4 py-3">
+              <svg
+                class="h-5 w-5 flex-shrink-0 text-stone"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+              <input
+                ref={inputRef}
+                type="text"
+                class="flex-1 bg-transparent text-sm text-ink placeholder:text-stone outline-none"
+                placeholder="Search commands..."
+                aria-label="Search commands"
+                value={query()}
+                onInput={(event) => setQuery(event.currentTarget.value)}
+              />
+              <kbd class="hidden sm:inline text-xs font-mono bg-surface border border-border rounded px-1.5 py-0.5 text-stone">
+                Esc
+              </kbd>
+            </div>
+
+            <div ref={listRef} class="max-h-80 overflow-y-auto p-2" role="listbox" aria-label="Commands">
+              <Show
+                when={filteredActions().length > 0}
+                fallback={<p class="px-3 py-6 text-center text-sm text-stone">No matching commands</p>}
+              >
+                <For each={filteredActions()}>
+                  {(action, index) => (
+                    <>
+                      <Show when={!query().trim() && index() === 0 && recentCount() > 0}>
+                        <div class="px-3 pb-1 pt-2 text-[10px] font-mono uppercase tracking-wider text-stone/70">
+                          Recent
+                        </div>
+                      </Show>
+                      <Show
+                        when={
+                          !query().trim() &&
+                          recentCount() > 0 &&
+                          index() === recentCount() &&
+                          index() < filteredActions().length
+                        }
+                      >
+                        <div class="px-3 pb-1 pt-3 text-[10px] font-mono uppercase tracking-wider text-stone/70">
+                          All commands
+                        </div>
+                      </Show>
+                      <button
+                        type="button"
+                        role="option"
+                        data-index={index()}
+                        aria-selected={selectedIndex() === index()}
+                        class={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition-colors
+                          ${
+                            selectedIndex() === index()
+                              ? "bg-accent/10 text-accent"
+                              : "text-ink hover:bg-surface"
+                          }`}
+                        onMouseEnter={() => setSelectedIndex(index())}
+                        onClick={() => executeAction(action)}
+                      >
+                        <span>{action.label}</span>
+                        <Show when={action.group}>
+                          <span class="text-xs text-stone">{action.group}</span>
+                        </Show>
+                      </button>
+                    </>
+                  )}
+                </For>
+              </Show>
+            </div>
+          </Dialog.Content>
+        </div>
+      </Dialog.Portal>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ui/CommandPalette.tsx
+++ b/apps/web/src/components/ui/CommandPalette.tsx
@@ -43,9 +43,13 @@ function getRecentIds(): string[] {
 }
 
 function pushRecent(id: string) {
-  const recent = getRecentIds().filter((entry) => entry !== id);
-  recent.unshift(id);
-  sessionStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+  try {
+    const recent = getRecentIds().filter((entry) => entry !== id);
+    recent.unshift(id);
+    sessionStorage.setItem(RECENT_STORAGE_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+  } catch {
+    // Storage may be blocked (private mode, disabled cookies) -- recents are best-effort.
+  }
 }
 
 export function CommandPalette(props: CommandPaletteProps) {
@@ -120,10 +124,10 @@ export function CommandPalette(props: CommandPaletteProps) {
   };
 
   const executeAction = (action: CommandAction) => {
-    pushRecent(action.id);
-    setRecentIds(getRecentIds());
     closeModal();
     action.handler();
+    pushRecent(action.id);
+    setRecentIds(getRecentIds());
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -153,6 +157,7 @@ export function CommandPalette(props: CommandPaletteProps) {
             class="bg-paper rounded-xl shadow-elevated w-full max-w-lg animate-slide-up overflow-hidden"
             onKeyDown={handleKeyDown}
           >
+            <Dialog.Title class="sr-only">Command palette</Dialog.Title>
             <div class="flex items-center gap-3 border-b border-border px-4 py-3">
               <svg
                 class="h-5 w-5 flex-shrink-0 text-stone"
@@ -176,6 +181,12 @@ export function CommandPalette(props: CommandPaletteProps) {
                 class="flex-1 bg-transparent text-sm text-ink placeholder:text-stone outline-none"
                 placeholder="Search commands..."
                 aria-label="Search commands"
+                role="combobox"
+                aria-expanded="true"
+                aria-controls="command-palette-listbox"
+                aria-activedescendant={
+                  filteredActions().length > 0 ? `command-option-${selectedIndex()}` : undefined
+                }
                 value={query()}
                 onInput={(event) => setQuery(event.currentTarget.value)}
               />
@@ -188,13 +199,16 @@ export function CommandPalette(props: CommandPaletteProps) {
               ref={(el) => {
                 listRef = el;
               }}
+              id="command-palette-listbox"
               class="max-h-80 overflow-y-auto p-2"
               role="listbox"
               aria-label="Commands"
             >
               <Show
                 when={filteredActions().length > 0}
-                fallback={<p class="px-3 py-6 text-center text-sm text-stone">No matching commands</p>}
+                fallback={
+                  <p class="px-3 py-6 text-center text-sm text-stone">No matching commands</p>
+                }
               >
                 <For each={filteredActions()}>
                   {(action, index) => (
@@ -205,12 +219,7 @@ export function CommandPalette(props: CommandPaletteProps) {
                         </div>
                       </Show>
                       <Show
-                        when={
-                          !query().trim() &&
-                          recentCount() > 0 &&
-                          index() === recentCount() &&
-                          index() < filteredActions().length
-                        }
+                        when={!query().trim() && recentCount() > 0 && index() === recentCount()}
                       >
                         <div class="px-3 pb-1 pt-3 text-[10px] font-mono uppercase tracking-wider text-stone/70">
                           All commands
@@ -219,6 +228,7 @@ export function CommandPalette(props: CommandPaletteProps) {
                       <button
                         type="button"
                         role="option"
+                        id={`command-option-${index()}`}
                         data-index={index()}
                         aria-selected={selectedIndex() === index()}
                         class={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition-colors

--- a/apps/web/src/components/ui/CommandPalette.tsx
+++ b/apps/web/src/components/ui/CommandPalette.tsx
@@ -169,7 +169,9 @@ export function CommandPalette(props: CommandPaletteProps) {
                 />
               </svg>
               <input
-                ref={inputRef}
+                ref={(el) => {
+                  inputRef = el;
+                }}
                 type="text"
                 class="flex-1 bg-transparent text-sm text-ink placeholder:text-stone outline-none"
                 placeholder="Search commands..."
@@ -182,7 +184,14 @@ export function CommandPalette(props: CommandPaletteProps) {
               </kbd>
             </div>
 
-            <div ref={listRef} class="max-h-80 overflow-y-auto p-2" role="listbox" aria-label="Commands">
+            <div
+              ref={(el) => {
+                listRef = el;
+              }}
+              class="max-h-80 overflow-y-auto p-2"
+              role="listbox"
+              aria-label="Commands"
+            >
               <Show
                 when={filteredActions().length > 0}
                 fallback={<p class="px-3 py-6 text-center text-sm text-stone">No matching commands</p>}

--- a/apps/web/src/components/ui/__tests__/CommandPalette.test.tsx
+++ b/apps/web/src/components/ui/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRoot } from "solid-js";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { CommandPalette, fuzzyMatch } from "../CommandPalette";
+import { uiStore } from "../../../stores/ui";
+
+describe("fuzzyMatch", () => {
+  it("matches empty query", () => {
+    expect(fuzzyMatch("", "Export PDF")).toBe(true);
+  });
+
+  it("matches substring", () => {
+    expect(fuzzyMatch("pdf", "Export PDF")).toBe(true);
+  });
+
+  it("matches sequential characters", () => {
+    expect(fuzzyMatch("ct", "Create Resume")).toBe(true);
+  });
+
+  it("rejects non-matching query", () => {
+    expect(fuzzyMatch("xyz", "Export PDF")).toBe(false);
+  });
+});
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    createRoot((dispose) => {
+      uiStore.closeModal();
+      dispose();
+    });
+  });
+
+  it("opens when command palette modal is active", () => {
+    uiStore.openModal("commandPalette");
+    render(() => (
+      <CommandPalette
+        actions={[{ id: "export-pdf", label: "Export PDF", handler: vi.fn() }]}
+      />
+    ));
+
+    expect(screen.getByLabelText("Search commands")).toBeInTheDocument();
+    expect(screen.getByText("Export PDF")).toBeInTheDocument();
+  });
+
+  it("filters actions by query", () => {
+    uiStore.openModal("commandPalette");
+    render(() => (
+      <CommandPalette
+        actions={[
+          { id: "export-pdf", label: "Export PDF", handler: vi.fn() },
+          { id: "theme", label: "Change Theme", handler: vi.fn() },
+        ]}
+      />
+    ));
+
+    fireEvent.input(screen.getByLabelText("Search commands"), {
+      target: { value: "theme" },
+    });
+
+    expect(screen.getByText("Change Theme")).toBeInTheDocument();
+    expect(screen.queryByText("Export PDF")).not.toBeInTheDocument();
+  });
+
+  it("executes selected action on click", () => {
+    const handler = vi.fn();
+    uiStore.openModal("commandPalette");
+    render(() => (
+      <CommandPalette actions={[{ id: "export-pdf", label: "Export PDF", handler }]} />
+    ));
+
+    fireEvent.click(screen.getByText("Export PDF"));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(uiStore.store.modal).toBe(null);
+  });
+
+  it("executes highlighted action on Enter", () => {
+    const handler = vi.fn();
+    uiStore.openModal("commandPalette");
+    render(() => (
+      <CommandPalette
+        actions={[
+          { id: "theme", label: "Change Theme", handler: vi.fn() },
+          { id: "export-pdf", label: "Export PDF", handler },
+        ]}
+      />
+    ));
+
+    fireEvent.keyDown(screen.getByLabelText("Search commands"), { key: "ArrowDown" });
+    fireEvent.keyDown(screen.getByLabelText("Search commands"), { key: "Enter" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(uiStore.store.modal).toBe(null);
+  });
+});

--- a/apps/web/src/components/ui/__tests__/CommandPalette.test.tsx
+++ b/apps/web/src/components/ui/__tests__/CommandPalette.test.tsx
@@ -34,9 +34,7 @@ describe("CommandPalette", () => {
   it("opens when command palette modal is active", () => {
     uiStore.openModal("commandPalette");
     render(() => (
-      <CommandPalette
-        actions={[{ id: "export-pdf", label: "Export PDF", handler: vi.fn() }]}
-      />
+      <CommandPalette actions={[{ id: "export-pdf", label: "Export PDF", handler: vi.fn() }]} />
     ));
 
     expect(screen.getByLabelText("Search commands")).toBeInTheDocument();
@@ -65,14 +63,56 @@ describe("CommandPalette", () => {
   it("executes selected action on click", () => {
     const handler = vi.fn();
     uiStore.openModal("commandPalette");
-    render(() => (
-      <CommandPalette actions={[{ id: "export-pdf", label: "Export PDF", handler }]} />
-    ));
+    render(() => <CommandPalette actions={[{ id: "export-pdf", label: "Export PDF", handler }]} />);
 
     fireEvent.click(screen.getByText("Export PDF"));
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(uiStore.store.modal).toBe(null);
+  });
+
+  it("executes action even when sessionStorage writes are blocked", () => {
+    const handler = vi.fn();
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    try {
+      uiStore.openModal("commandPalette");
+      render(() => (
+        <CommandPalette actions={[{ id: "export-pdf", label: "Export PDF", handler }]} />
+      ));
+
+      fireEvent.click(screen.getByText("Export PDF"));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(uiStore.store.modal).toBe(null);
+    } finally {
+      setItemSpy.mockRestore();
+    }
+  });
+
+  it("wires combobox ARIA attributes to the listbox and options", () => {
+    uiStore.openModal("commandPalette");
+    render(() => (
+      <CommandPalette
+        actions={[
+          { id: "export-pdf", label: "Export PDF", handler: vi.fn() },
+          { id: "theme", label: "Change Theme", handler: vi.fn() },
+        ]}
+      />
+    ));
+
+    const input = screen.getByRole("combobox");
+    expect(input).toHaveAttribute("aria-expanded", "true");
+    expect(input).toHaveAttribute("aria-controls", "command-palette-listbox");
+    expect(input).toHaveAttribute("aria-activedescendant", "command-option-0");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input).toHaveAttribute("aria-activedescendant", "command-option-1");
+
+    const options = screen.getAllByRole("option");
+    expect(options[0]).toHaveAttribute("id", "command-option-0");
+    expect(options[1]).toHaveAttribute("aria-selected", "true");
   });
 
   it("executes highlighted action on Enter", () => {

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -12,3 +12,4 @@ export { Switch, type SwitchProps } from "./Switch";
 export { Spinner, type SpinnerProps } from "./Spinner";
 export { ToastRegion, toast } from "./Toast";
 export { ShortcutsModal, type ShortcutsModalProps } from "./ShortcutsModal";
+export { CommandPalette, fuzzyMatch, type CommandAction, type CommandPaletteProps } from "./CommandPalette";

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -12,4 +12,9 @@ export { Switch, type SwitchProps } from "./Switch";
 export { Spinner, type SpinnerProps } from "./Spinner";
 export { ToastRegion, toast } from "./Toast";
 export { ShortcutsModal, type ShortcutsModalProps } from "./ShortcutsModal";
-export { CommandPalette, fuzzyMatch, type CommandAction, type CommandPaletteProps } from "./CommandPalette";
+export {
+  CommandPalette,
+  fuzzyMatch,
+  type CommandAction,
+  type CommandPaletteProps,
+} from "./CommandPalette";

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -1,6 +1,6 @@
 import { createMemo, createSignal, lazy, onMount, Show, Suspense } from "solid-js";
 import { useParams, useNavigate } from "@solidjs/router";
-import { Button, toast, ShortcutsModal, Spinner } from "../components/ui";
+import { Button, toast, ShortcutsModal, Spinner, CommandPalette, type CommandAction } from "../components/ui";
 import { useHotkeys, type Shortcut } from "../hooks/useHotkeys";
 import { useNavigationGuard } from "../hooks/useNavigationGuard";
 import { SplitPane } from "../components/layout/SplitPane";
@@ -25,6 +25,7 @@ import {
 } from "../components/builder";
 import { resumeStore, isNotFoundError } from "../stores/resume";
 import { uiStore } from "../stores/ui";
+import { generateId } from "../wasm/types";
 import { isWasmReady } from "../wasm";
 
 const Preview = lazy(() =>
@@ -234,6 +235,13 @@ export default function Editor() {
 
   const shortcuts: Shortcut[] = [
     {
+      key: "k",
+      mod: true,
+      handler: () => openModal("commandPalette"),
+      label: "Command palette",
+      category: "General",
+    },
+    {
       key: "s",
       mod: true,
       handler: () => {
@@ -290,6 +298,72 @@ export default function Editor() {
 
   useHotkeys(shortcuts);
   useNavigationGuard(() => store.isDirty);
+
+  const commandActions = createMemo<CommandAction[]>(() => {
+    const sectionActions: CommandAction[] = sidebarItems().flatMap((item) => {
+      const actions: CommandAction[] = [
+        {
+          id: `section:${item.id}`,
+          label: `Go to ${item.label}`,
+          group: "Sections",
+          keywords: item.label,
+          handler: () => setActiveTab(item.id as EditorTab),
+        },
+      ];
+
+      for (const child of item.children ?? []) {
+        actions.push({
+          id: `section:${child.id}`,
+          label: `Go to ${child.label}`,
+          group: "Sections",
+          keywords: child.label,
+          handler: () => setActiveTab(child.id as EditorTab),
+        });
+      }
+
+      return actions;
+    });
+
+    return [
+      {
+        id: "template",
+        label: "Switch Template",
+        group: "Actions",
+        handler: () => openModal("template"),
+      },
+      {
+        id: "theme",
+        label: "Change Theme",
+        group: "Actions",
+        handler: () => setActiveTab("theme"),
+      },
+      {
+        id: "export-pdf",
+        label: "Export PDF",
+        group: "Actions",
+        handler: () => openModal("export"),
+      },
+      {
+        id: "export-json",
+        label: "Export JSON",
+        group: "Actions",
+        handler: () => openModal("export"),
+      },
+      {
+        id: "create-resume",
+        label: "Create Resume",
+        group: "Actions",
+        handler: () => navigate(`/edit/${generateId()}`),
+      },
+      {
+        id: "toggle-sidebar",
+        label: "Toggle Sidebar",
+        group: "Actions",
+        handler: () => uiStore.toggleSidebar(),
+      },
+      ...sectionActions,
+    ];
+  });
 
   async function attemptLoad() {
     if (!params.id) {
@@ -597,6 +671,7 @@ export default function Editor() {
         </Suspense>
       </Show>
       <ShortcutsModal shortcuts={shortcuts} />
+      <CommandPalette actions={commandActions()} />
     </div>
   );
 }

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -1,6 +1,22 @@
-import { createMemo, createSignal, lazy, onMount, Show, Suspense } from "solid-js";
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  lazy,
+  on,
+  onMount,
+  Show,
+  Suspense,
+} from "solid-js";
 import { useParams, useNavigate } from "@solidjs/router";
-import { Button, toast, ShortcutsModal, Spinner, CommandPalette, type CommandAction } from "../components/ui";
+import {
+  Button,
+  toast,
+  ShortcutsModal,
+  Spinner,
+  CommandPalette,
+  type CommandAction,
+} from "../components/ui";
 import { useHotkeys, type Shortcut } from "../hooks/useHotkeys";
 import { useNavigationGuard } from "../hooks/useNavigationGuard";
 import { SplitPane } from "../components/layout/SplitPane";
@@ -24,6 +40,7 @@ import {
   CustomSectionsIndex,
 } from "../components/builder";
 import { resumeStore, isNotFoundError } from "../stores/resume";
+import { downloadResumeJson } from "../components/export/exportJson";
 import { uiStore } from "../stores/ui";
 import { generateId } from "../wasm/types";
 import { isWasmReady } from "../wasm";
@@ -347,7 +364,16 @@ export default function Editor() {
         id: "export-json",
         label: "Export JSON",
         group: "Actions",
-        handler: () => openModal("export"),
+        handler: () => {
+          if (!store.resume) return;
+          try {
+            downloadResumeJson(store.resume);
+            toast.success("JSON exported successfully");
+          } catch (error) {
+            console.error("Export error:", error);
+            toast.error(error instanceof Error ? error.message : "Failed to export JSON");
+          }
+        },
       },
       {
         id: "create-resume",
@@ -409,6 +435,22 @@ export default function Editor() {
   }
 
   onMount(attemptLoad);
+
+  // The router reuses this component on /edit/:id param changes (no remount),
+  // so reload when the id changes. Flush any pending autosave of the previous
+  // resume first so its in-flight edits are not lost when the store is replaced.
+  createEffect(
+    on(
+      () => params.id,
+      () => {
+        void (async () => {
+          if (store.isDirty) await resumeStore.forceSave();
+          await attemptLoad();
+        })();
+      },
+      { defer: true },
+    ),
+  );
 
   const renderTabContent = () => {
     switch (activeTab()) {

--- a/apps/web/src/stores/ui.ts
+++ b/apps/web/src/stores/ui.ts
@@ -1,6 +1,13 @@
 import { createStore } from "solid-js/store";
 
-export type ModalType = "import" | "export" | "template" | "settings" | "shortcuts" | null;
+export type ModalType =
+  | "import"
+  | "export"
+  | "template"
+  | "settings"
+  | "shortcuts"
+  | "commandPalette"
+  | null;
 
 export type Panel = "editor" | "preview" | "both";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add command palette
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds a Cmd/Ctrl+K command palette in the editor for keyboard-driven navigation and actions: switch template, open theme, export PDF/JSON, create resume, jump to sections, and toggle the sidebar. Includes fuzzy filtering, recent actions, and full keyboard navigation.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Related Issues

Closes #68

## Details

### Web (`apps/web`)
- New `CommandPalette` built on Kobalte Dialog
- `ModalType` extended with `"commandPalette"`
- Wired into `Editor.tsx` via `useHotkeys` (Cmd/Ctrl+K)
- Sidebar respects `ui.sidebarOpen` for palette toggle
- Recent actions stored in `sessionStorage`
- Vitest coverage for fuzzy match and palette interactions

### Testing
- `bun run test` — CommandPalette tests pass; typecheck passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a Cmd/Ctrl+K command palette built on Kobalte Dialog, enabling keyboard-driven navigation and actions in the editor. The `ExportModal` JSON export logic is extracted into a shared `exportJson.ts` utility (`downloadBlob`, `resumeFileName`) so the palette's direct "Export JSON" action doesn't need to open a modal. The sidebar gains a `<Show when={ui.sidebarOpen}>` wrapper to support palette-driven toggle, and a `createEffect` that resets hover state on each visibility change.

- `CommandPalette.tsx` implements fuzzy filtering, recent-action tracking via `sessionStorage`, full keyboard navigation (Arrow/Enter/Escape), and combobox ARIA wiring.
- `Editor.tsx` gains a `commandActions` reactive memo feeding the palette, and a deferred `createEffect` to reload when `params.id` changes (router component-reuse on route navigation).
- All three previously flagged issues (export-json/PDF same modal, missing dialog accessible name, hover-timeout flicker) have been resolved in this revision.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three previously flagged issues are resolved and no new correctness problems were introduced.

The command palette implementation is well-structured: fuzzy matching, recent-action tracking, keyboard navigation, and ARIA wiring are all correct. The export-json path now downloads directly without opening a modal, the dialog has a visually-hidden title for screen readers, and the Sidebar hover-timeout bug is fixed via a reactive createEffect. The two comments left are minor: a redundant setRecentIds call after executeAction, and a missing cancellation guard in the deferred route-reload effect that could race on rapid successive navigations. Neither is a blocking issue.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/ui/CommandPalette.tsx | New command palette component with fuzzy filtering, sessionStorage-backed recent actions, keyboard navigation, and combobox ARIA; the three previously flagged issues (accessible name, hover timeout, export modal disambiguation) are addressed in this revision. |
| apps/web/src/pages/Editor.tsx | Adds commandActions memo, Cmd+K hotkey, CommandPalette render, and a deferred createEffect for router component-reuse on param changes; export-json now directly downloads without opening the export modal. |
| apps/web/src/components/export/exportJson.ts | New shared utility extracting resumeFileName sanitisation and downloadResumeJson logic; delegates blob download to the existing downloadBlob helper which correctly revokes the object URL. |
| apps/web/src/components/layout/Sidebar.tsx | Sidebar content wrapped in Show when={ui.sidebarOpen}; createEffect tracking sidebarOpen clears any pending hover debounce and resets isHovered on every visibility change, fixing the previously reported flicker bug. |
| apps/web/src/components/export/ExportModal.tsx | Refactored to use shared resumeFileName and downloadResumeJson utilities; getFileName and inline blob logic removed cleanly. |
| apps/web/src/stores/ui.ts | ModalType union extended with 'commandPalette'; toggleSidebar already present and wired correctly. |
| apps/web/src/components/ui/__tests__/CommandPalette.test.tsx | Vitest coverage for fuzzyMatch, open/filter/click/keyboard/ARIA/sessionStorage-blocked scenarios; solid test surface for the new component. |
| apps/web/src/components/ui/index.ts | Barrel updated to export CommandPalette, fuzzyMatch, and related types. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User presses Cmd/Ctrl+K] --> B[useHotkeys → openModal 'commandPalette']
    B --> C[uiStore.modal = 'commandPalette']
    C --> D[CommandPalette: isOpen = true]
    D --> E[createEffect: reset query, load recentIds from sessionStorage, focus input]
    E --> F{User interaction}
    F -->|Types| G[query signal updates → filteredActions memo recalculates]
    F -->|Arrow Up/Down| H[selectedIndex updates → item scrolls into view]
    F -->|Enter or Click| I[executeAction]
    F -->|Escape| J[closeModal → ui.modal = null]
    G --> K[Show filtered results with Recent / All Commands sections]
    H --> K
    I --> L[closeModal]
    L --> M[action.handler executes]
    M --> N{Action type}
    N -->|Switch Template| O[openModal 'template']
    N -->|Change Theme| P[setActiveTab 'theme']
    N -->|Export PDF| Q[openModal 'export']
    N -->|Export JSON| R[downloadResumeJson → downloadBlob]
    N -->|Create Resume| S[navigate /edit/newId]
    N -->|Toggle Sidebar| T[uiStore.toggleSidebar → sidebarOpen flips]
    N -->|Go to Section| U[setActiveTab sectionId]
    T --> V[Sidebar Show/Hide + createEffect resets isHovered]
    S --> W[createEffect on params.id: forceSave if dirty → attemptLoad]
    M --> X[pushRecent to sessionStorage]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User presses Cmd/Ctrl+K] --> B[useHotkeys → openModal 'commandPalette']
    B --> C[uiStore.modal = 'commandPalette']
    C --> D[CommandPalette: isOpen = true]
    D --> E[createEffect: reset query, load recentIds from sessionStorage, focus input]
    E --> F{User interaction}
    F -->|Types| G[query signal updates → filteredActions memo recalculates]
    F -->|Arrow Up/Down| H[selectedIndex updates → item scrolls into view]
    F -->|Enter or Click| I[executeAction]
    F -->|Escape| J[closeModal → ui.modal = null]
    G --> K[Show filtered results with Recent / All Commands sections]
    H --> K
    I --> L[closeModal]
    L --> M[action.handler executes]
    M --> N{Action type}
    N -->|Switch Template| O[openModal 'template']
    N -->|Change Theme| P[setActiveTab 'theme']
    N -->|Export PDF| Q[openModal 'export']
    N -->|Export JSON| R[downloadResumeJson → downloadBlob]
    N -->|Create Resume| S[navigate /edit/newId]
    N -->|Toggle Sidebar| T[uiStore.toggleSidebar → sidebarOpen flips]
    N -->|Go to Section| U[setActiveTab sectionId]
    T --> V[Sidebar Show/Hide + createEffect resets isHovered]
    S --> W[createEffect on params.id: forceSave if dirty → attemptLoad]
    M --> X[pushRecent to sessionStorage]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): reset sidebar hover state when..."](https://github.com/lgtm-hq/rustume/commit/0ebece557fd23a88ac1b8dba278686d813b09181) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45739879)</sub>

<!-- /greptile_comment -->