### PR TITLE
feat(web): add custom CSS editor in theme sidebar

### DIFF
--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -285,8 +285,11 @@ export function Preview() {
             height: `${842 * ui.previewZoom}px`,
           }}
         >
-          {/* Paper Effect */}
+          {/* Paper Effect — marked as the custom CSS root so user CSS
+              (scoped via @scope in lib/customCss.ts) can style the resume
+              paper surface but never the surrounding app UI. */}
           <div
+            data-custom-css-root
             class="bg-white rounded-sm shadow-paper paper-texture
               transition-all duration-300 hover:shadow-elevated
               hover:rotate-[0.3deg]"

--- a/apps/web/src/components/templates/CustomCssInjector.tsx
+++ b/apps/web/src/components/templates/CustomCssInjector.tsx
@@ -12,6 +12,11 @@ export function CustomCssInjector() {
       clearCustomCssStyle();
       return;
     }
+    // Inject unconditionally, even if no `[data-custom-css-root]` element is
+    // mounted yet: the CSS is wrapped in `@scope ([data-custom-css-root])`,
+    // so without a matching root it simply applies to nothing. This keeps the
+    // injector safe against pathological rules while staying render-order
+    // independent.
     syncCustomCssStyle(css.visible, css.value);
   });
 

--- a/apps/web/src/components/templates/CustomCssInjector.tsx
+++ b/apps/web/src/components/templates/CustomCssInjector.tsx
@@ -1,0 +1,23 @@
+import { createEffect, onCleanup } from "solid-js";
+import { resumeStore } from "../../stores/resume";
+import { clearCustomCssStyle, syncCustomCssStyle } from "../../lib/customCss";
+
+/** Keeps document-level custom CSS in sync with the active resume metadata. */
+export function CustomCssInjector() {
+  const { store } = resumeStore;
+
+  createEffect(() => {
+    const css = store.resume?.metadata.css;
+    if (!css) {
+      clearCustomCssStyle();
+      return;
+    }
+    syncCustomCssStyle(css.visible, css.value);
+  });
+
+  onCleanup(() => {
+    clearCustomCssStyle();
+  });
+
+  return null;
+}

--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -226,7 +226,6 @@ function CustomCssTab(props: CustomCssTabProps) {
         </label>
         <textarea
           id="custom-css-input"
-          aria-label="Custom CSS"
           value={props.css.value}
           onInput={(e) => handleInput(e.currentTarget.value)}
           rows={10}

--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -141,7 +141,7 @@ export function ThemeEditor() {
             {/* Custom CSS Tab */}
             <Show when={activeTab() === "css"}>
               <CustomCssTab
-                css={resume().metadata.css}
+                css={resume().metadata.css ?? { value: "", visible: false }}
                 onChange={(css) => updateMetadata("css", css)}
               />
             </Show>
@@ -202,7 +202,6 @@ function CustomCssTab(props: CustomCssTabProps) {
         </div>
         <button
           type="button"
-          role="button"
           aria-pressed={props.css.visible}
           aria-label="Enable custom CSS"
           onClick={toggleVisible}
@@ -219,7 +218,10 @@ function CustomCssTab(props: CustomCssTabProps) {
       </div>
 
       <div class="space-y-2">
-        <label for="custom-css-input" class="font-mono text-xs uppercase tracking-wider text-stone block">
+        <label
+          for="custom-css-input"
+          class="font-mono text-xs uppercase tracking-wider text-stone block"
+        >
           Custom CSS
         </label>
         <textarea
@@ -237,8 +239,9 @@ function CustomCssTab(props: CustomCssTabProps) {
 
       <p class="text-xs text-stone leading-relaxed">
         Custom CSS applies to HTML and print surfaces in the editor (for example browser print via
-        Cmd/Ctrl+P). The live preview image and PDF export use Typst templates and theme controls
-        instead — custom CSS does not affect PDF export.
+        Cmd/Ctrl+P). Selectors are scoped to the resume content area and cannot affect the app UI.
+        The live preview image and PDF export use Typst templates and theme controls instead —
+        custom CSS does not affect PDF export.
       </p>
     </div>
   );

--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -4,8 +4,8 @@ import { getThemePresets } from "../../stores/themePresets";
 import type { ThemePresetInfo } from "../../wasm/types";
 
 export function ThemeEditor() {
-  const { store, updateTheme } = resumeStore;
-  const [activeTab, setActiveTab] = createSignal<"presets" | "custom">("presets");
+  const { store, updateTheme, updateMetadata } = resumeStore;
+  const [activeTab, setActiveTab] = createSignal<"presets" | "custom" | "css">("presets");
 
   // Theme presets are embedded client-side -- no network dependency.
   const presets = getThemePresets();
@@ -60,7 +60,15 @@ export function ThemeEditor() {
             activeTab() === "custom" ? "bg-white text-ink shadow-sm" : "text-stone hover:text-ink"
           }`}
         >
-          Custom
+          Custom Colors
+        </button>
+        <button
+          onClick={() => setActiveTab("css")}
+          class={`flex-1 px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+            activeTab() === "css" ? "bg-white text-ink shadow-sm" : "text-stone hover:text-ink"
+          }`}
+        >
+          CSS
         </button>
       </div>
 
@@ -108,7 +116,7 @@ export function ThemeEditor() {
               </div>
             </Show>
 
-            {/* Custom Tab */}
+            {/* Custom Colors Tab */}
             <Show when={activeTab() === "custom"}>
               {/* Color Inputs */}
               <div class="grid grid-cols-3 gap-4">
@@ -128,6 +136,14 @@ export function ThemeEditor() {
                   onChange={(v) => updateTheme({ primary: v, preset: undefined })}
                 />
               </div>
+            </Show>
+
+            {/* Custom CSS Tab */}
+            <Show when={activeTab() === "css"}>
+              <CustomCssTab
+                css={resume().metadata.css}
+                onChange={(css) => updateMetadata("css", css)}
+              />
             </Show>
 
             {/* Preview */}
@@ -159,6 +175,71 @@ export function ThemeEditor() {
           </div>
         )}
       </Show>
+    </div>
+  );
+}
+
+interface CustomCssTabProps {
+  css: { value: string; visible: boolean };
+  onChange: (css: { value: string; visible: boolean }) => void;
+}
+
+function CustomCssTab(props: CustomCssTabProps) {
+  const toggleVisible = () => {
+    props.onChange({ ...props.css, visible: !props.css.visible });
+  };
+
+  const handleInput = (value: string) => {
+    props.onChange({ ...props.css, value });
+  };
+
+  return (
+    <div class="space-y-4">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <p class="text-sm font-medium text-ink">Enable custom CSS</p>
+          <p class="text-xs text-stone">Inject styles into HTML and print views</p>
+        </div>
+        <button
+          type="button"
+          role="button"
+          aria-pressed={props.css.visible}
+          aria-label="Enable custom CSS"
+          onClick={toggleVisible}
+          class={`relative h-5 w-9 flex-shrink-0 rounded-full transition-colors ${
+            props.css.visible ? "bg-accent" : "bg-border"
+          }`}
+        >
+          <span
+            class={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-paper shadow-sm transition-transform ${
+              props.css.visible ? "translate-x-4" : "translate-x-0"
+            }`}
+          />
+        </button>
+      </div>
+
+      <div class="space-y-2">
+        <label for="custom-css-input" class="font-mono text-xs uppercase tracking-wider text-stone block">
+          Custom CSS
+        </label>
+        <textarea
+          id="custom-css-input"
+          aria-label="Custom CSS"
+          value={props.css.value}
+          onInput={(e) => handleInput(e.currentTarget.value)}
+          rows={10}
+          spellcheck={false}
+          class="w-full px-3 py-2 text-xs font-mono bg-surface border border-border rounded-lg
+            focus:outline-none focus:border-accent resize-y min-h-[160px]"
+          placeholder={`.resume-title {\n  letter-spacing: 0.05em;\n}`}
+        />
+      </div>
+
+      <p class="text-xs text-stone leading-relaxed">
+        Custom CSS applies to HTML and print surfaces in the editor (for example browser print via
+        Cmd/Ctrl+P). The live preview image and PDF export use Typst templates and theme controls
+        instead — custom CSS does not affect PDF export.
+      </p>
     </div>
   );
 }

--- a/apps/web/src/components/templates/__tests__/ThemeEditor.test.tsx
+++ b/apps/web/src/components/templates/__tests__/ThemeEditor.test.tsx
@@ -50,9 +50,12 @@ describe("ThemeEditor custom CSS tab", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "CSS" }));
 
+    expect(screen.getByText(/HTML and print surfaces/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/HTML and print surfaces/i),
+      screen.getByText(/scoped to the resume content area and cannot affect the app UI/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/PDF export use Typst templates and theme controls/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/PDF export use Typst templates and theme controls/i),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/templates/__tests__/ThemeEditor.test.tsx
+++ b/apps/web/src/components/templates/__tests__/ThemeEditor.test.tsx
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { ThemeEditor } from "../ThemeEditor";
+import { resumeStore } from "../../../stores/resume";
+
+vi.mock("../../../wasm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../wasm")>();
+  return {
+    ...actual,
+    saveResume: vi.fn().mockResolvedValue(undefined),
+    isWasmReady: () => false,
+  };
+});
+
+describe("ThemeEditor custom CSS tab", () => {
+  beforeEach(() => {
+    resumeStore.createNewResume("theme-editor-css-test");
+  });
+
+  it("shows the CSS tab and persists textarea changes", async () => {
+    render(() => <ThemeEditor />);
+
+    fireEvent.click(screen.getByRole("button", { name: "CSS" }));
+
+    const textarea = screen.getByLabelText("Custom CSS");
+    fireEvent.input(textarea, { target: { value: ".resume { color: red; }" } });
+
+    expect(resumeStore.store.resume?.metadata.css.value).toBe(".resume { color: red; }");
+  });
+
+  it("toggles custom CSS visibility via metadata.css.visible", async () => {
+    render(() => <ThemeEditor />);
+
+    fireEvent.click(screen.getByRole("button", { name: "CSS" }));
+
+    const toggle = screen.getByRole("button", { name: "Enable custom CSS" });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(toggle);
+    expect(resumeStore.store.resume?.metadata.css.visible).toBe(true);
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(toggle);
+    expect(resumeStore.store.resume?.metadata.css.visible).toBe(false);
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("explains that custom CSS applies to HTML and print surfaces only", async () => {
+    render(() => <ThemeEditor />);
+
+    fireEvent.click(screen.getByRole("button", { name: "CSS" }));
+
+    expect(
+      screen.getByText(/HTML and print surfaces/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/PDF export use Typst templates and theme controls/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/__tests__/customCss.test.ts
+++ b/apps/web/src/lib/__tests__/customCss.test.ts
@@ -1,17 +1,24 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { CUSTOM_CSS_STYLE_ID, clearCustomCssStyle, syncCustomCssStyle } from "../customCss";
+import {
+  CUSTOM_CSS_ROOT_ATTRIBUTE,
+  CUSTOM_CSS_STYLE_ID,
+  clearCustomCssStyle,
+  syncCustomCssStyle,
+} from "../customCss";
+
+const scoped = (value: string) => `@scope ([${CUSTOM_CSS_ROOT_ATTRIBUTE}]) {\n${value}\n}`;
 
 describe("customCss", () => {
   afterEach(() => {
     clearCustomCssStyle();
   });
 
-  it("injects a style element when visible with non-empty CSS", () => {
+  it("injects a style element scoped to the custom CSS root when visible", () => {
     syncCustomCssStyle(true, ".resume { color: red; }");
 
     const style = document.getElementById(CUSTOM_CSS_STYLE_ID);
     expect(style).toBeInstanceOf(HTMLStyleElement);
-    expect(style?.textContent).toBe(".resume { color: red; }");
+    expect(style?.textContent).toBe(scoped(".resume { color: red; }"));
   });
 
   it("removes the style element when disabled or empty", () => {
@@ -30,6 +37,6 @@ describe("customCss", () => {
 
     const styles = document.querySelectorAll(`#${CUSTOM_CSS_STYLE_ID}`);
     expect(styles.length).toBe(1);
-    expect(styles[0]?.textContent).toBe("a { color: green; }");
+    expect(styles[0]?.textContent).toBe(scoped("a { color: green; }"));
   });
 });

--- a/apps/web/src/lib/__tests__/customCss.test.ts
+++ b/apps/web/src/lib/__tests__/customCss.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { CUSTOM_CSS_STYLE_ID, clearCustomCssStyle, syncCustomCssStyle } from "../customCss";
+
+describe("customCss", () => {
+  afterEach(() => {
+    clearCustomCssStyle();
+  });
+
+  it("injects a style element when visible with non-empty CSS", () => {
+    syncCustomCssStyle(true, ".resume { color: red; }");
+
+    const style = document.getElementById(CUSTOM_CSS_STYLE_ID);
+    expect(style).toBeInstanceOf(HTMLStyleElement);
+    expect(style?.textContent).toBe(".resume { color: red; }");
+  });
+
+  it("removes the style element when disabled or empty", () => {
+    syncCustomCssStyle(true, "body { margin: 0; }");
+    syncCustomCssStyle(false, "body { margin: 0; }");
+    expect(document.getElementById(CUSTOM_CSS_STYLE_ID)).toBeNull();
+
+    syncCustomCssStyle(true, "body { margin: 0; }");
+    syncCustomCssStyle(true, "   ");
+    expect(document.getElementById(CUSTOM_CSS_STYLE_ID)).toBeNull();
+  });
+
+  it("updates existing style content in place", () => {
+    syncCustomCssStyle(true, "a { color: blue; }");
+    syncCustomCssStyle(true, "a { color: green; }");
+
+    const styles = document.querySelectorAll(`#${CUSTOM_CSS_STYLE_ID}`);
+    expect(styles.length).toBe(1);
+    expect(styles[0]?.textContent).toBe("a { color: green; }");
+  });
+});

--- a/apps/web/src/lib/__tests__/customCss.test.ts
+++ b/apps/web/src/lib/__tests__/customCss.test.ts
@@ -39,4 +39,16 @@ describe("customCss", () => {
     expect(styles.length).toBe(1);
     expect(styles[0]?.textContent).toBe(scoped("a { color: green; }"));
   });
+
+  it("strips unmatched closing braces so user CSS cannot escape the scope", () => {
+    syncCustomCssStyle(true, "} * { display: none; }");
+    const style = document.getElementById(CUSTOM_CSS_STYLE_ID);
+    expect(style?.textContent).toBe(scoped(" * { display: none; }"));
+  });
+
+  it("keeps balanced braces and ignores braces inside comments", () => {
+    syncCustomCssStyle(true, "/* } */ a { color: red; }");
+    const style = document.getElementById(CUSTOM_CSS_STYLE_ID);
+    expect(style?.textContent).toBe(scoped(" a { color: red; }"));
+  });
 });

--- a/apps/web/src/lib/customCss.ts
+++ b/apps/web/src/lib/customCss.ts
@@ -1,0 +1,29 @@
+export const CUSTOM_CSS_STYLE_ID = "rustume-custom-css";
+
+/** Inject or remove resume custom CSS on the document for HTML and print surfaces. */
+export function syncCustomCssStyle(visible: boolean, value: string): void {
+  const existing = document.getElementById(CUSTOM_CSS_STYLE_ID);
+
+  if (!visible || value.trim() === "") {
+    existing?.remove();
+    return;
+  }
+
+  if (existing instanceof HTMLStyleElement) {
+    if (existing.textContent !== value) {
+      existing.textContent = value;
+    }
+    return;
+  }
+
+  existing?.remove();
+
+  const style = document.createElement("style");
+  style.id = CUSTOM_CSS_STYLE_ID;
+  style.textContent = value;
+  document.head.appendChild(style);
+}
+
+export function clearCustomCssStyle(): void {
+  document.getElementById(CUSTOM_CSS_STYLE_ID)?.remove();
+}

--- a/apps/web/src/lib/customCss.ts
+++ b/apps/web/src/lib/customCss.ts
@@ -4,6 +4,29 @@ export const CUSTOM_CSS_STYLE_ID = "rustume-custom-css";
 export const CUSTOM_CSS_ROOT_ATTRIBUTE = "data-custom-css-root";
 
 /**
+ * Drop brace characters that would escape the wrapping `@scope` block: an
+ * unmatched `}` at nesting depth 0 would close the scope early and make
+ * everything after it apply globally. Comments are stripped first so braces
+ * inside them don't skew the depth count. Valid CSS is unaffected (its braces
+ * are balanced); malformed CSS loses only the unmatched closers.
+ */
+export function stripUnmatchedClosers(value: string): string {
+  const withoutComments = value.replace(/\/\*[\s\S]*?(?:\*\/|$)/g, "");
+  let depth = 0;
+  let out = "";
+  for (const char of withoutComments) {
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      if (depth === 0) continue;
+      depth -= 1;
+    }
+    out += char;
+  }
+  return out;
+}
+
+/**
  * Wrap user CSS in a native `@scope` block so selectors only match inside
  * elements marked with `data-custom-css-root`. This prevents pathological
  * rules (e.g. `* { display: none !important }`) from hiding the app UI —
@@ -12,7 +35,7 @@ export const CUSTOM_CSS_ROOT_ATTRIBUTE = "data-custom-css-root";
  * no-op rather than an unscoped injection.
  */
 function scopeCustomCss(value: string): string {
-  return `@scope ([${CUSTOM_CSS_ROOT_ATTRIBUTE}]) {\n${value}\n}`;
+  return `@scope ([${CUSTOM_CSS_ROOT_ATTRIBUTE}]) {\n${stripUnmatchedClosers(value)}\n}`;
 }
 
 /** Inject or remove resume custom CSS on the document for HTML and print surfaces. */

--- a/apps/web/src/lib/customCss.ts
+++ b/apps/web/src/lib/customCss.ts
@@ -1,5 +1,20 @@
 export const CUSTOM_CSS_STYLE_ID = "rustume-custom-css";
 
+/** Attribute marking the container(s) that user CSS is allowed to style. */
+export const CUSTOM_CSS_ROOT_ATTRIBUTE = "data-custom-css-root";
+
+/**
+ * Wrap user CSS in a native `@scope` block so selectors only match inside
+ * elements marked with `data-custom-css-root`. This prevents pathological
+ * rules (e.g. `* { display: none !important }`) from hiding the app UI —
+ * including the toggle needed to disable the CSS again. Browsers without
+ * `@scope` support ignore the whole block, so the feature degrades to a
+ * no-op rather than an unscoped injection.
+ */
+function scopeCustomCss(value: string): string {
+  return `@scope ([${CUSTOM_CSS_ROOT_ATTRIBUTE}]) {\n${value}\n}`;
+}
+
 /** Inject or remove resume custom CSS on the document for HTML and print surfaces. */
 export function syncCustomCssStyle(visible: boolean, value: string): void {
   const existing = document.getElementById(CUSTOM_CSS_STYLE_ID);
@@ -9,9 +24,11 @@ export function syncCustomCssStyle(visible: boolean, value: string): void {
     return;
   }
 
+  const scoped = scopeCustomCss(value);
+
   if (existing instanceof HTMLStyleElement) {
-    if (existing.textContent !== value) {
-      existing.textContent = value;
+    if (existing.textContent !== scoped) {
+      existing.textContent = scoped;
     }
     return;
   }
@@ -20,7 +37,7 @@ export function syncCustomCssStyle(visible: boolean, value: string): void {
 
   const style = document.createElement("style");
   style.id = CUSTOM_CSS_STYLE_ID;
-  style.textContent = value;
+  style.textContent = scoped;
   document.head.appendChild(style);
 }
 

--- a/apps/web/src/pages/Editor.tsx
+++ b/apps/web/src/pages/Editor.tsx
@@ -26,6 +26,7 @@ import {
 import { resumeStore, isNotFoundError } from "../stores/resume";
 import { uiStore } from "../stores/ui";
 import { isWasmReady } from "../wasm";
+import { CustomCssInjector } from "../components/templates/CustomCssInjector";
 
 const Preview = lazy(() =>
   import("../components/preview").then((module) => ({ default: module.Preview })),
@@ -401,6 +402,7 @@ export default function Editor() {
 
   return (
     <div class="h-[calc(100vh-3.5rem)] flex flex-col">
+      <CustomCssInjector />
       {/* Toolbar */}
       <div class="h-12 border-b border-border bg-paper flex items-center justify-between px-4">
         <div class="flex items-center gap-2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add custom CSS editor in theme sidebar
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds a Custom CSS tab in the theme editor so users can edit and toggle `metadata.css` (already in the schema). When enabled, CSS is injected into the document as `<style id="rustume-custom-css">` for HTML/print surfaces. Typst PDF preview/export is unchanged — helper copy in the UI states this clearly (no CSS→Typst compiler in this PR).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Related Issues

Closes #71

## Details

### Web (`apps/web`)
- ThemeEditor tabs: Presets | Custom Colors | CSS
- Monospace textarea + enable toggle bound to `metadata.css.value` / `visible`
- `CustomCssInjector` keeps document head style in sync while editing
- Vitest coverage for ThemeEditor CSS tab and inject/remove helpers

### Limitations
- Does not affect Typst→PNG live preview or PDF export
- Global document injection — users should scope selectors carefully

### Testing
- `bun run test`, typecheck, and lint pass for web changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a Custom CSS tab to the theme sidebar, letting users write CSS that is scoped to the resume paper surface via a native `@scope ([data-custom-css-root])` wrapper and injected into `document.head` through a new reactive `CustomCssInjector` component. The security architecture is sound — unmatched `}` closers are stripped before wrapping, and the `data-custom-css-root` anchor in `Preview.tsx` keeps styles confined to the resume area.

- **`customCss.ts`**: `stripUnmatchedClosers` removes block-escape attempts but doesn't track CSS string delimiters, so a `}` inside a string value (e.g. `content: \"}\"`) is misread as a block closer, potentially corrupting sibling rules that follow.
- **`CustomCssInjector.tsx`**: SolidJS `createEffect` + `onCleanup` wiring is correct and render-order independent; the `@scope` fallback (no-op on older browsers) is well-considered.
- **Tests**: Cover the primary injection, toggle, deduplication, and escape scenarios; a case for `}` inside a quoted string value is missing.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the CSS scoping mechanism and injection lifecycle are correct, and the only defect requires a `}` character inside a CSS quoted string — an extremely rare pattern for resume styling.

The `@scope` security boundary holds: unmatched closers are stripped before wrapping, and `data-custom-css-root` correctly anchors scope to the resume paper div. The one correctness gap — `}` inside string literals bypasses the depth counter — is a narrow edge case that produces malformed but still largely functional CSS rather than an escape.

`apps/web/src/lib/customCss.ts` — the `stripUnmatchedClosers` function needs string-delimiter tracking to handle `}` inside CSS quoted values correctly.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/customCss.ts | Core CSS sanitization and injection logic — `stripUnmatchedClosers` correctly handles unmatched `}` for security but does not track CSS string delimiters, causing `}` inside string values (e.g. `content: "}"`) to be counted as block closers, which can corrupt subsequent sibling rules. |
| apps/web/src/components/templates/CustomCssInjector.tsx | SolidJS reactive component that syncs store CSS to document head; effect + onCleanup wiring is correct and render-order independent. |
| apps/web/src/components/templates/ThemeEditor.tsx | Adds CSS tab with toggle and monospace textarea; props flow and reactive bindings look correct, previous ARIA concerns appear addressed. |
| apps/web/src/components/preview/Preview.tsx | Adds `data-custom-css-root` attribute to the paper div so `@scope` targeting is correctly anchored to the resume surface. |
| apps/web/src/pages/Editor.tsx | Mounts `CustomCssInjector` as the first child of the editor root; it renders null so placement is inconsequential. |
| apps/web/src/lib/__tests__/customCss.test.ts | Good coverage for injection, removal, deduplication, and the `}` escape test; missing a case for `}` inside a CSS string value where the stripping misfires. |
| apps/web/src/components/templates/__tests__/ThemeEditor.test.tsx | Covers tab navigation, textarea persistence, toggle round-trip, and help-text assertions; straightforward and correct. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant TE as ThemeEditor (CSS Tab)
    participant RS as resumeStore
    participant CI as CustomCssInjector
    participant CC as customCss.ts
    participant DOM as document.head

    U->>TE: Types CSS / toggles enable
    TE->>RS: "updateMetadata("css", {value, visible})"
    RS-->>CI: reactive update (createEffect)
    CI->>CC: syncCustomCssStyle(visible, value)
    CC->>CC: stripUnmatchedClosers(value)
    CC->>CC: "scopeCustomCss → @scope([data-custom-css-root])"
    CC->>DOM: "style#rustume-custom-css.textContent = scoped"

    note over DOM: @scope limits rules to [data-custom-css-root] in Preview.tsx

    U->>TE: Disables toggle
    TE->>RS: "updateMetadata("css", {visible: false})"
    RS-->>CI: reactive update
    CI->>CC: syncCustomCssStyle(false, value)
    CC->>DOM: "style#rustume-custom-css.remove()"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant TE as ThemeEditor (CSS Tab)
    participant RS as resumeStore
    participant CI as CustomCssInjector
    participant CC as customCss.ts
    participant DOM as document.head

    U->>TE: Types CSS / toggles enable
    TE->>RS: "updateMetadata("css", {value, visible})"
    RS-->>CI: reactive update (createEffect)
    CI->>CC: syncCustomCssStyle(visible, value)
    CC->>CC: stripUnmatchedClosers(value)
    CC->>CC: "scopeCustomCss → @scope([data-custom-css-root])"
    CC->>DOM: "style#rustume-custom-css.textContent = scoped"

    note over DOM: @scope limits rules to [data-custom-css-root] in Preview.tsx

    U->>TE: Disables toggle
    TE->>RS: "updateMetadata("css", {visible: false})"
    RS-->>CI: reactive update
    CI->>CC: syncCustomCssStyle(false, value)
    CC->>DOM: "style#rustume-custom-css.remove()"
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): prevent scope escape via unmat..."](https://github.com/lgtm-hq/rustume/commit/b8879c1e80f41b0aad7680cb010b80ef17966c63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45739895)</sub>

<!-- /greptile_comment -->