### PR TITLE
test(render): assert sidebar ratio changes layout and clamps

### DIFF
--- a/crates/render/tests/integration_tests.rs
+++ b/crates/render/tests/integration_tests.rs
@@ -515,12 +515,17 @@ fn test_sidebar_ratio_changes_layout_and_clamps(#[case] template_name: &str) {
         renderer.render_pdf(&resume).unwrap()
     };
 
-    // Guard: only compare renders if output is byte-deterministic.
+    // These comparisons require byte-deterministic output. Fail loudly if
+    // that ever changes so the assertions get reworked instead of silently
+    // stopping to enforce anything.
     let narrow = render(Some(0.1));
-    if render(Some(0.1)) != narrow {
-        eprintln!("skipping byte comparisons: PDF output is not deterministic");
-        return;
-    }
+    assert_eq!(
+        render(Some(0.1)),
+        narrow,
+        "PDF output is no longer byte-deterministic; rework this test's \
+         comparisons (e.g. compare rendered PNG pixels or generated Typst \
+         source) instead of skipping"
+    );
 
     let wide = render(Some(0.5));
     assert_ne!(

--- a/crates/render/tests/integration_tests.rs
+++ b/crates/render/tests/integration_tests.rs
@@ -500,6 +500,47 @@ fn test_sidebar_templates_render_with_and_without_sidebar_ratio(#[case] template
     }
 }
 
+/// The ratio must actually change the layout (not merely render), and raw
+/// out-of-range values must hit the render-time clamp — the export path
+/// renders stored JSON without schema validation.
+#[rstest]
+#[case("azurill")]
+#[case("pikachu")]
+fn test_sidebar_ratio_changes_layout_and_clamps(#[case] template_name: &str) {
+    let renderer = TypstRenderer::new();
+    let render = |ratio: Option<f32>| {
+        let mut resume = sample_resume();
+        resume.metadata.template = template_name.to_string();
+        resume.metadata.page.sidebar_ratio = ratio;
+        renderer.render_pdf(&resume).unwrap()
+    };
+
+    // Guard: only compare renders if output is byte-deterministic.
+    let narrow = render(Some(0.1));
+    if render(Some(0.1)) != narrow {
+        eprintln!("skipping byte comparisons: PDF output is not deterministic");
+        return;
+    }
+
+    let wide = render(Some(0.5));
+    assert_ne!(
+        narrow, wide,
+        "sidebar ratio has no effect on layout for '{template_name}'"
+    );
+
+    // Values outside [0.1, 0.5] clamp to the nearest bound.
+    assert_eq!(
+        render(Some(-1.0)),
+        narrow,
+        "ratio below range should clamp to 0.1 for '{template_name}'"
+    );
+    assert_eq!(
+        render(Some(0.75)),
+        wide,
+        "ratio above range should clamp to 0.5 for '{template_name}'"
+    );
+}
+
 #[rstest]
 fn test_render_template_with_level_display_override(
     // rhyhorn covers the grid-cell rendering path, azurill the guarded


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `test(render): assert sidebar ratio changes layout and clamps`

- Type:
  - [x] test

## What's Changing

Follow-up from CodeRabbit review on #534: the sidebar-ratio smoke tests only asserted that PDFs render, which would still pass if every template ignored the value. This adds a test that byte-compares renders at ratio 0.1 vs 0.5 (layout must actually respond) and feeds raw out-of-range values (`-1.0`, `0.75`) through the render path to pin the Typst-side clamp to its bounds — the export path renders stored JSON without schema validation, so the clamp is the only guard. A determinism probe degrades to a skip if PDF output ever becomes nondeterministic.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing (not applicable)
- [x] Local CI passed (`cargo test -p rustume-render`, `uv run lintro chk` — zero repo issues)

## Related Issues

Related #84

## Details

Addresses the resolved review thread on #534 about assertion strength; no production code changes.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR strengthens integration coverage for sidebar-ratio rendering. The main changes are:

- Verifies that ratios `0.1` and `0.5` produce different layouts.
- Verifies that values outside the supported range clamp to the nearest bound.
- Fails loudly when repeated PDF renders are not byte-deterministic.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Nondeterministic output now fails the test instead of skipping its behavior checks.
- No blocking issues remain in the updated test.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/render/tests/integration_tests.rs | Adds layout and clamp assertions and replaces the nondeterminism bypass with an explicit failure. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(render): fail loudly if PDF output ..."](https://github.com/lgtm-hq/rustume/commit/e3a5c6d64484234e5429e3efbaed3ddeb085c145) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45925753)</sub>

<!-- /greptile_comment -->