### PR TITLE
feat(web): add proficiency level display types

### DIFF
--- a/apps/web/src/api/__tests__/render.test.ts
+++ b/apps/web/src/api/__tests__/render.test.ts
@@ -180,6 +180,7 @@ const mockResume: ResumeData = {
       underlineLinks: false,
     },
     notes: "",
+    levelDisplay: "template-default",
   },
 };
 

--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -1,7 +1,16 @@
 import { Show, For, createSignal } from "solid-js";
 import { resumeStore } from "../../stores/resume";
 import { getThemePresets } from "../../stores/themePresets";
-import type { ThemePresetInfo } from "../../wasm/types";
+import type { Metadata, ThemePresetInfo } from "../../wasm/types";
+
+const LEVEL_DISPLAY_OPTIONS: { value: Metadata["levelDisplay"]; label: string }[] = [
+  { value: "template-default", label: "Template default" },
+  { value: "hidden", label: "Hidden" },
+  { value: "circle", label: "Circles" },
+  { value: "square", label: "Squares" },
+  { value: "progress-bar", label: "Progress bar" },
+  { value: "text", label: "Text label" },
+];
 
 export function ThemeEditor() {
   const { store, updateTheme, updateMetadata } = resumeStore;
@@ -145,6 +154,31 @@ export function ThemeEditor() {
                 onChange={(css) => updateMetadata("css", css)}
               />
             </Show>
+
+            <div class="space-y-2">
+              <label
+                for="proficiency-display"
+                class="font-mono text-xs uppercase tracking-wider text-stone block"
+              >
+                Proficiency display
+              </label>
+              <select
+                id="proficiency-display"
+                value={resume().metadata.levelDisplay ?? "template-default"}
+                onChange={(e) =>
+                  updateMetadata(
+                    "levelDisplay",
+                    e.currentTarget.value as Metadata["levelDisplay"],
+                  )
+                }
+                class="w-full px-3 py-2 text-sm bg-surface border border-border rounded-lg
+                  focus:outline-none focus:border-accent"
+              >
+                <For each={LEVEL_DISPLAY_OPTIONS}>
+                  {(option) => <option value={option.value}>{option.label}</option>}
+                </For>
+              </select>
+            </div>
 
             {/* Preview */}
             <div class="p-4 rounded-lg border border-border">

--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -166,10 +166,7 @@ export function ThemeEditor() {
                 id="proficiency-display"
                 value={resume().metadata.levelDisplay ?? "template-default"}
                 onChange={(e) =>
-                  updateMetadata(
-                    "levelDisplay",
-                    e.currentTarget.value as Metadata["levelDisplay"],
-                  )
+                  updateMetadata("levelDisplay", e.currentTarget.value as Metadata["levelDisplay"])
                 }
                 class="w-full px-3 py-2 text-sm bg-surface border border-border rounded-lg
                   focus:outline-none focus:border-accent"

--- a/apps/web/src/components/templates/__tests__/ThemeEditor.test.tsx
+++ b/apps/web/src/components/templates/__tests__/ThemeEditor.test.tsx
@@ -58,4 +58,16 @@ describe("ThemeEditor custom CSS tab", () => {
       screen.getByText(/PDF export use Typst templates and theme controls/i),
     ).toBeInTheDocument();
   });
+
+  it("reflects and updates the proficiency display metadata", async () => {
+    render(() => <ThemeEditor />);
+
+    const select = screen.getByLabelText("Proficiency display");
+    expect(select).toHaveValue("template-default");
+
+    fireEvent.change(select, { target: { value: "progress-bar" } });
+
+    expect(resumeStore.store.resume?.metadata.levelDisplay).toBe("progress-bar");
+    expect(select).toHaveValue("progress-bar");
+  });
 });

--- a/apps/web/src/wasm/defaults.ts
+++ b/apps/web/src/wasm/defaults.ts
@@ -243,6 +243,7 @@ export function createSampleResume(): ResumeData {
         underlineLinks: false,
       },
       notes: "",
+      levelDisplay: "template-default",
     },
   };
 }
@@ -489,6 +490,7 @@ export function createDefaultResume(): ResumeData {
         underlineLinks: false,
       },
       notes: "",
+      levelDisplay: "template-default",
     },
   };
 }

--- a/apps/web/src/wasm/types.ts
+++ b/apps/web/src/wasm/types.ts
@@ -262,7 +262,8 @@ export interface Metadata {
   theme: Theme;
   typography: Typography;
   notes: string;
-  levelDisplay: LevelDisplay;
+  /** Optional: resumes stored before this field existed lack it. */
+  levelDisplay?: LevelDisplay;
 }
 
 export interface ResumeData {

--- a/apps/web/src/wasm/types.ts
+++ b/apps/web/src/wasm/types.ts
@@ -246,6 +246,14 @@ export interface Typography {
   underlineLinks: boolean;
 }
 
+export type LevelDisplay =
+  | "template-default"
+  | "hidden"
+  | "circle"
+  | "square"
+  | "progress-bar"
+  | "text";
+
 export interface Metadata {
   template: string;
   layout: string[][][];
@@ -254,6 +262,7 @@ export interface Metadata {
   theme: Theme;
   typography: Typography;
   notes: string;
+  levelDisplay: LevelDisplay;
 }
 
 export interface ResumeData {

--- a/crates/parser/src/reactive_resume_v3.rs
+++ b/crates/parser/src/reactive_resume_v3.rs
@@ -13,9 +13,9 @@
 use crate::traits::{ParseError, Parser};
 use rustume_schema::{
     validate_hex_color_with_optional_alpha, Award, Basics, Certification, CustomCss, CustomField,
-    CustomItem, Education, Experience, FontConfig, Interest, Language, Metadata, PageConfig,
-    PageFormat, PageOptions, Profile, Project, Publication, Reference, ResumeData, Section, Skill,
-    SummarySection, Theme, Typography, Url, Volunteer,
+    CustomItem, Education, Experience, FontConfig, Interest, Language, LevelDisplay, Metadata,
+    PageConfig, PageFormat, PageOptions, Profile, Project, Publication, Reference, ResumeData,
+    Section, Skill, SummarySection, Theme, Typography, Url, Volunteer,
 };
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -1111,6 +1111,7 @@ fn convert_metadata(v3: &V3Metadata) -> Metadata {
             underline_links: v3.typography.underline_links.unwrap_or(true),
         },
         notes: String::new(),
+        level_display: LevelDisplay::TemplateDefault,
     }
 }
 

--- a/crates/render/src/typst_engine/templates/_common.typ
+++ b/crates/render/src/typst_engine/templates/_common.typ
@@ -114,6 +114,45 @@
   }
 }
 
+/// Render a skill/language level in the configured global display style.
+#let render-level(
+  level,
+  display,
+  filled-color,
+  empty-color,
+  width: 6pt,
+  height: 6pt,
+  spacing: 2pt,
+  track-width: 48pt,
+  track-height: 4pt,
+  text-size: 8pt,
+) = {
+  let level = clamp-level(level)
+
+  if display == "hidden" {
+    return
+  } else if display == "circle" {
+    rating-indicators(level, width, height, filled-color, empty-color, 50%, spacing)
+  } else if display == "square" {
+    rating-indicators(level, width, height, filled-color, empty-color, 0pt, spacing)
+  } else if display == "progress-bar" {
+    box(width: track-width, height: track-height, fill: empty-color, radius: track-height / 2)[
+      #box(
+        width: track-width * level / 5,
+        height: track-height,
+        fill: filled-color,
+        radius: track-height / 2,
+      )
+    ]
+  } else if display == "text" {
+    let labels = ("", "Novice", "Beginner", "Intermediate", "Advanced", "Expert")
+    let label = labels.at(level)
+    if label != "" {
+      text(size: text-size, fill: filled-color)[#label]
+    }
+  }
+}
+
 /// Render a pre-processed rich-text string (Typst markup) as content.
 /// Plain text passes through unchanged; Typst markup is evaluated.
 /// Accepts optional text-styling parameters (size, fill, style) to avoid

--- a/crates/render/src/typst_engine/templates/_common.typ
+++ b/crates/render/src/typst_engine/templates/_common.typ
@@ -114,6 +114,17 @@
   }
 }
 
+/// Whether an overridden level display should render an indicator for `level`.
+/// False for the template's native rendering ("template-default"), for
+/// "hidden", and for a "text" display with no level set (level 0).
+#let should-render-level(level, level-display) = {
+  (
+    level-display != "template-default"
+      and level-display != "hidden"
+      and not (level-display == "text" and level == 0)
+  )
+}
+
 /// Render a skill/language level in the configured global display style.
 #let render-level(
   level,
@@ -136,14 +147,18 @@
   } else if display == "square" {
     rating-indicators(level, width, height, filled-color, empty-color, 0pt, spacing)
   } else if display == "progress-bar" {
-    box(width: track-width, height: track-height, fill: empty-color, radius: track-height / 2)[
-      #box(
+    box(
+      width: track-width,
+      height: track-height,
+      fill: empty-color,
+      radius: track-height / 2,
+      place(top + left, box(
         width: track-width * level / 5,
         height: track-height,
         fill: filled-color,
         radius: track-height / 2,
-      )
-    ]
+      )),
+    )
   } else if display == "text" {
     let labels = ("", "Novice", "Beginner", "Intermediate", "Advanced", "Expert")
     let label = labels.at(level)

--- a/crates/render/src/typst_engine/templates/azurill.typ
+++ b/crates/render/src/typst_engine/templates/azurill.typ
@@ -41,16 +41,10 @@
     let level = clamp-level(level)
     if level-display == "template-default" {
       rating-indicators(level, 14pt, 4pt, primary-color, bar-empty, 2pt, 2pt)
+    } else if level-display == "progress-bar" {
+      render-level(level, level-display, primary-color, bar-empty, track-width: 70pt)
     } else {
-      render-level(
-        level,
-        level-display,
-        primary-color,
-        bar-empty,
-        width: 14pt,
-        height: 4pt,
-        track-width: 70pt,
-      )
+      render-level(level, level-display, primary-color, bar-empty)
     }
   }
 
@@ -128,7 +122,7 @@
     if level-display == "template-default" and level > 0 {
       v(2pt)
       rating-bars(level)
-    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       v(2pt)
       rating-bars(level)
     }
@@ -155,7 +149,7 @@
     if level-display == "template-default" and level > 0 {
       v(2pt)
       rating-bars(level)
-    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       v(2pt)
       rating-bars(level)
     }

--- a/crates/render/src/typst_engine/templates/azurill.typ
+++ b/crates/render/src/typst_engine/templates/azurill.typ
@@ -9,6 +9,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#d97706"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = text-color.lighten(40%)
 
@@ -37,7 +38,20 @@
 
   // Rating bars helper (0-5 scale)
   let rating-bars(level) = {
-    rating-indicators(level, 14pt, 4pt, primary-color, bar-empty, 2pt, 2pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      rating-indicators(level, 14pt, 4pt, primary-color, bar-empty, 2pt, 2pt)
+    } else {
+      render-level(
+        level,
+        level-display,
+        primary-color,
+        bar-empty,
+        width: 14pt,
+        height: 4pt,
+        track-width: 70pt,
+      )
+    }
   }
 
   let render-experience(item) = {
@@ -111,7 +125,10 @@
     }
 
     let level = clamp-level(item.level)
-    if level > 0 {
+    if level-display == "template-default" and level > 0 {
+      v(2pt)
+      rating-bars(level)
+    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
       v(2pt)
       rating-bars(level)
     }
@@ -135,7 +152,10 @@
     }
 
     let level = clamp-level(item.level)
-    if level > 0 {
+    if level-display == "template-default" and level > 0 {
+      v(2pt)
+      rating-bars(level)
+    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
       v(2pt)
       rating-bars(level)
     }

--- a/crates/render/src/typst_engine/templates/bronzor.typ
+++ b/crates/render/src/typst_engine/templates/bronzor.typ
@@ -10,6 +10,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#0891b2"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = rgb("#6b7280")
 
@@ -35,8 +36,14 @@
   }
 
   let skill-bar(level) = {
-    h(4pt)
-    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      h(4pt)
+      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
+    } else if level-display != "hidden" and not (level-display == "text" and level == 0) {
+      h(4pt)
+      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+    }
   }
 
   let render-experience(item) = {

--- a/crates/render/src/typst_engine/templates/bronzor.typ
+++ b/crates/render/src/typst_engine/templates/bronzor.typ
@@ -40,7 +40,7 @@
     if level-display == "template-default" {
       h(4pt)
       rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
-    } else if level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       h(4pt)
       render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
     }

--- a/crates/render/src/typst_engine/templates/chikorita.typ
+++ b/crates/render/src/typst_engine/templates/chikorita.typ
@@ -9,6 +9,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#16a34a"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#166534"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = rgb("#6b7280")
 
@@ -38,7 +39,12 @@
   }
 
   let rating-dots(level) = {
-    rating-indicators(level, 6pt, 6pt, primary-color, border-color, 50%, 3pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      rating-indicators(level, 6pt, 6pt, primary-color, border-color, 50%, 3pt)
+    } else {
+      render-level(level, level-display, primary-color, border-color, spacing: 3pt)
+    }
   }
 
   let render-experience(item) = {
@@ -105,7 +111,10 @@
     }
 
     let level = clamp-level(item.level)
-    if level > 0 {
+    if level-display == "template-default" and level > 0 {
+      v(2pt)
+      rating-dots(level)
+    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
       v(2pt)
       rating-dots(level)
     }
@@ -129,7 +138,10 @@
     }
 
     let level = clamp-level(item.level)
-    if level > 0 {
+    if level-display == "template-default" and level > 0 {
+      v(2pt)
+      rating-dots(level)
+    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
       v(2pt)
       rating-dots(level)
     }

--- a/crates/render/src/typst_engine/templates/chikorita.typ
+++ b/crates/render/src/typst_engine/templates/chikorita.typ
@@ -114,7 +114,7 @@
     if level-display == "template-default" and level > 0 {
       v(2pt)
       rating-dots(level)
-    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       v(2pt)
       rating-dots(level)
     }
@@ -141,7 +141,7 @@
     if level-display == "template-default" and level > 0 {
       v(2pt)
       rating-dots(level)
-    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       v(2pt)
       rating-dots(level)
     }

--- a/crates/render/src/typst_engine/templates/ditto.typ
+++ b/crates/render/src/typst_engine/templates/ditto.typ
@@ -9,6 +9,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#0891b2"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = rgb("#6b7280")
 
@@ -107,9 +108,12 @@
     }
 
     let level = clamp-level(item.level)
-    if level > 0 {
+    if level-display == "template-default" and level > 0 {
       v(2pt)
       rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+      v(2pt)
+      render-level(level, level-display, primary-color, bg-color.darken(10%))
     }
 
     if has-keywords(item) {
@@ -130,9 +134,12 @@
     }
 
     let level = clamp-level(item.level)
-    if level > 0 {
+    if level-display == "template-default" and level > 0 {
       v(2pt)
       rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+      v(2pt)
+      render-level(level, level-display, primary-color, bg-color.darken(10%))
     }
 
     v(6pt)

--- a/crates/render/src/typst_engine/templates/ditto.typ
+++ b/crates/render/src/typst_engine/templates/ditto.typ
@@ -111,7 +111,7 @@
     if level-display == "template-default" and level > 0 {
       v(2pt)
       rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
-    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       v(2pt)
       render-level(level, level-display, primary-color, bg-color.darken(10%))
     }
@@ -137,7 +137,7 @@
     if level-display == "template-default" and level > 0 {
       v(2pt)
       rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
-    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       v(2pt)
       render-level(level, level-display, primary-color, bg-color.darken(10%))
     }

--- a/crates/render/src/typst_engine/templates/gengar.typ
+++ b/crates/render/src/typst_engine/templates/gengar.typ
@@ -10,6 +10,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#67b8c8"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = rgb("#6b7280")
 
@@ -46,7 +47,12 @@
   }
 
   let rating-boxes(level) = {
-    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 1pt, 2pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 1pt, 2pt)
+    } else {
+      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+    }
   }
 
   let render-experience(item) = {

--- a/crates/render/src/typst_engine/templates/glalie.typ
+++ b/crates/render/src/typst_engine/templates/glalie.typ
@@ -12,6 +12,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#14b8a6"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#0f172a"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = rgb("#64748b")
   let sidebar-bg = primary-color.lighten(90%)
@@ -35,7 +36,12 @@
   }
 
   let skill-dots(level) = {
-    rating-indicators(level, 6pt, 6pt, primary-color, primary-color.lighten(70%), 50%, 2pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      rating-indicators(level, 6pt, 6pt, primary-color, primary-color.lighten(70%), 50%, 2pt)
+    } else {
+      render-level(level, level-display, primary-color, primary-color.lighten(70%))
+    }
   }
 
   let render-experience(item) = {
@@ -106,7 +112,10 @@
     }
 
     let level = clamp-level(item.level)
-    if level > 0 {
+    if level-display == "template-default" and level > 0 {
+      v(2pt)
+      skill-dots(level)
+    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
       v(2pt)
       skill-dots(level)
     }
@@ -130,7 +139,10 @@
     }
 
     let level = clamp-level(item.level)
-    if level > 0 {
+    if level-display == "template-default" and level > 0 {
+      v(2pt)
+      skill-dots(level)
+    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
       v(2pt)
       skill-dots(level)
     }

--- a/crates/render/src/typst_engine/templates/glalie.typ
+++ b/crates/render/src/typst_engine/templates/glalie.typ
@@ -115,7 +115,7 @@
     if level-display == "template-default" and level > 0 {
       v(2pt)
       skill-dots(level)
-    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       v(2pt)
       skill-dots(level)
     }
@@ -142,7 +142,7 @@
     if level-display == "template-default" and level > 0 {
       v(2pt)
       skill-dots(level)
-    } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       v(2pt)
       skill-dots(level)
     }

--- a/crates/render/src/typst_engine/templates/kakuna.typ
+++ b/crates/render/src/typst_engine/templates/kakuna.typ
@@ -10,6 +10,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#78716c"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#422006"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = text-color.lighten(40%)
 
@@ -30,8 +31,14 @@
   }
 
   let skill-bar(level) = {
-    h(4pt)
-    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      h(4pt)
+      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+    } else if level-display != "hidden" and not (level-display == "text" and level == 0) {
+      h(4pt)
+      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+    }
   }
 
   let entry-header(left-content, right-content) = {

--- a/crates/render/src/typst_engine/templates/kakuna.typ
+++ b/crates/render/src/typst_engine/templates/kakuna.typ
@@ -35,7 +35,7 @@
     if level-display == "template-default" {
       h(4pt)
       rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 50%, 2pt)
-    } else if level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       h(4pt)
       render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
     }

--- a/crates/render/src/typst_engine/templates/leafish.typ
+++ b/crates/render/src/typst_engine/templates/leafish.typ
@@ -9,6 +9,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#9f1239"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = text-color.lighten(40%)
 
@@ -32,7 +33,12 @@
   }
 
   let rating-dots(level) = {
-    rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+    } else {
+      render-level(level, level-display, primary-color, bg-color.darken(10%))
+    }
   }
 
   let render-experience(item) = {

--- a/crates/render/src/typst_engine/templates/nosepass.typ
+++ b/crates/render/src/typst_engine/templates/nosepass.typ
@@ -9,6 +9,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#3b82f6"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#1f2937"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = text-color.lighten(30%)
 
@@ -95,7 +96,7 @@
       [
         #text(size: 9pt, weight: "medium")[#item.name]
         #let level = clamp-level(item.level)
-        #if level > 0 {
+        #if level-display == "template-default" and level > 0 {
           h(4pt)
           for i in range(level) {
             text(fill: primary-color)[●]
@@ -103,6 +104,9 @@
           for i in range(5 - level) {
             text(fill: border-color)[●]
           }
+        } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+          h(4pt)
+          render-level(level, level-display, primary-color, border-color)
         }
       ]
     )

--- a/crates/render/src/typst_engine/templates/nosepass.typ
+++ b/crates/render/src/typst_engine/templates/nosepass.typ
@@ -104,7 +104,7 @@
           for i in range(5 - level) {
             text(fill: border-color)[●]
           }
-        } else if level-display != "template-default" and level-display != "hidden" and not (level-display == "text" and level == 0) {
+        } else if should-render-level(level, level-display) {
           h(4pt)
           render-level(level, level-display, primary-color, border-color)
         }

--- a/crates/render/src/typst_engine/templates/onyx.typ
+++ b/crates/render/src/typst_engine/templates/onyx.typ
@@ -9,6 +9,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#dc2626"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#111827"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = rgb("#6b7280")
 
@@ -37,7 +38,12 @@
   }
 
   let rating-squares(level) = {
-    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 0pt, 2pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 0pt, 2pt)
+    } else {
+      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+    }
   }
 
   let render-experience(item) = {

--- a/crates/render/src/typst_engine/templates/pikachu.typ
+++ b/crates/render/src/typst_engine/templates/pikachu.typ
@@ -9,6 +9,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#ca8a04"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#1c1917"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = rgb("#78716c")
 
@@ -36,7 +37,12 @@
   }
 
   let skill-dots(level) = {
-    rating-indicators(level, 6pt, 6pt, primary-color, sidebar-bg.darken(15%), 50%, 3pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      rating-indicators(level, 6pt, 6pt, primary-color, sidebar-bg.darken(15%), 50%, 3pt)
+    } else {
+      render-level(level, level-display, primary-color, sidebar-bg.darken(15%), spacing: 3pt)
+    }
   }
 
   let render-experience(item) = {

--- a/crates/render/src/typst_engine/templates/rhyhorn.typ
+++ b/crates/render/src/typst_engine/templates/rhyhorn.typ
@@ -10,6 +10,7 @@
   let primary-color = rgb(data.metadata.theme.at("primary", default: "#65a30d"))
   let text-color = rgb(data.metadata.theme.at("text", default: "#000000"))
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
+  let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = rgb("#6b7280")
 
@@ -35,8 +36,14 @@
   }
 
   let skill-bar(level) = {
-    h(4pt)
-    rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
+    let level = clamp-level(level)
+    if level-display == "template-default" {
+      h(4pt)
+      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
+    } else if level-display != "hidden" and not (level-display == "text" and level == 0) {
+      h(4pt)
+      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+    }
   }
 
   let render-experience(item) = {

--- a/crates/render/src/typst_engine/templates/rhyhorn.typ
+++ b/crates/render/src/typst_engine/templates/rhyhorn.typ
@@ -40,7 +40,7 @@
     if level-display == "template-default" {
       h(4pt)
       rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
-    } else if level-display != "hidden" and not (level-display == "text" and level == 0) {
+    } else if should-render-level(level, level-display) {
       h(4pt)
       render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
     }

--- a/crates/render/tests/integration_tests.rs
+++ b/crates/render/tests/integration_tests.rs
@@ -476,24 +476,52 @@ fn test_render_template_with_content(#[case] template_name: &str) {
 }
 
 #[rstest]
-#[case(LevelDisplay::Hidden)]
-#[case(LevelDisplay::Circle)]
-#[case(LevelDisplay::Square)]
-#[case(LevelDisplay::ProgressBar)]
-#[case(LevelDisplay::Text)]
-fn test_render_template_with_level_display_override(#[case] level_display: LevelDisplay) {
+fn test_render_template_with_level_display_override(
+    // rhyhorn covers the grid-cell rendering path, azurill the guarded
+    // per-item rendering path shared by the other templates.
+    #[values("rhyhorn", "azurill")] template_name: &str,
+    #[values(
+        LevelDisplay::Hidden,
+        LevelDisplay::Circle,
+        LevelDisplay::Square,
+        LevelDisplay::ProgressBar,
+        LevelDisplay::Text
+    )]
+    level_display: LevelDisplay,
+) {
     let renderer = TypstRenderer::new();
     let mut resume = sample_resume();
-    resume.metadata.template = "rhyhorn".to_string();
+    resume.metadata.template = template_name.to_string();
     resume.metadata.level_display = level_display;
 
     let result = renderer.render_pdf(&resume);
     assert!(
         result.is_ok(),
-        "PDF rendering failed for level display '{level_display:?}': {:?}",
+        "PDF rendering failed for template '{template_name}' with level display \
+         '{level_display:?}': {:?}",
         result.err()
     );
     assert!(result.unwrap().starts_with(b"%PDF-"));
+}
+
+/// Every template must compile with a non-default level display so a Typst
+/// syntax error in any template's override branch is caught.
+#[test]
+fn test_render_all_templates_with_circle_level_display() {
+    let renderer = TypstRenderer::new();
+    for template_name in TEMPLATES {
+        let mut resume = sample_resume();
+        resume.metadata.template = (*template_name).to_string();
+        resume.metadata.level_display = LevelDisplay::Circle;
+
+        let result = renderer.render_pdf(&resume);
+        assert!(
+            result.is_ok(),
+            "PDF rendering failed for template '{template_name}' with circle level display: {:?}",
+            result.err()
+        );
+        assert!(result.unwrap().starts_with(b"%PDF-"));
+    }
 }
 
 #[rstest]

--- a/crates/render/tests/integration_tests.rs
+++ b/crates/render/tests/integration_tests.rs
@@ -7,8 +7,8 @@ use rstest::rstest;
 use rustume_parser::{JsonResumeParser, Parser, ReactiveResumeV3Parser};
 use rustume_render::{get_page_size, get_template_theme, Renderer, TypstRenderer, TEMPLATES};
 use rustume_schema::{
-    Basics, CustomItem, Education, Experience, PageFormat, Picture, PictureEffects, ResumeData,
-    Section, Skill,
+    Basics, CustomItem, Education, Experience, LevelDisplay, PageFormat, Picture, PictureEffects,
+    ResumeData, Section, Skill,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -473,6 +473,27 @@ fn test_render_template_with_content(#[case] template_name: &str) {
         "Output for '{}' is not a valid PDF",
         template_name
     );
+}
+
+#[rstest]
+#[case(LevelDisplay::Hidden)]
+#[case(LevelDisplay::Circle)]
+#[case(LevelDisplay::Square)]
+#[case(LevelDisplay::ProgressBar)]
+#[case(LevelDisplay::Text)]
+fn test_render_template_with_level_display_override(#[case] level_display: LevelDisplay) {
+    let renderer = TypstRenderer::new();
+    let mut resume = sample_resume();
+    resume.metadata.template = "rhyhorn".to_string();
+    resume.metadata.level_display = level_display;
+
+    let result = renderer.render_pdf(&resume);
+    assert!(
+        result.is_ok(),
+        "PDF rendering failed for level display '{level_display:?}': {:?}",
+        result.err()
+    );
+    assert!(result.unwrap().starts_with(b"%PDF-"));
 }
 
 #[rstest]

--- a/crates/schema/src/metadata.rs
+++ b/crates/schema/src/metadata.rs
@@ -4,6 +4,19 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
 
+/// Controls how skill and language proficiency levels are rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, ToSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum LevelDisplay {
+    #[default]
+    TemplateDefault,
+    Hidden,
+    Circle,
+    Square,
+    ProgressBar,
+    Text,
+}
+
 /// Resume metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -33,6 +46,9 @@ pub struct Metadata {
 
     #[serde(default)]
     pub notes: String,
+
+    #[serde(default)]
+    pub level_display: LevelDisplay,
 }
 
 impl Default for Metadata {
@@ -45,6 +61,7 @@ impl Default for Metadata {
             theme: Theme::default(),
             typography: Typography::default(),
             notes: String::new(),
+            level_display: LevelDisplay::TemplateDefault,
         }
     }
 }
@@ -260,4 +277,36 @@ fn default_layout() -> Vec<Vec<Vec<String>>> {
             "languages".to_string(),
         ],
     ]]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn level_display_uses_kebab_case_round_trip() {
+        let cases = [
+            (LevelDisplay::TemplateDefault, "template-default"),
+            (LevelDisplay::Hidden, "hidden"),
+            (LevelDisplay::Circle, "circle"),
+            (LevelDisplay::Square, "square"),
+            (LevelDisplay::ProgressBar, "progress-bar"),
+            (LevelDisplay::Text, "text"),
+        ];
+
+        for (value, serialized) in cases {
+            let json = serde_json::to_value(value).unwrap();
+            assert_eq!(json, json!(serialized));
+
+            let parsed: LevelDisplay = serde_json::from_value(json).unwrap();
+            assert_eq!(parsed, value);
+        }
+    }
+
+    #[test]
+    fn metadata_defaults_missing_level_display_to_template_default() {
+        let metadata: Metadata = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(metadata.level_display, LevelDisplay::TemplateDefault);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add proficiency level display types
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds `metadata.levelDisplay` so users can choose how skill/language proficiency levels render: template default, hidden, circles, squares, progress bar, or text labels. Default is `template-default` so existing resumes keep each template’s native style (e.g. azurill bars, onyx squares). Theme editor includes a “Proficiency display” selector.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Notes

- Text display labels (Novice through Expert) are hardcoded English for now; localization is deferred to the i18n effort (#370).
- With a non-default display selected, level-0 items render an empty indicator (all-empty circles/squares or an empty progress bar) rather than nothing, matching the native behavior of the grid-cell templates.

## Related Issues

Closes #90

## Details

### Schema
- `LevelDisplay` enum (`kebab-case`): `template-default` | `hidden` | `circle` | `square` | `progress-bar` | `text`
- `Metadata.level_display` defaults to `TemplateDefault`

### Typst
- Shared `render-level` in `_common.typ` (hidden / circle / square / progress-bar / text labels Novice→Expert)
- All level-rendering templates consult `data.metadata.levelDisplay` and fall back to native style for `template-default`

### Web
- ThemeEditor “Proficiency display” selector → `updateMetadata("levelDisplay", …)`

### Out of scope
- Per-section overrides (skills vs languages) — follow-up

### Testing
- Schema kebab-case round-trip + missing field default
- Render integration for each non-default display value
- Vitest selector update coverage

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds configurable proficiency-level displays for skills and languages. The main changes are:

- A schema field with backward-compatible defaults.
- Shared Typst renderers for indicators, progress bars, and text labels.
- Template integration for native and overridden display styles.
- A theme editor selector for choosing the display style.
- Parser, web, schema, and rendering test updates.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after resolving the existing review feedback.

- No additional blocking issue was found in the updated code.
- The remaining Nosepass language behavior is already covered by existing feedback.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/render/src/typst_engine/templates/_common.typ | Adds shared proficiency visibility checks and renderers for each display style. |
| crates/render/src/typst_engine/templates/nosepass.typ | Connects the global proficiency setting to Nosepass skill rendering. |
| crates/schema/src/metadata.rs | Adds the serialized display enum and a backward-compatible metadata default. |
| apps/web/src/components/templates/ThemeEditor.tsx | Adds the proficiency display selector to the theme editor. |
| crates/parser/src/reactive_resume_v3.rs | Defaults imported Reactive Resume metadata to the template-native display. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(render): address level-display revie..."](https://github.com/lgtm-hq/rustume/commit/cea2f0093c4fe2c203e9d19a3a3393cc50885dfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45900708)</sub>

<!-- /greptile_comment -->