### PR TITLE
ci: let auto-rerun inspect tag workflow failures

### DIFF
--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -9,8 +9,10 @@ name: Auto Rerun on Infra Failure
 # loop on incidents like 2026-07-13 (runs 29252857248, 29252725585,
 # 29261557105) where pure infra failures needed manual reruns. See #463.
 #
-# workflow_run triggers only run from the definition on the default branch,
-# so changes here take effect after merging to main.
+# workflow_run triggers only run from the definition on the default branch, so
+# changes here take effect after merging to main. Do not use
+# workflow_run.branches: tag-push runs expose the tag as head_branch and would
+# be filtered before this job can inspect/rerun matching infra failures.
 
 "on":
   workflow_run:
@@ -21,13 +23,16 @@ name: Auto Rerun on Infra Failure
       - Rust Build (workspace)
       - Quality - Lint & Format
     types: [completed]
-    branches: [main]
 
 permissions: {}
 
 jobs:
   rerun:
-    if: github.event.workflow_run.conclusion == 'failure'
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      (github.event.workflow_run.head_branch == 'main' ||
+      startsWith(github.event.workflow_run.head_branch, 'v'))
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci: let auto-rerun inspect tag workflow failures
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Auto-rerun only listened to `workflow_run` failures on `main`. Tag-push Docker publishes use the tag as `head_branch` (`v0.41.0`, `v0.42.0`, …), so infra EOF/runner-shutdown failures on release tags were skipped and never auto-retried.

Remove the `branches: [main]` filter and gate the job on same-repo `main` or `v*` heads instead.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Relates to #463

## Details

Immediate v0.41.0 / v0.42.0 tag Docker failures are the same infra signature (`EOF` + runner shutdown on linux/amd64). GitHub Releases already published; GHCR multi-arch manifests did not. This PR only unblocks future auto-reruns — the two failed tag runs still need a manual "Re-run failed jobs" (this agent token lacks `actions:write`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-740e8fc0-244e-4d3d-88fb-ed49ed4f7ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-740e8fc0-244e-4d3d-88fb-ed49ed4f7ac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR broadens the infrastructure-failure auto-rerun workflow to inspect same-repository main and `v`-prefixed workflow heads.
- Removes the event-level main-branch filter.
- Adds job-level repository and head-name guards so release-tag Docker failures can be rerun.
</details>

<h3>Confidence Score: 4/5</h3>

The pull request should not merge until the gate distinguishes release-tag runs from same-repository pull-request branches beginning with `v`.

The monitored Docker workflow runs on pull requests, so a same-repository PR branch beginning with `v` satisfies the new condition and can have its failed jobs automatically rerun despite not being a release tag.

.github/workflows/auto-rerun-on-infra-failure.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/auto-rerun-on-infra-failure.yml | Broadens workflow-run handling for release tags, but the prefix-only gate also admits same-repository pull-request branches beginning with `v`. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fauto-rerun-on-infra-failure.yml%3A34-35%0A**PR%20branches%20pass%20tag%20gate**%0A%0AWhen%20a%20same-repository%20pull%20request%20uses%20a%20source%20branch%20beginning%20with%20%60v%60%2C%20the%20Docker%20workflow's%20completed%20run%20satisfies%20this%20prefix%20check%2C%20causing%20its%20failed%20jobs%20to%20be%20automatically%20rerun%20even%20though%20the%20run%20did%20not%20originate%20from%20%60main%60%20or%20a%20release%20tag.%0A%0A&pr=559&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fauto-rerun-on-infra-failure.yml%3A34-35%0A**PR%20branches%20pass%20tag%20gate**%0A%0AWhen%20a%20same-repository%20pull%20request%20uses%20a%20source%20branch%20beginning%20with%20%60v%60%2C%20the%20Docker%20workflow's%20completed%20run%20satisfies%20this%20prefix%20check%2C%20causing%20its%20failed%20jobs%20to%20be%20automatically%20rerun%20even%20though%20the%20run%20did%20not%20originate%20from%20%60main%60%20or%20a%20release%20tag.%0A%0A&repo=lgtm-hq%2Frustume&pr=559&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22cursor%2Fci-auto-rerun-tag-docker-7ac5%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fci-auto-rerun-tag-docker-7ac5%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fauto-rerun-on-infra-failure.yml%3A34-35%0A**PR%20branches%20pass%20tag%20gate**%0A%0AWhen%20a%20same-repository%20pull%20request%20uses%20a%20source%20branch%20beginning%20with%20%60v%60%2C%20the%20Docker%20workflow's%20completed%20run%20satisfies%20this%20prefix%20check%2C%20causing%20its%20failed%20jobs%20to%20be%20automatically%20rerun%20even%20though%20the%20run%20did%20not%20originate%20from%20%60main%60%20or%20a%20release%20tag.%0A%0A&repo=lgtm-hq%2Frustume&pr=559&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci: let auto-rerun inspect tag workflow ..."](https://github.com/lgtm-hq/rustume/commit/5b27701f0d5b63c34fa2e0226fb87c372a767b75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46769281)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->


Closes #596

<!-- Verified 2026-07-27: real tag-push runs expose `head_branch=v0.49.1` with
`head_repository.full_name=lgtm-hq/Rustume`, so the `startsWith(head_branch, 'v')`
gate admits release builds and the same-repo check excludes fork PRs. -->
