### PR TITLE
feat(web): add print-optimized view

### DIFF
--- a/apps/web/src/__tests__/printStyles.test.ts
+++ b/apps/web/src/__tests__/printStyles.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("print styles", () => {
+  const css = readFileSync(resolve(__dirname, "../index.css"), "utf8");
+
+  it("defines print media rules that hide builder chrome", () => {
+    expect(css).toContain("@media print");
+    expect(css).toContain("[data-print-hide]");
+    expect(css).toContain("[data-print-screen]");
+    expect(css).toContain("[data-print-stack]");
+  });
+
+  it("supports A4 and letter page sizes via named @page rules", () => {
+    expect(css).toContain("@page a4");
+    expect(css).toContain("@page letter");
+    expect(css).toContain("html[data-print-format=\"a4\"]");
+    expect(css).toContain("html[data-print-format=\"letter\"]");
+  });
+
+  it("targets the resume preview paper element", () => {
+    expect(css).toContain("[data-print-root]");
+    expect(css).toContain("page-break-after");
+  });
+});

--- a/apps/web/src/__tests__/printStyles.test.ts
+++ b/apps/web/src/__tests__/printStyles.test.ts
@@ -15,8 +15,8 @@ describe("print styles", () => {
   it("supports A4 and letter page sizes via named @page rules", () => {
     expect(css).toContain("@page a4");
     expect(css).toContain("@page letter");
-    expect(css).toContain("html[data-print-format=\"a4\"]");
-    expect(css).toContain("html[data-print-format=\"letter\"]");
+    expect(css).toContain('html[data-print-format="a4"]');
+    expect(css).toContain('html[data-print-format="letter"]');
   });
 
   it("targets the resume preview paper element", () => {

--- a/apps/web/src/components/builder/SectionPanel.tsx
+++ b/apps/web/src/components/builder/SectionPanel.tsx
@@ -48,6 +48,7 @@ export function SectionPanel() {
       class={`absolute bottom-0 right-0 top-12 z-10 transition-[width] duration-200 ease-out ${
         ui.sectionPanelOpen ? "w-[336px]" : "w-28"
       }`}
+      data-print-hide
       onMouseEnter={() => setSectionPanelOpen(true)}
       onMouseLeave={() => setSectionPanelOpen(false)}
       onFocusIn={() => setSectionPanelOpen(true)}

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -14,7 +14,7 @@ export const AppShell: ParentComponent = (props) => {
   return (
     <div class="min-h-screen bg-paper flex flex-col">
       {/* Top Bar */}
-      <header class="h-14 border-b border-border bg-paper/80 backdrop-blur-sm sticky top-0 z-30">
+      <header class="h-14 border-b border-border bg-paper/80 backdrop-blur-sm sticky top-0 z-30" data-print-hide>
         <div class="h-full px-4 flex items-center justify-between">
           {/* Logo */}
           <A href="/" class="flex items-center gap-2 group">
@@ -56,7 +56,7 @@ export const AppShell: ParentComponent = (props) => {
       <main class="flex-1">{props.children}</main>
 
       {/* Footer */}
-      <footer class="border-t border-border px-4 py-4 text-center text-xs text-stone">
+      <footer class="border-t border-border px-4 py-4 text-center text-xs text-stone" data-print-hide>
         <A href="/terms" class="hover:text-ink underline">
           Terms of Service
         </A>

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -14,7 +14,10 @@ export const AppShell: ParentComponent = (props) => {
   return (
     <div class="min-h-screen bg-paper flex flex-col">
       {/* Top Bar */}
-      <header class="h-14 border-b border-border bg-paper/80 backdrop-blur-sm sticky top-0 z-30" data-print-hide>
+      <header
+        class="h-14 border-b border-border bg-paper/80 backdrop-blur-sm sticky top-0 z-30"
+        data-print-hide
+      >
         <div class="h-full px-4 flex items-center justify-between">
           {/* Logo */}
           <A href="/" class="flex items-center gap-2 group">
@@ -56,7 +59,10 @@ export const AppShell: ParentComponent = (props) => {
       <main class="flex-1">{props.children}</main>
 
       {/* Footer */}
-      <footer class="border-t border-border px-4 py-4 text-center text-xs text-stone" data-print-hide>
+      <footer
+        class="border-t border-border px-4 py-4 text-center text-xs text-stone"
+        data-print-hide
+      >
         <A href="/terms" class="hover:text-ink underline">
           Terms of Service
         </A>

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, Show, For, onCleanup } from "solid-js";
+import { createSignal, createEffect, Show, For, onCleanup, untrack } from "solid-js";
 import { toast } from "../ui";
 import { resumeStore } from "../../stores/resume";
 import { uiStore } from "../../stores/ui";
@@ -20,6 +20,9 @@ export function Preview() {
   const [printPageUrls, setPrintPageUrls] = createSignal<string[]>([]);
 
   let printPagesRequestId = 0;
+
+  // Dedup guard so a degraded print stack only toasts once until a full success
+  let printStackErrorToasted = false;
 
   // Request ID to guard against race conditions
   let resumeRequestId = 0;
@@ -177,7 +180,6 @@ export function Preview() {
       });
   });
 
-
   createEffect(() => {
     setPrintPageFormat(store.resume?.metadata.page.format ?? "a4");
   });
@@ -186,42 +188,69 @@ export function Preview() {
     clearPrintPageFormat();
   });
 
+  // Always keep the current page's URL in the print stack synchronously so
+  // single-page printing never regresses while the multi-page prefetch idles.
   createEffect(() => {
-    const resume = store.resume;
-    const count = totalPages();
-    const currentPage = ui.previewPage;
     const currentUrl = previewUrl();
+    const currentPage = untrack(() => ui.previewPage);
 
-    if (!resume || !currentUrl) {
+    if (!currentUrl) {
       setPrintPageUrls([]);
       return;
     }
 
-    if (!isOnline()) {
-      setPrintPageUrls([currentUrl]);
-      return;
-    }
+    setPrintPageUrls((prev) => {
+      if (currentPage >= prev.length) return [currentUrl];
+      const next = [...prev];
+      next[currentPage] = currentUrl;
+      return next;
+    });
+  });
+
+  // Prefetch the remaining pages for the print stack on a longer idle delay so
+  // rapid edits and page navigation don't multiply server render load.
+  const debouncedPrintStackUrl = useDebounce(previewUrl, 2500);
+
+  createEffect(() => {
+    const currentUrl = debouncedPrintStackUrl();
+    if (!currentUrl) return;
+
+    const resume = untrack(() => store.resume);
+    const count = untrack(totalPages);
+    const currentPage = untrack(() => ui.previewPage);
+
+    if (!resume || count <= 1) return;
+    if (!untrack(isOnline)) return;
 
     const requestId = ++printPagesRequestId;
 
     void (async () => {
-      try {
-        const urls = await Promise.all(
-          Array.from({ length: count }, async (_, page) => {
-            if (page === currentPage) return currentUrl;
-            const result = await renderPreview(resume, page);
-            return result.url;
-          }),
-        );
-        if (requestId === printPagesRequestId) {
-          setPrintPageUrls(urls);
+      const results = await Promise.allSettled(
+        Array.from({ length: count }, async (_, page) => {
+          if (page === currentPage) return currentUrl;
+          const result = await renderPreview(resume, page);
+          return result.url;
+        }),
+      );
+      if (requestId !== printPagesRequestId) return;
+
+      const urls = results
+        .filter((result): result is PromiseFulfilledResult<string> => result.status === "fulfilled")
+        .map((result) => result.value);
+      const failures = results.filter((result) => result.status === "rejected");
+
+      if (failures.length > 0) {
+        console.error("Failed to load print pages:", failures[0].reason);
+        if (!printStackErrorToasted) {
+          printStackErrorToasted = true;
+          toast.error("Some pages may be missing from print output");
         }
-      } catch (printError) {
-        console.error("Failed to load print pages:", printError);
-        if (requestId === printPagesRequestId) {
-          setPrintPageUrls([currentUrl]);
-        }
+      } else {
+        printStackErrorToasted = false;
       }
+
+      // Keep the successfully fetched pages rather than collapsing the stack
+      setPrintPageUrls(urls.length > 0 ? urls : [currentUrl]);
     })();
   });
 
@@ -238,7 +267,10 @@ export function Preview() {
       </div>
 
       {/* Controls */}
-      <div class="flex items-center justify-between px-4 py-2 border-b border-border bg-paper" data-print-hide>
+      <div
+        class="flex items-center justify-between px-4 py-2 border-b border-border bg-paper"
+        data-print-hide
+      >
         <div class="flex items-center gap-2">
           <button
             type="button"
@@ -350,7 +382,6 @@ export function Preview() {
         >
           {/* Paper Effect */}
           <div
-            data-print-root
             class="bg-white rounded-sm shadow-paper paper-texture
               transition-all duration-300 hover:shadow-elevated
               hover:rotate-[0.3deg]"

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -1,10 +1,11 @@
-import { createSignal, createEffect, Show } from "solid-js";
+import { createSignal, createEffect, Show, For, onCleanup } from "solid-js";
 import { toast } from "../ui";
 import { resumeStore } from "../../stores/resume";
 import { uiStore } from "../../stores/ui";
 import { renderPreview } from "../../api/render";
 import { useDebounce } from "../../hooks/useDebounce";
 import { useOnline } from "../../hooks/useOnline";
+import { clearPrintPageFormat, setPrintPageFormat } from "../../lib/printFormat";
 
 export function Preview() {
   const { store } = resumeStore;
@@ -16,6 +17,9 @@ export function Preview() {
   const [error, setError] = createSignal<string | null>(null);
   const [lastCachedUrl, setLastCachedUrl] = createSignal<string | null>(null);
   const [totalPages, setTotalPages] = createSignal(1);
+  const [printPageUrls, setPrintPageUrls] = createSignal<string[]>([]);
+
+  let printPagesRequestId = 0;
 
   // Request ID to guard against race conditions
   let resumeRequestId = 0;
@@ -173,10 +177,68 @@ export function Preview() {
       });
   });
 
+
+  createEffect(() => {
+    setPrintPageFormat(store.resume?.metadata.page.format ?? "a4");
+  });
+
+  onCleanup(() => {
+    clearPrintPageFormat();
+  });
+
+  createEffect(() => {
+    const resume = store.resume;
+    const count = totalPages();
+    const currentPage = ui.previewPage;
+    const currentUrl = previewUrl();
+
+    if (!resume || !currentUrl) {
+      setPrintPageUrls([]);
+      return;
+    }
+
+    if (!isOnline()) {
+      setPrintPageUrls([currentUrl]);
+      return;
+    }
+
+    const requestId = ++printPagesRequestId;
+
+    void (async () => {
+      try {
+        const urls = await Promise.all(
+          Array.from({ length: count }, async (_, page) => {
+            if (page === currentPage) return currentUrl;
+            const result = await renderPreview(resume, page);
+            return result.url;
+          }),
+        );
+        if (requestId === printPagesRequestId) {
+          setPrintPageUrls(urls);
+        }
+      } catch (printError) {
+        console.error("Failed to load print pages:", printError);
+        if (requestId === printPagesRequestId) {
+          setPrintPageUrls([currentUrl]);
+        }
+      }
+    })();
+  });
+
   return (
     <div class="h-full flex flex-col bg-stone/5">
+      <div data-print-stack aria-hidden="true">
+        <For each={printPageUrls()}>
+          {(url) => (
+            <div data-print-root class="bg-white">
+              <img src={url} alt="Resume page" />
+            </div>
+          )}
+        </For>
+      </div>
+
       {/* Controls */}
-      <div class="flex items-center justify-between px-4 py-2 border-b border-border bg-paper">
+      <div class="flex items-center justify-between px-4 py-2 border-b border-border bg-paper" data-print-hide>
         <div class="flex items-center gap-2">
           <button
             type="button"
@@ -274,6 +336,7 @@ export function Preview() {
         class="flex-1 overflow-auto p-6 flex items-start justify-center
           focus:outline-none focus-visible:ring-2 focus-visible:ring-accent
           focus-visible:ring-offset-2 focus-visible:ring-offset-paper"
+        data-print-screen
         tabIndex={0}
         onWheel={handleWheel}
         onKeyDown={handleKeyDown}
@@ -287,6 +350,7 @@ export function Preview() {
         >
           {/* Paper Effect */}
           <div
+            data-print-root
             class="bg-white rounded-sm shadow-paper paper-texture
               transition-all duration-300 hover:shadow-elevated
               hover:rotate-[0.3deg]"

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -181,12 +181,28 @@ export function Preview() {
   });
 
   createEffect(() => {
-    setPrintPageFormat(store.resume?.metadata.page.format ?? "a4");
+    const format = store.resume?.metadata.page.format;
+    if (format) {
+      setPrintPageFormat(format);
+    } else {
+      clearPrintPageFormat();
+    }
   });
 
   onCleanup(() => {
     clearPrintPageFormat();
   });
+
+  // The multi-page prefetch is debounced, so a print triggered inside that
+  // window can go out with pages missing — warn rather than print silently
+  // incomplete output.
+  const handleBeforePrint = () => {
+    if (totalPages() > 1 && printPageUrls().length < totalPages()) {
+      toast.error("Print pages are still loading — some pages may be missing");
+    }
+  };
+  window.addEventListener("beforeprint", handleBeforePrint);
+  onCleanup(() => window.removeEventListener("beforeprint", handleBeforePrint));
 
   // Always keep the current page's URL in the print stack synchronously so
   // single-page printing never regresses while the multi-page prefetch idles.

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -400,8 +400,10 @@ body {
     padding: 0 !important;
     width: 100% !important;
     max-width: none !important;
-    height: auto !important;
-    overflow: visible !important;
+    /* 100vh equals the page box height in print context; hard-constrain so a
+       rounding pixel of overflow can't insert blank interleaved sheets. */
+    height: 100vh !important;
+    overflow: hidden !important;
     background: #fff !important;
     transform: none !important;
     rotate: none !important;
@@ -423,7 +425,7 @@ body {
   [data-print-root] img {
     display: block;
     width: 100%;
-    height: auto;
+    height: 100%;
     max-width: 100%;
     object-fit: contain;
   }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -348,3 +348,87 @@ body {
     transform: translateX(100%);
   }
 }
+
+/* Print — resume preview only (Cmd+P in editor) */
+@page a4 {
+  size: A4;
+  margin: 0;
+}
+
+@page letter {
+  size: letter;
+  margin: 0;
+}
+
+[data-print-stack] {
+  display: none;
+}
+
+@media print {
+  [data-print-hide],
+  [data-print-screen],
+  header,
+  footer,
+  [data-kb-toast-root],
+  [data-kb-dialog-overlay],
+  [data-kb-dialog-content] {
+    display: none !important;
+  }
+
+  html,
+  body,
+  #root,
+  main {
+    background: #fff !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    min-height: 0 !important;
+    height: auto !important;
+    overflow: visible !important;
+  }
+
+  [data-print-stack] {
+    display: block !important;
+  }
+
+  [data-print-root] {
+    page-break-after: always;
+    break-after: page;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+    max-width: none !important;
+    height: auto !important;
+    overflow: visible !important;
+    background: #fff !important;
+    transform: none !important;
+    rotate: none !important;
+  }
+
+  html[data-print-format="a4"] [data-print-root] {
+    page: a4;
+  }
+
+  html[data-print-format="letter"] [data-print-root] {
+    page: letter;
+  }
+
+  [data-print-root]:last-child {
+    page-break-after: auto;
+    break-after: auto;
+  }
+
+  [data-print-root] img {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-width: 100%;
+    object-fit: contain;
+  }
+
+  [data-print-root]::after {
+    display: none !important;
+  }
+}

--- a/apps/web/src/lib/__tests__/printFormat.test.ts
+++ b/apps/web/src/lib/__tests__/printFormat.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearPrintPageFormat, setPrintPageFormat } from "../printFormat";
+
+describe("printFormat", () => {
+  afterEach(() => {
+    clearPrintPageFormat();
+  });
+
+  it("sets data-print-format on the document element", () => {
+    setPrintPageFormat("letter");
+    expect(document.documentElement.dataset.printFormat).toBe("letter");
+  });
+
+  it("clears data-print-format", () => {
+    setPrintPageFormat("a4");
+    clearPrintPageFormat();
+    expect(document.documentElement.dataset.printFormat).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/printFormat.ts
+++ b/apps/web/src/lib/printFormat.ts
@@ -1,0 +1,14 @@
+export type PrintPageFormat = "a4" | "letter";
+
+/** Sync resume page format to the document root for @page print CSS. */
+export function setPrintPageFormat(format: PrintPageFormat | undefined): void {
+  if (format) {
+    document.documentElement.dataset.printFormat = format;
+  } else {
+    delete document.documentElement.dataset.printFormat;
+  }
+}
+
+export function clearPrintPageFormat(): void {
+  delete document.documentElement.dataset.printFormat;
+}

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -402,7 +402,10 @@ export default function Editor() {
   return (
     <div class="h-[calc(100vh-3.5rem)] flex flex-col">
       {/* Toolbar */}
-      <div class="h-12 border-b border-border bg-paper flex items-center justify-between px-4" data-print-hide>
+      <div
+        class="h-12 border-b border-border bg-paper flex items-center justify-between px-4"
+        data-print-hide
+      >
         <div class="flex items-center gap-2">
           {/* Panel Toggle */}
           <div class="flex items-center bg-surface rounded-lg p-0.5">

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -246,8 +246,8 @@ export default function Editor() {
     {
       key: "p",
       mod: true,
-      handler: () => openModal("export"),
-      label: "Export PDF",
+      handler: () => window.print(),
+      label: "Print",
       category: "General",
     },
     {
@@ -402,7 +402,7 @@ export default function Editor() {
   return (
     <div class="h-[calc(100vh-3.5rem)] flex flex-col">
       {/* Toolbar */}
-      <div class="h-12 border-b border-border bg-paper flex items-center justify-between px-4">
+      <div class="h-12 border-b border-border bg-paper flex items-center justify-between px-4" data-print-hide>
         <div class="flex items-center gap-2">
           {/* Panel Toggle */}
           <div class="flex items-center bg-surface rounded-lg p-0.5">
@@ -556,7 +556,7 @@ export default function Editor() {
             showRight={ui.panel !== "editor"}
             defaultRatio={0.45}
             left={
-              <div class="h-full flex">
+              <div class="h-full flex" data-print-hide>
                 {/* Sidebar Navigation */}
                 <Sidebar
                   items={sidebarItems()}

--- a/apps/web/src/pages/__tests__/Editor.print.test.tsx
+++ b/apps/web/src/pages/__tests__/Editor.print.test.tsx
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import { Route, MemoryRouter, createMemoryHistory } from "@solidjs/router";
+import Editor from "../Editor";
+
+const { mockAuthState, navigateMock, ResumeNotFoundErrorMock, RESUME_ID } = vi.hoisted(() => {
+  class ResumeNotFoundError extends Error {
+    constructor(id: string) {
+      super(`Resume not found: ${id}`);
+      this.name = "ResumeNotFoundError";
+    }
+  }
+
+  return {
+    mockAuthState: {
+      loading: false,
+      cloudEnabled: false,
+      requireAuth: false,
+      user: null as { id: string; plan: string } | null,
+    },
+    navigateMock: vi.fn(),
+    ResumeNotFoundErrorMock: ResumeNotFoundError,
+    RESUME_ID: "resume-test-id",
+  };
+});
+
+vi.mock("../../stores/auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    displayName: () => "User",
+  },
+}));
+
+vi.mock("../../wasm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../wasm")>();
+  return {
+    ...actual,
+    getResume: vi.fn().mockRejectedValue(new ResumeNotFoundErrorMock(RESUME_ID)),
+    isWasmReady: () => false,
+    saveResume: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("../../api/render", () => ({
+  renderPreview: vi.fn().mockResolvedValue({ url: "blob:preview", totalPages: 1 }),
+  downloadPdf: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../components/ui")>();
+  return {
+    ...actual,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@solidjs/router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solidjs/router")>();
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+function renderEditor() {
+  const history = createMemoryHistory();
+  history.set({ value: `/edit/${RESUME_ID}`, scroll: false, replace: true });
+
+  return render(() => (
+    <MemoryRouter history={history}>
+      <Route path="/edit/:id" component={Editor} />
+    </MemoryRouter>
+  ));
+}
+
+describe("Editor print shortcut", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+  });
+
+  it("Cmd/Ctrl+P opens the browser print dialog", async () => {
+    const printSpy = vi.spyOn(window, "print").mockImplementation(() => {});
+
+    renderEditor();
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("Full Name")).toBeInTheDocument();
+      },
+      { timeout: 10000 },
+    );
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "p", ctrlKey: true, bubbles: true }),
+    );
+
+    expect(printSpy).toHaveBeenCalledOnce();
+    printSpy.mockRestore();
+  }, 15000);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add print-optimized view
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds a print stylesheet that hides builder chrome and prints only the resume preview pages. Cmd/Ctrl+P in the editor now opens the browser print dialog. Page size follows the resume's A4/Letter format via a `data-print-format` attribute.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Related Issues

Closes #73

## Details

### Web (`apps/web`)
- `@media print` rules in `index.css` with named `@page a4` / `@page letter`
- `data-print-hide` markers on toolbar, sidebar, AppShell chrome, and preview controls
- Print-only page stack for multi-page resumes
- Editor shortcut: Cmd/Ctrl+P → `window.print()` (export remains on the toolbar)
- Helpers + Vitest coverage for format sync, CSS presence, and print hotkey

### Testing
- `bun run test` — print-related suites pass

## Known Limitations

- Printed output uses the 2x-scale preview PNG (~144 DPI), which is softer than PDF export — PDF export remains the quality path for final documents.
- Safari ignores named `@page` size rules, so paper size follows whatever is selected in the print dialog rather than the resume's A4/Letter format.
- Full-bleed pages may clip on printers with hardware margins unless "scale to fit" is enabled in the print dialog.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added browser printing for resumes with dedicated print layouts.
  - Supports A4 and Letter page formats.
  - Automatically hides editor controls, navigation, and other screen-only elements when printing.
  - Added multi-page preview handling and print-specific pagination.
  - Updated the editor shortcut from “Export PDF” to “Print” using Ctrl+P.

- **Tests**
  - Added coverage for print formatting, print styles, and the editor print shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a print-optimized view for the resume editor: Cmd/Ctrl+P now calls `window.print()` (replacing the old "Export PDF" shortcut), builder chrome is hidden via `data-print-hide` / `data-print-screen` markers, and a hidden `[data-print-stack]` renders pre-fetched page images that appear only during printing.

- **Print-stack architecture**: `Preview.tsx` keeps the current page's URL in `printPageUrls` synchronously, then prefetches remaining pages on a 2500 ms debounce. A `beforeprint` listener warns users if the multi-page stack hasn't finished loading.
- **Page-format CSS**: Named `@page a4` / `@page letter` rules combined with a `data-print-format` attribute on `<html>` drive paper-size selection; `printFormat.ts` manages that attribute reactively.
- **Known gaps carried from previous review threads**: the print-stack-collapse on page navigation (line 334 of `Preview.tsx`) and the timing window where `window.print()` can fire before the debounced prefetch completes are still present in this revision — the `beforeprint` toast provides a user-visible warning but does not block the incomplete print job.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for the single-page resume case; multi-page printing may produce incomplete or mis-ordered output until the debounce + collapse issues from prior review threads are addressed.

The page-navigation print-stack collapse (returning `[currentUrl]` whenever `currentPage >= prev.length`) and the unguarded timing window where `window.print()` fires before the multi-page prefetch resolves are both still in the codebase. These affect the print output for any resume with more than one page.

apps/web/src/components/preview/Preview.tsx — specifically the `setPrintPageUrls` updater at line 334 and the `beforeprint` / debounce interaction.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/preview/Preview.tsx | Core of the print feature: adds a hidden print-stack with synchronous single-page caching and a 2500ms-debounced multi-page prefetch. The page-collapse bug flagged in Previous Threads (line 334) is still present; the timing window is mitigated with a beforeprint toast but not eliminated. |
| apps/web/src/index.css | Adds named @page rules (a4/letter) and a @media print block that hides builder chrome and shows the print stack. The reset targets html/body/#root/main but not intermediate SplitPane/flex containers, which could constrain print width in some browsers. |
| apps/web/src/pages/Editor.tsx | Repurposes Cmd/Ctrl+P from "Export PDF" to window.print(); adds data-print-hide to toolbar and left pane. Export PDF remains accessible via toolbar button and command palette. |
| apps/web/src/lib/printFormat.ts | Thin utility that syncs the resume's page format to data-print-format on the document root for named @page CSS rules. Clean and straightforward. |
| apps/web/src/pages/__tests__/Editor.print.test.tsx | Integration test for the Cmd/Ctrl+P → window.print() shortcut. The resume-load mock rejects, yet the test waits for "Full Name" which may only appear in a fallback/placeholder state; the assertion works but tests an error-state editor rather than a loaded one. |
| apps/web/src/components/layout/AppShell.tsx | Adds data-print-hide to the header and footer, correctly hiding AppShell chrome during printing. |
| apps/web/src/components/builder/SectionPanel.tsx | Adds data-print-hide to the section panel overlay so it does not appear in print output. |
| apps/web/src/lib/__tests__/printFormat.test.ts | Vitest unit tests for setPrintPageFormat / clearPrintPageFormat — straightforward and correct. |
| apps/web/src/__tests__/printStyles.test.ts | Snapshot-style test that verifies key CSS selectors and @page rules exist in index.css. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Editor
    participant useHotkeys
    participant Preview
    participant renderPreview
    participant window

    User->>Editor: Cmd/Ctrl+P
    Editor->>useHotkeys: keydown event (preventDefault)
    useHotkeys->>window: window.print()
    window->>Preview: beforeprint event
    Preview->>Preview: handleBeforePrint()
    alt "printPageUrls.length < totalPages"
        Preview->>User: toast.error(pages may be missing)
    end
    window-->>User: browser print dialog

    note over Preview: On resume load / page change
    Preview->>Preview: createEffect → previewUrl()
    Preview->>Preview: setPrintPageUrls (sync, current page)

    note over Preview: After 2500ms debounce
    Preview->>renderPreview: fetch remaining pages
    renderPreview-->>Preview: url + totalPages per page
    Preview->>Preview: setPrintPageUrls (all pages)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Editor
    participant useHotkeys
    participant Preview
    participant renderPreview
    participant window

    User->>Editor: Cmd/Ctrl+P
    Editor->>useHotkeys: keydown event (preventDefault)
    useHotkeys->>window: window.print()
    window->>Preview: beforeprint event
    Preview->>Preview: handleBeforePrint()
    alt "printPageUrls.length < totalPages"
        Preview->>User: toast.error(pages may be missing)
    end
    window-->>User: browser print dialog

    note over Preview: On resume load / page change
    Preview->>Preview: createEffect → previewUrl()
    Preview->>Preview: setPrintPageUrls (sync, current page)

    note over Preview: After 2500ms debounce
    Preview->>renderPreview: fetch remaining pages
    renderPreview-->>Preview: url + totalPages per page
    Preview->>Preview: setPrintPageUrls (all pages)
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["chore: merge main into print-view branch"](https://github.com/lgtm-hq/rustume/commit/b9e31904821e1f54a5923102cf9d85d8b6e26d13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45739888)</sub>

<!-- /greptile_comment -->