### PR TITLE
feat(web): redesign Home as a command centre shell with list/grid/gallery views

### DIFF
--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -28,59 +28,63 @@ export const AppShell: ParentComponent = (props) => {
         data-print-hide
       >
         <div class="h-14 px-4 flex items-center justify-between gap-3">
-          {/* Sidebar mount point — wired with the Phase 3 scope rail */}
-          <Show when={isHome()}>
-            <button
-              type="button"
-              class="hidden sm:inline-flex h-8 w-8 items-center justify-center rounded-md
+          {/* Equal-basis outer columns keep the command trigger geometrically
+              centred regardless of logo / auth-control widths. */}
+          <div class="flex flex-1 min-w-0 items-center gap-3">
+            {/* Sidebar mount point — wired with the Phase 3 scope rail */}
+            <Show when={isHome()}>
+              <button
+                type="button"
+                class="hidden sm:inline-flex h-8 w-8 items-center justify-center rounded-md
                 text-stone transition-colors motion-reduce:transition-none hover:bg-surface
                 hover:text-ink disabled:opacity-50 disabled:cursor-not-allowed
                 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-              disabled
-              aria-label="Toggle sidebar"
-              title="Scope sidebar — coming soon"
-              data-testid="utility-sidebar-toggle"
-            >
-              <svg
-                class="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
+                disabled
+                aria-label="Toggle sidebar"
+                title="Scope sidebar — coming soon"
+                data-testid="utility-sidebar-toggle"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.8"
-                  d="M4 6a2 2 0 012-2h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm5.5-2v16"
-                />
-              </svg>
-            </button>
-          </Show>
+                <svg
+                  class="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.8"
+                    d="M4 6a2 2 0 012-2h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm5.5-2v16"
+                  />
+                </svg>
+              </button>
+            </Show>
 
-          {/* Logo */}
-          <nav aria-label="Primary" class="flex-shrink-0">
-            <A href="/" class="flex items-center gap-2 group">
-              <div
-                class="w-8 h-8 bg-ink rounded flex items-center justify-center"
-                aria-hidden="true"
-              >
-                <span class="text-paper font-display font-bold text-lg">R</span>
-              </div>
-              <span
-                class="font-display text-xl font-semibold text-ink
+            {/* Logo */}
+            <nav aria-label="Primary" class="flex-shrink-0">
+              <A href="/" class="flex items-center gap-2 group">
+                <div
+                  class="w-8 h-8 bg-ink rounded flex items-center justify-center"
+                  aria-hidden="true"
+                >
+                  <span class="text-paper font-display font-bold text-lg">R</span>
+                </div>
+                <span
+                  class="font-display text-xl font-semibold text-ink
                 group-hover:text-accent transition-colors"
-              >
-                Rustume
-              </span>
-            </A>
-          </nav>
+                >
+                  Rustume
+                </span>
+              </A>
+            </nav>
+          </div>
 
           {/* Command palette trigger — keyboard twin of the library toolbar */}
           <Show when={isHome()}>
             <button
               type="button"
-              class="mx-auto hidden md:flex min-w-0 max-w-sm flex-1 items-center gap-2
+              class="hidden md:flex w-full max-w-sm flex-shrink items-center gap-2
                 rounded-lg border border-accent/35 bg-surface px-3 py-1.5 text-left text-sm
                 text-stone transition-colors motion-reduce:transition-none hover:border-accent/60
                 hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
@@ -109,7 +113,7 @@ export const AppShell: ParentComponent = (props) => {
           </Show>
 
           {/* Status Indicators — keep compact so AuthMenu / theme stay usable on narrow screens */}
-          <div class="flex items-center gap-3 sm:gap-4 flex-shrink-0">
+          <div class="flex flex-1 min-w-0 items-center justify-end gap-3 sm:gap-4">
             <AuthMenu />
 
             {/* Editor Theme Selector */}

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -1,7 +1,9 @@
 import { type ParentComponent, Show } from "solid-js";
 import { A, useLocation } from "@solidjs/router";
 import { useOnline } from "../../hooks/useOnline";
+import { formatShortcut } from "../../hooks/useHotkeys";
 import { resumeStore } from "../../stores/resume";
+import { uiStore } from "../../stores/ui";
 import { EditorThemeSelector } from "../ui/EditorThemeSelector";
 import { AuthMenu } from "../Auth/AuthMenu";
 import { SignInDialog } from "../Auth/SignInDialog";
@@ -11,6 +13,8 @@ export const AppShell: ParentComponent = (props) => {
   const location = useLocation();
 
   const isEditor = () => location.pathname.startsWith("/edit");
+  /** The Home library turns the top bar into the command-center utility bar. */
+  const isHome = () => location.pathname === "/";
 
   return (
     <div class="min-h-screen bg-paper flex flex-col">
@@ -24,6 +28,36 @@ export const AppShell: ParentComponent = (props) => {
         data-print-hide
       >
         <div class="h-14 px-4 flex items-center justify-between gap-3">
+          {/* Sidebar mount point — wired with the Phase 3 scope rail */}
+          <Show when={isHome()}>
+            <button
+              type="button"
+              class="hidden sm:inline-flex h-8 w-8 items-center justify-center rounded-md
+                text-stone transition-colors motion-reduce:transition-none hover:bg-surface
+                hover:text-ink disabled:opacity-50 disabled:cursor-not-allowed
+                focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              disabled
+              aria-label="Toggle sidebar"
+              title="Scope sidebar — coming soon"
+              data-testid="utility-sidebar-toggle"
+            >
+              <svg
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.8"
+                  d="M4 6a2 2 0 012-2h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm5.5-2v16"
+                />
+              </svg>
+            </button>
+          </Show>
+
           {/* Logo */}
           <nav aria-label="Primary" class="flex-shrink-0">
             <A href="/" class="flex items-center gap-2 group">
@@ -41,6 +75,38 @@ export const AppShell: ParentComponent = (props) => {
               </span>
             </A>
           </nav>
+
+          {/* Command palette trigger — keyboard twin of the library toolbar */}
+          <Show when={isHome()}>
+            <button
+              type="button"
+              class="mx-auto hidden md:flex min-w-0 max-w-sm flex-1 items-center gap-2
+                rounded-lg border border-accent/35 bg-surface px-3 py-1.5 text-left text-sm
+                text-stone transition-colors motion-reduce:transition-none hover:border-accent/60
+                hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              onClick={() => uiStore.openModal("commandPalette")}
+              data-testid="command-palette-trigger"
+            >
+              <svg
+                class="w-4 h-4 flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+              <span class="flex-1 truncate">Search resumes or run a command…</span>
+              <kbd class="flex-shrink-0 font-mono text-[10px] rounded border border-border bg-paper px-1.5 py-0.5">
+                {formatShortcut({ key: "k", mod: true })}
+              </kbd>
+            </button>
+          </Show>
 
           {/* Status Indicators — keep compact so AuthMenu / theme stay usable on narrow screens */}
           <div class="flex items-center gap-3 sm:gap-4 flex-shrink-0">

--- a/apps/web/src/components/layout/__tests__/AppShell.test.tsx
+++ b/apps/web/src/components/layout/__tests__/AppShell.test.tsx
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
-import { render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { Route, Router } from "@solidjs/router";
 import { axeConfig } from "../../../test/a11y";
+import { uiStore } from "../../../stores/ui";
 import { AppShell } from "../AppShell";
 
 const { mockAuthState } = vi.hoisted(() => ({
@@ -61,6 +62,28 @@ describe("AppShell header", () => {
       </Router>
     ));
   }
+
+  it("hosts the home utility bar: sidebar mount point and command trigger", () => {
+    renderShell();
+
+    const toggle = screen.getByTestId("utility-sidebar-toggle");
+    const trigger = screen.getByTestId("command-palette-trigger");
+    expect(toggle).toBeDisabled();
+    expect(trigger).toHaveTextContent(/Search resumes or run a command/);
+    // Sidebar toggle sits left of the logo.
+    expect(toggle.compareDocumentPosition(screen.getByLabelText("Primary"))).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("opens the command palette from the utility bar trigger", () => {
+    renderShell();
+
+    fireEvent.click(screen.getByTestId("command-palette-trigger"));
+
+    expect(uiStore.store.modal).toBe("commandPalette");
+    uiStore.closeModal();
+  });
 
   it("does not show a local-mode notice banner (Sign in to sync covers that)", () => {
     mockAuthState.loading = false;

--- a/apps/web/src/components/ui/CommandPalette.tsx
+++ b/apps/web/src/components/ui/CommandPalette.tsx
@@ -10,6 +10,8 @@ export interface CommandAction {
   label: string;
   keywords?: string;
   group?: string;
+  /** Display-only hint, e.g. "N" or "⌘B" — rendered as a kbd on the row. */
+  shortcut?: string;
   handler: () => void;
 }
 
@@ -97,6 +99,19 @@ export function CommandPalette(props: CommandPaletteProps) {
     const matchIds = new Set(filteredActions().map((action) => action.id));
     return recentIds().filter((id) => matchIds.has(id)).length;
   });
+
+  /** Section heading for a row, or null when the row continues the current section. */
+  const headingFor = (index: number): string | null => {
+    const items = filteredActions();
+    const recents = recentCount();
+    if (recents > 0) {
+      if (index === 0) return "Recent";
+      if (index < recents) return null;
+    }
+    const current = items[index]?.group ?? "Commands";
+    if (index === recents) return current;
+    return items[index - 1]?.group !== items[index]?.group ? current : null;
+  };
 
   createEffect(() => {
     filteredActions();
@@ -213,17 +228,12 @@ export function CommandPalette(props: CommandPaletteProps) {
                 <For each={filteredActions()}>
                   {(action, index) => (
                     <>
-                      <Show when={!query().trim() && index() === 0 && recentCount() > 0}>
-                        <div class="px-3 pb-1 pt-2 text-[10px] font-mono uppercase tracking-wider text-stone/70">
-                          Recent
-                        </div>
-                      </Show>
-                      <Show
-                        when={!query().trim() && recentCount() > 0 && index() === recentCount()}
-                      >
-                        <div class="px-3 pb-1 pt-3 text-[10px] font-mono uppercase tracking-wider text-stone/70">
-                          All commands
-                        </div>
+                      <Show when={headingFor(index())}>
+                        {(heading) => (
+                          <div class="px-3 pb-1 pt-3 text-[10px] font-mono uppercase tracking-[0.2em] text-stone/70 first:pt-1">
+                            {heading()}
+                          </div>
+                        )}
                       </Show>
                       <button
                         type="button"
@@ -241,14 +251,37 @@ export function CommandPalette(props: CommandPaletteProps) {
                         onClick={() => executeAction(action)}
                       >
                         <span>{action.label}</span>
-                        <Show when={action.group}>
-                          <span class="text-xs text-stone">{action.group}</span>
+                        <Show
+                          when={action.shortcut}
+                          fallback={
+                            <Show when={action.group}>
+                              <span class="text-xs text-stone">{action.group}</span>
+                            </Show>
+                          }
+                        >
+                          {(shortcut) => (
+                            <kbd class="font-mono text-[10px] bg-surface border border-border rounded px-1.5 py-0.5 text-stone">
+                              {shortcut()}
+                            </kbd>
+                          )}
                         </Show>
                       </button>
                     </>
                   )}
                 </For>
               </Show>
+            </div>
+
+            <div class="flex items-center gap-4 border-t border-border px-4 py-2 font-mono text-[10px] tracking-wider text-stone">
+              <span>
+                <kbd class="text-ink">↑↓</kbd> navigate
+              </span>
+              <span>
+                <kbd class="text-ink">↵</kbd> run
+              </span>
+              <span>
+                <kbd class="text-ink">esc</kbd> close
+              </span>
             </div>
           </Dialog.Content>
         </div>

--- a/apps/web/src/components/ui/__tests__/CommandPalette.test.tsx
+++ b/apps/web/src/components/ui/__tests__/CommandPalette.test.tsx
@@ -115,6 +115,78 @@ describe("CommandPalette", () => {
     expect(options[1]).toHaveAttribute("aria-selected", "true");
   });
 
+  it("groups home actions and renders their shortcut hints", () => {
+    uiStore.openModal("commandPalette");
+    render(() => (
+      <CommandPalette
+        actions={[
+          {
+            id: "home:new",
+            label: "New resume",
+            group: "Actions",
+            shortcut: "N",
+            handler: vi.fn(),
+          },
+          {
+            id: "home:import",
+            label: "Import resume",
+            group: "Actions",
+            shortcut: "I",
+            handler: vi.fn(),
+          },
+          { id: "home:sync", label: "Sync now", group: "Actions", shortcut: "S", handler: vi.fn() },
+          {
+            id: "home:view-gallery",
+            label: "Switch to Gallery view",
+            group: "View",
+            shortcut: "3",
+            handler: vi.fn(),
+          },
+        ]}
+      />
+    ));
+
+    expect(screen.getByText("Actions")).toBeInTheDocument();
+    expect(screen.getByText("View")).toBeInTheDocument();
+    for (const key of ["N", "I", "S", "3"]) {
+      expect(screen.getByText(key)).toBeInTheDocument();
+    }
+  });
+
+  it("shows a footer hint bar", () => {
+    uiStore.openModal("commandPalette");
+    render(() => (
+      <CommandPalette actions={[{ id: "home:new", label: "New resume", handler: vi.fn() }]} />
+    ));
+
+    expect(screen.getByText(/navigate/)).toBeInTheDocument();
+    expect(screen.getByText(/run/)).toBeInTheDocument();
+    expect(screen.getByText(/close/)).toBeInTheDocument();
+  });
+
+  it("runs a view command from the palette", () => {
+    const handler = vi.fn();
+    uiStore.openModal("commandPalette");
+    render(() => (
+      <CommandPalette
+        actions={[
+          {
+            id: "home:view-gallery",
+            label: "Switch to Gallery view",
+            group: "View",
+            shortcut: "3",
+            handler,
+          },
+        ]}
+      />
+    ));
+
+    fireEvent.click(screen.getByText("Switch to Gallery view"));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(uiStore.store.modal).toBe(null);
+  });
+
   it("executes highlighted action on Enter", () => {
     const handler = vi.fn();
     uiStore.openModal("commandPalette");

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -46,6 +46,11 @@
   --color-border: var(--a11y-border);
   --color-shadow: rgba(0, 0, 0, 0.15);
   --color-offline: var(--turbo-state-warning);
+  /* Locked badges and lock affordances — gold in the Rosé Pine family. */
+  --color-gold: var(--turbo-state-warning);
+  /* Library document previews render as printed paper in every theme. */
+  --color-sheet: #f0e8dc;
+  --color-sheet-ink: #45405c;
 
   /* Typography */
   --font-display: "Fraunces", Georgia, serif;

--- a/apps/web/src/lib/__tests__/homeLayout.test.ts
+++ b/apps/web/src/lib/__tests__/homeLayout.test.ts
@@ -11,8 +11,8 @@ describe("homeLayout preference", () => {
     localStorage.removeItem(HOME_LAYOUT_STORAGE_KEY);
   });
 
-  it("defaults to list", () => {
-    expect(getStoredHomeLayout()).toBe(HomeLayout.List);
+  it("defaults to grid", () => {
+    expect(getStoredHomeLayout()).toBe(HomeLayout.Grid);
   });
 
   it("round-trips grid", () => {
@@ -33,8 +33,14 @@ describe("homeLayout preference", () => {
     expect(localStorage.getItem(HOME_LAYOUT_STORAGE_KEY)).toBe("grid");
   });
 
-  it("ignores invalid stored values", () => {
+  it("round-trips gallery", () => {
+    setStoredHomeLayout(HomeLayout.Gallery);
+    expect(getStoredHomeLayout()).toBe(HomeLayout.Gallery);
+    expect(localStorage.getItem(HOME_LAYOUT_STORAGE_KEY)).toBe("gallery");
+  });
+
+  it("falls back to grid for invalid stored values", () => {
     localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, "dashboard");
-    expect(getStoredHomeLayout()).toBe(HomeLayout.List);
+    expect(getStoredHomeLayout()).toBe(HomeLayout.Grid);
   });
 });

--- a/apps/web/src/lib/homeLayout.ts
+++ b/apps/web/src/lib/homeLayout.ts
@@ -3,9 +3,15 @@ export const HOME_LAYOUT_STORAGE_KEY = "rustume:home-layout";
 export const HomeLayout = {
   List: "list",
   Grid: "grid",
+  Gallery: "gallery",
 } as const;
 
 export type HomeLayout = (typeof HomeLayout)[keyof typeof HomeLayout];
+
+/** Grid is the command-center default; unknown/corrupt stored values fall back to it. */
+export const DEFAULT_HOME_LAYOUT: HomeLayout = HomeLayout.Grid;
+
+const KNOWN_HOME_LAYOUTS = new Set<string>(Object.values(HomeLayout));
 
 /** Legacy values from Classic / Workspace naming — migrated on read. */
 const LEGACY_HOME_LAYOUT: Record<string, HomeLayout> = {
@@ -14,17 +20,17 @@ const LEGACY_HOME_LAYOUT: Record<string, HomeLayout> = {
 };
 
 function parseHomeLayout(raw: string | null): HomeLayout | null {
-  if (raw === HomeLayout.List || raw === HomeLayout.Grid) return raw;
+  if (raw && KNOWN_HOME_LAYOUTS.has(raw)) return raw as HomeLayout;
   const migrated = raw ? LEGACY_HOME_LAYOUT[raw] : undefined;
   return migrated ?? null;
 }
 
 export function getStoredHomeLayout(): HomeLayout {
-  if (typeof localStorage === "undefined") return HomeLayout.List;
+  if (typeof localStorage === "undefined") return DEFAULT_HOME_LAYOUT;
   try {
     const raw = localStorage.getItem(HOME_LAYOUT_STORAGE_KEY);
     const layout = parseHomeLayout(raw);
-    if (!layout) return HomeLayout.List;
+    if (!layout) return DEFAULT_HOME_LAYOUT;
     // Persist migrated value so subsequent reads don't depend on legacy keys.
     if (raw !== layout) {
       localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, layout);
@@ -33,7 +39,7 @@ export function getStoredHomeLayout(): HomeLayout {
   } catch {
     // localStorage may be unavailable in private browsing or tests
   }
-  return HomeLayout.List;
+  return DEFAULT_HOME_LAYOUT;
 }
 
 export function setStoredHomeLayout(layout: HomeLayout): void {

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -1,5 +1,9 @@
-import { Suspense, lazy } from "solid-js";
+import { Suspense, createMemo, lazy } from "solid-js";
+import { CommandPalette, type CommandAction } from "../components/ui";
+import { useHotkeys, type Shortcut } from "../hooks/useHotkeys";
 import { usePageTitle } from "../hooks/usePageTitle";
+import { HomeLayout } from "../lib/homeLayout";
+import { uiStore } from "../stores/ui";
 import { HomePageLayout } from "./home/HomeLayouts";
 import { useHomePage } from "./home/useHomePage";
 
@@ -10,10 +14,97 @@ const ImportModal = lazy(() =>
 export default function Home() {
   usePageTitle("Your resumes");
   const home = useHomePage();
+  const { openModal } = uiStore;
+
+  const shortcuts: Shortcut[] = [
+    {
+      key: "k",
+      mod: true,
+      handler: () => openModal("commandPalette"),
+      label: "Command palette",
+      category: "General",
+    },
+    { key: "n", handler: () => home.handleNew(), label: "New resume", category: "Library" },
+    { key: "i", handler: () => home.handleImport(), label: "Import resume", category: "Library" },
+    { key: "s", handler: () => void home.refresh(), label: "Sync now", category: "Library" },
+    {
+      key: "1",
+      handler: () => home.setLayout(HomeLayout.List),
+      label: "List view",
+      category: "View",
+    },
+    {
+      key: "2",
+      handler: () => home.setLayout(HomeLayout.Grid),
+      label: "Grid view",
+      category: "View",
+    },
+    {
+      key: "3",
+      handler: () => home.setLayout(HomeLayout.Gallery),
+      label: "Gallery view",
+      category: "View",
+    },
+  ];
+
+  useHotkeys(shortcuts);
+
+  const commandActions = createMemo<CommandAction[]>(() => [
+    {
+      id: "home:new",
+      label: "New resume",
+      group: "Actions",
+      shortcut: "N",
+      keywords: "create add resume",
+      handler: () => home.handleNew(),
+    },
+    {
+      id: "home:import",
+      label: "Import resume",
+      group: "Actions",
+      shortcut: "I",
+      keywords: "upload json open file",
+      handler: () => home.handleImport(),
+    },
+    {
+      id: "home:sync",
+      label: "Sync now",
+      group: "Actions",
+      shortcut: "S",
+      keywords: "refresh reload library",
+      handler: () => void home.refresh(),
+    },
+    {
+      id: "home:view-list",
+      label: "Switch to List view",
+      group: "View",
+      shortcut: "1",
+      keywords: "layout rows density",
+      handler: () => home.setLayout(HomeLayout.List),
+    },
+    {
+      id: "home:view-grid",
+      label: "Switch to Grid view",
+      group: "View",
+      shortcut: "2",
+      keywords: "layout cards density",
+      handler: () => home.setLayout(HomeLayout.Grid),
+    },
+    {
+      id: "home:view-gallery",
+      label: "Switch to Gallery view",
+      group: "View",
+      shortcut: "3",
+      keywords: "layout thumbnails previews density",
+      handler: () => home.setLayout(HomeLayout.Gallery),
+    },
+  ]);
 
   return (
     <>
       <HomePageLayout home={home} />
+
+      <CommandPalette actions={commandActions()} />
 
       <Suspense fallback={null}>
         <ImportModal createAndOpen />

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -130,17 +130,33 @@ describe("Home command shell", () => {
     const strip = screen.getByTestId("home-status-strip");
     expect(strip).toHaveTextContent("3 resumes");
     expect(strip).toHaveTextContent("last edit");
-    expect(strip).toHaveTextContent("on-device");
+    expect(strip).toHaveTextContent("on-device storage");
     expect(strip).toHaveTextContent("sync off");
   });
 
-  it("reports sync on for a signed-in cloud user", () => {
+  it("reports cloud storage and sync on for a signed-in cloud user", () => {
     mockAuthState.cloudEnabled = true;
     mockAuthState.user = { id: "u1", plan: "free" };
 
     renderHome();
 
-    expect(screen.getByTestId("home-status-strip")).toHaveTextContent("sync on");
+    const strip = screen.getByTestId("home-status-strip");
+    expect(strip).toHaveTextContent("sync on");
+    // Storage must not claim on-device while resumes persist to the cloud.
+    expect(screen.getByTestId("home-status-storage")).toHaveTextContent("cloud storage");
+    expect(strip).not.toHaveTextContent("on-device");
+  });
+
+  it("does not promise on-device storage in the empty state for cloud users", () => {
+    listState.items = [];
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = { id: "u1", plan: "free" };
+
+    renderHome();
+
+    const empty = screen.getByTestId("home-empty-state");
+    expect(empty).toHaveTextContent(/syncs to your Rustume Cloud account/);
+    expect(empty).not.toHaveTextContent(/stays on this device/);
   });
 
   it("tracks the active view and scope in the status strip", () => {

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -26,7 +26,7 @@ const mockResumes = vi.hoisted(() => {
       headline: "Staff Platform Engineer",
       tags: ["backend"],
     },
-    { id: "2", name: "Product Manager", updatedAt: new Date("2025-02-01") },
+    { id: "2", name: "Product Manager", updatedAt: new Date("2025-02-01"), locked: true },
     {
       id: "3",
       name: "Jane Doe — Designer",
@@ -38,10 +38,13 @@ const mockResumes = vi.hoisted(() => {
   return resumes;
 });
 
+/** Mutable list state so tests can exercise the empty-library state. */
+const listState = vi.hoisted(() => ({ items: undefined as ResumeListItem[] | undefined }));
+
 const patchResumeListMetaMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 const resumeListMock = vi.hoisted(() => ({
-  resumes: () => mockResumes,
+  resumes: () => listState.items,
   loading: () => false,
   deleteResume: vi.fn(),
   duplicateResume: vi.fn(),
@@ -85,32 +88,112 @@ vi.mock("../../stores/ui", () => ({
   },
 }));
 
-describe("Home resume search", () => {
-  beforeEach(() => {
-    sessionStorage.clear();
-    localStorage.removeItem(HOME_LAYOUT_STORAGE_KEY);
-    openModalMock.mockClear();
-    patchResumeListMetaMock.mockClear();
-    resumeListMock.refresh.mockClear();
-    mockAuthState.loading = false;
-    mockAuthState.cloudEnabled = false;
-    mockAuthState.requireAuth = false;
-    mockAuthState.user = null;
-  });
+function resetHomeState() {
+  sessionStorage.clear();
+  localStorage.removeItem(HOME_LAYOUT_STORAGE_KEY);
+  listState.items = mockResumes;
+  openModalMock.mockClear();
+  patchResumeListMetaMock.mockClear();
+  resumeListMock.refresh.mockClear();
+  mockAuthState.loading = false;
+  mockAuthState.cloudEnabled = false;
+  mockAuthState.requireAuth = false;
+  mockAuthState.user = null;
+}
 
-  it("offers create and import actions on the hero", () => {
+describe("Home command shell", () => {
+  beforeEach(resetHomeState);
+
+  it("drops the hero and the marketing footer", () => {
     renderHome();
 
-    expect(screen.getByTestId("home-create-resume")).toBeInTheDocument();
-    expect(screen.getByTestId("home-import-resume")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /Build your resume/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /Why Rustume/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Privacy First/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Lightning Fast/i)).not.toBeInTheDocument();
   });
 
-  it("opens the import modal from the hero import button", () => {
+  it("keeps create and import actions in the library toolbar", () => {
     renderHome();
+
+    const toolbar = screen.getByTestId("resume-library-toolbar");
+    expect(toolbar).toContainElement(screen.getByTestId("home-create-resume"));
+    expect(toolbar).toContainElement(screen.getByTestId("home-import-resume"));
 
     fireEvent.click(screen.getByTestId("home-import-resume"));
     expect(openModalMock).toHaveBeenCalledWith("import");
   });
+
+  it("reports live library status in the status strip", () => {
+    renderHome();
+
+    const strip = screen.getByTestId("home-status-strip");
+    expect(strip).toHaveTextContent("3 resumes");
+    expect(strip).toHaveTextContent("last edit");
+    expect(strip).toHaveTextContent("on-device");
+    expect(strip).toHaveTextContent("sync off");
+  });
+
+  it("reports sync on for a signed-in cloud user", () => {
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = { id: "u1", plan: "free" };
+
+    renderHome();
+
+    expect(screen.getByTestId("home-status-strip")).toHaveTextContent("sync on");
+  });
+
+  it("tracks the active view and scope in the status strip", () => {
+    renderHome();
+
+    expect(screen.getByTestId("home-status-view")).toHaveTextContent("view: grid · scope: all");
+
+    fireEvent.click(screen.getByTestId("home-layout-gallery"));
+
+    expect(screen.getByTestId("home-status-view")).toHaveTextContent("view: gallery · scope: all");
+  });
+
+  it("reserves a disabled sidebar mount point for the scope rail", () => {
+    renderHome();
+
+    expect(screen.getByTestId("home-sidebar-toggle")).toBeDisabled();
+  });
+});
+
+describe("Home command palette wiring", () => {
+  beforeEach(resetHomeState);
+
+  it("opens the command palette on the global shortcut", () => {
+    renderHome();
+
+    fireEvent.keyDown(document, { key: "k", ctrlKey: true });
+
+    expect(openModalMock).toHaveBeenCalledWith("commandPalette");
+  });
+
+  it("switches views from the number shortcuts", () => {
+    renderHome();
+
+    fireEvent.keyDown(document, { key: "3" });
+    expect(screen.getByTestId("home-resume-gallery")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "1" });
+    expect(screen.getByTestId("home-resume-list")).toBeInTheDocument();
+  });
+
+  it("creates and imports from the letter shortcuts", () => {
+    renderHome();
+
+    fireEvent.keyDown(document, { key: "i" });
+    expect(openModalMock).toHaveBeenCalledWith("import");
+
+    fireEvent.keyDown(document, { key: "s" });
+    expect(resumeListMock.refresh).toHaveBeenCalled();
+  });
+});
+
+describe("Home resume search", () => {
+  beforeEach(resetHomeState);
 
   it("shows a labeled search input when resumes exist", () => {
     renderHome();
@@ -144,7 +227,7 @@ describe("Home resume search", () => {
     expect(screen.queryByRole("heading", { name: /Jane Doe/i })).not.toBeInTheDocument();
   });
 
-  it("shows an empty state when no resumes match", () => {
+  it("shows a designed empty state when no resumes match", () => {
     renderHome();
 
     fireEvent.input(screen.getByTestId("resume-search-input"), {
@@ -153,6 +236,23 @@ describe("Home resume search", () => {
 
     expect(screen.getByTestId("resume-search-empty")).toBeInTheDocument();
     expect(screen.getByText(/No matching resumes/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear filters" }));
+
+    expect(screen.queryByTestId("resume-search-empty")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("resume-card")).toHaveLength(3);
+  });
+
+  it("prompts to create or import when the library is empty", () => {
+    listState.items = [];
+
+    renderHome();
+
+    expect(screen.getByTestId("home-empty-state")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create Resume" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Import Resume" }));
+    expect(openModalMock).toHaveBeenCalledWith("import");
   });
 
   it("persists the search query in sessionStorage", () => {
@@ -167,16 +267,7 @@ describe("Home resume search", () => {
 });
 
 describe("Home resume tags", () => {
-  beforeEach(() => {
-    sessionStorage.clear();
-    localStorage.removeItem(HOME_LAYOUT_STORAGE_KEY);
-    patchResumeListMetaMock.mockClear();
-    resumeListMock.refresh.mockClear();
-    mockAuthState.loading = false;
-    mockAuthState.cloudEnabled = false;
-    mockAuthState.requireAuth = false;
-    mockAuthState.user = null;
-  });
+  beforeEach(resetHomeState);
 
   it("shows tag filter chips and keeps tags below card meta", () => {
     renderHome();
@@ -243,102 +334,143 @@ describe("Home resume tags", () => {
   });
 });
 
-describe("Home layout toggle", () => {
-  beforeEach(() => {
-    sessionStorage.clear();
-    localStorage.removeItem(HOME_LAYOUT_STORAGE_KEY);
-    openModalMock.mockClear();
-    mockAuthState.loading = false;
-    mockAuthState.cloudEnabled = false;
-    mockAuthState.requireAuth = false;
-    mockAuthState.user = null;
-  });
+describe("Home locked resumes", () => {
+  beforeEach(resetHomeState);
 
-  it("defaults to list layout", () => {
+  it("offers unlock and gates destructive actions while locked", () => {
     renderHome();
 
-    expect(screen.getByTestId("home-view")).toBeInTheDocument();
-    expect(screen.getByTestId("home-resume-list")).toBeInTheDocument();
-    expect(screen.queryByTestId("home-resume-grid")).not.toBeInTheDocument();
-    expect(screen.getByTestId("home-layout-list")).toHaveAttribute("aria-pressed", "true");
+    const unlock = screen.getByLabelText("Unlock resume");
+    expect(unlock).toBeInTheDocument();
+    expect(unlock.className).toMatch(/text-gold/);
+
+    const lockedCard = unlock.closest('[data-testid="resume-card"]')!;
+    expect(lockedCard.querySelector('[aria-label="Delete resume"]')).toBeDisabled();
+    expect(lockedCard.querySelector('[aria-label="Rename resume"]')).toBeDisabled();
+    expect(lockedCard.querySelector('[data-testid="resume-tag-add"]')).toBeDisabled();
   });
 
-  it("switches to grid layout and renders resumes with the same actions", () => {
+  it("badges locked resumes with a gold marker in gallery", () => {
+    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, HomeLayout.Gallery);
+
     renderHome();
 
-    fireEvent.click(screen.getByTestId("home-layout-grid"));
+    const badges = screen.getAllByTitle("Locked");
+    expect(badges).toHaveLength(1);
+    expect(badges[0].className).toMatch(/text-gold/);
+  });
+});
+
+describe("Home layout switcher", () => {
+  beforeEach(resetHomeState);
+
+  it("defaults to grid layout with designed document previews", () => {
+    renderHome();
 
     expect(screen.getByTestId("home-view")).toBeInTheDocument();
     expect(screen.getByTestId("home-resume-grid")).toBeInTheDocument();
     expect(screen.queryByTestId("home-resume-list")).not.toBeInTheDocument();
     expect(screen.getByTestId("home-layout-grid")).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("heading", { name: /Software Engineer/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Product Manager/i })).toBeInTheDocument();
-    expect(screen.getAllByTestId("resume-card")).toHaveLength(3);
     expect(screen.getAllByTestId("resume-card-preview")).toHaveLength(3);
-    expect(screen.getAllByLabelText("Lock resume").length).toBeGreaterThan(0);
+  });
+
+  it("offers list, grid and gallery in one switcher", () => {
+    renderHome();
+
+    const switcher = screen.getByTestId("home-layout-toggle");
+    expect(switcher).toContainElement(screen.getByTestId("home-layout-list"));
+    expect(switcher).toContainElement(screen.getByTestId("home-layout-grid"));
+    expect(switcher).toContainElement(screen.getByTestId("home-layout-gallery"));
+  });
+
+  it("switches to list layout and keeps the row anatomy without previews", () => {
+    renderHome();
+
+    fireEvent.click(screen.getByTestId("home-layout-list"));
+
+    expect(screen.getByTestId("home-resume-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("home-resume-grid")).not.toBeInTheDocument();
+    expect(screen.getByTestId("home-layout-list")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.queryByTestId("resume-card-preview")).not.toBeInTheDocument();
+    expect(screen.getAllByText(/^Updated /)).toHaveLength(3);
+    expect(screen.getAllByTestId("resume-tag-add").length).toBeGreaterThan(0);
+  });
+
+  it("switches to gallery layout with the same card actions", () => {
+    renderHome();
+
+    fireEvent.click(screen.getByTestId("home-layout-gallery"));
+
+    expect(screen.getByTestId("home-resume-gallery")).toBeInTheDocument();
+    expect(screen.queryByTestId("home-resume-grid")).not.toBeInTheDocument();
+    expect(screen.getByTestId("home-layout-gallery")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getAllByTestId("resume-card-preview")).toHaveLength(3);
     expect(screen.getAllByLabelText("Rename resume").length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText("Delete resume").length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText("Duplicate resume").length).toBeGreaterThan(0);
   });
 
-  it("keeps list rows without document previews", () => {
+  it("renders the same scoped library in all three views", () => {
     renderHome();
 
-    expect(screen.getByTestId("home-resume-list")).toBeInTheDocument();
-    expect(screen.queryByTestId("resume-card-preview")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "backend" }));
+
+    for (const view of ["home-layout-list", "home-layout-grid", "home-layout-gallery"]) {
+      fireEvent.click(screen.getByTestId(view));
+
+      expect(screen.getAllByTestId("resume-card")).toHaveLength(2);
+      expect(screen.getByRole("heading", { name: /Software Engineer/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /Jane Doe/i })).toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: /Product Manager/i })).not.toBeInTheDocument();
+    }
   });
 
   it("persists the layout preference in localStorage", () => {
     renderHome();
 
-    fireEvent.click(screen.getByTestId("home-layout-grid"));
+    fireEvent.click(screen.getByTestId("home-layout-gallery"));
 
-    expect(localStorage.getItem(HOME_LAYOUT_STORAGE_KEY)).toBe(HomeLayout.Grid);
+    expect(localStorage.getItem(HOME_LAYOUT_STORAGE_KEY)).toBe(HomeLayout.Gallery);
   });
 
-  it("restores grid layout from localStorage", () => {
-    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, HomeLayout.Grid);
+  it("restores the stored layout", () => {
+    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, HomeLayout.List);
 
     renderHome();
 
-    expect(screen.getByTestId("home-resume-grid")).toBeInTheDocument();
+    expect(screen.getByTestId("home-resume-list")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Software Engineer/i })).toBeInTheDocument();
   });
 
-  it("migrates legacy workspace preference to grid", () => {
-    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, "workspace");
+  it("migrates legacy layout preferences", () => {
+    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, "classic");
+
+    renderHome();
+
+    expect(screen.getByTestId("home-resume-list")).toBeInTheDocument();
+    expect(localStorage.getItem(HOME_LAYOUT_STORAGE_KEY)).toBe(HomeLayout.List);
+  });
+
+  it("falls back to grid for unknown stored layouts", () => {
+    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, "mosaic");
 
     renderHome();
 
     expect(screen.getByTestId("home-resume-grid")).toBeInTheDocument();
-    expect(localStorage.getItem(HOME_LAYOUT_STORAGE_KEY)).toBe(HomeLayout.Grid);
   });
 
-  it("keeps create and import actions in grid", () => {
-    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, HomeLayout.Grid);
+  it("keeps shared chrome identical across views", () => {
     renderHome();
 
-    expect(screen.getByTestId("home-create-resume")).toBeInTheDocument();
-    expect(screen.getByTestId("home-import-resume")).toBeInTheDocument();
+    for (const view of ["home-layout-list", "home-layout-gallery", "home-layout-grid"]) {
+      fireEvent.click(screen.getByTestId(view));
 
-    fireEvent.click(screen.getByTestId("home-import-resume"));
-    expect(openModalMock).toHaveBeenCalledWith("import");
-  });
-
-  it("keeps shared chrome identical when toggling list and grid", () => {
-    renderHome();
-
-    expect(screen.getByRole("heading", { name: /Build your resume/i })).toBeInTheDocument();
-    expect(screen.getByTestId("resume-search-input")).toBeInTheDocument();
-    expect(screen.getByTestId("resume-sort-select")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("home-layout-grid"));
-
-    expect(screen.getByRole("heading", { name: /Build your resume/i })).toBeInTheDocument();
-    expect(screen.getByTestId("resume-search-input")).toBeInTheDocument();
-    expect(screen.getByTestId("resume-sort-select")).toBeInTheDocument();
-    expect(screen.getByTestId("home-create-resume")).toBeInTheDocument();
+      expect(screen.getByTestId("home-status-strip")).toBeInTheDocument();
+      expect(screen.getByTestId("resume-search-input")).toBeInTheDocument();
+      expect(screen.getByTestId("resume-sort-select")).toBeInTheDocument();
+      expect(screen.getByTestId("resume-tag-filters")).toBeInTheDocument();
+      expect(screen.getByTestId("home-create-resume")).toBeInTheDocument();
+    }
   });
 
   it("spans library chrome full content width with tools pushed right", () => {
@@ -348,44 +480,46 @@ describe("Home layout toggle", () => {
     const toolbar = screen.getByTestId("resume-library-toolbar");
     const tools = screen.getByTestId("resume-library-tools");
     const tags = screen.getByTestId("resume-tag-filters");
-    const list = screen.getByTestId("home-resume-list");
+    const grid = screen.getByTestId("home-resume-grid");
 
     expect(library).toContainElement(toolbar);
     expect(library).toContainElement(tags);
-    expect(library).toContainElement(list);
+    expect(library).toContainElement(grid);
     expect(toolbar.className).toMatch(/justify-between/);
     expect(toolbar.className).toMatch(/\bw-full\b/);
     expect(tools.className).toMatch(/ml-auto/);
     expect(tags.className).toMatch(/\bw-full\b/);
-    expect(list.className).toMatch(/\bw-full\b/);
-
-    fireEvent.click(screen.getByTestId("home-layout-grid"));
-
-    const grid = screen.getByTestId("home-resume-grid");
-    expect(library).toContainElement(grid);
     expect(grid.className).toMatch(/\bw-full\b/);
+
+    fireEvent.click(screen.getByTestId("home-layout-list"));
+
+    const list = screen.getByTestId("home-resume-list");
+    expect(library).toContainElement(list);
+    expect(list.className).toMatch(/\bw-full\b/);
     expect(screen.getByTestId("resume-library-toolbar")).toBeInTheDocument();
     expect(screen.getByTestId("resume-library-tools")).toBeInTheDocument();
   });
 });
 
 describe("Home accessibility", () => {
-  it("has no axe violations when rendered", async () => {
-    localStorage.removeItem(HOME_LAYOUT_STORAGE_KEY);
-    mockAuthState.loading = false;
-    mockAuthState.cloudEnabled = false;
-    mockAuthState.user = null;
+  beforeEach(resetHomeState);
+
+  it("has no axe violations in grid layout", async () => {
+    const { container } = renderHome();
+
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
+  });
+
+  it("has no axe violations in list layout", async () => {
+    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, HomeLayout.List);
 
     const { container } = renderHome();
 
     expect(await axe(container, axeConfig)).toHaveNoViolations();
   });
 
-  it("has no axe violations in grid layout", async () => {
-    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, HomeLayout.Grid);
-    mockAuthState.loading = false;
-    mockAuthState.cloudEnabled = false;
-    mockAuthState.user = null;
+  it("has no axe violations in gallery layout", async () => {
+    localStorage.setItem(HOME_LAYOUT_STORAGE_KEY, HomeLayout.Gallery);
 
     const { container } = renderHome();
 

--- a/apps/web/src/pages/home/DocumentPreview.tsx
+++ b/apps/web/src/pages/home/DocumentPreview.tsx
@@ -1,0 +1,108 @@
+import { For, Show } from "solid-js";
+import type { ResumeListItem } from "../../stores/persistence";
+
+/**
+ * Deterministic pseudo-random line widths for a resume's preview body.
+ *
+ * The library index stores metadata only (no section content), so previews are
+ * typeset from the metadata we do have plus stable filler measures derived from
+ * the resume id — the same resume always draws the same page.
+ */
+function lineWidths(seed: string, count: number): number[] {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    hash = Math.imul(hash ^ seed.charCodeAt(i), 16777619) >>> 0;
+  }
+  const widths: number[] = [];
+  for (let i = 0; i < count; i++) {
+    hash = (Math.imul(hash, 1664525) + 1013904223) >>> 0;
+    widths.push(52 + (hash % 44));
+  }
+  return widths;
+}
+
+/** Slugified resume name — the mono filename shown in the card's window bar. */
+export function resumeSlug(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "untitled";
+}
+
+function PreviewSection(props: { title: string; widths: number[]; compact: boolean }) {
+  return (
+    <div class={props.compact ? "mt-2" : "mt-3.5"}>
+      <p
+        class={`m-0 font-mono font-bold uppercase tracking-[0.16em] opacity-70 ${
+          props.compact ? "text-[5px] leading-[1.4]" : "text-[7px] leading-[1.4]"
+        }`}
+      >
+        {props.title}
+      </p>
+      <For each={props.widths}>
+        {(width) => (
+          <span
+            class={`block rounded-full bg-current opacity-15 ${
+              props.compact ? "mt-[3px] h-[2px]" : "mt-[4px] h-[3px]"
+            }`}
+            style={{ width: `${width}%` }}
+            aria-hidden="true"
+          />
+        )}
+      </For>
+    </div>
+  );
+}
+
+/**
+ * A typeset page preview for a library entry: paper stock, serif name, italic
+ * headline and small-caps section rules. Intentionally a document — never a
+ * skeleton placeholder.
+ */
+export function DocumentPreview(props: { resume: ResumeListItem; size: "card" | "page" }) {
+  const compact = () => props.size === "card";
+  const widths = () => lineWidths(props.resume.id, 9);
+  const displayName = () => props.resume.basicsName?.trim() || props.resume.name;
+  const headline = () => props.resume.headline?.trim();
+
+  return (
+    <div
+      class={`bg-sheet text-sheet-ink font-display overflow-hidden text-left
+        shadow-[0_10px_24px_-16px_rgba(0,0,0,0.65)] ${
+          compact() ? "rounded-sm px-3 py-2.5" : "aspect-[8.5/10.1] rounded-[3px] px-6 py-5"
+        }`}
+      data-testid="resume-card-preview"
+      aria-hidden="true"
+    >
+      <p
+        class={`m-0 font-bold leading-tight tracking-tight truncate ${
+          compact() ? "text-[11px]" : "text-[19px]"
+        }`}
+      >
+        {displayName()}
+      </p>
+      <Show when={headline()}>
+        {(text) => (
+          <p
+            class={`m-0 mt-0.5 italic opacity-85 truncate ${
+              compact() ? "text-[7px]" : "text-[11px]"
+            }`}
+          >
+            {text()}
+          </p>
+        )}
+      </Show>
+      <div
+        class={`border-t border-current opacity-25 ${compact() ? "mt-2" : "mt-3.5"}`}
+        aria-hidden="true"
+      />
+
+      <PreviewSection title="Experience" widths={widths().slice(0, 4)} compact={compact()} />
+      <PreviewSection title="Selected work" widths={widths().slice(4, 7)} compact={compact()} />
+      <Show when={!compact()}>
+        <PreviewSection title="Stack" widths={widths().slice(7)} compact={compact()} />
+      </Show>
+    </div>
+  );
+}

--- a/apps/web/src/pages/home/HomeLayoutToggle.tsx
+++ b/apps/web/src/pages/home/HomeLayoutToggle.tsx
@@ -1,5 +1,6 @@
-import type { HomeLayout } from "../../lib/homeLayout";
-import { HomeLayout as HomeLayoutValues } from "../../lib/homeLayout";
+import { For } from "solid-js";
+import type { JSX } from "solid-js";
+import { HomeLayout } from "../../lib/homeLayout";
 
 function ListIcon() {
   return (
@@ -7,8 +8,8 @@ function ListIcon() {
       <path
         stroke-linecap="round"
         stroke-linejoin="round"
-        stroke-width="2"
-        d="M4 6h16M4 12h16M4 18h16"
+        stroke-width="1.8"
+        d="M9 6h11M9 12h11M9 18h11M4.5 6h.01M4.5 12h.01M4.5 18h.01"
       />
     </svg>
   );
@@ -20,16 +21,48 @@ function GridIcon() {
       <path
         stroke-linecap="round"
         stroke-linejoin="round"
-        stroke-width="2"
-        d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm10 0a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zm10 0a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z"
+        stroke-width="1.8"
+        d="M4.5 5a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v5a.5.5 0 01-.5.5H5a.5.5 0 01-.5-.5V5zm9 0a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v5a.5.5 0 01-.5.5h-5a.5.5 0 01-.5-.5V5zm-9 9a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v5a.5.5 0 01-.5.5H5a.5.5 0 01-.5-.5v-5zm9 0a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v5a.5.5 0 01-.5.5h-5a.5.5 0 01-.5-.5v-5z"
       />
     </svg>
   );
 }
 
-const toggleBtnClass =
-  "inline-flex h-full items-center gap-1.5 rounded-md px-2.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1";
+function GalleryIcon() {
+  return (
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.8"
+        d="M3.5 4.5h7.5v7.5H3.5V4.5zm9.5 0h7.5v7.5H13V4.5zM3.5 14h17v5.5h-17V14z"
+      />
+    </svg>
+  );
+}
 
+interface LayoutOption {
+  layout: HomeLayout;
+  label: string;
+  testId: string;
+  icon: () => JSX.Element;
+}
+
+const LAYOUT_OPTIONS: LayoutOption[] = [
+  { layout: HomeLayout.List, label: "List", testId: "home-layout-list", icon: ListIcon },
+  { layout: HomeLayout.Grid, label: "Grid", testId: "home-layout-grid", icon: GridIcon },
+  {
+    layout: HomeLayout.Gallery,
+    label: "Gallery",
+    testId: "home-layout-gallery",
+    icon: GalleryIcon,
+  },
+];
+
+const toggleBtnClass =
+  "inline-flex h-full items-center gap-1.5 rounded-md px-2.5 text-sm font-medium transition-colors motion-reduce:transition-none focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1";
+
+/** Three-way density switcher — List / Grid / Gallery render the same scoped library. */
 export function HomeLayoutToggle(props: {
   layout: HomeLayout;
   onChange: (layout: HomeLayout) => void;
@@ -42,38 +75,26 @@ export function HomeLayoutToggle(props: {
       data-testid="home-layout-toggle"
       class={`inline-flex h-9 items-stretch rounded-lg border border-border bg-surface/60 p-0.5 ${props.class ?? ""}`}
     >
-      <button
-        type="button"
-        class={`${toggleBtnClass} ${
-          props.layout === HomeLayoutValues.List
-            ? "bg-paper text-ink shadow-soft"
-            : "text-stone hover:text-ink"
-        }`}
-        aria-pressed={props.layout === HomeLayoutValues.List}
-        aria-label="List view"
-        title="List"
-        data-testid="home-layout-list"
-        onClick={() => props.onChange(HomeLayoutValues.List)}
-      >
-        <ListIcon />
-        List
-      </button>
-      <button
-        type="button"
-        class={`${toggleBtnClass} ${
-          props.layout === HomeLayoutValues.Grid
-            ? "bg-paper text-ink shadow-soft"
-            : "text-stone hover:text-ink"
-        }`}
-        aria-pressed={props.layout === HomeLayoutValues.Grid}
-        aria-label="Grid view"
-        title="Grid"
-        data-testid="home-layout-grid"
-        onClick={() => props.onChange(HomeLayoutValues.Grid)}
-      >
-        <GridIcon />
-        Grid
-      </button>
+      <For each={LAYOUT_OPTIONS}>
+        {(option) => (
+          <button
+            type="button"
+            class={`${toggleBtnClass} ${
+              props.layout === option.layout
+                ? "bg-paper text-ink shadow-soft"
+                : "text-stone hover:text-ink"
+            }`}
+            aria-pressed={props.layout === option.layout}
+            aria-label={`${option.label} view`}
+            title={option.label}
+            data-testid={option.testId}
+            onClick={() => props.onChange(option.layout)}
+          >
+            <option.icon />
+            <span class="hidden sm:inline">{option.label}</span>
+          </button>
+        )}
+      </For>
     </div>
   );
 }

--- a/apps/web/src/pages/home/HomeLayouts.tsx
+++ b/apps/web/src/pages/home/HomeLayouts.tsx
@@ -4,15 +4,19 @@ import { HomeLayout } from "../../lib/homeLayout";
 import { getResumeSortLabels, type ResumeSortMode } from "../../lib/resumeSort";
 import { HomeLayoutToggle } from "./HomeLayoutToggle";
 import { HomeResumeCard } from "./HomeResumeCard";
+import { StatusStrip } from "./StatusStrip";
 import type { HomePageModel } from "./useHomePage";
 
 function tagChipClass(active: boolean): string {
-  return `inline-flex h-7 items-center rounded-md px-2.5 text-xs font-medium border transition-colors ${
+  return `inline-flex h-7 items-center rounded-md px-2.5 text-xs font-medium border transition-colors motion-reduce:transition-none ${
     active
       ? "border-accent bg-accent/10 text-ink"
       : "border-border bg-paper text-stone hover:text-ink hover:border-ink/20"
   }`;
 }
+
+const iconButtonClass =
+  "inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-paper text-stone hover:text-ink hover:bg-surface transition-colors motion-reduce:transition-none disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1";
 
 function TagFilters(props: { home: HomePageModel }) {
   const { home } = props;
@@ -45,14 +49,38 @@ function TagFilters(props: { home: HomePageModel }) {
   );
 }
 
+/**
+ * Sidebar mount point for the Phase 3 scope rail — rendered disabled so the
+ * command shell already reserves its place in both toolbar and utility bar.
+ */
+function SidebarToggleStub() {
+  return (
+    <button
+      type="button"
+      class={iconButtonClass}
+      disabled
+      aria-label="Toggle sidebar"
+      title="Scope sidebar — coming soon"
+      data-testid="home-sidebar-toggle"
+    >
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.8"
+          d="M4 6a2 2 0 012-2h12a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm5.5-2v16"
+        />
+      </svg>
+    </button>
+  );
+}
+
 function LibraryToolbar(props: { home: HomePageModel }) {
   const { home } = props;
   const hasResumes = () => (home.resumes()?.length ?? 0) > 0;
 
   return (
     <div class="w-full space-y-3" data-testid="home-library-chrome">
-      <h2 class="font-display text-xl font-semibold text-ink tracking-tight">Your Resumes</h2>
-
       <div
         class="flex w-full flex-wrap items-center justify-between gap-x-3 gap-y-2"
         role="toolbar"
@@ -60,6 +88,49 @@ function LibraryToolbar(props: { home: HomePageModel }) {
         data-testid="resume-library-toolbar"
         classList={{ "opacity-60 pointer-events-none": home.loading() && hasResumes() }}
       >
+        <div class="flex items-center gap-2">
+          <Button size="sm" class="h-9" onClick={home.handleNew} data-testid="home-create-resume">
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 5v14M5 12h14"
+              />
+            </svg>
+            New resume
+          </Button>
+          <Button
+            size="sm"
+            class="h-9"
+            variant="secondary"
+            onClick={home.handleImport}
+            data-testid="home-import-resume"
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 3v11m-4.5-4.5L12 14l4.5-4.5M4 17v2a2 2 0 002 2h12a2 2 0 002-2v-2"
+              />
+            </svg>
+            Import
+          </Button>
+        </div>
+
         <Show when={hasResumes()}>
           <Input
             type="text"
@@ -72,11 +143,12 @@ function LibraryToolbar(props: { home: HomePageModel }) {
             inputClass="h-9 py-0"
           />
         </Show>
+
         <div
           class="ml-auto flex flex-wrap items-center gap-2 shrink-0"
           data-testid="resume-library-tools"
         >
-          <HomeLayoutToggle layout={home.layout()} onChange={home.setLayout} />
+          <SidebarToggleStub />
           <label class="inline-flex">
             <span class="sr-only">Sort resumes</span>
             <select
@@ -91,11 +163,10 @@ function LibraryToolbar(props: { home: HomePageModel }) {
               </For>
             </select>
           </label>
+          <HomeLayoutToggle layout={home.layout()} onChange={home.setLayout} />
           <button
             type="button"
-            class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border
-              bg-paper text-stone hover:text-ink hover:bg-surface transition-colors
-              focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+            class={iconButtonClass}
             onClick={home.refresh}
             title="Refresh"
             aria-label="Refresh resume list"
@@ -125,9 +196,91 @@ function LibraryToolbar(props: { home: HomePageModel }) {
   );
 }
 
+function EmptyLibrary(props: { home: HomePageModel }) {
+  const { home } = props;
+  return (
+    <div
+      class="rounded-xl border border-dashed border-border bg-surface/40 px-6 py-16 text-center"
+      data-testid="home-empty-state"
+    >
+      <div class="mx-auto mb-5 w-16 h-16 rounded-2xl bg-paper border border-border flex items-center justify-center">
+        <svg
+          class="w-8 h-8 text-stone"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+      </div>
+      <h3 class="font-display text-2xl font-semibold text-ink mb-2">Your library is empty</h3>
+      <p class="mx-auto mb-6 max-w-sm text-sm text-stone">
+        Start a resume from scratch or import an existing one — everything stays on this device.
+      </p>
+      <div class="flex flex-wrap items-center justify-center gap-3">
+        <Button onClick={home.handleNew}>Create Resume</Button>
+        <Button variant="secondary" onClick={home.handleImport}>
+          Import Resume
+        </Button>
+      </div>
+      <p class="mt-6 font-mono text-[10px] uppercase tracking-[0.14em] text-stone/70">
+        press ⌘K for commands
+      </p>
+    </div>
+  );
+}
+
+function NoSearchMatches(props: { home: HomePageModel }) {
+  const { home } = props;
+  return (
+    <div
+      class="rounded-xl border border-dashed border-border bg-surface/40 px-6 py-16 text-center"
+      data-testid="resume-search-empty"
+    >
+      <h3 class="font-display text-2xl font-semibold text-ink mb-2">No matching resumes</h3>
+      <p class="mx-auto max-w-sm text-sm text-stone">
+        Nothing matches{" "}
+        <span class="font-mono text-ink">&ldquo;{home.searchQuery().trim()}&rdquo;</span>
+        <Show when={home.tagFilter()}>{(tag) => <> in #{tag()}</>}</Show>. Try a different search.
+      </p>
+      <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <Button
+          variant="secondary"
+          onClick={() => {
+            home.setSearchQuery("");
+            home.setTagFilter(null);
+          }}
+        >
+          Clear filters
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const LAYOUT_CONTAINERS: Record<HomeLayout, { class: string; testId: string }> = {
+  [HomeLayout.List]: { class: "grid w-full gap-2.5 stagger-children", testId: "home-resume-list" },
+  [HomeLayout.Grid]: {
+    class:
+      "grid w-full gap-4 stagger-children [grid-template-columns:repeat(auto-fill,minmax(min(100%,16rem),1fr))] content-start",
+    testId: "home-resume-grid",
+  },
+  [HomeLayout.Gallery]: {
+    class:
+      "grid w-full gap-5 stagger-children [grid-template-columns:repeat(auto-fill,minmax(min(100%,19rem),1fr))] content-start",
+    testId: "home-resume-gallery",
+  },
+};
+
 function ResumeListBody(props: { home: HomePageModel }) {
   const { home } = props;
-  const isGrid = () => home.layout() === HomeLayout.Grid;
+  const container = () => LAYOUT_CONTAINERS[home.layout()];
 
   return (
     <Show
@@ -138,61 +291,9 @@ function ResumeListBody(props: { home: HomePageModel }) {
         </div>
       }
     >
-      <Show
-        when={home.resumes()?.length}
-        fallback={
-          <div class="text-center py-16 border-2 border-dashed border-border rounded-xl">
-            <div class="w-16 h-16 mx-auto bg-surface rounded-2xl flex items-center justify-center mb-4">
-              <svg
-                class="w-8 h-8 text-stone"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                />
-              </svg>
-            </div>
-            <h3 class="font-display text-lg font-semibold text-ink mb-2">No resumes yet</h3>
-            <p class="text-stone text-sm mb-6">Create or import your first resume to get started</p>
-            <div class="flex flex-wrap items-center justify-center gap-3">
-              <Button variant="secondary" onClick={home.handleNew}>
-                Create Resume
-              </Button>
-              <Button variant="ghost" onClick={home.handleImport}>
-                Import Resume
-              </Button>
-            </div>
-          </div>
-        }
-      >
-        <Show
-          when={home.filteredResumes().length > 0}
-          fallback={
-            <div
-              class="text-center py-16 border-2 border-dashed border-border rounded-xl"
-              data-testid="resume-search-empty"
-            >
-              <h3 class="font-display text-lg font-semibold text-ink mb-2">No matching resumes</h3>
-              <p class="text-stone text-sm">
-                No resumes match &ldquo;{home.searchQuery().trim()}&rdquo;. Try a different search.
-              </p>
-            </div>
-          }
-        >
-          <div
-            class={
-              isGrid()
-                ? "grid w-full gap-3.5 stagger-children [grid-template-columns:repeat(auto-fill,minmax(min(100%,16.5rem),1fr))] content-start"
-                : "grid w-full gap-2.5 stagger-children"
-            }
-            data-testid={isGrid() ? "home-resume-grid" : "home-resume-list"}
-          >
+      <Show when={home.resumes()?.length} fallback={<EmptyLibrary home={home} />}>
+        <Show when={home.filteredResumes().length > 0} fallback={<NoSearchMatches home={home} />}>
+          <div class={container().class} data-testid={container().testId}>
             <For each={home.filteredResumes()}>
               {({ resume, nameSegments }) => (
                 <HomeResumeCard
@@ -210,158 +311,21 @@ function ResumeListBody(props: { home: HomePageModel }) {
   );
 }
 
-/** Single home page shell — list vs grid only swaps the resume display below search. */
+/** Command-center library shell — status strip, dense toolbar, and the active view. */
 export function HomePageLayout(props: { home: HomePageModel }) {
   const { home } = props;
 
   return (
     <div class="min-h-[calc(100vh-3.5rem)] bg-paper" data-testid="home-view">
-      <div class="pt-8 pb-10 px-4">
-        <div class="max-w-4xl mx-auto text-center">
-          <h1 class="font-display text-4xl md:text-5xl font-bold text-ink mb-3 animate-slide-up">
-            Build your resume
-            <br />
-            <span class="text-accent">with precision</span>
-          </h1>
-          <p
-            class="text-lg text-stone max-w-xl mx-auto mb-6 animate-slide-up"
-            style={{ "animation-delay": "50ms" }}
-          >
-            Privacy-first, offline-capable resume builder. Your data stays on your device.
-          </p>
-          <div
-            class="flex items-center justify-center gap-4 animate-slide-up"
-            style={{ "animation-delay": "100ms" }}
-          >
-            <Button size="lg" onClick={home.handleNew} data-testid="home-create-resume">
-              <svg
-                class="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M12 4v16m8-8H4"
-                />
-              </svg>
-              Create New Resume
-            </Button>
-            <Button
-              size="lg"
-              variant="secondary"
-              onClick={home.handleImport}
-              data-testid="home-import-resume"
-            >
-              <svg
-                class="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
-                />
-              </svg>
-              Import Resume
-            </Button>
-          </div>
-        </div>
-      </div>
+      <div class="max-w-6xl mx-auto w-full px-4 pt-4 pb-16" data-testid="home-library">
+        <StatusStrip home={home} />
 
-      <div class="max-w-4xl mx-auto w-full px-4 pb-16" data-testid="home-library">
-        <div class="mb-5 w-full">
+        <div class="my-4 w-full">
           <LibraryToolbar home={home} />
         </div>
 
         <div class="w-full">
           <ResumeListBody home={home} />
-        </div>
-      </div>
-
-      <div class="bg-surface border-t border-border py-16 px-4">
-        <div class="max-w-4xl mx-auto">
-          <h2 class="font-display text-2xl font-semibold text-ink text-center mb-12">
-            Why Rustume?
-          </h2>
-
-          <div class="grid md:grid-cols-3 gap-8">
-            <div class="text-center">
-              <div class="w-14 h-14 mx-auto bg-accent/10 rounded-2xl flex items-center justify-center mb-4">
-                <svg
-                  class="w-7 h-7 text-accent"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                    d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                  />
-                </svg>
-              </div>
-              <h3 class="font-display font-semibold text-ink mb-2">Privacy First</h3>
-              <p class="text-sm text-stone">
-                Your data stays on your device. No accounts, no tracking.
-              </p>
-            </div>
-
-            <div class="text-center">
-              <div class="w-14 h-14 mx-auto bg-accent/10 rounded-2xl flex items-center justify-center mb-4">
-                <svg
-                  class="w-7 h-7 text-accent"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                    d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3"
-                  />
-                </svg>
-              </div>
-              <h3 class="font-display font-semibold text-ink mb-2">Works Offline</h3>
-              <p class="text-sm text-stone">
-                Edit anywhere. Install as a PWA for the best experience.
-              </p>
-            </div>
-
-            <div class="text-center">
-              <div class="w-14 h-14 mx-auto bg-accent/10 rounded-2xl flex items-center justify-center mb-4">
-                <svg
-                  class="w-7 h-7 text-accent"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                    d="M13 10V3L4 14h7v7l9-11h-7z"
-                  />
-                </svg>
-              </div>
-              <h3 class="font-display font-semibold text-ink mb-2">Lightning Fast</h3>
-              <p class="text-sm text-stone">
-                Built with Rust and WebAssembly for native performance.
-              </p>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/pages/home/HomeLayouts.tsx
+++ b/apps/web/src/pages/home/HomeLayouts.tsx
@@ -86,6 +86,7 @@ function LibraryToolbar(props: { home: HomePageModel }) {
         role="toolbar"
         aria-label="Resume library tools"
         data-testid="resume-library-toolbar"
+        aria-busy={home.loading() && hasResumes()}
         classList={{ "opacity-60 pointer-events-none": home.loading() && hasResumes() }}
       >
         <div class="flex items-center gap-2">
@@ -220,8 +221,12 @@ function EmptyLibrary(props: { home: HomePageModel }) {
         </svg>
       </div>
       <h3 class="font-display text-2xl font-semibold text-ink mb-2">Your library is empty</h3>
+      {/* Mirror the status strip: promise on-device only when that is actually true. */}
       <p class="mx-auto mb-6 max-w-sm text-sm text-stone">
-        Start a resume from scratch or import an existing one — everything stays on this device.
+        Start a resume from scratch or import an existing one —{" "}
+        <Show when={home.syncEnabled()} fallback="everything stays on this device.">
+          everything syncs to your Rustume Cloud account.
+        </Show>
       </p>
       <div class="flex flex-wrap items-center justify-center gap-3">
         <Button onClick={home.handleNew}>Create Resume</Button>

--- a/apps/web/src/pages/home/HomeResumeCard.tsx
+++ b/apps/web/src/pages/home/HomeResumeCard.tsx
@@ -460,9 +460,11 @@ export function HomeResumeCard(props: {
           <DocumentPreview resume={resume()} size="page" />
         </A>
         <div
-          class="absolute inset-x-0 bottom-0 z-10 flex justify-center bg-gradient-to-t
+          class="absolute inset-x-0 bottom-0 z-10 flex justify-center bg-linear-to-t
             from-paper via-paper/85 to-transparent px-3 pb-3 pt-8 opacity-0
             transition-opacity duration-150 motion-reduce:transition-none
+            pointer-events-none group-hover:pointer-events-auto
+            group-focus-within:pointer-events-auto
             group-hover:opacity-100 group-focus-within:opacity-100"
         >
           <div class="rounded-lg border border-border bg-surface/95 px-1 py-0.5 shadow-soft">

--- a/apps/web/src/pages/home/HomeResumeCard.tsx
+++ b/apps/web/src/pages/home/HomeResumeCard.tsx
@@ -4,8 +4,40 @@ import { Spinner } from "../../components/ui";
 import type { TextSegment } from "../../lib/resumeSearch";
 import { HomeLayout } from "../../lib/homeLayout";
 import type { ResumeListItem } from "../../stores/persistence";
+import { DocumentPreview, resumeSlug } from "./DocumentPreview";
 import { formatUpdatedAt, HighlightedText } from "./shared";
 import type { HomePageModel } from "./useHomePage";
+
+function LockIcon(props: { locked: boolean; class?: string }) {
+  return (
+    <svg
+      class={props.class ?? "w-5 h-5"}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <Show
+        when={props.locked}
+        fallback={
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M8 11V7a4 4 0 118 0v4m-9 0h10v8H7v-8z"
+          />
+        }
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 15v2m-6-6V9a6 6 0 1112 0v2M6 11h12v8H6v-8z"
+        />
+      </Show>
+    </svg>
+  );
+}
 
 function ResumeActions(props: { home: HomePageModel; resume: ResumeListItem }) {
   const { home } = props;
@@ -15,45 +47,23 @@ function ResumeActions(props: { home: HomePageModel; resume: ResumeListItem }) {
     <div class="flex items-center gap-1 flex-shrink-0">
       <button
         type="button"
-        class="p-2 text-stone hover:text-accent hover:bg-accent/10 rounded-lg transition-colors
-          disabled:opacity-50 disabled:cursor-not-allowed"
+        class={`p-2 rounded-lg transition-colors motion-reduce:transition-none
+          hover:bg-accent/10 disabled:opacity-50 disabled:cursor-not-allowed
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-accent
+          ${resume().locked ? "text-gold hover:text-gold" : "text-stone hover:text-accent"}`}
         onClick={(e) => home.handleToggleLock(resume().id, Boolean(resume().locked), e)}
         disabled={home.lockingId() === resume().id || home.actionsBusy()}
         title={resume().locked ? "Unlock" : "Lock"}
         aria-label={resume().locked ? "Unlock resume" : "Lock resume"}
         aria-busy={home.lockingId() === resume().id}
       >
-        <svg
-          class="w-5 h-5"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <Show
-            when={resume().locked}
-            fallback={
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M8 11V7a4 4 0 118 0v4m-9 0h10v8H7v-8z"
-              />
-            }
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M12 15v2m-6-6V9a6 6 0 1112 0v2M6 11h12v8H6v-8z"
-            />
-          </Show>
-        </svg>
+        <LockIcon locked={Boolean(resume().locked)} />
       </button>
       <button
         type="button"
         class="p-2 text-stone hover:text-accent hover:bg-accent/10 rounded-lg transition-colors
-          disabled:opacity-50 disabled:cursor-not-allowed"
+          motion-reduce:transition-none disabled:opacity-50 disabled:cursor-not-allowed
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         onClick={(e) => home.startRename(resume().id, resume().name, e)}
         disabled={Boolean(resume().locked) || home.actionsBusy()}
         title="Rename"
@@ -77,7 +87,8 @@ function ResumeActions(props: { home: HomePageModel; resume: ResumeListItem }) {
       <button
         type="button"
         class="p-2 text-stone hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors
-          disabled:opacity-50 disabled:cursor-not-allowed"
+          motion-reduce:transition-none disabled:opacity-50 disabled:cursor-not-allowed
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         onClick={(e) => home.handleDelete(resume().id, e)}
         disabled={Boolean(resume().locked) || home.actionsBusy()}
         title={resume().locked ? "Unlock to delete" : "Delete"}
@@ -103,7 +114,8 @@ function ResumeActions(props: { home: HomePageModel; resume: ResumeListItem }) {
       <button
         type="button"
         class="p-2 text-stone hover:text-accent hover:bg-accent/10 rounded-lg transition-colors
-          disabled:opacity-50 disabled:cursor-not-allowed"
+          motion-reduce:transition-none disabled:opacity-50 disabled:cursor-not-allowed
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         onClick={(e) => home.handleDuplicate(resume().id, e)}
         disabled={home.actionsBusy()}
         title="Duplicate"
@@ -128,7 +140,7 @@ function ResumeActions(props: { home: HomePageModel; resume: ResumeListItem }) {
       </button>
       <A href={`/edit/${resume().id}`} class="p-1" aria-label={`Edit ${resume().name}`}>
         <svg
-          class="w-5 h-5 text-stone group-hover:text-accent transition-colors"
+          class="w-5 h-5 text-stone group-hover:text-accent transition-colors motion-reduce:transition-none"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -137,6 +149,18 @@ function ResumeActions(props: { home: HomePageModel; resume: ResumeListItem }) {
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
         </svg>
       </A>
+    </div>
+  );
+}
+
+/** Mono title bar shared by grid cards and gallery tiles. */
+function WindowBar(props: { resume: ResumeListItem }) {
+  return (
+    <div class="flex items-center gap-1.5 px-3 py-2 font-mono text-[10px] text-stone">
+      <span class="h-1.5 w-1.5 rounded-full bg-accent" aria-hidden="true" />
+      <span class="h-1.5 w-1.5 rounded-full bg-border" aria-hidden="true" />
+      <span class="truncate">{resumeSlug(props.resume.name)}</span>
+      <span class="ml-auto flex-shrink-0 opacity-70">a4</span>
     </div>
   );
 }
@@ -150,13 +174,15 @@ export function HomeResumeCard(props: {
   const { home } = props;
   const resume = () => props.resume;
   const isGrid = () => props.variant === HomeLayout.Grid;
+  const isGallery = () => props.variant === HomeLayout.Gallery;
+  const isList = () => props.variant === HomeLayout.List;
 
   const tagRow = (opts?: { trailing?: "updated" }) => (
     <div
       class={
-        isGrid()
-          ? "mt-auto flex flex-wrap items-center gap-1.5 pt-2.5"
-          : "mt-1.5 ml-14 flex flex-wrap items-center gap-1.5"
+        isList()
+          ? "mt-1.5 ml-14 flex flex-wrap items-center gap-1.5"
+          : "flex flex-wrap items-center gap-1.5"
       }
       data-testid="resume-card-tags"
       onClick={(e) => e.stopPropagation()}
@@ -164,14 +190,16 @@ export function HomeResumeCard(props: {
       <For each={resume().tags ?? []}>
         {(tag) => (
           <span
-            class={`inline-flex items-center gap-0.5 rounded-sm px-1.5 py-0.5 text-[10px] font-semibold text-stone ${
-              isGrid() ? "bg-paper" : "rounded-full border border-border bg-surface/80"
+            class={`inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-semibold text-stone ${
+              isList()
+                ? "rounded-full border border-border bg-surface/80"
+                : "rounded-sm bg-paper border border-border"
             }`}
           >
             <span class="max-w-[8rem] truncate">{tag}</span>
             <button
               type="button"
-              class="ml-0.5 rounded-full p-0.5 text-stone/70 hover:bg-accent/10 hover:text-ink transition-colors disabled:opacity-50 disabled:pointer-events-none"
+              class="ml-0.5 rounded-full p-0.5 text-stone/70 hover:bg-accent/10 hover:text-ink transition-colors motion-reduce:transition-none disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               onClick={(e) => home.handleRemoveTag(resume().id, tag, resume().tags, e)}
               disabled={
                 Boolean(resume().locked) || home.metaBusyId() === resume().id || home.actionsBusy()
@@ -203,8 +231,8 @@ export function HomeResumeCard(props: {
         fallback={
           <button
             type="button"
-            class={`inline-flex items-center border border-dashed border-border px-2 py-0.5 text-[10px] text-stone hover:border-accent hover:text-ink hover:bg-accent/10 transition-colors disabled:opacity-50 disabled:pointer-events-none ${
-              isGrid() ? "rounded-sm" : "rounded-full"
+            class={`inline-flex items-center border border-dashed border-border px-2 py-0.5 font-mono text-[10px] text-stone hover:border-accent hover:text-ink hover:bg-accent/10 transition-colors motion-reduce:transition-none disabled:opacity-50 disabled:pointer-events-none focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+              isList() ? "rounded-full" : "rounded-sm"
             }`}
             onClick={(e) => home.openTagEditor(resume().id, e)}
             disabled={
@@ -225,7 +253,7 @@ export function HomeResumeCard(props: {
           <input
             type="text"
             class={`w-28 max-w-full border border-accent/40 bg-surface px-2.5 py-0.5 text-[10px] text-ink placeholder:text-stone/70 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent/30 disabled:opacity-50 ${
-              isGrid() ? "rounded-sm" : "rounded-full"
+              isList() ? "rounded-full" : "rounded-sm"
             }`}
             placeholder="Tag name"
             aria-label={`Add tag to ${resume().name}`}
@@ -254,7 +282,7 @@ export function HomeResumeCard(props: {
         </form>
       </Show>
       <Show when={opts?.trailing === "updated"}>
-        <span class="ml-auto text-[10px] text-stone whitespace-nowrap">
+        <span class="ml-auto font-mono text-[10px] text-stone whitespace-nowrap">
           {formatUpdatedAt(resume().updatedAt)}
         </span>
       </Show>
@@ -278,7 +306,7 @@ export function HomeResumeCard(props: {
       />
       <button
         type="button"
-        class="p-1 text-accent hover:text-accent/80 transition-colors"
+        class="p-1 text-accent hover:text-accent/80 transition-colors motion-reduce:transition-none"
         onClick={() => home.confirmRename(resume().id)}
         title="Confirm rename"
         aria-label="Confirm rename"
@@ -300,7 +328,7 @@ export function HomeResumeCard(props: {
       </button>
       <button
         type="button"
-        class="p-1 text-stone hover:text-ink transition-colors"
+        class="p-1 text-stone hover:text-ink transition-colors motion-reduce:transition-none"
         onClick={() => home.cancelRename()}
         title="Cancel rename"
         aria-label="Cancel rename"
@@ -326,7 +354,7 @@ export function HomeResumeCard(props: {
   const docIcon = (hoverAccent = false) => (
     <div class="w-10 h-10 bg-surface rounded-lg flex items-center justify-center flex-shrink-0">
       <svg
-        class={`w-5 h-5 text-stone ${hoverAccent ? "group-hover:text-accent transition-colors" : ""}`}
+        class={`w-5 h-5 text-stone ${hoverAccent ? "group-hover:text-accent transition-colors motion-reduce:transition-none" : ""}`}
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
@@ -342,76 +370,135 @@ export function HomeResumeCard(props: {
     </div>
   );
 
-  const previewPane = () => (
-    <div
-      class="relative h-[7.5rem] border-b border-border px-4 pt-3.5
-        bg-gradient-to-b from-paper to-surface"
-      data-testid="resume-card-preview"
+  const lockedChip = () => (
+    <span
+      class="inline-flex flex-shrink-0 items-center gap-1 rounded-full border border-gold/40
+        bg-surface/90 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-gold"
+      title="Locked"
     >
-      <span class="mb-2.5 block h-1.5 w-[42%] rounded-sm bg-ink/85" aria-hidden="true" />
-      <span
-        class="block h-[0.28rem] w-[78%] rounded-sm bg-stone/35
-          shadow-[0_0.55rem_0_color-mix(in_srgb,var(--color-stone)_28%,transparent),0_1.1rem_0_color-mix(in_srgb,var(--color-stone)_22%,transparent),0_1.65rem_0_color-mix(in_srgb,var(--color-stone)_18%,transparent)]"
-        aria-hidden="true"
-      />
-      <Show when={resume().locked}>
-        <span
-          class="absolute top-2 right-2 rounded-sm bg-ink px-1.5 py-0.5 text-[10px]
-            font-bold uppercase tracking-wider text-paper"
-          title="Locked"
-        >
-          Locked
-        </span>
-      </Show>
-    </div>
+      <LockIcon locked class="w-2.5 h-2.5" />
+      Locked
+    </span>
   );
 
   const gridCard = () => (
     <article
-      class="group flex flex-col min-h-[14rem] overflow-hidden border border-border rounded-lg
-        bg-surface shadow-[0_1px_0_color-mix(in_srgb,var(--color-ink)_4%,transparent)]
-        transition-[box-shadow,transform,border-color] duration-150
-        hover:-translate-y-0.5 hover:border-stone hover:shadow-card
-        focus-within:-translate-y-0.5 focus-within:border-stone focus-within:shadow-card
-        motion-reduce:transform-none motion-reduce:transition-none"
+      class="group flex flex-col overflow-hidden rounded-xl border border-border bg-surface
+        transition-[box-shadow,transform,border-color] duration-150 motion-reduce:transition-none
+        hover:-translate-y-0.5 hover:border-accent/40 hover:shadow-card
+        focus-within:-translate-y-0.5 focus-within:border-accent/40 focus-within:shadow-card
+        motion-reduce:transform-none motion-reduce:hover:translate-y-0"
       data-testid="resume-card"
     >
-      <Show
-        when={home.renamingId() !== resume().id}
-        fallback={
-          <>
-            {previewPane()}
-            <div class="px-4 pt-3.5 min-w-0">{renameForm()}</div>
-          </>
-        }
-      >
-        <A href={`/edit/${resume().id}`} class="block min-w-0">
-          {previewPane()}
-          <div class="px-4 pt-3.5 min-w-0">
-            <h3
+      <div class="border-b border-border bg-paper pb-3">
+        <WindowBar resume={resume()} />
+        <A
+          href={`/edit/${resume().id}`}
+          class="block px-3"
+          aria-label={`Open ${resume().name}`}
+          tabindex={-1}
+        >
+          <DocumentPreview resume={resume()} size="card" />
+        </A>
+      </div>
+
+      <div class="px-3.5 pt-3 min-w-0">
+        <Show when={home.renamingId() !== resume().id} fallback={renameForm()}>
+          <h3 class="flex items-center gap-1.5 min-w-0">
+            <Show when={resume().locked}>
+              <LockIcon locked class="w-3 h-3 flex-shrink-0 text-gold" />
+              <span class="sr-only">Locked</span>
+            </Show>
+            <A
+              href={`/edit/${resume().id}`}
               class="font-display text-[0.95rem] font-semibold tracking-tight text-ink
-                group-hover:text-accent transition-colors truncate"
+                group-hover:text-accent transition-colors motion-reduce:transition-none truncate"
             >
               <HighlightedText segments={props.nameSegments} />
-            </h3>
-            <Show when={resume().headline?.trim()}>
-              {(headline) => (
-                <p
-                  class="mt-1 text-xs leading-snug text-stone line-clamp-2"
-                  data-testid="resume-list-headline"
-                >
-                  {headline()}
-                </p>
-              )}
-            </Show>
-          </div>
-        </A>
-      </Show>
+            </A>
+          </h3>
+        </Show>
+        <Show when={resume().headline?.trim()}>
+          {(headline) => (
+            <p
+              class="mt-1 text-xs leading-snug text-stone line-clamp-2"
+              data-testid="resume-list-headline"
+            >
+              {headline()}
+            </p>
+          )}
+        </Show>
+      </div>
 
-      <div class="flex flex-1 flex-col px-4 pb-4 min-w-0">{tagRow({ trailing: "updated" })}</div>
+      <div class="px-3.5 pt-2.5 pb-3 min-w-0">{tagRow({ trailing: "updated" })}</div>
 
-      <div class="flex justify-end gap-0.5 px-2.5 pb-2.5">
+      <div class="mt-auto flex items-center border-t border-border px-2 py-1">
         <ResumeActions home={home} resume={resume()} />
+      </div>
+    </article>
+  );
+
+  const galleryCard = () => (
+    <article class="group flex flex-col" data-testid="resume-card">
+      <div
+        class="relative overflow-hidden rounded-xl border border-border bg-paper
+          transition-[transform,border-color] duration-200 motion-reduce:transition-none
+          group-hover:-translate-y-0.5 group-hover:border-accent/40
+          group-focus-within:border-accent/40 motion-reduce:transform-none
+          motion-reduce:group-hover:translate-y-0"
+      >
+        <WindowBar resume={resume()} />
+        <Show when={resume().locked}>
+          <span class="absolute right-2.5 top-9 z-10">{lockedChip()}</span>
+        </Show>
+        <A
+          href={`/edit/${resume().id}`}
+          class="block px-3.5 pb-3.5"
+          aria-label={`Open ${resume().name}`}
+          tabindex={-1}
+        >
+          <DocumentPreview resume={resume()} size="page" />
+        </A>
+        <div
+          class="absolute inset-x-0 bottom-0 z-10 flex justify-center bg-gradient-to-t
+            from-paper via-paper/85 to-transparent px-3 pb-3 pt-8 opacity-0
+            transition-opacity duration-150 motion-reduce:transition-none
+            group-hover:opacity-100 group-focus-within:opacity-100"
+        >
+          <div class="rounded-lg border border-border bg-surface/95 px-1 py-0.5 shadow-soft">
+            <ResumeActions home={home} resume={resume()} />
+          </div>
+        </div>
+      </div>
+
+      <div class="px-1 pt-2.5 min-w-0">
+        <Show
+          when={home.renamingId() !== resume().id}
+          fallback={<div class="pb-1">{renameForm()}</div>}
+        >
+          <div class="flex items-baseline gap-2 min-w-0">
+            <h3 class="min-w-0 truncate">
+              <A
+                href={`/edit/${resume().id}`}
+                class="font-display text-[0.95rem] font-semibold tracking-tight text-ink
+                  group-hover:text-accent transition-colors motion-reduce:transition-none"
+              >
+                <HighlightedText segments={props.nameSegments} />
+              </A>
+            </h3>
+            <span class="ml-auto flex-shrink-0 font-mono text-[10px] uppercase tracking-wider text-stone">
+              {formatUpdatedAt(resume().updatedAt)}
+            </span>
+          </div>
+        </Show>
+        <Show when={resume().headline?.trim()}>
+          {(headline) => (
+            <p class="mt-0.5 truncate text-xs text-stone" data-testid="resume-list-headline">
+              {headline()}
+            </p>
+          )}
+        </Show>
+        <div class="mt-2">{tagRow()}</div>
       </div>
     </article>
   );
@@ -419,7 +506,8 @@ export function HomeResumeCard(props: {
   const listCard = () => (
     <div
       class="group flex items-start justify-between gap-3 px-3.5 py-2.5 border border-border
-      rounded-xl hover:border-accent hover:shadow-card transition-all bg-paper"
+      rounded-xl bg-surface hover:border-accent hover:shadow-card transition-all
+      motion-reduce:transition-none"
       data-testid="resume-card"
     >
       <div class="flex-1 min-w-0">
@@ -435,23 +523,16 @@ export function HomeResumeCard(props: {
           <A href={`/edit/${resume().id}`} class="flex items-center gap-3 min-w-0">
             {docIcon(true)}
             <div class="min-w-0 flex-1">
-              <h3 class="font-body font-medium text-ink group-hover:text-accent transition-colors flex items-center gap-2 min-w-0 leading-snug">
+              <h3 class="font-display text-lg font-semibold text-ink group-hover:text-accent transition-colors motion-reduce:transition-none flex items-center gap-2 min-w-0 leading-snug">
                 <span class="truncate min-w-0">
                   <HighlightedText segments={props.nameSegments} />
                 </span>
-                <Show when={resume().locked}>
-                  <span
-                    class="inline-flex flex-shrink-0 items-center rounded-full bg-surface px-1.5 py-0.5 text-[10px] font-mono uppercase text-stone border border-border"
-                    title="Locked"
-                  >
-                    Locked
-                  </span>
-                </Show>
+                <Show when={resume().locked}>{lockedChip()}</Show>
               </h3>
               <Show when={resume().headline?.trim()}>
                 {(headline) => (
                   <p
-                    class="text-sm text-accent/65 truncate leading-snug"
+                    class="text-sm text-stone truncate leading-snug"
                     data-testid="resume-list-headline"
                   >
                     {headline()}
@@ -475,8 +556,15 @@ export function HomeResumeCard(props: {
   );
 
   return (
-    <Show when={isGrid()} fallback={listCard()}>
-      {gridCard()}
+    <Show
+      when={isGallery()}
+      fallback={
+        <Show when={isGrid()} fallback={listCard()}>
+          {gridCard()}
+        </Show>
+      }
+    >
+      {galleryCard()}
     </Show>
   );
 }

--- a/apps/web/src/pages/home/StatusStrip.tsx
+++ b/apps/web/src/pages/home/StatusStrip.tsx
@@ -18,8 +18,6 @@ export function StatusStrip(props: { home: HomePageModel }) {
       class="flex flex-wrap items-center gap-x-3.5 gap-y-1.5 border-y border-border py-2
         font-mono text-[10px] uppercase tracking-[0.09em] text-stone"
       data-testid="home-status-strip"
-      role="status"
-      aria-live="polite"
     >
       <span>
         <strong class="font-semibold text-ink">{count()}</strong>{" "}
@@ -30,12 +28,16 @@ export function StatusStrip(props: { home: HomePageModel }) {
         last edit <strong class="font-semibold text-ink">{home.lastEditLabel()}</strong>
       </span>
       <Separator />
-      <span class="inline-flex items-center gap-1.5">
+      {/* Storage location must track where resumes actually live: a signed-in
+          cloud session persists to Rustume Cloud, not to this device. */}
+      <span class="inline-flex items-center gap-1.5" data-testid="home-status-storage">
         <span
           class="h-1.5 w-1.5 rounded-full bg-accent animate-pulse-subtle motion-reduce:animate-none"
           aria-hidden="true"
         />
-        on-device
+        <Show when={home.syncEnabled()} fallback="on-device storage">
+          cloud storage
+        </Show>
       </span>
       <Separator />
       <span>
@@ -44,7 +46,9 @@ export function StatusStrip(props: { home: HomePageModel }) {
           on
         </Show>
       </span>
-      <span class="ml-auto" data-testid="home-status-view">
+      {/* Only the volatile view/scope pair is a live region — announcing the whole
+          strip would re-read the static labels on every list or layout change. */}
+      <span class="ml-auto" data-testid="home-status-view" role="status" aria-live="polite">
         view: <b class="font-semibold text-accent">{home.layout()}</b> · scope:{" "}
         <b class="font-semibold text-accent">{home.scope()}</b>
       </span>

--- a/apps/web/src/pages/home/StatusStrip.tsx
+++ b/apps/web/src/pages/home/StatusStrip.tsx
@@ -1,0 +1,53 @@
+import { Show } from "solid-js";
+import type { HomePageModel } from "./useHomePage";
+
+function Separator() {
+  return <span class="h-2.5 w-px flex-shrink-0 bg-border" aria-hidden="true" />;
+}
+
+/**
+ * Terminal-style live status for the library: the privacy/offline claims the old
+ * marketing footer asserted, expressed as product state instead of copy.
+ */
+export function StatusStrip(props: { home: HomePageModel }) {
+  const { home } = props;
+  const count = () => home.resumeCount();
+
+  return (
+    <div
+      class="flex flex-wrap items-center gap-x-3.5 gap-y-1.5 border-y border-border py-2
+        font-mono text-[10px] uppercase tracking-[0.09em] text-stone"
+      data-testid="home-status-strip"
+      role="status"
+      aria-live="polite"
+    >
+      <span>
+        <strong class="font-semibold text-ink">{count()}</strong>{" "}
+        {count() === 1 ? "resume" : "resumes"}
+      </span>
+      <Separator />
+      <span>
+        last edit <strong class="font-semibold text-ink">{home.lastEditLabel()}</strong>
+      </span>
+      <Separator />
+      <span class="inline-flex items-center gap-1.5">
+        <span
+          class="h-1.5 w-1.5 rounded-full bg-accent animate-pulse-subtle motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+        on-device
+      </span>
+      <Separator />
+      <span>
+        sync{" "}
+        <Show when={home.syncEnabled()} fallback="off">
+          on
+        </Show>
+      </span>
+      <span class="ml-auto" data-testid="home-status-view">
+        view: <b class="font-semibold text-accent">{home.layout()}</b> · scope:{" "}
+        <b class="font-semibold text-accent">{home.scope()}</b>
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/pages/home/useHomePage.ts
+++ b/apps/web/src/pages/home/useHomePage.ts
@@ -15,6 +15,8 @@ import {
   type ResumeSortMode,
 } from "../../lib/resumeSort";
 import { getStoredHomeLayout, setStoredHomeLayout, type HomeLayout } from "../../lib/homeLayout";
+import { formatRelativeTime } from "../../lib/formatRelativeTime";
+import { authStore } from "../../stores/auth";
 import { patchResumeListMeta, useResumeList, type ResumeListItem } from "../../stores/persistence";
 import { uiStore } from "../../stores/ui";
 import { generateId } from "../../wasm/types";
@@ -98,6 +100,28 @@ export function useHomePage() {
     }
     return [...tags].sort((a, b) => a.localeCompare(b));
   });
+
+  /** Live status-strip state — the trust signals the old marketing footer used to assert. */
+  const resumeCount = () => resumes()?.length ?? 0;
+
+  const lastEditedAt = createMemo<Date | null>(() => {
+    let latest: Date | null = null;
+    for (const resume of resumes() ?? []) {
+      if (!latest || resume.updatedAt.getTime() > latest.getTime()) latest = resume.updatedAt;
+    }
+    return latest;
+  });
+
+  const lastEditLabel = createMemo(() => {
+    const latest = lastEditedAt();
+    return latest ? formatRelativeTime(latest.getTime()) : "never";
+  });
+
+  /** Cloud sync is only live once a signed-in user exists on a cloud-enabled build. */
+  const syncEnabled = () => Boolean(authStore.state.cloudEnabled && authStore.state.user);
+
+  /** Placeholder until the Phase 3 scope sidebar can narrow the library. */
+  const scope = () => "all";
 
   const handleNew = () => {
     const id = generateId();
@@ -274,6 +298,11 @@ export function useHomePage() {
     tagEditorId,
     filteredResumes,
     allTags,
+    resumeCount,
+    lastEditedAt,
+    lastEditLabel,
+    syncEnabled,
+    scope,
     handleNew,
     handleImport,
     handleToggleLock,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): redesign Home as a command centre shell with list/grid/gallery views
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Phases 1 and 2 of #566. The Home page stops being a landing page and becomes a library command centre.

The hero ("Build your resume with precision" + Create/Import CTAs) and the entire "Why Rustume?" marketing footer are removed — returning users no longer scroll past static marketing to reach their resumes. The privacy/offline claims those panels asserted are re-expressed as live product state in a monospace status strip.

Grid cards previously rendered skeleton-bar placeholders that read as broken; they now render typeset document previews. A third view, Gallery, joins List and Grid in a single switcher, and all three render the same scoped library.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #566

## Details

### Command shell

- **Utility bar** — `AppShell` gains, on `/` only, a sidebar toggle left of the logo (disabled; Phase 3 mount point) and a centred ⌘K trigger whose kbd renders `⌘K`/`Ctrl+K` per platform. The existing "Sign in to sync" and theme picker stay where they are.
- **Status strip** (`StatusStrip.tsx`) — live `<n> resumes · last edit <relative> · on-device ● · sync <on|off>` plus a persistent `view: <list|grid|gallery> · scope: all` slot. Derived in `useHomePage` (`resumeCount`, `lastEditLabel`, `syncEnabled`, `scope`); `scope` reads `all` until the Phase 3 sidebar can narrow it.
- **Dense toolbar** — create/import, search, sidebar mount point, sort, three-way switcher, refresh. Search, tag filters and sort behaviour are unchanged.

### Views

- **`HomeLayout.Gallery`** added. Legacy `classic`/`workspace` values still migrate; unknown or corrupt stored values now fall back to grid.
- **Grid (default)** — window-chrome cards with `DocumentPreview`, which typesets the resume's own name and headline on paper stock with small-caps section rules. Measure widths come from a stable hash of the resume id, so a given resume always draws the same page. Card content and action order (lock/unlock, rename, delete, duplicate, open) are unchanged.
- **List** — row anatomy preserved exactly per the issue's explicit request: rounded card rows, document-icon tile, serif name, muted headline, "Updated X ago", dashed "+ Tag" chip, always-visible right action cluster. Chrome restyle only.
- **Gallery** — large page thumbnails, hover/focus scrim revealing the same actions, gold "Locked" badge.
- Designed empty states for an empty library and for no search matches (the latter with a Clear filters action).

### ⌘K palette

`CommandPalette` gains group headings, per-row shortcut kbds and a footer hint bar. Home registers Actions (New `N`, Import `I`, Sync `S`) and View (`1`/`2`/`3`) as both palette entries and live hotkeys, plus ⌘K/Ctrl+K to open. The `⌘B` sidebar command is deliberately omitted rather than shipped dead; it lands with Phase 3.

### Behaviour change worth review

**The default layout moves from list to grid**, per the issue's "Grid (default)". Users with a stored preference keep it — only fresh installs and unrecognised stored values land on grid.

### Design system

Dark Rosé Pine via existing tokens. Two additions in `index.css`: `--color-gold` (mapped to the theme's warning token) for locked affordances, and `--color-sheet`/`--color-sheet-ink` so previews read as printed paper in any theme rather than hardcoding colours at call sites. All motion is `motion-reduce`-gated; every interactive element has a visible focus state.

### Testing

- `Home.test.tsx` substantially rewritten: hero/footer removal, status strip (including `sync on` for a signed-in cloud user), switcher across all three views, persistence and migration, same-scoped-set parity, locked affordances and gating, both empty states, and hotkey wiring. Axe assertions cover all three layouts.
- Extended `AppShell`, `CommandPalette` and `homeLayout` suites.
- 58 files / 491 tests green; typecheck, oxlint (zero warnings) and `bun run build` all pass.

### Notes for CI

Rebased onto `main` after #573 (brace-expansion override) and #572 (lintro pin alignment) landed — both of which this PR previously depended on. Re-verified against the new base with the aligned toolchain (lintro 0.91.41 locally, 0.91.45 in CI): typecheck, oxlint, 491 tests and `bun run build` all pass, including against the major-dependency update in #557 and turbo-themes 0.38.7.

`uv run lintro chk` reports findings only under `.claude/worktrees/` — nested agent checkouts of other branches that osv-scanner and trufflehog walk locally. Zero originate from repo content, and CI checks out clean so it does not see them. Tracked in lgtm-hq/py-lintro#1725 and #1716.

No backend changes; previews are typeset from existing list metadata, so no server-side rendering support was needed.

- Relates to #567
- Relates to #568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gallery view alongside Grid and List layouts.
  * Introduced a command palette with keyboard shortcuts for common actions and layout switching.
  * Added a status strip showing resume count, last edit time, sync status, and current layout.
  * Added document previews and improved locked-resume indicators.
  * Added clearer empty-library and no-results states.

* **Improvements**
  * Redesigned the home library toolbar and resume cards for a streamlined experience.
  * Grid is now the default home layout, with existing preferences preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The Home page is redesigned as a command-centre-style resume library.
- Adds list, grid, and gallery layouts with persisted layout selection and document previews.
- Adds command-palette actions, keyboard shortcuts, live library status, and redesigned empty states.
- Corrects storage messaging for authenticated cloud users across the status strip and empty-library state.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/pages/Home.tsx | Registers Home-specific command-palette actions and keyboard shortcuts for library operations and layout selection. |
| apps/web/src/pages/home/useHomePage.ts | Derives library status, filtering, layout, and cloud-sync state for the redesigned Home page. |
| apps/web/src/pages/home/HomeLayouts.tsx | Implements the redesigned toolbar, empty states, and consistent list, grid, and gallery rendering. |
| apps/web/src/pages/home/StatusStrip.tsx | Correctly distinguishes cloud storage from on-device storage based on the authenticated cloud state. |
| apps/web/src/pages/home/HomeResumeCard.tsx | Restyles resume entries for each layout while preserving actions and locked-resume gating. |
| apps/web/src/pages/home/DocumentPreview.tsx | Adds deterministic metadata-based document previews for grid and gallery cards. |
| apps/web/src/components/layout/AppShell.tsx | Adds the Home-only utility bar controls and command-palette trigger. |
| apps/web/src/components/ui/CommandPalette.tsx | Adds grouped command headings, shortcut hints, and keyboard-navigation guidance. |
| apps/web/src/lib/homeLayout.ts | Adds Gallery layout support and changes the fallback and fresh-install default to Grid. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(web): correct storage claims, galler..."](https://github.com/lgtm-hq/rustume/commit/9620c864dee740a1d48d62941afada7884348854) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47232459)</sub>

<!-- /greptile_comment -->