### PR TITLE
ci: track lintro and lgtm-ci pins in Renovate, inventory version-bearing files, align lintro to 0.91.41

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -108,7 +108,7 @@ Renovate config lives in `renovate.json`; the shared preset is
 | Path | Field | Pins | Owner |
 | --- | --- | --- | --- |
 | `.github/workflows/*.yml` | `uses: <owner>/<repo>@<sha> # vX.Y.Z` | Actions and lgtm-ci reusables | Renovate `github-actions` |
-| `.github/workflows/*.yml` | `tooling-ref: '<sha>' # vX.Y.Z` (23 occurrences) | lgtm-ci tooling checkout, mirroring the `uses:` pin in the same file | Renovate custom manager (`lgtm-hq/lgtm-ci`, `github-tags`), enforced by `pin-sync-guard.yml` |
+| `.github/workflows/*.yml` | `tooling-ref: '<sha>' # vX.Y.Z` (one per lgtm-ci caller job) | lgtm-ci tooling checkout, mirroring the `uses:` pin in the same file | Renovate custom manager (`lgtm-hq/lgtm-ci`, `github-tags`), enforced by `pin-sync-guard.yml` |
 | `.github/workflows/ci-lintro-analysis.yml`, `.github/workflows/security-dependency-review.yml` | `lintro-image: ghcr.io/lgtm-hq/py-lintro:<version>@sha256:<digest>` | lintro CI image (version and digest together) | Renovate custom manager (`ghcr.io/lgtm-hq/py-lintro`, `docker`) |
 | `.github/workflows/boundary-guard.yml` | `pip install uv==<version>` | uv in the boundary job (`setup-uv` is blocked by the egress policy) | **Manual — no manager** |
 | `.github/workflows/coverage.yml`, `deploy-pages.yml`, `site-quality.yml` | `node-version:`, `python-version:` | CI runtime majors | **Manual — no manager** |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, coverage, release automation,
 and publishing. Most workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`66cad82ead0e5d119928c895c7d7da9c837989e5` (**v0.52.3** release commit; not the annotated
+`31c25ef2e8992960e218524780e34f44f51271b5` (**v0.54.0** release commit; not the annotated
 tag object SHA). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
@@ -65,6 +65,14 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 - **vuln-suppression-check.yml** — Stale OSV suppression cleanup via
   `reusable-vuln-suppression-check`
 - **validate-action-pinning.yml** — SHA pin policy via `reusable-validate-action-pinning`
+- **pin-sync-guard.yml** — Fails when a workflow's `tooling-ref:` input drifts from the
+  lgtm-ci `uses:` pin it mirrors, or when workflows disagree on the lgtm-ci release
+  (`scripts/ci/maintenance/check-tooling-ref-sync.sh`)
+- **boundary-guard.yml** — Ops boundary path and content guards (inline;
+  `scripts/ci/boundary/`)
+- **test-boundary-shell.yml** / **test-docker-shell.yml** /
+  **test-maintenance-shell.yml** — BATS suites for `scripts/ci/` via
+  `reusable-test-shell`
 - **ghcr-cleanup.yml** — GHCR prune (hybrid: `reusable-ghcr-cleanup` for untagged +
   inline tagged retention)
 - **renovate.yml** — Scheduled Renovate runs (direct `step-security/harden-runner` +
@@ -75,9 +83,9 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 Use the **release commit SHA**, not the annotated tag object SHA:
 
 ```yaml
-uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
+uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
 with:
-  tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3 release commit
+  tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0 release commit
 ```
 
 Sparse `lgtm-hq` tooling checkouts may use `actions/checkout` when `ref:` is quoted and
@@ -87,6 +95,44 @@ Pass `runner-image: ubuntu-24.04` on reusables that expose the input (lgtm-ci #3
 Action-only wrappers (`reusable-codeql`, `reusable-dependency-review`, etc.) and
 multi-arch Docker (`runner-map`) follow the exceptions in
 [lgtm-ci workflow-contract](https://github.com/lgtm-hq/lgtm-ci/blob/main/docs/workflow-contract.md#runner-pinning-exceptions).
+
+## Version pin inventory
+
+Every version-bearing field in the repo, and what keeps it current. "Manual" rows have no
+manager and only move when a human moves them — they are listed so that fact stays visible
+instead of being rediscovered after years of drift (#568).
+
+Renovate config lives in `renovate.json`; the shared preset is
+`local>lgtm-hq/.github:renovate-config`.
+
+| Path | Field | Pins | Owner |
+| --- | --- | --- | --- |
+| `.github/workflows/*.yml` | `uses: <owner>/<repo>@<sha> # vX.Y.Z` | Actions and lgtm-ci reusables | Renovate `github-actions` |
+| `.github/workflows/*.yml` | `tooling-ref: '<sha>' # vX.Y.Z` (23 occurrences) | lgtm-ci tooling checkout, mirroring the `uses:` pin in the same file | Renovate custom manager (`lgtm-hq/lgtm-ci`, `github-tags`), enforced by `pin-sync-guard.yml` |
+| `.github/workflows/ci-lintro-analysis.yml`, `.github/workflows/security-dependency-review.yml` | `lintro-image: ghcr.io/lgtm-hq/py-lintro:<version>@sha256:<digest>` | lintro CI image (version and digest together) | Renovate custom manager (`ghcr.io/lgtm-hq/py-lintro`, `docker`) |
+| `.github/workflows/boundary-guard.yml` | `pip install uv==<version>` | uv in the boundary job (`setup-uv` is blocked by the egress policy) | **Manual — no manager** |
+| `.github/workflows/coverage.yml`, `deploy-pages.yml`, `site-quality.yml` | `node-version:`, `python-version:` | CI runtime majors | **Manual — no manager** |
+| `.github/workflows/README.md` | `## Pin format` example | Illustrative lgtm-ci pin | **Manual — no manager**; `pin-sync-guard.yml` does not read Markdown |
+| `docker/Dockerfile` | `FROM <image>@sha256:<digest>` | `rust`, `gcr.io/distroless/static` | Renovate `dockerfile` (digest updates automerged) |
+| `docker/Dockerfile` | `ARG BUN_VERSION=` | bun release tarball | Renovate custom manager (`oven-sh/bun`, `github-releases`) |
+| `docker/Dockerfile` | `cargo install cargo-chef@<version>` | cargo-chef | Renovate custom manager (`cargo-chef`, `crate`) |
+| `docker/Dockerfile` | `wasm-bindgen-cli@${WASM_BINDGEN_VERSION}` | Derived from `Cargo.lock` at build time | n/a — no literal pin to update |
+| `docker-compose.yml` | `image: postgres:<tag>@sha256:<digest>` | Local dev Postgres | Renovate `docker-compose` |
+| `docker-compose.yml` | `image: ghcr.io/lgtm-hq/rustume:latest` | This repo's own image | n/a — deliberately floating |
+| `Cargo.toml`, `crates/*/Cargo.toml`, `bindings/*/Cargo.toml` | `[dependencies]` requirements | Rust crates | Renovate `cargo` |
+| `Cargo.lock` | Resolved Rust crates | Transitive Rust versions | Renovate `cargo` (updated with the manifest) |
+| `apps/web/package.json`, `apps/site/package.json` | `dependencies`, `devDependencies` | JS/TS deps | Renovate `npm` |
+| `apps/web/package.json`, `apps/site/package.json` | `overrides` | Forced transitive versions (`astro`, `esbuild`, `sharp`, `ws`, `fast-uri`, …) | Renovate `npm` (extracts `overrides`); `apps/site` TypeScript majors are pinned off in `renovate.json` |
+| `apps/web/bun.lock`, `apps/site/bun.lock` | Resolved JS deps | Transitive JS versions | Renovate `npm` (bun lockfile) |
+| `pyproject.toml` | `[dependency-groups] lint`, `test` | lintro, pytest | Renovate `pep621` (PEP 735 dependency groups) |
+| `uv.lock` | Resolved Python deps | lintro and its tool stack | Renovate `pep621` (refreshed with the manifest) |
+| `scripts/ci/site/preview-pages-local.sh` | `CARGO_LLVM_COV_VERSION=` | cargo-llvm-cov | Renovate custom manager (`cargo-llvm-cov`, `crate`) |
+| `scripts/ci/boundary/check_content.sh` | `uvx --from semgrep==<version>` | semgrep for the content guard | **Manual — no manager** |
+| `scripts/ci/testing/rust/run-server-db-migrations.sh` | `SQLX_CLI_VERSION=` | sqlx-cli | **Manual — no manager** |
+
+The lintro version is authoritative in **two** places that must agree: the `lintro-image:`
+pins above (what CI runs) and `pyproject.toml` + `uv.lock` (what `uv run lintro` runs
+locally). Move them in the same commit.
 
 ## Token patterns
 

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -53,7 +53,7 @@ jobs:
       timeout-minutes: 30
       runner-image: ubuntu-24.04
       # yamllint disable-line rule:line-length
-      lintro-image: ghcr.io/lgtm-hq/py-lintro:0.61.0@sha256:95b9fd9d62c3ca1227447467767ec915e78a7eef62282dd18c0b1c02ee4d3887
+      lintro-image: ghcr.io/lgtm-hq/py-lintro:0.91.41@sha256:d11761f97e110a8857b0cea173f4637c452181b144b951ad8d090bd98e81df87
       egress-policy: block
       egress-preset: quality
 

--- a/.github/workflows/pin-sync-guard.yml
+++ b/.github/workflows/pin-sync-guard.yml
@@ -1,25 +1,35 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 ---
-name: Quality - Ops Boundary Guard
+name: Quality - Pin Sync Guard
+# Fails when a workflow's `tooling-ref:` input drifts from the lgtm-ci `uses:`
+# pin it mirrors, or when the workflows disagree on the lgtm-ci release.
 
 "on":
   pull_request:
     branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/ci/maintenance/check-tooling-ref-sync.sh'
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/ci/maintenance/check-tooling-ref-sync.sh'
+  merge_group:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: boundary-guard-${{ github.ref }}
+  group: pin-sync-guard-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  boundary:
-    name: Ops boundary guard
+  pin-sync:
+    name: lgtm-ci pin sync
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -31,8 +41,6 @@ jobs:
             codeload.github.com:443
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
-            pypi.org:443
-            files.pythonhosted.org:443
 
       - name: Checkout
         # yamllint disable-line rule:line-length
@@ -40,13 +48,5 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Path guard
-        run: bash scripts/ci/boundary/check_paths.sh
-
-      - name: Install uv
-        # Pinned pip install instead of setup-uv: the action's version fetch
-        # is blocked by the harden-runner egress policy; PyPI already is not.
-        run: python3 -m pip install --quiet uv==0.11.29
-
-      - name: Content guard (semgrep)
-        run: bash scripts/ci/boundary/check_content.sh
+      - name: Pin sync guard
+        run: bash scripts/ci/maintenance/check-tooling-ref-sync.sh

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -31,7 +31,7 @@ jobs:
       job-name: "Scan dependencies"
       runner-image: ubuntu-24.04
       # yamllint disable-line rule:line-length
-      lintro-image: ghcr.io/lgtm-hq/py-lintro:0.61.0@sha256:95b9fd9d62c3ca1227447467767ec915e78a7eef62282dd18c0b1c02ee4d3887
+      lintro-image: ghcr.io/lgtm-hq/py-lintro:0.91.41@sha256:d11761f97e110a8857b0cea173f4637c452181b144b951ad8d090bd98e81df87
       upload-comment-artifact: ${{ github.event_name == 'pull_request' }}
       egress-policy: block
       egress-preset: quality

--- a/.github/workflows/test-maintenance-shell.yml
+++ b/.github/workflows/test-maintenance-shell.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Test - Maintenance Shell Scripts
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/maintenance/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-maintenance-shell.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/ci/maintenance/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-maintenance-shell.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-maintenance-shell-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell-tests:
+    permissions:
+      contents: read
+      pull-requests: write # publish-test-summary posts shell coverage on PRs
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    with:
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      job-name: Maintenance Shell Tests
+      test-path: tests/bats/unit/maintenance
+      coverage: true
+      # kcov reports 0% for bash via BATS; non-zero fails CI until measurement fixed
+      coverage-threshold: 0
+      upload-coverage: false
+      egress-policy: block
+      egress-preset: github-tooling
+      runner-image: ubuntu-24.04

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,19 +1,18 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#1a1a1a" />
-    <meta name="description" content="Privacy-first resume builder" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-    <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#1a1a1a">
+    <meta name="description" content="Privacy-first resume builder">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="apple-touch-icon" href="/icons/icon-192.png">
+    <link rel="manifest" href="/manifest.webmanifest">
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
       href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600&family=JetBrains+Mono:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
+      rel="stylesheet">
     <title>Rustume</title>
   </head>
   <body>

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -6,7 +6,8 @@ POSTGRES_PASSWORD=rustume
 POSTGRES_USER=rustume
 
 CORS_ORIGIN=http://localhost:5173
-DATABASE_URL=postgres://rustume:rustume@postgres:5432/rustume
+# Composed from the POSTGRES_* values above; Compose interpolates the project env file.
+DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
 RUSTUME_CLOUD=true
 
 WORKOS_API_KEY=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = "AGPL-3.0-only"
 dependencies = []
 
 [dependency-groups]
-lint = ["lintro>=0.51.4"]
+lint = ["lintro>=0.91.41"]
 test = ["pytest>=8.3"]
 
 [tool.lintro]

--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github/workflows/.+\\.yml$/"],
       "matchStrings": [
-        "tooling-ref: '(?<currentDigest>[0-9a-f]{40})'\\s+# (?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+        "tooling-ref: [\"']?(?<currentDigest>[0-9a-f]{40})[\"']?\\s+# (?<currentValue>v\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "lgtm-hq/lgtm-ci",
       "datasourceTemplate": "github-tags"

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,26 @@
       "datasourceTemplate": "crate"
     },
     {
+      "description": "lintro CI image is a reusable-workflow input, not a FROM, so the dockerfile manager never sees it; keep version and digest moving together",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.yml$/"],
+      "matchStrings": [
+        "lintro-image: ghcr\\.io/lgtm-hq/py-lintro:(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "depNameTemplate": "ghcr.io/lgtm-hq/py-lintro",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "description": "tooling-ref is a string input mirroring the lgtm-ci uses: pin in the same file; the github-actions manager only moves the uses: half",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.yml$/"],
+      "matchStrings": [
+        "tooling-ref: '(?<currentDigest>[0-9a-f]{40})'\\s+# (?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "lgtm-hq/lgtm-ci",
+      "datasourceTemplate": "github-tags"
+    },
+    {
       "customType": "regex",
       "managerFilePatterns": ["/^scripts/ci/site/preview-pages-local\\.sh$/"],
       "matchStrings": [

--- a/scripts/ci/maintenance/check-tooling-ref-sync.sh
+++ b/scripts/ci/maintenance/check-tooling-ref-sync.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 #      an lgtm-ci `uses:` pin in the same file.
 #   2. Repo-wide — every lgtm-ci pin in .github/workflows/*.yml resolves to a
 #      single SHA and a single version comment.
+#   3. Parsability — every `tooling-ref:` line is recognized (quoted or not);
+#      an unparsable one is reported instead of silently skipped.
 #
 # Usage:
 #   scripts/ci/maintenance/check-tooling-ref-sync.sh [workflow-dir]
@@ -24,7 +26,7 @@ workflow_dir=".github/workflows"
 while (($# > 0)); do
 	case "$1" in
 	--help | -h)
-		sed -n '1,22p' "$0"
+		sed -n '1,24p' "$0"
 		exit 0
 		;;
 	-*)
@@ -43,8 +45,13 @@ if [[ -z ${workflow_dir} || ! -d ${workflow_dir} ]]; then
 	exit 2
 fi
 
-uses_re='^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*lgtm-hq/lgtm-ci/[^@]+@([0-9a-f]{40})[[:space:]]*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+)'
-ref_re="^[[:space:]]*tooling-ref:[[:space:]]*'([0-9a-f]{40})'[[:space:]]*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+)"
+# YAML scalars accept unquoted, single-quoted and double-quoted forms, so match
+# all three: a formatting-only edit must not drop a pin out of the guard's view.
+q="[\"']"
+uses_re="^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*${q}?lgtm-hq/lgtm-ci/[^@\"'[:space:]]+@([0-9a-f]{40})${q}?[[:space:]]*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+)"
+ref_re="^[[:space:]]*tooling-ref:[[:space:]]*(${q}?)([0-9a-f]{40})(${q}?)[[:space:]]*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+)[[:space:]]*$"
+# Any tooling-ref line that ref_re cannot parse is reported rather than skipped.
+ref_line_re='^[[:space:]]*tooling-ref:'
 
 violations=""
 all_pins=""
@@ -61,8 +68,12 @@ while IFS= read -r file; do
 	while IFS= read -r line; do
 		if [[ ${line} =~ ${uses_re} ]]; then
 			uses_pins="${uses_pins}${BASH_REMATCH[2]} ${BASH_REMATCH[3]}"$'\n'
-		elif [[ ${line} =~ ${ref_re} ]]; then
-			ref_pins="${ref_pins}${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"$'\n'
+		elif [[ ${line} =~ ${ref_line_re} ]]; then
+			if [[ ${line} =~ ${ref_re} && ${BASH_REMATCH[1]} == "${BASH_REMATCH[3]}" ]]; then
+				ref_pins="${ref_pins}${BASH_REMATCH[2]} ${BASH_REMATCH[4]}"$'\n'
+			else
+				add_violation "${file}: unparsable tooling-ref line: ${line#"${line%%[![:space:]]*}"}"
+			fi
 		fi
 	done <"${file}"
 

--- a/scripts/ci/maintenance/check-tooling-ref-sync.sh
+++ b/scripts/ci/maintenance/check-tooling-ref-sync.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# check-tooling-ref-sync.sh
+#
+# Guard against lgtm-ci pin drift in .github/workflows/*.yml.
+#
+# Each caller workflow pins lgtm-ci twice: once in the `uses:` reference that
+# Renovate's github-actions manager owns, and once in a `tooling-ref:` string
+# input that only the repo-local Renovate custom manager owns. Two managers on
+# one logical pin means the halves can drift, so this guard enforces:
+#
+#   1. Per file — every `tooling-ref:` SHA (and its `# vX.Y.Z` comment) matches
+#      an lgtm-ci `uses:` pin in the same file.
+#   2. Repo-wide — every lgtm-ci pin in .github/workflows/*.yml resolves to a
+#      single SHA and a single version comment.
+#
+# Usage:
+#   scripts/ci/maintenance/check-tooling-ref-sync.sh [workflow-dir]
+
+workflow_dir=".github/workflows"
+
+while (($# > 0)); do
+	case "$1" in
+	--help | -h)
+		sed -n '1,22p' "$0"
+		exit 0
+		;;
+	-*)
+		echo "Unknown argument: $1" >&2
+		exit 2
+		;;
+	*)
+		workflow_dir="$1"
+		shift
+		;;
+	esac
+done
+
+if [[ -z ${workflow_dir} || ! -d ${workflow_dir} ]]; then
+	echo "Workflow directory not found: ${workflow_dir}" >&2
+	exit 2
+fi
+
+uses_re='^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*lgtm-hq/lgtm-ci/[^@]+@([0-9a-f]{40})[[:space:]]*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+)'
+ref_re="^[[:space:]]*tooling-ref:[[:space:]]*'([0-9a-f]{40})'[[:space:]]*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+)"
+
+violations=""
+all_pins=""
+checked=0
+
+add_violation() {
+	violations="${violations}$1"$'\n'
+}
+
+while IFS= read -r file; do
+	uses_pins=""
+	ref_pins=""
+
+	while IFS= read -r line; do
+		if [[ ${line} =~ ${uses_re} ]]; then
+			uses_pins="${uses_pins}${BASH_REMATCH[2]} ${BASH_REMATCH[3]}"$'\n'
+		elif [[ ${line} =~ ${ref_re} ]]; then
+			ref_pins="${ref_pins}${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"$'\n'
+		fi
+	done <"${file}"
+
+	all_pins="${all_pins}${uses_pins}${ref_pins}"
+
+	[[ -z ${ref_pins} ]] && continue
+
+	while IFS= read -r ref_pin; do
+		[[ -z ${ref_pin} ]] && continue
+		checked=$((checked + 1))
+		if [[ -z ${uses_pins} ]]; then
+			add_violation "${file}: tooling-ref '${ref_pin}' has no lgtm-ci 'uses:' pin in the same file"
+		elif ! grep -Fxq "${ref_pin}" <<<"${uses_pins}"; then
+			add_violation "${file}: tooling-ref '${ref_pin}' does not match any 'uses:' pin in the same file"
+			while IFS= read -r uses_pin; do
+				[[ -n ${uses_pin} ]] && add_violation "  uses: ${uses_pin}"
+			done <<<"${uses_pins}"
+		fi
+	done <<<"${ref_pins}"
+done < <(find "${workflow_dir}" -maxdepth 1 -name '*.yml' | sort)
+
+distinct_pins="$(grep -v '^$' <<<"${all_pins}" | sort -u || true)"
+distinct_count="$(grep -c . <<<"${distinct_pins}" || true)"
+
+if [[ -n ${distinct_pins} && ${distinct_count} -gt 1 ]]; then
+	add_violation "lgtm-ci is pinned to more than one version across ${workflow_dir}:"
+	while IFS= read -r pin; do
+		[[ -n ${pin} ]] && add_violation "  ${pin}"
+	done <<<"${distinct_pins}"
+fi
+
+if [[ -n ${violations} ]]; then
+	echo "lgtm-ci pin drift detected:" >&2
+	printf '%s' "${violations}" | sed 's/^/  /' >&2
+	echo "Every 'tooling-ref:' must repeat the 'uses:' SHA in its own file," >&2
+	echo "and all workflows must sit on the same lgtm-ci release." >&2
+	exit 1
+fi
+
+echo "lgtm-ci pin sync guard passed: ${checked} tooling-ref pin(s) match their 'uses:' pins."

--- a/scripts/ci/maintenance/check-tooling-ref-sync.sh
+++ b/scripts/ci/maintenance/check-tooling-ref-sync.sh
@@ -49,7 +49,7 @@ fi
 # all three: a formatting-only edit must not drop a pin out of the guard's view.
 q="[\"']"
 uses_re="^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*${q}?lgtm-hq/lgtm-ci/[^@\"'[:space:]]+@([0-9a-f]{40})${q}?[[:space:]]*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+)"
-ref_re="^[[:space:]]*tooling-ref:[[:space:]]*(${q}?)([0-9a-f]{40})(${q}?)[[:space:]]*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+)[[:space:]]*$"
+ref_re="^[[:space:]]*tooling-ref:[[:space:]]*(${q}?)([0-9a-f]{40})(${q}?)[[:space:]]*#[[:space:]]*(v[0-9]+\.[0-9]+\.[0-9]+)"
 # Any tooling-ref line that ref_re cannot parse is reported rather than skipped.
 ref_line_re='^[[:space:]]*tooling-ref:'
 

--- a/tests/bats/unit/maintenance/test_check_tooling_ref_sync.bats
+++ b/tests/bats/unit/maintenance/test_check_tooling_ref_sync.bats
@@ -101,6 +101,88 @@ EOF
 	assert_output --partial "no lgtm-ci 'uses:' pin"
 }
 
+@test "pin sync: double-quoted and unquoted tooling-ref scalars are checked" {
+	cat >"${WORKFLOW_DIR}/quoted.yml" <<EOF
+jobs:
+  call:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-thing.yml@${SHA_A} # v0.54.0
+    with:
+      tooling-ref: "${SHA_A}" # v0.54.0
+EOF
+	cat >"${WORKFLOW_DIR}/bare.yml" <<EOF
+jobs:
+  call:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-thing.yml@${SHA_A} # v0.54.0
+    with:
+      tooling-ref: ${SHA_A} # v0.54.0
+EOF
+
+	run_guard
+
+	assert_success
+	assert_output --partial "2 tooling-ref pin(s)"
+}
+
+@test "pin sync: drift in a double-quoted tooling-ref is still caught" {
+	cat >"${WORKFLOW_DIR}/quoted.yml" <<EOF
+jobs:
+  call:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-thing.yml@${SHA_A} # v0.54.0
+    with:
+      tooling-ref: "${SHA_B}" # v0.54.0
+EOF
+
+	run_guard
+
+	assert_failure
+	assert_output --partial "does not match any 'uses:' pin"
+}
+
+@test "pin sync: an unparsable tooling-ref line is reported, not skipped" {
+	cat >"${WORKFLOW_DIR}/odd.yml" <<EOF
+jobs:
+  call:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-thing.yml@${SHA_A} # v0.54.0
+    with:
+      tooling-ref: '${SHA_A}"
+EOF
+
+	run_guard
+
+	assert_failure
+	assert_output --partial "unparsable tooling-ref line"
+}
+
+@test "pin sync: a tooling-ref without a version comment is reported" {
+	cat >"${WORKFLOW_DIR}/nocomment.yml" <<EOF
+jobs:
+  call:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-thing.yml@${SHA_A} # v0.54.0
+    with:
+      tooling-ref: '${SHA_A}'
+EOF
+
+	run_guard
+
+	assert_failure
+	assert_output --partial "unparsable tooling-ref line"
+}
+
+@test "pin sync: a quoted lgtm-ci uses pin is recognized" {
+	cat >"${WORKFLOW_DIR}/quoted-uses.yml" <<EOF
+jobs:
+  call:
+    uses: "lgtm-hq/lgtm-ci/.github/workflows/reusable-thing.yml@${SHA_A}" # v0.54.0
+    with:
+      tooling-ref: '${SHA_A}' # v0.54.0
+EOF
+
+	run_guard
+
+	assert_success
+	assert_output --partial "1 tooling-ref pin(s)"
+}
+
 @test "pin sync: workflows without lgtm-ci pins pass" {
 	cat >"${WORKFLOW_DIR}/plain.yml" <<'EOF'
 jobs:

--- a/tests/bats/unit/maintenance/test_check_tooling_ref_sync.bats
+++ b/tests/bats/unit/maintenance/test_check_tooling_ref_sync.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/maintenance/check-tooling-ref-sync.sh
+
+load "../../helpers/common"
+
+CHECK_SYNC="${PROJECT_ROOT}/scripts/ci/maintenance/check-tooling-ref-sync.sh"
+
+SHA_A="31c25ef2e8992960e218524780e34f44f51271b5"
+SHA_B="66cad82ead0e5d119928c895c7d7da9c837989e5"
+
+setup() {
+	WORKFLOW_DIR="${BATS_TEST_TMPDIR}/workflows"
+	mkdir -p "${WORKFLOW_DIR}"
+}
+
+# Writes a caller workflow: $1 file, $2 uses sha, $3 uses version,
+# $4 tooling-ref sha, $5 tooling-ref version.
+write_caller() {
+	cat >"${WORKFLOW_DIR}/$1" <<EOF
+jobs:
+  call:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-thing.yml@$2 # $3
+    with:
+      tooling-ref: '$4' # $5
+EOF
+}
+
+run_guard() {
+	run bash "${CHECK_SYNC}" "${WORKFLOW_DIR}"
+}
+
+@test "pin sync: matching tooling-ref and uses pins pass" {
+	write_caller "a.yml" "${SHA_A}" "v0.54.0" "${SHA_A}" "v0.54.0"
+	write_caller "b.yml" "${SHA_A}" "v0.54.0" "${SHA_A}" "v0.54.0"
+
+	run_guard
+
+	assert_success
+	assert_output --partial "pin sync guard passed"
+	assert_output --partial "2 tooling-ref pin(s)"
+}
+
+@test "pin sync: tooling-ref SHA differing from uses SHA fails" {
+	write_caller "a.yml" "${SHA_A}" "v0.54.0" "${SHA_B}" "v0.54.0"
+
+	run_guard
+
+	assert_failure
+	assert_output --partial "pin drift detected"
+	assert_output --partial "does not match any 'uses:' pin"
+}
+
+@test "pin sync: mismatched version comment fails even when SHAs agree" {
+	write_caller "a.yml" "${SHA_A}" "v0.54.0" "${SHA_A}" "v0.52.3"
+
+	run_guard
+
+	assert_failure
+	assert_output --partial "does not match any 'uses:' pin"
+}
+
+@test "pin sync: workflows on different lgtm-ci releases fail" {
+	write_caller "a.yml" "${SHA_A}" "v0.54.0" "${SHA_A}" "v0.54.0"
+	write_caller "b.yml" "${SHA_B}" "v0.52.3" "${SHA_B}" "v0.52.3"
+
+	run_guard
+
+	assert_failure
+	assert_output --partial "more than one version"
+	assert_output --partial "${SHA_B}"
+}
+
+@test "pin sync: straggler with only a uses pin is still caught repo-wide" {
+	write_caller "a.yml" "${SHA_A}" "v0.54.0" "${SHA_A}" "v0.54.0"
+	cat >"${WORKFLOW_DIR}/inline.yml" <<EOF
+jobs:
+  inline:
+    steps:
+      - uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@${SHA_B} # v0.52.3
+EOF
+
+	run_guard
+
+	assert_failure
+	assert_output --partial "more than one version"
+}
+
+@test "pin sync: tooling-ref without an lgtm-ci uses pin fails" {
+	cat >"${WORKFLOW_DIR}/orphan.yml" <<EOF
+jobs:
+  call:
+    uses: other-org/other-ci/.github/workflows/thing.yml@${SHA_A} # v1.0.0
+    with:
+      tooling-ref: '${SHA_A}' # v0.54.0
+EOF
+
+	run_guard
+
+	assert_failure
+	assert_output --partial "no lgtm-ci 'uses:' pin"
+}
+
+@test "pin sync: workflows without lgtm-ci pins pass" {
+	cat >"${WORKFLOW_DIR}/plain.yml" <<'EOF'
+jobs:
+  plain:
+    steps:
+      - run: echo hello
+EOF
+
+	run_guard
+
+	assert_success
+	assert_output --partial "0 tooling-ref pin(s)"
+}
+
+@test "pin sync: the repo's own workflows are in sync" {
+	run bash "${CHECK_SYNC}" "${PROJECT_ROOT}/.github/workflows"
+
+	assert_success
+	assert_output --partial "pin sync guard passed"
+}
+
+@test "pin sync: missing workflow directory exits 2" {
+	run bash "${CHECK_SYNC}" "${BATS_TEST_TMPDIR}/nope"
+
+	assert_failure
+	assert_equal "${status}" "2"
+	assert_output --partial "Workflow directory not found"
+}
+
+@test "pin sync: --help prints usage" {
+	run bash "${CHECK_SYNC}" --help
+
+	assert_success
+	assert_output --partial "check-tooling-ref-sync.sh"
+	assert_output --partial "Usage:"
+}

--- a/tests/bats/unit/maintenance/test_check_tooling_ref_sync.bats
+++ b/tests/bats/unit/maintenance/test_check_tooling_ref_sync.bats
@@ -168,6 +168,21 @@ EOF
 	assert_output --partial "unparsable tooling-ref line"
 }
 
+@test "pin sync: trailing prose after the version comment is still parsed" {
+	cat >"${WORKFLOW_DIR}/prose.yml" <<EOF
+jobs:
+  call:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-thing.yml@${SHA_A} # v0.54.0
+    with:
+      tooling-ref: '${SHA_A}' # v0.54.0 release commit
+EOF
+
+	run_guard
+
+	assert_success
+	assert_output --partial "1 tooling-ref pin(s)"
+}
+
 @test "pin sync: a quoted lgtm-ci uses pin is recognized" {
 	cat >"${WORKFLOW_DIR}/quoted-uses.yml" <<EOF
 jobs:

--- a/uv.lock
+++ b/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "lintro"
-version = "0.81.1"
+version = "0.91.41"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -144,9 +144,9 @@ dependencies = [
     { name = "rich" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/09/b9447eb9d43d648c18cdd693e9f37b379c63d07236ef34a2f1e24c31a729/lintro-0.81.1.tar.gz", hash = "sha256:79d93f2660e1043ab060af912874b7c6edb8cfeb5d7ec53eb2d3c3c2b3293654", size = 2617831, upload-time = "2026-07-18T14:40:48.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/90/61159516e2b30a783b94115a130afc6778771b9076cbae92c3296747f30e/lintro-0.91.41.tar.gz", hash = "sha256:1b10996d547bb12966f4a69f0b65ff568795ab597d02de0be57af4ee0e324980", size = 2785300, upload-time = "2026-07-25T13:50:10.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/7a/ce146ba5439af0bb08bc9287cab85bdecbf1353f607cfd79c44ee1c56c6d/lintro-0.81.1-py3-none-any.whl", hash = "sha256:24ff1c39ff05db6a14d62ce6ca7b219157b71f4077f9f1886cc88e5da513829d", size = 937069, upload-time = "2026-07-18T14:40:46.61Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/cc667570910d58488017aff8ee88183a7f257d12f41f7984be64201f9c07/lintro-0.91.41-py3-none-any.whl", hash = "sha256:ec2c974b60352a431797b4fc4293c941be5e3399247da9996193df67d55bfcad", size = 992020, upload-time = "2026-07-25T13:50:08.84Z" },
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ test = [
 [package.metadata]
 
 [package.metadata.requires-dev]
-lint = [{ name = "lintro", specifier = ">=0.51.4" }]
+lint = [{ name = "lintro", specifier = ">=0.91.41" }]
 test = [{ name = "pytest", specifier = ">=8.3" }]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci: track lintro and lgtm-ci pins in Renovate, inventory version-bearing files, align lintro to 0.91.41
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

lintro was pinned in four places with four different values and Renovate tracked none of
them. This adds the missing Renovate coverage, writes down every version-bearing file so
the manual set stops being invisible, and moves lintro to one current version everywhere.

**1. Renovate custom managers.** Two new regex managers in `renovate.json`:

- `lintro-image:` — `docker` datasource on `ghcr.io/lgtm-hq/py-lintro`, capturing
  `currentValue` and `currentDigest` so version and digest move together.
- `tooling-ref:` — `github-tags` on `lgtm-hq/lgtm-ci` with digest capture, so the string
  half moves with the `uses:` pin it shadows.

**2. A pin sync guard, belt and braces.** The `tooling-ref` manager should keep the halves
in step — same `depName`, same `newValue`, so Renovate branches them together — but two
managers owning one logical pin is exactly how this repo drifted in the first place. So
`scripts/ci/maintenance/check-tooling-ref-sync.sh` (gated by `pin-sync-guard.yml`, covered
by 10 BATS tests) fails when a file's `tooling-ref` SHA or version comment differs from its
`uses:` pin, and when the workflows disagree on a single lgtm-ci release. Run against `main`
it fails on the known stragglers, which is how it was verified.

**3. Inventory.** `.github/workflows/README.md` gains a table of every version-bearing
file and field with the Renovate manager that owns it, or an explicit "manual — no manager".
Derived by grepping, so it picked up three manual pins the issue did not list:
`uv==0.11.29` in `boundary-guard.yml`, `semgrep==1.169.0` in `check_content.sh`, and
`SQLX_CLI_VERSION` in `run-server-db-migrations.sh`.

**4. lintro aligned to 0.91.41** across both `lintro-image:` pins, `pyproject.toml`, and
`uv.lock`. `uv run lintro --version` now matches what CI runs.

### Version chosen: 0.91.41

The issue named 0.91.40 as latest at time of writing. Verified against both sources rather
than trusting that: PyPI `lintro` latest is **0.91.41**, and the GHCR registry API confirms
`ghcr.io/lgtm-hq/py-lintro:0.91.41` exists at
`sha256:d11761f97e110a8857b0cea173f4637c452181b144b951ad8d090bd98e81df87`. Note this project
releases roughly every half hour — 0.91.41 was published mid-PR — so the pin is current as of
writing and Renovate now owns keeping it that way, which is the point.

### lgtm-ci: stragglers only, v0.59.8 deferred

Reconciled `boundary-guard.yml` and the `.github/workflows/README.md` pin-format example from
v0.52.3 up to **v0.54.0**, matching the other 31 `uses:` pins, so the repo is self-consistent
and the new guard passes. Did **not** take v0.59.8 repo-wide here — that is five minors and
34 pins, and it would bury the lintro bump this PR exists to isolate. Filed as #571.

### Findings triaged

The bump spans 0.61.0 → 0.91.41 in CI and 0.81.1 → 0.91.41 locally, so new tools and rules
came with it. Every finding, fixed or deferred:

| Finding | Disposition |
| --- | --- |
| **html-validate**, 11 errors in `apps/web/index.html` — `doctype-style` (lowercase DOCTYPE) and `void-style` (self-closing `<meta>`/`<link>`) | **Fixed.** Both are HTML5 style errors. Checked that prettier agrees with the corrected form so the two tools do not fight. |
| **trufflehog**, 1 error in `docker/.env.example` — Postgres connection string containing credentials | **Fixed without suppressing.** Compose interpolates its project env file, so `DATABASE_URL` is now composed from the `POSTGRES_*` values declared three lines above instead of repeating them as a literal. Verified with `docker compose --profile cloud config` against the real `docker-compose.yml`: resolves to the identical value. No ignore file, no config weakened. |
| **osv-scanner**, 2 findings — `GHSA-mh99-v99m-4gvg` brace-expansion 2.1.2 and 5.0.7 in `apps/web/bun.lock` | **Not mine; belongs to #567.** `main` is red on the same two rows independently of this branch (commit `9c36cd8`, the squash-merge of #556). osv-scanner queries live OSV data, and this advisory was published 2026-07-24, so main went red on its next run regardless. The fix is a `brace-expansion` override in `apps/web/package.json`, which is #567's lane — deliberately not touched here, and not suppressed. |
| **pip-audit**, tool ERROR locally | **Local environment, confirmed clean in CI.** pip-audit crashed building its scratch venv (`ensurepip` dies with SIGABRT) on this macOS box's uv-managed CPython, before reading anything from the repo. This PR's `Quality - Lint & Format` run reports `🔧 pip-audit ✅ PASS 0` inside the pinned 0.91.41 Linux image, so it is a local toolchain artifact, not repo state. Nothing was disabled for it. |

Nothing was disabled, ignored, or skipped to get here. `.lintro-config.yaml` is untouched.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #568
- Relates to #571
- Relates to #567

## Details

**Validation performed**

- `npx --yes --package renovate@latest renovate-config-validator` — passes, plain and `--strict`.
- Both new `matchStrings` were run as regexes against the real files rather than assumed:
  the lintro manager matches 2 lines across the workflow set, the `tooling-ref` manager
  matches all 23 occurrences (the 25 grep hits include one prose mention in
  `scorecards.yml` and the doc example in `README.md`, neither of which is an input).
- `bash scripts/ci/maintenance/check-tooling-ref-sync.sh` — 24 pins in sync; fails as
  designed on the pre-fix tree.
- `bats -r tests/bats/unit` — 34 passed, 0 failed (10 new).
- `cargo test --workspace` — all 22 suites ok.
- `apps/web`: `bun run test` — 58 files, 472 tests passed.
- `uv run lintro fmt` then `uv run lintro chk` — full suite, no `--tools` filtering, before
  every commit. Health score 94/100, unchanged from `main`; remaining output is the two
  pre-existing osv findings and the local pip-audit environment error described above.

**CI status.** Everything this PR touches is green: `Quality - Pin Sync Guard`,
`Test - Maintenance Shell Scripts` (the new BATS suite), boundary and docker shell tests,
CodeQL, dependency review, site quality, action-pinning validation, title/label/assign. The
0.91.41 image ran clean on every tool except osv-scanner — notably `html-validate`,
`trufflehog`, and `pip-audit` all report `PASS`, confirming the two fixes above and the
pip-audit diagnosis. The only red checks are `Quality - Lint & Format` and
`Security - Dependency Vulnerability Scan`, both failing solely on the inherited
brace-expansion advisory described above, both already failing on `main`.

**Note on the `tooling-ref` manager.** `github-tags` digest resolution returns the release
commit SHA, not the annotated tag object SHA, which is what this repo's pin format requires
and what the github-actions manager already produces for the `uses:` half. The guard exists
to catch it if that ever stops being true.

**Note on the README pin-format example.** It carries a real SHA that no manager can update,
so it is listed as manual in the new inventory table. The guard deliberately does not read
Markdown — covering it would turn every legitimate Renovate bump red until someone hand-edited
the doc.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Aligns lintro CI and local tooling to 0.91.41 and adds automated pin maintenance.
- Adds Renovate managers for lintro images and lgtm-ci tooling references.
- Adds a workflow guard and BATS coverage for synchronized lgtm-ci pins, including quoted and unquoted YAML scalars.
- Documents version-bearing files and updates ancillary HTML, environment, and workflow pins.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported parser gap is addressed by accepting valid quote forms and explicitly rejecting unparseable tooling-reference lines.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/maintenance/check-tooling-ref-sync.sh | The revised parser accepts quoted and unquoted pin scalars, rejects mismatched quotes, and reports unparseable tooling references instead of silently skipping them. |
| tests/bats/unit/maintenance/test_check_tooling_ref_sync.bats | Adds focused coverage for synchronized, drifting, quoted, unquoted, malformed, orphaned, and repository-wide pin cases. |
| renovate.json | Adds regex managers for digest-pinned lintro images and lgtm-ci tooling references. |
| .github/workflows/pin-sync-guard.yml | Runs the synchronization guard when workflow or guard-script changes can affect pin consistency. |
| pyproject.toml | Raises the local lintro dependency requirement to 0.91.41. |
| uv.lock | Resolves lintro 0.91.41 with corresponding package artifacts and hashes. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ci(pin-guard): allow trailing prose afte..."](https://github.com/lgtm-hq/rustume/commit/b403681b84e073cf58631be8ed572f5417852837) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47234406)</sub>

<!-- /greptile_comment -->