### PR TITLE
fix(web): handle cover letter sections after schema merge

### DIFF
--- a/apps/web/src/api/__tests__/render.test.ts
+++ b/apps/web/src/api/__tests__/render.test.ts
@@ -64,6 +64,19 @@ const mockResume: ResumeData = {
       visible: false,
       content: "",
     },
+    coverLetter: {
+      id: "coverLetter",
+      name: "Cover Letter",
+      visible: false,
+      recipient: {
+        name: "",
+        title: "",
+        company: "",
+        address: "",
+        email: "",
+      },
+      content: "",
+    },
     experience: {
       id: "experience",
       name: "Experience",

--- a/apps/web/src/components/builder/SectionList.tsx
+++ b/apps/web/src/components/builder/SectionList.tsx
@@ -14,6 +14,13 @@ export function SectionList() {
   const getItemCount = (key: LayoutSectionKey): number => {
     if (!store.resume) return 0;
     if (key === "summary") return store.resume.sections.summary.content ? 1 : 0;
+    if (key === "coverLetter") {
+      const coverLetter = store.resume.sections.coverLetter;
+      const hasRecipient = Object.values(coverLetter.recipient).some(
+        (value) => value.trim() !== "",
+      );
+      return coverLetter.content.trim() !== "" || hasRecipient ? 1 : 0;
+    }
     if (key === "custom") {
       return Object.values(store.resume.sections.custom).reduce(
         (total, section) => total + section.items.length,

--- a/apps/web/src/components/builder/SectionList.tsx
+++ b/apps/web/src/components/builder/SectionList.tsx
@@ -2,6 +2,8 @@ import { For, Show } from "solid-js";
 import { resumeStore, type LayoutSectionKey } from "../../stores/resume";
 import { SECTIONS } from "./constants";
 
+const hasText = (value: unknown): boolean => typeof value === "string" && value.trim() !== "";
+
 export function SectionList() {
   const { store, toggleSectionVisibility, addCustomSection } = resumeStore;
 
@@ -16,10 +18,11 @@ export function SectionList() {
     if (key === "summary") return store.resume.sections.summary.content ? 1 : 0;
     if (key === "coverLetter") {
       const coverLetter = store.resume.sections.coverLetter;
-      const hasRecipient = Object.values(coverLetter.recipient).some(
-        (value) => value.trim() !== "",
-      );
-      return coverLetter.content.trim() !== "" || hasRecipient ? 1 : 0;
+      const recipient = coverLetter.recipient;
+      const recipientValues =
+        recipient && typeof recipient === "object" ? Object.values(recipient) : [];
+      const hasRecipient = recipientValues.some(hasText);
+      return hasText(coverLetter.content) || hasRecipient ? 1 : 0;
     }
     if (key === "custom") {
       return Object.values(store.resume.sections.custom).reduce(

--- a/apps/web/src/components/builder/__tests__/SectionList.test.tsx
+++ b/apps/web/src/components/builder/__tests__/SectionList.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resumeStore } from "../../../stores/resume";
+import { createDefaultResume } from "../../../wasm/defaults";
+import type { ResumeData } from "../../../wasm/types";
+import { SectionList } from "../SectionList";
+
+vi.mock("../../../wasm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../wasm")>();
+  return {
+    ...actual,
+    saveResume: vi.fn().mockResolvedValue(undefined),
+    isWasmReady: () => false,
+  };
+});
+
+describe("SectionList", () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it.each([null, { name: null, title: 42, company: {}, address: "", email: false }])(
+    "renders when cover letter recipient is malformed: %j",
+    (recipient) => {
+      const resume = createDefaultResume() as ResumeData;
+      resume.sections.coverLetter.visible = true;
+      resume.sections.coverLetter.content = "";
+      (resume.sections.coverLetter as unknown as { recipient: unknown }).recipient = recipient;
+
+      resumeStore.importResume(resume);
+
+      render(() => <SectionList />);
+
+      expect(screen.getByText("Cover Letter")).toBeInTheDocument();
+    },
+  );
+});

--- a/apps/web/src/components/builder/constants.ts
+++ b/apps/web/src/components/builder/constants.ts
@@ -1,13 +1,18 @@
-import type { SectionKey } from "../../stores/resume";
+import type { LayoutSectionKey } from "../../stores/resume";
 
 export interface SectionInfo {
-  key: SectionKey | "summary" | "custom";
+  key: LayoutSectionKey;
   name: string;
   icon: string;
 }
 
 export const SECTIONS: SectionInfo[] = [
   { key: "summary", name: "Summary", icon: "M4 6h16M4 12h16M4 18h7" },
+  {
+    key: "coverLetter",
+    name: "Cover Letter",
+    icon: "M4 4h16v16H4V4zm4 4h8M8 12h8M8 16h5",
+  },
   {
     key: "experience",
     name: "Experience",

--- a/apps/web/src/stores/__tests__/resume.test.ts
+++ b/apps/web/src/stores/__tests__/resume.test.ts
@@ -321,7 +321,8 @@ describe("useResumeStore", () => {
         visible: true,
         items: [],
       };
-      imported.metadata.layout = [[/* empty first page */], [["experience"]]];
+      // Exercise normalization when the first page has no columns.
+      imported.metadata.layout = [[], [["experience"]]];
 
       importResume(imported);
 
@@ -337,7 +338,8 @@ describe("useResumeStore", () => {
     createRoot((dispose) => {
       const { store, importResume } = useResumeStore();
       const imported = createDefaultResume();
-      imported.metadata.layout = [[/* empty first page */], [["coverLetter", "experience"]]];
+      // Exercise normalization when the first page has no columns.
+      imported.metadata.layout = [[], [["coverLetter", "experience"]]];
 
       importResume(imported);
 

--- a/apps/web/src/stores/__tests__/resume.test.ts
+++ b/apps/web/src/stores/__tests__/resume.test.ts
@@ -321,12 +321,7 @@ describe("useResumeStore", () => {
         visible: true,
         items: [],
       };
-      imported.metadata.layout = [
-        [
-          /* empty first page */
-        ],
-        [["experience"]],
-      ];
+      imported.metadata.layout = [[/* empty first page */], [["experience"]]];
 
       importResume(imported);
 
@@ -342,12 +337,7 @@ describe("useResumeStore", () => {
     createRoot((dispose) => {
       const { store, importResume } = useResumeStore();
       const imported = createDefaultResume();
-      imported.metadata.layout = [
-        [
-          /* empty first page */
-        ],
-        [["coverLetter", "experience"]],
-      ];
+      imported.metadata.layout = [[/* empty first page */], [["coverLetter", "experience"]]];
 
       importResume(imported);
 

--- a/scripts/ci/testing/rust/setup-postgres-test-db.sh
+++ b/scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -16,7 +16,8 @@ set -euo pipefail
 : "${POSTGRES_READY_TIMEOUT_SECONDS:=60}"
 
 # Local CI-only trust auth — no password credential embedded in this script.
-TEST_DATABASE_URL="postgres://${POSTGRES_USER}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}"
+# The dockerized Postgres instance does not use TLS, so keep SQLx from probing SSL.
+TEST_DATABASE_URL="postgres://${POSTGRES_USER}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=disable"
 
 wait_for_postgres() {
 	local attempt=0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(web): handle cover letter sections after schema merge
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Restores green `main` after #423. The cover letter schema made `sections.coverLetter` required, but web fixtures/builder code still assumed every non-summary section had `items`, which broke `bun run typecheck` in Coverage Reports.

- Add `coverLetter` to the render test fixture
- Register Cover Letter in shared builder section metadata
- Count Cover Letter by content/recipient fields instead of `items`

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #553

## Details

P0 fix for red `main`. Do not merge release #554 until this lands and main is green again.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-740e8fc0-244e-4d3d-88fb-ed49ed4f7ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-740e8fc0-244e-4d3d-88fb-ed49ed4f7ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Cover Letter section to the resume builder.
  * Cover Letter item counts now reflect entered content or recipient details.

* **Tests**
  * Updated resume and preview test coverage to include Cover Letter data and layout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR completes cover-letter support in the web builder and repairs the Rust CI database connection.
- Registers Cover Letter in the builder’s shared section metadata.
- Counts cover-letter content defensively, including malformed recipient values.
- Adds and updates fixtures and tests for cover-letter rendering, section-list behavior, and layout normalization.
- Disables SSL probing for the local Dockerized Postgres test database.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/components/builder/SectionList.tsx | Adds defensive cover-letter item counting and fully addresses the previously reported malformed-recipient crash. |
| apps/web/src/components/builder/constants.ts | Registers Cover Letter as a typed layout section in the builder list. |
| apps/web/src/components/builder/__tests__/SectionList.test.tsx | Verifies the section list renders safely when cover-letter recipient data is malformed. |
| apps/web/src/api/__tests__/render.test.ts | Updates the render fixture to satisfy the merged cover-letter schema. |
| apps/web/src/stores/__tests__/resume.test.ts | Retains coverage for cover-letter backfilling and layout normalization with clearer fixtures. |
| scripts/ci/testing/rust/setup-postgres-test-db.sh | Configures SQLx to avoid TLS probing against the local non-TLS Postgres test container. |

</details>

<sub>Reviews (4): Last reviewed commit: ["ci: disable SSL for local Postgres tests"](https://github.com/lgtm-hq/rustume/commit/f1834e4c85e41907a1fa70f06305cf5b7642ec36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46683345)</sub>

<!-- /greptile_comment -->