### PR TITLE
feat(web): add adjustable sidebar width ratio

### DIFF
--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -1,7 +1,20 @@
 import { Show, For, createSignal } from "solid-js";
 import { resumeStore } from "../../stores/resume";
 import { getThemePresets } from "../../stores/themePresets";
-import type { ThemePresetInfo } from "../../wasm/types";
+import type { PageConfig, ThemePresetInfo } from "../../wasm/types";
+
+const SIDEBAR_TEMPLATES = new Set(["azurill", "pikachu", "chikorita", "ditto", "gengar", "glalie"]);
+const SIDEBAR_TEMPLATE_RATIO_DEFAULT = 1 / 3;
+const FIXED_SIDEBAR_WIDTH_PT: Record<string, number> = {
+  pikachu: 180,
+  ditto: 160,
+  gengar: 170,
+  glalie: 170,
+};
+const PAPER_WIDTH_PT: Record<PageConfig["format"], number> = {
+  a4: 595.28,
+  letter: 612,
+};
 
 export function ThemeEditor() {
   const { store, updateTheme, updateMetadata } = resumeStore;
@@ -23,6 +36,7 @@ export function ThemeEditor() {
   };
 
   const currentPresetId = () => store.resume?.metadata.theme.preset;
+  const isSidebarTemplate = (template: string) => SIDEBAR_TEMPLATES.has(template);
 
   return (
     <div class="space-y-4">
@@ -146,6 +160,16 @@ export function ThemeEditor() {
               />
             </Show>
 
+            <Show when={isSidebarTemplate(resume().metadata.template)}>
+              <SidebarRatioControl
+                template={resume().metadata.template}
+                page={resume().metadata.page}
+                onChange={(sidebarRatio) =>
+                  updateMetadata("page", { ...resume().metadata.page, sidebarRatio })
+                }
+              />
+            </Show>
+
             {/* Preview */}
             <div class="p-4 rounded-lg border border-border">
               <div
@@ -175,6 +199,71 @@ export function ThemeEditor() {
           </div>
         )}
       </Show>
+    </div>
+  );
+}
+
+interface SidebarRatioControlProps {
+  template: string;
+  page: PageConfig;
+  onChange: (sidebarRatio: number | undefined) => void;
+}
+
+function defaultSidebarRatio(template: string, page: PageConfig): number {
+  const fixedWidth = FIXED_SIDEBAR_WIDTH_PT[template];
+  if (fixedWidth === undefined) return SIDEBAR_TEMPLATE_RATIO_DEFAULT;
+
+  const paperWidth = PAPER_WIDTH_PT[page.format] ?? PAPER_WIDTH_PT.a4;
+  const contentWidth = paperWidth - 2 * page.margin;
+  if (contentWidth <= 0) return SIDEBAR_TEMPLATE_RATIO_DEFAULT;
+
+  return Math.min(0.5, Math.max(0.1, fixedWidth / contentWidth));
+}
+
+function formatRatio(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function SidebarRatioControl(props: SidebarRatioControlProps) {
+  const currentRatio = () =>
+    props.page.sidebarRatio ?? defaultSidebarRatio(props.template, props.page);
+  const labelValue = () =>
+    props.page.sidebarRatio === undefined
+      ? "Template default"
+      : formatRatio(props.page.sidebarRatio);
+
+  return (
+    <div class="space-y-3 pt-4 border-t border-border">
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <h3 class="font-mono text-xs uppercase tracking-wider text-stone">Sidebar Width</h3>
+          <p class="text-xs text-stone mt-1">Adjust the sidebar column for this template.</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => props.onChange(undefined)}
+          class="text-xs font-medium text-accent hover:text-accent/80"
+        >
+          Reset to template default
+        </button>
+      </div>
+
+      <div class="space-y-1.5">
+        <label class="font-mono text-xs uppercase tracking-wider text-stone flex justify-between">
+          <span>Width</span>
+          <span class="font-body normal-case tracking-normal">{labelValue()}</span>
+        </label>
+        <input
+          type="range"
+          min="0.10"
+          max="0.50"
+          step="0.01"
+          value={currentRatio()}
+          onInput={(e) => props.onChange(parseFloat(e.currentTarget.value))}
+          class="w-full accent-[var(--turbo-brand-primary)]"
+          aria-label="Sidebar width"
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -3,8 +3,12 @@ import { resumeStore } from "../../stores/resume";
 import { getThemePresets } from "../../stores/themePresets";
 import type { PageConfig, ThemePresetInfo } from "../../wasm/types";
 
+// Must match the templates wired to sidebar-ratio helpers in
+// crates/render/src/typst_engine/templates/<template>.typ.
 const SIDEBAR_TEMPLATES = new Set(["azurill", "pikachu", "chikorita", "ditto", "gengar", "glalie"]);
 const SIDEBAR_TEMPLATE_RATIO_DEFAULT = 1 / 3;
+// Must match the sidebar-width defaults in
+// crates/render/src/typst_engine/templates/<template>.typ.
 const FIXED_SIDEBAR_WIDTH_PT: Record<string, number> = {
   pikachu: 180,
   ditto: 160,
@@ -249,11 +253,15 @@ function SidebarRatioControl(props: SidebarRatioControlProps) {
       </div>
 
       <div class="space-y-1.5">
-        <label class="font-mono text-xs uppercase tracking-wider text-stone flex justify-between">
+        <label
+          for="sidebar-ratio-input"
+          class="font-mono text-xs uppercase tracking-wider text-stone flex justify-between"
+        >
           <span>Width</span>
           <span class="font-body normal-case tracking-normal">{labelValue()}</span>
         </label>
         <input
+          id="sidebar-ratio-input"
           type="range"
           min="0.10"
           max="0.50"
@@ -262,6 +270,7 @@ function SidebarRatioControl(props: SidebarRatioControlProps) {
           onInput={(e) => props.onChange(parseFloat(e.currentTarget.value))}
           class="w-full accent-[var(--turbo-brand-primary)]"
           aria-label="Sidebar width"
+          aria-valuetext={formatRatio(currentRatio())}
         />
       </div>
     </div>

--- a/apps/web/src/components/templates/ThemeEditor.tsx
+++ b/apps/web/src/components/templates/ThemeEditor.tsx
@@ -229,12 +229,14 @@ function formatRatio(value: number): string {
 }
 
 function SidebarRatioControl(props: SidebarRatioControlProps) {
-  const currentRatio = () =>
-    props.page.sidebarRatio ?? defaultSidebarRatio(props.template, props.page);
-  const labelValue = () =>
-    props.page.sidebarRatio === undefined
-      ? "Template default"
-      : formatRatio(props.page.sidebarRatio);
+  // Older server payloads serialized the unset ratio as an explicit null;
+  // normalize so null and undefined both mean "template default".
+  const ratioOverride = () => props.page.sidebarRatio ?? undefined;
+  const currentRatio = () => ratioOverride() ?? defaultSidebarRatio(props.template, props.page);
+  const labelValue = () => {
+    const override = ratioOverride();
+    return override === undefined ? "Template default" : formatRatio(override);
+  };
 
   return (
     <div class="space-y-3 pt-4 border-t border-border">

--- a/apps/web/src/components/templates/__tests__/ThemeEditor.test.tsx
+++ b/apps/web/src/components/templates/__tests__/ThemeEditor.test.tsx
@@ -59,3 +59,42 @@ describe("ThemeEditor custom CSS tab", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("ThemeEditor sidebar width control", () => {
+  beforeEach(() => {
+    resumeStore.createNewResume("theme-editor-sidebar-test");
+  });
+
+  it("only shows the sidebar width slider for sidebar templates", async () => {
+    render(() => <ThemeEditor />);
+
+    expect(screen.queryByRole("slider", { name: "Sidebar width" })).not.toBeInTheDocument();
+
+    resumeStore.updateTemplate("azurill");
+
+    expect(screen.getByRole("slider", { name: "Sidebar width" })).toBeInTheDocument();
+  });
+
+  it("updates metadata.page.sidebarRatio when the slider moves", async () => {
+    resumeStore.updateTemplate("pikachu");
+    render(() => <ThemeEditor />);
+
+    const slider = screen.getByRole("slider", { name: "Sidebar width" });
+    fireEvent.input(slider, { target: { value: "0.25" } });
+
+    expect(resumeStore.store.resume?.metadata.page.sidebarRatio).toBe(0.25);
+  });
+
+  it("clears metadata.page.sidebarRatio when reset to template default", async () => {
+    resumeStore.updateTemplate("chikorita");
+    resumeStore.updateMetadata("page", {
+      ...resumeStore.store.resume!.metadata.page,
+      sidebarRatio: 0.25,
+    });
+    render(() => <ThemeEditor />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset to template default" }));
+
+    expect(resumeStore.store.resume?.metadata.page.sidebarRatio).toBeUndefined();
+  });
+});

--- a/apps/web/src/wasm/types.ts
+++ b/apps/web/src/wasm/types.ts
@@ -212,6 +212,7 @@ export interface CustomCss {
 export interface PageConfig {
   margin: number;
   format: "a4" | "letter";
+  sidebarRatio?: number;
   breakLine: boolean;
   pageNumbers: boolean;
 }

--- a/crates/parser/src/reactive_resume_v3.rs
+++ b/crates/parser/src/reactive_resume_v3.rs
@@ -1047,6 +1047,7 @@ fn convert_metadata(v3: &V3Metadata) -> Metadata {
                 _ => PageFormat::A4,
             },
             margin: v3.page.margin.unwrap_or(18),
+            sidebar_ratio: None,
             options: PageOptions {
                 break_line: v3
                     .page

--- a/crates/render/src/typst_engine/templates/_common.typ
+++ b/crates/render/src/typst_engine/templates/_common.typ
@@ -174,8 +174,19 @@
 }
 
 /// Content width after subtracting resume page margins.
+/// Note: fixed-width sidebar templates set the real page margin to 0/48pt, so
+/// subtracting 2x the metadata margin here is an approximation. The web UI's
+/// default-ratio math (ThemeEditor.tsx) mirrors the same approximation, so the
+/// two stay self-consistent — do not "fix" the math on one side only.
 #let content-width(data) = {
   paper-width(data) - (2 * data.metadata.page.at("margin", default: 18) * 1pt)
+}
+
+/// Clamp a sidebar ratio to the supported [0.1, 0.5] range.
+/// The export path renders stored JSON without schema validation, so
+/// out-of-range stored values must be clamped here as defense-in-depth.
+#let clamp-sidebar-ratio(ratio) = {
+  calc.max(0.1, calc.min(0.5, ratio))
 }
 
 /// Resolve a fixed sidebar width from sidebarRatio, preserving native defaults.
@@ -184,7 +195,7 @@
   if ratio == none {
     default
   } else {
-    ratio * content-width(data)
+    clamp-sidebar-ratio(ratio) * content-width(data)
   }
 }
 
@@ -194,6 +205,7 @@
   if ratio == none {
     return default
   }
+  let ratio = clamp-sidebar-ratio(ratio)
 
   let sidebar-width = ratio * 100fr
   let main-width = (1 - ratio) * 100fr

--- a/crates/render/src/typst_engine/templates/_common.typ
+++ b/crates/render/src/typst_engine/templates/_common.typ
@@ -158,6 +158,52 @@
   items
 }
 
+/// Optional sidebar width ratio from metadata.page.sidebarRatio.
+#let sidebar-ratio(data) = {
+  data.metadata.page.at("sidebarRatio", default: none)
+}
+
+/// Paper width in points for supported page formats.
+#let paper-width(data) = {
+  let format = data.metadata.page.at("format", default: "a4")
+  if format == "letter" or format == "us-letter" {
+    612pt
+  } else {
+    595.28pt
+  }
+}
+
+/// Content width after subtracting resume page margins.
+#let content-width(data) = {
+  paper-width(data) - (2 * data.metadata.page.at("margin", default: 18) * 1pt)
+}
+
+/// Resolve a fixed sidebar width from sidebarRatio, preserving native defaults.
+#let sidebar-width-from-ratio(data, default) = {
+  let ratio = sidebar-ratio(data)
+  if ratio == none {
+    default
+  } else {
+    ratio * content-width(data)
+  }
+}
+
+/// Resolve proportional two-column widths, preserving native defaults.
+#let sidebar-ratio-columns(data, default, sidebar-side: "left") = {
+  let ratio = sidebar-ratio(data)
+  if ratio == none {
+    return default
+  }
+
+  let sidebar-width = ratio * 100fr
+  let main-width = (1 - ratio) * 100fr
+  if sidebar-side == "right" {
+    (main-width, sidebar-width)
+  } else {
+    (sidebar-width, main-width)
+  }
+}
+
 /// Fixed-width sidebar plus flowing main content.
 ///
 /// The grid owns the sidebar background while each column receives breakable

--- a/crates/render/src/typst_engine/templates/azurill.typ
+++ b/crates/render/src/typst_engine/templates/azurill.typ
@@ -437,7 +437,7 @@
   render-resume(data, (
     layout: "two-column",
     renderers: renderers,
-    columns: (1fr, 2fr),
+    columns: sidebar-ratio-columns(data, (1fr, 2fr), sidebar-side: "left"),
     column-gutter: 20pt,
     left-column: 0,
     left-fallback: default-sidebar-sections,

--- a/crates/render/src/typst_engine/templates/chikorita.typ
+++ b/crates/render/src/typst_engine/templates/chikorita.typ
@@ -434,7 +434,7 @@
   render-resume(data, (
     layout: "two-column",
     renderers: renderers,
-    columns: (2fr, 1fr),
+    columns: sidebar-ratio-columns(data, (2fr, 1fr), sidebar-side: "right"),
     column-gutter: 20pt,
     left-column: 0,
     left-fallback: default-main-sections + ("custom",),

--- a/crates/render/src/typst_engine/templates/ditto.typ
+++ b/crates/render/src/typst_engine/templates/ditto.typ
@@ -427,7 +427,7 @@
   render-resume(data, (
     layout: "full-header-sidebar",
     renderers: renderers,
-    sidebar-width: 160pt,
+    sidebar-width: sidebar-width-from-ratio(data, 160pt),
     sidebar-bg: sidebar-bg,
     body-bg: bg-color,
     sidebar-inset: (x: 14pt, y: 12pt),

--- a/crates/render/src/typst_engine/templates/ditto.typ
+++ b/crates/render/src/typst_engine/templates/ditto.typ
@@ -427,6 +427,7 @@
   render-resume(data, (
     layout: "full-header-sidebar",
     renderers: renderers,
+    // Default width must match FIXED_SIDEBAR_WIDTH_PT in apps/web/src/components/templates/ThemeEditor.tsx.
     sidebar-width: sidebar-width-from-ratio(data, 160pt),
     sidebar-bg: sidebar-bg,
     body-bg: bg-color,

--- a/crates/render/src/typst_engine/templates/gengar.typ
+++ b/crates/render/src/typst_engine/templates/gengar.typ
@@ -429,6 +429,7 @@
   render-resume(data, (
     layout: "sidebar-left",
     renderers: renderers,
+    // Default width must match FIXED_SIDEBAR_WIDTH_PT in apps/web/src/components/templates/ThemeEditor.tsx.
     sidebar-width: sidebar-width-from-ratio(data, 170pt),
     sidebar-bg: sidebar-bg,
     body-bg: bg-color,

--- a/crates/render/src/typst_engine/templates/gengar.typ
+++ b/crates/render/src/typst_engine/templates/gengar.typ
@@ -429,7 +429,7 @@
   render-resume(data, (
     layout: "sidebar-left",
     renderers: renderers,
-    sidebar-width: 170pt,
+    sidebar-width: sidebar-width-from-ratio(data, 170pt),
     sidebar-bg: sidebar-bg,
     body-bg: bg-color,
     sidebar-inset: (x: 16pt, y: 28pt),

--- a/crates/render/src/typst_engine/templates/glalie.typ
+++ b/crates/render/src/typst_engine/templates/glalie.typ
@@ -413,7 +413,7 @@
   render-resume(data, (
     layout: "sidebar-left",
     renderers: renderers,
-    sidebar-width: 170pt,
+    sidebar-width: sidebar-width-from-ratio(data, 170pt),
     sidebar-bg: sidebar-bg,
     sidebar-inset: (x: 16pt, y: 24pt),
     main-inset: (x: 24pt, y: 24pt),

--- a/crates/render/src/typst_engine/templates/glalie.typ
+++ b/crates/render/src/typst_engine/templates/glalie.typ
@@ -413,6 +413,7 @@
   render-resume(data, (
     layout: "sidebar-left",
     renderers: renderers,
+    // Default width must match FIXED_SIDEBAR_WIDTH_PT in apps/web/src/components/templates/ThemeEditor.tsx.
     sidebar-width: sidebar-width-from-ratio(data, 170pt),
     sidebar-bg: sidebar-bg,
     sidebar-inset: (x: 16pt, y: 24pt),

--- a/crates/render/src/typst_engine/templates/leafish.typ
+++ b/crates/render/src/typst_engine/templates/leafish.typ
@@ -458,6 +458,8 @@
   render-resume(data, (
     layout: "two-column",
     renderers: renderers,
+    // Intentionally not wired to sidebar-ratio-columns: leafish is excluded from
+    // the adjustable sidebar-ratio template list in issue #84.
     columns: (1fr, 1fr),
     column-gutter: 20pt,
     left-column: 0,

--- a/crates/render/src/typst_engine/templates/pikachu.typ
+++ b/crates/render/src/typst_engine/templates/pikachu.typ
@@ -368,6 +368,7 @@
   render-resume(data, (
     layout: "sidebar-left",
     renderers: renderers,
+    // Default width must match FIXED_SIDEBAR_WIDTH_PT in apps/web/src/components/templates/ThemeEditor.tsx.
     sidebar-width: sidebar-width-from-ratio(data, 180pt),
     sidebar-bg: sidebar-bg,
     body-bg: bg-color,

--- a/crates/render/src/typst_engine/templates/pikachu.typ
+++ b/crates/render/src/typst_engine/templates/pikachu.typ
@@ -368,7 +368,7 @@
   render-resume(data, (
     layout: "sidebar-left",
     renderers: renderers,
-    sidebar-width: 180pt,
+    sidebar-width: sidebar-width-from-ratio(data, 180pt),
     sidebar-bg: sidebar-bg,
     body-bg: bg-color,
     sidebar-inset: (x: 16pt, y: 32pt),

--- a/crates/render/tests/integration_tests.rs
+++ b/crates/render/tests/integration_tests.rs
@@ -476,6 +476,27 @@ fn test_render_template_with_content(#[case] template_name: &str) {
 }
 
 #[rstest]
+#[case("azurill")]
+#[case("pikachu")]
+fn test_sidebar_templates_render_with_and_without_sidebar_ratio(#[case] template_name: &str) {
+    let renderer = TypstRenderer::new();
+
+    for sidebar_ratio in [None, Some(0.25)] {
+        let mut resume = sample_resume();
+        resume.metadata.template = template_name.to_string();
+        resume.metadata.page.sidebar_ratio = sidebar_ratio;
+
+        let result = renderer.render_pdf(&resume);
+        assert!(
+            result.is_ok(),
+            "PDF rendering failed for template '{template_name}' with sidebar ratio {sidebar_ratio:?}: {:?}",
+            result.err()
+        );
+        assert!(result.unwrap().starts_with(b"%PDF-"));
+    }
+}
+
+#[rstest]
 #[case("rhyhorn")]
 #[case("azurill")]
 #[case("pikachu")]

--- a/crates/render/tests/integration_tests.rs
+++ b/crates/render/tests/integration_tests.rs
@@ -478,10 +478,14 @@ fn test_render_template_with_content(#[case] template_name: &str) {
 #[rstest]
 #[case("azurill")]
 #[case("pikachu")]
+#[case("chikorita")]
+#[case("ditto")]
+#[case("gengar")]
+#[case("glalie")]
 fn test_sidebar_templates_render_with_and_without_sidebar_ratio(#[case] template_name: &str) {
     let renderer = TypstRenderer::new();
 
-    for sidebar_ratio in [None, Some(0.25)] {
+    for sidebar_ratio in [None, Some(0.1), Some(0.25), Some(0.5)] {
         let mut resume = sample_resume();
         resume.metadata.template = template_name.to_string();
         resume.metadata.page.sidebar_ratio = sidebar_ratio;

--- a/crates/schema/src/metadata.rs
+++ b/crates/schema/src/metadata.rs
@@ -79,6 +79,10 @@ pub struct PageConfig {
     #[serde(default)]
     pub format: PageFormat,
 
+    #[validate(range(min = 0.1, max = 0.5))]
+    #[serde(default)]
+    pub sidebar_ratio: Option<f32>,
+
     #[validate(nested)]
     #[serde(default)]
     pub options: PageOptions,
@@ -89,6 +93,7 @@ impl Default for PageConfig {
         Self {
             margin: default_margin(),
             format: PageFormat::A4,
+            sidebar_ratio: None,
             options: PageOptions::default(),
         }
     }
@@ -260,4 +265,37 @@ fn default_layout() -> Vec<Vec<Vec<String>>> {
             "languages".to_string(),
         ],
     ]]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use validator::Validate;
+
+    #[test]
+    fn page_config_accepts_sidebar_ratio_bounds_and_none() {
+        let none = PageConfig::default();
+        assert!(none.validate().is_ok());
+
+        let valid = PageConfig {
+            sidebar_ratio: Some(0.25),
+            ..Default::default()
+        };
+        assert!(valid.validate().is_ok());
+    }
+
+    #[test]
+    fn page_config_rejects_sidebar_ratio_outside_bounds() {
+        let too_small = PageConfig {
+            sidebar_ratio: Some(0.05),
+            ..Default::default()
+        };
+        assert!(too_small.validate().is_err());
+
+        let too_large = PageConfig {
+            sidebar_ratio: Some(0.6),
+            ..Default::default()
+        };
+        assert!(too_large.validate().is_err());
+    }
 }

--- a/crates/schema/src/metadata.rs
+++ b/crates/schema/src/metadata.rs
@@ -79,8 +79,10 @@ pub struct PageConfig {
     #[serde(default)]
     pub format: PageFormat,
 
+    // Omit when unset so clients see the field absent (template default)
+    // rather than an explicit null they must special-case.
     #[validate(range(min = 0.1, max = 0.5))]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sidebar_ratio: Option<f32>,
 
     #[validate(nested)]
@@ -282,6 +284,19 @@ mod tests {
             ..Default::default()
         };
         assert!(valid.validate().is_ok());
+    }
+
+    #[test]
+    fn page_config_omits_unset_sidebar_ratio_when_serialized() {
+        let json = serde_json::to_value(PageConfig::default()).unwrap();
+        assert!(json.get("sidebarRatio").is_none());
+
+        let set = PageConfig {
+            sidebar_ratio: Some(0.25),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(set).unwrap();
+        assert_eq!(json["sidebarRatio"], 0.25);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add adjustable sidebar width ratio
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds an optional `metadata.page.sidebarRatio` (0.1–0.5) so users can adjust sidebar vs main content width on sidebar templates. `None` keeps each template’s native default for backward compatibility. Theme editor shows a percentage slider only for sidebar templates (azurill, pikachu, chikorita, ditto, gengar, glalie), with a reset-to-default control.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Related Issues

Closes #84

## Details

### Schema
- `PageConfig.sidebar_ratio: Option<f32>` with validation 0.1–0.5 when set

### Typst
- Shared helpers in `_common.typ` (`sidebar-ratio`, `sidebar-width-from-ratio`, `sidebar-ratio-columns`)
- Fixed-width sidebars (pikachu/ditto/gengar/glalie): ratio × content width
- Proportional grids (azurill/chikorita): sidebar = ratio, main = 1 − ratio

### Web
- ThemeEditor slider (10%–50%) + reset, gated by `SIDEBAR_TEMPLATES`

### Testing
- Schema bounds + None acceptance
- Render integration for azurill/pikachu with and without ratio
- Vitest: visibility, update, reset

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a607f5d-46a0-4e11-9c1a-917f01838b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Notes

- The sidebar ratio is clamped to [0.1, 0.5] inside the Typst helpers as defense-in-depth: the export path renders stored JSON without schema validation, so out-of-range stored values would otherwise reach rendering.
- leafish is a two-column layout that is deliberately not wired to the sidebar ratio, matching the explicit template list in issue #84.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Sidebar Width slider for supported resume templates.
  - Adjust sidebar proportions directly in the theme editor.
  - Reset custom sizing to each template’s default width.
  - Sidebar sizing now adapts across supported layouts and paper formats.
  - Added support for saving sidebar width preferences in page settings.

- **Compatibility**
  - Existing resumes continue using template defaults when no custom sidebar width is set.

- **Tests**
  - Added coverage for slider visibility, updates, reset behavior, validation, and PDF rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds adjustable sidebar widths to supported resume templates. The main changes are:

- An optional validated sidebar ratio in page metadata.
- A theme-editor slider with template defaults and reset support.
- Shared Typst helpers for fixed and proportional sidebar layouts.
- Tests for validation, serialization, editor behavior, and PDF rendering.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Legacy null values now use the template default consistently.
- Unset ratios are omitted during serialization.
- Stored finite ratios are clamped before rendering.
- No blocking issues remain in the updated code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/templates/ThemeEditor.tsx | Adds the sidebar-width control and handles absent and legacy null values as template defaults. |
| crates/render/src/typst_engine/templates/_common.typ | Adds shared ratio helpers and clamps stored values before layout calculations. |
| crates/schema/src/metadata.rs | Adds the optional validated ratio and omits it from serialized data when unset. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore: merge main into sidebar-ratio bra..."](https://github.com/lgtm-hq/rustume/commit/463309eae84a3e7ef9434ccdeff2af4c142fee14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45900714)</sub>

<!-- /greptile_comment -->