### PR TITLE
feat(web): add fuzzy search across resumes

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -17,6 +17,7 @@
         "@tiptap/extension-underline": "^3.22.1",
         "@tiptap/pm": "^3.22.1",
         "@tiptap/starter-kit": "^3.22.1",
+        "fuse.js": "^7.5.0",
         "postcss": "^8.5.8",
         "solid-js": "^1.9.12",
         "tailwindcss": "^4.2.2",
@@ -766,6 +767,8 @@
     "function.prototype.name": ["function.prototype.name@1.2.0", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2", "hasown": "^2.0.4", "is-callable": "^1.2.7", "is-document.all": "^1.0.0" } }, "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew=="],
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="],
+
+    "fuse.js": ["fuse.js@7.5.0", "", {}, "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow=="],
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@tiptap/extension-underline": "^3.22.1",
     "@tiptap/pm": "^3.22.1",
     "@tiptap/starter-kit": "^3.22.1",
+    "fuse.js": "^7.5.0",
     "postcss": "^8.5.8",
     "solid-js": "^1.9.12",
     "tailwindcss": "^4.2.2",

--- a/apps/web/src/lib/__tests__/resumeSearch.test.ts
+++ b/apps/web/src/lib/__tests__/resumeSearch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ResumeListItem } from "../../stores/persistence";
-import { filterResumes } from "../resumeSearch";
+import { createResumeSearchIndex, filterResumes } from "../resumeSearch";
 
 const sampleResumes: ResumeListItem[] = [
   { id: "1", name: "Software Engineer", updatedAt: new Date("2025-01-01") },
@@ -8,9 +8,13 @@ const sampleResumes: ResumeListItem[] = [
   { id: "3", name: "Jane Doe — Designer", updatedAt: new Date("2025-03-01") },
 ];
 
+function search(resumes: ResumeListItem[], query: string) {
+  return filterResumes(createResumeSearchIndex(resumes), query);
+}
+
 describe("filterResumes", () => {
   it("returns all resumes when the query is empty", () => {
-    const results = filterResumes(sampleResumes, "");
+    const results = search(sampleResumes, "");
     expect(results).toHaveLength(3);
     expect(results.map((item) => item.resume.name)).toEqual([
       "Software Engineer",
@@ -20,26 +24,78 @@ describe("filterResumes", () => {
   });
 
   it("fuzzy-matches resume titles", () => {
-    const results = filterResumes(sampleResumes, "enginer");
+    const results = search(sampleResumes, "enginer");
     expect(results).toHaveLength(1);
     expect(results[0].resume.name).toBe("Software Engineer");
   });
 
   it("matches by person name in the title", () => {
-    const results = filterResumes(sampleResumes, "jane");
+    const results = search(sampleResumes, "jane");
     expect(results).toHaveLength(1);
     expect(results[0].resume.name).toBe("Jane Doe — Designer");
   });
 
   it("returns no results when nothing matches", () => {
-    expect(filterResumes(sampleResumes, "zzzznotfound")).toHaveLength(0);
+    expect(search(sampleResumes, "zzzznotfound")).toHaveLength(0);
   });
 
   it("marks matched substrings for highlighting", () => {
-    const results = filterResumes(sampleResumes, "product");
+    const results = search(sampleResumes, "product");
     expect(results[0].nameSegments).toEqual([
       { text: "Product", highlighted: true },
       { text: " Manager", highlighted: false },
     ]);
+  });
+
+  it("matches on basics.name metadata without highlighting the title", () => {
+    const resumes: ResumeListItem[] = [
+      {
+        id: "1",
+        name: "Backend CV",
+        basicsName: "Maria Silva",
+        updatedAt: new Date("2025-01-01"),
+      },
+      { id: "2", name: "Frontend CV", updatedAt: new Date("2025-02-01") },
+    ];
+    const results = search(resumes, "maria");
+    expect(results).toHaveLength(1);
+    expect(results[0].resume.name).toBe("Backend CV");
+    // Highlighting stays on the displayed name only — no marks here
+    expect(results[0].nameSegments).toEqual([{ text: "Backend CV", highlighted: false }]);
+  });
+
+  it("matches on headline metadata", () => {
+    const resumes: ResumeListItem[] = [
+      {
+        id: "1",
+        name: "My Resume",
+        headline: "Staff Platform Engineer",
+        updatedAt: new Date("2025-01-01"),
+      },
+      { id: "2", name: "Other Resume", updatedAt: new Date("2025-02-01") },
+    ];
+    const results = search(resumes, "platform");
+    expect(results).toHaveLength(1);
+    expect(results[0].resume.name).toBe("My Resume");
+  });
+
+  it("ignores diacritics so 'jose' matches 'José'", () => {
+    const resumes: ResumeListItem[] = [
+      { id: "1", name: "José García", updatedAt: new Date("2025-01-01") },
+      { id: "2", name: "Product Manager", updatedAt: new Date("2025-02-01") },
+    ];
+    const results = search(resumes, "jose");
+    expect(results).toHaveLength(1);
+    expect(results[0].resume.name).toBe("José García");
+  });
+
+  it("does not highlight single-character matches", () => {
+    const results = search(sampleResumes, "e");
+    for (const item of results) {
+      const highlighted = item.nameSegments.filter((segment) => segment.highlighted);
+      for (const segment of highlighted) {
+        expect(segment.text.length).toBeGreaterThanOrEqual(2);
+      }
+    }
   });
 });

--- a/apps/web/src/lib/__tests__/resumeSearch.test.ts
+++ b/apps/web/src/lib/__tests__/resumeSearch.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { ResumeListItem } from "../../stores/persistence";
+import { filterResumes } from "../resumeSearch";
+
+const sampleResumes: ResumeListItem[] = [
+  { id: "1", name: "Software Engineer", updatedAt: new Date("2025-01-01") },
+  { id: "2", name: "Product Manager", updatedAt: new Date("2025-02-01") },
+  { id: "3", name: "Jane Doe — Designer", updatedAt: new Date("2025-03-01") },
+];
+
+describe("filterResumes", () => {
+  it("returns all resumes when the query is empty", () => {
+    const results = filterResumes(sampleResumes, "");
+    expect(results).toHaveLength(3);
+    expect(results.map((item) => item.resume.name)).toEqual([
+      "Software Engineer",
+      "Product Manager",
+      "Jane Doe — Designer",
+    ]);
+  });
+
+  it("fuzzy-matches resume titles", () => {
+    const results = filterResumes(sampleResumes, "enginer");
+    expect(results).toHaveLength(1);
+    expect(results[0].resume.name).toBe("Software Engineer");
+  });
+
+  it("matches by person name in the title", () => {
+    const results = filterResumes(sampleResumes, "jane");
+    expect(results).toHaveLength(1);
+    expect(results[0].resume.name).toBe("Jane Doe — Designer");
+  });
+
+  it("returns no results when nothing matches", () => {
+    expect(filterResumes(sampleResumes, "zzzznotfound")).toHaveLength(0);
+  });
+
+  it("marks matched substrings for highlighting", () => {
+    const results = filterResumes(sampleResumes, "product");
+    expect(results[0].nameSegments).toEqual([
+      { text: "Product", highlighted: true },
+      { text: " Manager", highlighted: false },
+    ]);
+  });
+});

--- a/apps/web/src/lib/resumeSearch.ts
+++ b/apps/web/src/lib/resumeSearch.ts
@@ -33,10 +33,7 @@ export interface FilteredResumeItem {
   nameSegments: TextSegment[];
 }
 
-function buildHighlightSegments(
-  text: string,
-  indices: readonly [number, number][],
-): TextSegment[] {
+function buildHighlightSegments(text: string, indices: readonly [number, number][]): TextSegment[] {
   if (!indices.length) {
     return [{ text, highlighted: false }];
   }
@@ -60,27 +57,52 @@ function buildHighlightSegments(
   return segments.filter((segment) => segment.text.length > 0);
 }
 
-/** Fuzzy-filter resumes by title/name and return highlight segments for matches. */
-export function filterResumes(
-  resumes: ResumeListItem[],
-  query: string,
-): FilteredResumeItem[] {
+/** Strip diacritics so e.g. "jose" matches "José". */
+function foldDiacritics(text: string): string {
+  return text.normalize("NFD").replace(/\p{M}/gu, "");
+}
+
+export interface ResumeSearchIndex {
+  resumes: ResumeListItem[];
+  fuse: Fuse<ResumeListItem>;
+}
+
+/** Build a reusable Fuse index over resume title, basics.name, and headline. */
+export function createResumeSearchIndex(resumes: ResumeListItem[]): ResumeSearchIndex {
+  const fuse = new Fuse(resumes, {
+    keys: [
+      { name: "name", weight: 2 },
+      { name: "basicsName", weight: 2 },
+      { name: "headline", weight: 1 },
+    ],
+    threshold: 0.4,
+    includeMatches: true,
+    ignoreLocation: true,
+    minMatchCharLength: 2,
+    getFn: (obj, path) => {
+      const key = Array.isArray(path) ? path.join(".") : path;
+      const value = (obj as unknown as Record<string, unknown>)[key];
+      return typeof value === "string" ? foldDiacritics(value) : "";
+    },
+  });
+  return { resumes, fuse };
+}
+
+/**
+ * Fuzzy-filter resumes against a prebuilt index and return highlight segments.
+ * Highlighting applies to the displayed name only; matches on hidden fields
+ * (basics.name, headline) include the item without marks.
+ */
+export function filterResumes(index: ResumeSearchIndex, query: string): FilteredResumeItem[] {
   const trimmed = query.trim();
   if (!trimmed) {
-    return resumes.map((resume) => ({
+    return index.resumes.map((resume) => ({
       resume,
       nameSegments: [{ text: resume.name, highlighted: false }],
     }));
   }
 
-  const fuse = new Fuse(resumes, {
-    keys: ["name"],
-    threshold: 0.4,
-    includeMatches: true,
-    ignoreLocation: true,
-  });
-
-  return fuse.search(trimmed).map((result) => {
+  return index.fuse.search(foldDiacritics(trimmed)).map((result) => {
     const nameMatch = result.matches?.find((match) => match.key === "name");
     const nameSegments = nameMatch
       ? buildHighlightSegments(result.item.name, nameMatch.indices)

--- a/apps/web/src/lib/resumeSearch.ts
+++ b/apps/web/src/lib/resumeSearch.ts
@@ -1,0 +1,91 @@
+import Fuse from "fuse.js";
+import type { ResumeListItem } from "../stores/persistence";
+
+export const RESUME_SEARCH_QUERY_KEY = "rustume:home-resume-search";
+
+export function getStoredSearchQuery(): string {
+  try {
+    return sessionStorage.getItem(RESUME_SEARCH_QUERY_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function setStoredSearchQuery(query: string): void {
+  try {
+    if (query) {
+      sessionStorage.setItem(RESUME_SEARCH_QUERY_KEY, query);
+    } else {
+      sessionStorage.removeItem(RESUME_SEARCH_QUERY_KEY);
+    }
+  } catch {
+    // sessionStorage may be unavailable in private browsing or tests
+  }
+}
+
+export interface TextSegment {
+  text: string;
+  highlighted: boolean;
+}
+
+export interface FilteredResumeItem {
+  resume: ResumeListItem;
+  nameSegments: TextSegment[];
+}
+
+function buildHighlightSegments(
+  text: string,
+  indices: readonly [number, number][],
+): TextSegment[] {
+  if (!indices.length) {
+    return [{ text, highlighted: false }];
+  }
+
+  const sorted = [...indices].sort((a, b) => a[0] - b[0]);
+  const segments: TextSegment[] = [];
+  let cursor = 0;
+
+  for (const [start, end] of sorted) {
+    if (start > cursor) {
+      segments.push({ text: text.slice(cursor, start), highlighted: false });
+    }
+    segments.push({ text: text.slice(start, end + 1), highlighted: true });
+    cursor = end + 1;
+  }
+
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), highlighted: false });
+  }
+
+  return segments.filter((segment) => segment.text.length > 0);
+}
+
+/** Fuzzy-filter resumes by title/name and return highlight segments for matches. */
+export function filterResumes(
+  resumes: ResumeListItem[],
+  query: string,
+): FilteredResumeItem[] {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return resumes.map((resume) => ({
+      resume,
+      nameSegments: [{ text: resume.name, highlighted: false }],
+    }));
+  }
+
+  const fuse = new Fuse(resumes, {
+    keys: ["name"],
+    threshold: 0.4,
+    includeMatches: true,
+    ignoreLocation: true,
+  });
+
+  return fuse.search(trimmed).map((result) => {
+    const nameMatch = result.matches?.find((match) => match.key === "name");
+    const nameSegments = nameMatch
+      ? buildHighlightSegments(result.item.name, nameMatch.indices)
+      : [{ text: result.item.name, highlighted: false }];
+
+    return { resume: result.item, nameSegments };
+  });
+}

--- a/apps/web/src/lib/resumeSearch.ts
+++ b/apps/web/src/lib/resumeSearch.ts
@@ -39,10 +39,22 @@ function buildHighlightSegments(text: string, indices: readonly [number, number]
   }
 
   const sorted = [...indices].sort((a, b) => a[0] - b[0]);
+  // Merge overlapping/adjacent ranges so a range starting before the cursor
+  // can't duplicate characters across two highlighted segments.
+  const merged: [number, number][] = [];
+  for (const [start, end] of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && start <= last[1] + 1) {
+      last[1] = Math.max(last[1], end);
+    } else {
+      merged.push([start, end]);
+    }
+  }
+
   const segments: TextSegment[] = [];
   let cursor = 0;
 
-  for (const [start, end] of sorted) {
+  for (const [start, end] of merged) {
     if (start > cursor) {
       segments.push({ text: text.slice(cursor, start), highlighted: false });
     }

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,9 +1,30 @@
-import { For, Show, createSignal } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
 import { A, useNavigate } from "@solidjs/router";
-import { Button, Spinner, toast } from "../components/ui";
+import { Button, Input, Spinner, toast } from "../components/ui";
+import {
+  filterResumes,
+  getStoredSearchQuery,
+  setStoredSearchQuery,
+  type TextSegment,
+} from "../lib/resumeSearch";
 import { useResumeList } from "../stores/persistence";
 import { authStore } from "../stores/auth";
 import { generateId } from "../wasm/types";
+
+
+function HighlightedText(props: { segments: TextSegment[] }) {
+  return (
+    <For each={props.segments}>
+      {(segment) =>
+        segment.highlighted ? (
+          <mark class="text-accent bg-accent/10 rounded-sm">{segment.text}</mark>
+        ) : (
+          <>{segment.text}</>
+        )
+      }
+    </For>
+  );
+}
 
 /** Format a Date as a human-readable relative or absolute string. */
 function formatUpdatedAt(date: Date): string {
@@ -42,6 +63,13 @@ export default function Home() {
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [renameValue, setRenameValue] = createSignal("");
   const [signingIn, setSigningIn] = createSignal(false);
+  const [searchQuery, setSearchQuery] = createSignal(getStoredSearchQuery());
+
+  createEffect(() => {
+    setStoredSearchQuery(searchQuery());
+  });
+
+  const filteredResumes = createMemo(() => filterResumes(resumes() ?? [], searchQuery()));
 
   const showCloudSignInCta = () =>
     authState.cloudEnabled && !authState.requireAuth && !authState.loading && !authState.user;
@@ -185,7 +213,7 @@ export default function Home() {
 
       {/* Resume List */}
       <div class="max-w-4xl mx-auto px-4 pb-16">
-        <div class="flex items-center justify-between mb-6">
+        <div class="flex items-center justify-between mb-4">
           <h2 class="font-display text-xl font-semibold text-ink">Your Resumes</h2>
           <button
             type="button"
@@ -210,6 +238,20 @@ export default function Home() {
             </svg>
           </button>
         </div>
+
+        <Show when={!loading() && (resumes()?.length ?? 0) > 0}>
+          <div class="mb-6">
+            <Input
+              label="Search resumes"
+              type="text"
+              placeholder="Search by title or name…"
+              value={searchQuery()}
+              onInput={setSearchQuery}
+              class="max-w-md"
+              data-testid="resume-search-input"
+            />
+          </div>
+        </Show>
 
         <Show
           when={!loading()}
@@ -247,9 +289,23 @@ export default function Home() {
               </div>
             }
           >
-            <div class="grid gap-4 stagger-children">
-              <For each={resumes()}>
-                {(resume) => (
+            <Show
+              when={filteredResumes().length > 0}
+              fallback={
+                <div
+                  class="text-center py-16 border-2 border-dashed border-border rounded-xl"
+                  data-testid="resume-search-empty"
+                >
+                  <h3 class="font-display text-lg font-semibold text-ink mb-2">No matching resumes</h3>
+                  <p class="text-stone text-sm">
+                    No resumes match &ldquo;{searchQuery().trim()}&rdquo;. Try a different search.
+                  </p>
+                </div>
+              }
+            >
+              <div class="grid gap-4 stagger-children">
+                <For each={filteredResumes()}>
+                  {({ resume, nameSegments }) => (
                   <div
                     class="group flex items-center justify-between p-4 border border-border
                       rounded-xl hover:border-accent hover:shadow-card transition-all bg-paper"
@@ -356,7 +412,7 @@ export default function Home() {
                         </div>
                         <div class="min-w-0">
                           <h3 class="font-body font-medium text-ink group-hover:text-accent transition-colors truncate">
-                            {resume.name}
+                            <HighlightedText segments={nameSegments} />
                           </h3>
                           <p class="text-sm text-stone">
                             Updated {formatUpdatedAt(resume.updatedAt)}
@@ -475,9 +531,10 @@ export default function Home() {
                       </A>
                     </div>
                   </div>
-                )}
-              </For>
-            </div>
+                  )}
+                </For>
+              </div>
+            </Show>
           </Show>
         </Show>
       </div>

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -242,8 +242,10 @@ export default function Home() {
           </button>
         </div>
 
-        <Show when={!loading() && (resumes()?.length ?? 0) > 0}>
-          <div class="mb-6">
+        {/* Keep the input mounted during background refreshes so it doesn't
+            flicker away and lose focus while a populated list reloads. */}
+        <Show when={(resumes()?.length ?? 0) > 0}>
+          <div class="mb-6" classList={{ "opacity-60 pointer-events-none": loading() }}>
             <Input
               label="Search resumes"
               type="text"

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
 import { A, useNavigate } from "@solidjs/router";
 import { Button, Input, Spinner, toast } from "../components/ui";
 import {
+  createResumeSearchIndex,
   filterResumes,
   getStoredSearchQuery,
   setStoredSearchQuery,
@@ -10,7 +11,6 @@ import {
 import { useResumeList } from "../stores/persistence";
 import { authStore } from "../stores/auth";
 import { generateId } from "../wasm/types";
-
 
 function HighlightedText(props: { segments: TextSegment[] }) {
   return (
@@ -69,7 +69,10 @@ export default function Home() {
     setStoredSearchQuery(searchQuery());
   });
 
-  const filteredResumes = createMemo(() => filterResumes(resumes() ?? [], searchQuery()));
+  // Build the Fuse index only when the resume list changes; re-run the search
+  // separately as the query changes.
+  const searchIndex = createMemo(() => createResumeSearchIndex(resumes() ?? []));
+  const filteredResumes = createMemo(() => filterResumes(searchIndex(), searchQuery()));
 
   const showCloudSignInCta = () =>
     authState.cloudEnabled && !authState.requireAuth && !authState.loading && !authState.user;
@@ -296,7 +299,9 @@ export default function Home() {
                   class="text-center py-16 border-2 border-dashed border-border rounded-xl"
                   data-testid="resume-search-empty"
                 >
-                  <h3 class="font-display text-lg font-semibold text-ink mb-2">No matching resumes</h3>
+                  <h3 class="font-display text-lg font-semibold text-ink mb-2">
+                    No matching resumes
+                  </h3>
                   <p class="text-stone text-sm">
                     No resumes match &ldquo;{searchQuery().trim()}&rdquo;. Try a different search.
                   </p>
@@ -306,17 +311,100 @@ export default function Home() {
               <div class="grid gap-4 stagger-children">
                 <For each={filteredResumes()}>
                   {({ resume, nameSegments }) => (
-                  <div
-                    class="group flex items-center justify-between p-4 border border-border
+                    <div
+                      class="group flex items-center justify-between p-4 border border-border
                       rounded-xl hover:border-accent hover:shadow-card transition-all bg-paper"
-                  >
-                    <Show
-                      when={renamingId() !== resume.id}
-                      fallback={
-                        <div class="flex items-center gap-4 flex-1 min-w-0">
+                    >
+                      <Show
+                        when={renamingId() !== resume.id}
+                        fallback={
+                          <div class="flex items-center gap-4 flex-1 min-w-0">
+                            <div class="w-12 h-12 bg-surface rounded-lg flex items-center justify-center flex-shrink-0">
+                              <svg
+                                class="w-6 h-6 text-stone"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                                aria-hidden="true"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="1.5"
+                                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                                />
+                              </svg>
+                            </div>
+                            <div class="min-w-0 flex items-center gap-2">
+                              <input
+                                type="text"
+                                class="font-body font-medium text-ink bg-surface border border-border
+                                rounded px-2 py-0.5 text-sm focus:outline-none focus:border-accent w-48"
+                                aria-label="Rename resume"
+                                value={renameValue()}
+                                onInput={(e) => setRenameValue(e.currentTarget.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter") confirmRename(resume.id);
+                                  if (e.key === "Escape") cancelRename();
+                                }}
+                                ref={(el) => setTimeout(() => el?.focus(), 0)}
+                                data-testid="rename-input"
+                              />
+                              <button
+                                type="button"
+                                class="p-1 text-accent hover:text-accent/80 transition-colors"
+                                onClick={() => confirmRename(resume.id)}
+                                title="Confirm rename"
+                                aria-label="Confirm rename"
+                              >
+                                <svg
+                                  class="w-4 h-4"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  viewBox="0 0 24 24"
+                                  aria-hidden="true"
+                                >
+                                  <path
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M5 13l4 4L19 7"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                type="button"
+                                class="p-1 text-stone hover:text-ink transition-colors"
+                                onClick={() => cancelRename()}
+                                title="Cancel rename"
+                                aria-label="Cancel rename"
+                              >
+                                <svg
+                                  class="w-4 h-4"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  viewBox="0 0 24 24"
+                                  aria-hidden="true"
+                                >
+                                  <path
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M6 18L18 6M6 6l12 12"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        }
+                      >
+                        <A
+                          href={`/edit/${resume.id}`}
+                          class="flex items-center gap-4 flex-1 min-w-0"
+                        >
                           <div class="w-12 h-12 bg-surface rounded-lg flex items-center justify-center flex-shrink-0">
                             <svg
-                              class="w-6 h-6 text-stone"
+                              class="w-6 h-6 text-stone group-hover:text-accent transition-colors"
                               fill="none"
                               stroke="currentColor"
                               viewBox="0 0 24 24"
@@ -330,139 +418,30 @@ export default function Home() {
                               />
                             </svg>
                           </div>
-                          <div class="min-w-0 flex items-center gap-2">
-                            <input
-                              type="text"
-                              class="font-body font-medium text-ink bg-surface border border-border
-                                rounded px-2 py-0.5 text-sm focus:outline-none focus:border-accent w-48"
-                              aria-label="Rename resume"
-                              value={renameValue()}
-                              onInput={(e) => setRenameValue(e.currentTarget.value)}
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter") confirmRename(resume.id);
-                                if (e.key === "Escape") cancelRename();
-                              }}
-                              ref={(el) => setTimeout(() => el?.focus(), 0)}
-                              data-testid="rename-input"
-                            />
-                            <button
-                              type="button"
-                              class="p-1 text-accent hover:text-accent/80 transition-colors"
-                              onClick={() => confirmRename(resume.id)}
-                              title="Confirm rename"
-                              aria-label="Confirm rename"
-                            >
-                              <svg
-                                class="w-4 h-4"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                                aria-hidden="true"
-                              >
-                                <path
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                  d="M5 13l4 4L19 7"
-                                />
-                              </svg>
-                            </button>
-                            <button
-                              type="button"
-                              class="p-1 text-stone hover:text-ink transition-colors"
-                              onClick={() => cancelRename()}
-                              title="Cancel rename"
-                              aria-label="Cancel rename"
-                            >
-                              <svg
-                                class="w-4 h-4"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                                aria-hidden="true"
-                              >
-                                <path
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                  d="M6 18L18 6M6 6l12 12"
-                                />
-                              </svg>
-                            </button>
+                          <div class="min-w-0">
+                            <h3 class="font-body font-medium text-ink group-hover:text-accent transition-colors truncate">
+                              <HighlightedText segments={nameSegments} />
+                            </h3>
+                            <p class="text-sm text-stone">
+                              Updated {formatUpdatedAt(resume.updatedAt)}
+                            </p>
                           </div>
-                        </div>
-                      }
-                    >
-                      <A href={`/edit/${resume.id}`} class="flex items-center gap-4 flex-1 min-w-0">
-                        <div class="w-12 h-12 bg-surface rounded-lg flex items-center justify-center flex-shrink-0">
-                          <svg
-                            class="w-6 h-6 text-stone group-hover:text-accent transition-colors"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                            aria-hidden="true"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="1.5"
-                              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                            />
-                          </svg>
-                        </div>
-                        <div class="min-w-0">
-                          <h3 class="font-body font-medium text-ink group-hover:text-accent transition-colors truncate">
-                            <HighlightedText segments={nameSegments} />
-                          </h3>
-                          <p class="text-sm text-stone">
-                            Updated {formatUpdatedAt(resume.updatedAt)}
-                          </p>
-                        </div>
-                      </A>
-                    </Show>
+                        </A>
+                      </Show>
 
-                    <div class="flex items-center gap-2 flex-shrink-0">
-                      <button
-                        type="button"
-                        class="p-2 text-stone hover:text-accent hover:bg-accent/10 rounded-lg transition-colors
+                      <div class="flex items-center gap-2 flex-shrink-0">
+                        <button
+                          type="button"
+                          class="p-2 text-stone hover:text-accent hover:bg-accent/10 rounded-lg transition-colors
                           disabled:opacity-50 disabled:cursor-not-allowed"
-                        onClick={(e) => startRename(resume.id, resume.name, e)}
-                        disabled={
-                          deletingId() !== null || duplicatingId() !== null || renamingId() !== null
-                        }
-                        title="Rename"
-                        aria-label="Rename resume"
-                      >
-                        <svg
-                          class="w-5 h-5"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden="true"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                          />
-                        </svg>
-                      </button>
-
-                      <button
-                        type="button"
-                        class="p-2 text-stone hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors
-                          disabled:opacity-50 disabled:cursor-not-allowed"
-                        onClick={(e) => handleDelete(resume.id, e)}
-                        disabled={
-                          deletingId() !== null || duplicatingId() !== null || renamingId() !== null
-                        }
-                        title="Delete"
-                        aria-label="Delete resume"
-                      >
-                        <Show
-                          when={deletingId() !== resume.id}
-                          fallback={<Spinner class="w-5 h-5" />}
+                          onClick={(e) => startRename(resume.id, resume.name, e)}
+                          disabled={
+                            deletingId() !== null ||
+                            duplicatingId() !== null ||
+                            renamingId() !== null
+                          }
+                          title="Rename"
+                          aria-label="Rename resume"
                         >
                           <svg
                             class="w-5 h-5"
@@ -475,29 +454,86 @@ export default function Home() {
                               stroke-linecap="round"
                               stroke-linejoin="round"
                               stroke-width="2"
-                              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
                             />
                           </svg>
-                        </Show>
-                      </button>
+                        </button>
 
-                      <button
-                        type="button"
-                        class="p-2 text-stone hover:text-accent hover:bg-accent/10 rounded-lg transition-colors
+                        <button
+                          type="button"
+                          class="p-2 text-stone hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors
                           disabled:opacity-50 disabled:cursor-not-allowed"
-                        onClick={(e) => handleDuplicate(resume.id, e)}
-                        disabled={
-                          duplicatingId() !== null || deletingId() !== null || renamingId() !== null
-                        }
-                        title="Duplicate"
-                        aria-label="Duplicate resume"
-                      >
-                        <Show
-                          when={duplicatingId() !== resume.id}
-                          fallback={<Spinner class="w-5 h-5" />}
+                          onClick={(e) => handleDelete(resume.id, e)}
+                          disabled={
+                            deletingId() !== null ||
+                            duplicatingId() !== null ||
+                            renamingId() !== null
+                          }
+                          title="Delete"
+                          aria-label="Delete resume"
+                        >
+                          <Show
+                            when={deletingId() !== resume.id}
+                            fallback={<Spinner class="w-5 h-5" />}
+                          >
+                            <svg
+                              class="w-5 h-5"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                              aria-hidden="true"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                              />
+                            </svg>
+                          </Show>
+                        </button>
+
+                        <button
+                          type="button"
+                          class="p-2 text-stone hover:text-accent hover:bg-accent/10 rounded-lg transition-colors
+                          disabled:opacity-50 disabled:cursor-not-allowed"
+                          onClick={(e) => handleDuplicate(resume.id, e)}
+                          disabled={
+                            duplicatingId() !== null ||
+                            deletingId() !== null ||
+                            renamingId() !== null
+                          }
+                          title="Duplicate"
+                          aria-label="Duplicate resume"
+                        >
+                          <Show
+                            when={duplicatingId() !== resume.id}
+                            fallback={<Spinner class="w-5 h-5" />}
+                          >
+                            <svg
+                              class="w-5 h-5"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                              aria-hidden="true"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                              />
+                            </svg>
+                          </Show>
+                        </button>
+
+                        <A
+                          href={`/edit/${resume.id}`}
+                          class="p-1"
+                          aria-label={`Edit ${resume.name}`}
                         >
                           <svg
-                            class="w-5 h-5"
+                            class="w-5 h-5 text-stone group-hover:text-accent transition-colors"
                             fill="none"
                             stroke="currentColor"
                             viewBox="0 0 24 24"
@@ -507,30 +543,12 @@ export default function Home() {
                               stroke-linecap="round"
                               stroke-linejoin="round"
                               stroke-width="2"
-                              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                              d="M9 5l7 7-7 7"
                             />
                           </svg>
-                        </Show>
-                      </button>
-
-                      <A href={`/edit/${resume.id}`} class="p-1" aria-label={`Edit ${resume.name}`}>
-                        <svg
-                          class="w-5 h-5 text-stone group-hover:text-accent transition-colors"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden="true"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M9 5l7 7-7 7"
-                          />
-                        </svg>
-                      </A>
+                        </A>
+                      </div>
                     </div>
-                  </div>
                   )}
                 </For>
               </div>

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { axe } from "vitest-axe";
-import { render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { axeConfig } from "../../test/a11y";
 import { Route, Router } from "@solidjs/router";
+import type { ResumeListItem } from "../../stores/persistence";
 import Home from "../Home";
 
 const { mockAuthState, signInMock } = vi.hoisted(() => ({
@@ -15,6 +16,24 @@ const { mockAuthState, signInMock } = vi.hoisted(() => ({
   signInMock: vi.fn(),
 }));
 
+const mockResumes = vi.hoisted(() => {
+  const resumes: ResumeListItem[] = [
+    { id: "1", name: "Software Engineer", updatedAt: new Date("2025-01-01") },
+    { id: "2", name: "Product Manager", updatedAt: new Date("2025-02-01") },
+    { id: "3", name: "Jane Doe — Designer", updatedAt: new Date("2025-03-01") },
+  ];
+  return resumes;
+});
+
+const resumeListMock = vi.hoisted(() => ({
+  resumes: () => mockResumes,
+  loading: () => false,
+  deleteResume: vi.fn(),
+  duplicateResume: vi.fn(),
+  renameResume: vi.fn(),
+  refresh: vi.fn(),
+}));
+
 vi.mock("../../stores/auth", () => ({
   authStore: {
     get state() {
@@ -25,14 +44,7 @@ vi.mock("../../stores/auth", () => ({
 }));
 
 vi.mock("../../stores/persistence", () => ({
-  useResumeList: () => ({
-    resumes: () => [],
-    loading: () => false,
-    deleteResume: vi.fn(),
-    duplicateResume: vi.fn(),
-    renameResume: vi.fn(),
-    refresh: vi.fn(),
-  }),
+  useResumeList: () => resumeListMock,
 }));
 
 vi.mock("../../wasm/types", () => ({
@@ -46,6 +58,56 @@ function renderHome() {
     </Router>
   ));
 }
+
+describe("Home resume search", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockAuthState.loading = false;
+    mockAuthState.cloudEnabled = false;
+    mockAuthState.requireAuth = false;
+    mockAuthState.user = null;
+  });
+
+  it("shows a labeled search input when resumes exist", () => {
+    renderHome();
+
+    expect(screen.getByTestId("resume-search-input")).toBeInTheDocument();
+    expect(screen.getByLabelText("Search resumes")).toBeInTheDocument();
+  });
+
+  it("filters resumes as the user types", () => {
+    renderHome();
+
+    fireEvent.input(screen.getByTestId("resume-search-input"), {
+      target: { value: "product" },
+    });
+
+    expect(screen.getByRole("heading", { name: /Product Manager/i })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /Software Engineer/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /Jane Doe/i })).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when no resumes match", () => {
+    renderHome();
+
+    fireEvent.input(screen.getByTestId("resume-search-input"), {
+      target: { value: "zzzznotfound" },
+    });
+
+    expect(screen.getByTestId("resume-search-empty")).toBeInTheDocument();
+    expect(screen.getByText(/No matching resumes/i)).toBeInTheDocument();
+  });
+
+  it("persists the search query in sessionStorage", () => {
+    renderHome();
+
+    fireEvent.input(screen.getByTestId("resume-search-input"), {
+      target: { value: "jane" },
+    });
+
+    expect(sessionStorage.getItem("rustume:home-resume-search")).toBe("jane");
+  });
+});
 
 describe("Home cloud sign-in CTA", () => {
   it("shows the cloud banner when cloud is enabled and the user is signed out", () => {

--- a/apps/web/src/stores/persistence.ts
+++ b/apps/web/src/stores/persistence.ts
@@ -30,13 +30,24 @@ export interface ResumeListItem {
   id: string;
   name: string;
   updatedAt: Date;
+  /** basics.name from the stored resume, when known (for search). */
+  basicsName?: string;
+  /** basics.headline from the stored resume, when known (for search). */
+  headline?: string;
 }
 
 /** Serialized form stored in localStorage under the `_meta` key. */
 export interface ResumeMetaEntry {
   title: string;
   updatedAt: string; // ISO-8601
+  /** basics.name snapshot for search; absent on pre-existing entries. */
+  basicsName?: string;
+  /** basics.headline snapshot for search; absent on pre-existing entries. */
+  headline?: string;
 }
+
+/** Searchable fields snapshotted from resume data into metadata. */
+export type ResumeSearchMeta = Pick<ResumeMetaEntry, "basicsName" | "headline">;
 
 // LocalStorage fallback
 const STORAGE_KEY_PREFIX = "rustume:";
@@ -52,6 +63,8 @@ function isValidMetaEntry(v: unknown): v is ResumeMetaEntry {
   const obj = v as Record<string, unknown>;
   if (typeof obj.title !== "string") return false;
   if (typeof obj.updatedAt !== "string") return false;
+  if (obj.basicsName !== undefined && typeof obj.basicsName !== "string") return false;
+  if (obj.headline !== undefined && typeof obj.headline !== "string") return false;
   return !Number.isNaN(Date.parse(obj.updatedAt));
 }
 
@@ -87,12 +100,24 @@ function setMetaMap(map: Record<string, ResumeMetaEntry>): void {
   }
 }
 
-/** Upsert metadata for a single resume. */
-export function setResumeMeta(id: string, title: string, updatedAt?: Date): void {
+/**
+ * Upsert metadata for a single resume.
+ * Search fields (basicsName/headline) are merged: when `search` is omitted,
+ * any previously stored values are preserved.
+ */
+export function setResumeMeta(
+  id: string,
+  title: string,
+  updatedAt?: Date,
+  search?: ResumeSearchMeta,
+): void {
   const map = getMetaMap();
+  const existing = map[id];
   map[id] = {
     title,
     updatedAt: (updatedAt ?? new Date()).toISOString(),
+    basicsName: search ? search.basicsName : existing?.basicsName,
+    headline: search ? search.headline : existing?.headline,
   };
   setMetaMap(map);
 }
@@ -119,6 +144,16 @@ export function deriveTitleFromResume(data: ResumeData): string {
   return "Untitled Resume";
 }
 
+/** Extract searchable basics fields from resume data (trimmed, empty → undefined). */
+export function deriveSearchMetaFromResume(data: ResumeData): ResumeSearchMeta {
+  const basicsName = data.basics?.name?.trim();
+  const headline = data.basics?.headline?.trim();
+  return {
+    basicsName: basicsName || undefined,
+    headline: headline || undefined,
+  };
+}
+
 function resolveResumeTitle(id: string, data: ResumeData): string {
   const existing = getResumeMeta(id);
   const existingTitle = existing?.title?.trim();
@@ -126,11 +161,18 @@ function resolveResumeTitle(id: string, data: ResumeData): string {
   return deriveTitleFromResume(data);
 }
 
-function maybeUpdateResumeMeta(id: string, title: string): void {
+function maybeUpdateResumeMeta(id: string, title: string, data?: ResumeData): void {
   const existing = getResumeMeta(id);
-  if (existing?.title === title) return;
+  const search = data ? deriveSearchMetaFromResume(data) : undefined;
+  if (
+    existing?.title === title &&
+    (search === undefined ||
+      (existing?.basicsName === search.basicsName && existing?.headline === search.headline))
+  ) {
+    return;
+  }
   try {
-    setResumeMeta(id, title);
+    setResumeMeta(id, title, undefined, search);
   } catch (e) {
     console.error("Failed to update resume metadata:", e);
     toast.warning("Resume saved but metadata could not be updated — storage may be full");
@@ -209,7 +251,7 @@ function saveLocalResume(id: string, data: ResumeData): boolean {
   const existing = getResumeMeta(id);
   const title = existing?.title ?? deriveTitleFromResume(data);
   try {
-    setResumeMeta(id, title);
+    setResumeMeta(id, title, undefined, deriveSearchMetaFromResume(data));
   } catch (e) {
     console.error("Failed to update resume metadata:", e);
     toast.warning("Resume saved but metadata could not be updated — storage may be full");
@@ -274,12 +316,12 @@ async function saveResume(id: string, data: ResumeData): Promise<void> {
       }
       throw error;
     }
-    maybeUpdateResumeMeta(id, title);
+    maybeUpdateResumeMeta(id, title, data);
     return;
   }
   if (isWasmReady()) {
     await saveToWasmStorage(id, data);
-    maybeUpdateResumeMeta(id, resolveResumeTitle(id, data));
+    maybeUpdateResumeMeta(id, resolveResumeTitle(id, data), data);
     return;
   }
   if (!saveLocalResume(id, data)) {
@@ -295,10 +337,15 @@ async function fetchResumeList(): Promise<ResumeListItem[]> {
   try {
     if (isCloudAuthenticated()) {
       const rows = await listCloudResumeSummaries();
+      // Cloud summaries only carry the title; enrich search fields from the
+      // locally cached metadata when available.
+      const cachedMeta = getMetaMap();
       return rows.map((row) => ({
         id: row.id,
         name: row.title,
         updatedAt: new Date(row.updated_at),
+        basicsName: cachedMeta[row.id]?.basicsName,
+        headline: cachedMeta[row.id]?.headline,
       }));
     }
 
@@ -319,16 +366,18 @@ async function fetchResumeList(): Promise<ResumeListItem[]> {
         const id = needsMigration[i];
         const result = migrationResults[i];
         let title = "Untitled Resume";
+        let search: ResumeSearchMeta = {};
         if (result.status === "fulfilled") {
           title = deriveTitleFromResume(result.value.data);
+          search = deriveSearchMetaFromResume(result.value.data);
           // Persist the derived metadata so future loads are instant
           try {
-            setResumeMeta(id, title);
+            setResumeMeta(id, title, undefined, search);
           } catch (metaErr) {
             console.error("Failed to persist metadata for resume:", id, metaErr);
           }
         }
-        migratedMap.set(id, { id, name: title, updatedAt: new Date() });
+        migratedMap.set(id, { id, name: title, updatedAt: new Date(), ...search });
       }
     }
 
@@ -341,6 +390,8 @@ async function fetchResumeList(): Promise<ResumeListItem[]> {
         id,
         name: meta.title,
         updatedAt: new Date(meta.updatedAt),
+        basicsName: meta.basicsName,
+        headline: meta.headline,
       };
     });
   } catch (e) {
@@ -413,7 +464,7 @@ export function useResumeList() {
           await duplicateCloudResume(id, newId, structuredClone(original), copyTitle);
           saveCompleted = true;
           try {
-            setResumeMeta(newId, copyTitle);
+            setResumeMeta(newId, copyTitle, undefined, deriveSearchMetaFromResume(original));
           } catch (e) {
             console.error("Failed to cache resume metadata locally:", e);
             toast.warning(
@@ -424,7 +475,7 @@ export function useResumeList() {
           return newId;
         }
 
-        setResumeMeta(newId, copyTitle);
+        setResumeMeta(newId, copyTitle, undefined, deriveSearchMetaFromResume(original));
 
         await saveResume(newId, structuredClone(original));
         saveCompleted = true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add fuzzy search across resumes
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds a client-side fuzzy search bar on the Home page so users can quickly filter their resume grid by title as they type. Matching text is highlighted, the query persists in `sessionStorage`, and an empty state is shown when nothing matches.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Related Issues

Closes #75

## Details

### Web (`apps/web`)
- `fuse.js` for lightweight client-side fuzzy matching
- `lib/resumeSearch.ts` — filter + highlight helpers with session persistence
- Home page search input above the resume grid (shown when resumes exist)
- Vitest coverage for search utility and Home filtering UI

### Testing
- `bun run test` — resume search unit + Home integration tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a client-side fuzzy search bar to the Home page that filters the resume grid in real-time using Fuse.js, with matching text highlighted and the query persisted to `sessionStorage`. Previous review feedback has been fully addressed: the Fuse index is now built in a dedicated `createMemo` that only rebuilds when `resumes()` changes, highlight indices handle overlapping ranges via an explicit merge pass, and the search input stays mounted (dimmed) during background refreshes rather than unmounting.

- `lib/resumeSearch.ts` introduces `createResumeSearchIndex` / `filterResumes` with diacritic-folding via a custom `getFn`, keeping the heavyweight index construction separate from the per-keystroke search call.
- `stores/persistence.ts` extends `ResumeListItem` and `ResumeMetaEntry` with optional `basicsName` and `headline` search-snapshot fields, correctly merging them on save and enriching cloud-fetched summaries from the local metadata cache.
- `Home.tsx` renders a `<Show>`-gated search input above the resume grid and adds an empty-state card when no filtered results remain; the existing "No resumes yet" outer guard ensures the search empty state is never shown to users with zero resumes.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive client-side filtering with no mutations to stored data, and all previous review issues have been resolved.

The Fuse index/search memo split, overlap-merging in buildHighlightSegments, and sessionStorage persistence are all correctly implemented. Persistence layer additions are backward-compatible. Test coverage is solid across both utility functions and the Home integration path. The single remaining note (NFD ligature edge case) is a documentation-level concern for characters that essentially never appear in resume names.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/resumeSearch.ts | New file: fuzzy search utilities using Fuse.js — index creation, diacritic folding, and highlight segment building. All previous review issues (index rebuild per keystroke, overlapping indices) are addressed. |
| apps/web/src/pages/Home.tsx | Search input added above resume grid; index and filter memos correctly split so Fuse index rebuilds only when the resume list changes. Search input is mounted-but-dimmed during loading refreshes rather than unmounted. |
| apps/web/src/stores/persistence.ts | ResumeListItem and ResumeMetaEntry extended with optional basicsName/headline search fields; setResumeMeta correctly merges search fields when absent; backward-compatible with pre-existing entries. |
| apps/web/src/lib/__tests__/resumeSearch.test.ts | Good unit coverage: empty query, fuzzy match, diacritic folding, metadata-only match, highlight segments, no-highlight on single-char queries. |
| apps/web/src/pages/__tests__/Home.test.tsx | Integration tests added for the search UI: input visibility, filtering behavior, empty state, and sessionStorage persistence. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant H as Home (SolidJS)
    participant SM as searchIndex memo
    participant FM as filteredResumes memo
    participant RS as resumeSearch.ts
    participant SS as sessionStorage
    participant FJ as Fuse.js

    Note over H: Component mount
    H->>SS: getStoredSearchQuery()
    SS-->>H: "" or saved query
    H->>SM: createMemo (tracks resumes())
    H->>FM: createMemo (tracks searchIndex + searchQuery)

    Note over SM,FJ: resumes() changes → index rebuild
    SM->>RS: createResumeSearchIndex(resumes)
    RS->>FJ: "new Fuse(resumes, { getFn: foldDiacritics })"
    FJ-->>RS: Fuse index built
    RS-->>SM: "{ resumes, fuse }"

    Note over U,FM: User types query
    U->>H: onInput → setSearchQuery("eng")
    H->>SS: setStoredSearchQuery("eng") via createEffect
    H->>FM: searchQuery() changed → recompute
    FM->>RS: filterResumes(searchIndex(), "eng")
    RS->>FJ: fuse.search(foldDiacritics("eng"))
    FJ-->>RS: "[{ item, matches }]"
    RS->>RS: buildHighlightSegments(name, indices)
    RS-->>FM: FilteredResumeItem[]
    FM-->>H: Re-render grid with highlights
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant H as Home (SolidJS)
    participant SM as searchIndex memo
    participant FM as filteredResumes memo
    participant RS as resumeSearch.ts
    participant SS as sessionStorage
    participant FJ as Fuse.js

    Note over H: Component mount
    H->>SS: getStoredSearchQuery()
    SS-->>H: "" or saved query
    H->>SM: createMemo (tracks resumes())
    H->>FM: createMemo (tracks searchIndex + searchQuery)

    Note over SM,FJ: resumes() changes → index rebuild
    SM->>RS: createResumeSearchIndex(resumes)
    RS->>FJ: "new Fuse(resumes, { getFn: foldDiacritics })"
    FJ-->>RS: Fuse index built
    RS-->>SM: "{ resumes, fuse }"

    Note over U,FM: User types query
    U->>H: onInput → setSearchQuery("eng")
    H->>SS: setStoredSearchQuery("eng") via createEffect
    H->>FM: searchQuery() changed → recompute
    FM->>RS: filterResumes(searchIndex(), "eng")
    RS->>FJ: fuse.search(foldDiacritics("eng"))
    FJ-->>RS: "[{ item, matches }]"
    RS->>RS: buildHighlightSegments(name, indices)
    RS-->>FM: FilteredResumeItem[]
    FM-->>H: Re-render grid with highlights
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): merge overlapping highlight ra..."](https://github.com/lgtm-hq/rustume/commit/c1f66d7dbd9558f1e97a29927f541709d8c373cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45739898)</sub>

<!-- /greptile_comment -->