### PR TITLE
fix(deps): clear brace-expansion advisories and re-verify OSV suppressions

### DIFF
--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -1,75 +1,106 @@
 # OSV-Scanner configuration for Rustume.
 # Suppressions for transitive dependencies blocked on upstream releases.
+#
+# Every `ignoreUntil` below is reasoned for its own blocker (see each `reason`).
+# Do NOT batch-assign a shared expiry date: a common date across unrelated
+# blockers hides the fact that the blockers were never individually re-checked.
+# Blockers re-verified 2026-07-25 against Cargo.lock and crates.io latest
+# releases (#567).
 
-# --- Typst ecosystem: blocked on syntect/hayagriva upgrades ---
+# --- Typst ecosystem: syntect (unmaintained transitive deps, no fix possible) ---
+
+# syntect 5.3.0 is the latest release (2025-09-27) and still depends on
+# yaml-rust 0.4.5 and bincode 1.3.3. Both advisories are "unmaintained"
+# informational notices with no fixed version in OSV (introduced: 0, no fix),
+# so they can only clear when syntect itself migrates. syntect's release cadence
+# is slow (~10 months since 5.3.0), hence the long horizon.
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2024-0320"
-ignoreUntil = 2026-10-04
-reason = "yaml-rust — transitive via typst -> syntect; blocked until syntect migrates to yaml-rust2"
+ignoreUntil = 2027-03-31
+reason = "yaml-rust unmaintained — typst-library -> syntect 5.3.0 (latest) -> yaml-rust 0.4.5. Informational only; OSV lists no fixed version. Clears when syntect migrates to yaml-rust2. Re-check after the next syntect release."
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2025-0141"
-ignoreUntil = 2026-10-04
-reason = "bincode — transitive via typst -> syntect; blocked until syntect drops bincode"
+ignoreUntil = 2027-03-31
+reason = "bincode unmaintained — typst-library -> syntect 5.3.0 (latest) -> bincode 1.3.3. Informational only; OSV lists no fixed version. Clears when syntect drops bincode 1.x. Re-check after the next syntect release."
+
+# --- Typst ecosystem: hayagriva / biblatex / citationberg ---
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2024-0436"
-ignoreUntil = 2026-10-04
-reason = "paste — transitive via typst -> hayagriva; informational (unmaintained), functionally stable"
+ignoreUntil = 2026-12-31
+reason = "paste unmaintained — typst-library -> hayagriva 0.10.1 (latest, 2026-06-14) and biblatex 0.12.0 both depend on paste 1.0.15. Informational only; OSV lists no fixed version. Both crates are actively released by typst-org, so re-check within two release cycles."
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0194"
-ignoreUntil = 2026-10-04
-reason = "quick-xml 0.38 — transitive via typst-library -> hayagriva/citationberg; 0.41 present but hayagriva still pins 0.38; blocked until hayagriva upgrades"
+ignoreUntil = 2026-11-30
+reason = "quick-xml 0.38.4 quadratic duplicate-attribute check — typst-library -> hayagriva 0.10.1 -> citationberg 0.7.0, which pins quick-xml ^0.38. Fixed in quick-xml 0.41.0 (already in Cargo.lock via plist), so this is a one-line upstream dep bump in citationberg. Shortest horizon of the set: real DoS impact plus an available fix."
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0195"
-ignoreUntil = 2026-10-04
-reason = "quick-xml 0.38 — transitive via typst-library -> hayagriva/citationberg; 0.41 present but hayagriva still pins 0.38; blocked until hayagriva upgrades"
+ignoreUntil = 2026-11-30
+reason = "quick-xml 0.38.4 unbounded NsReader namespace allocation — same chain as RUSTSEC-2026-0194: citationberg 0.7.0 (latest) pins quick-xml ^0.38; fixed in 0.41.0. Blocked on a citationberg release; re-check alongside RUSTSEC-2026-0194."
+
+# --- Typst ecosystem: RazrFalcon text stack (unmaintained, no fix possible) ---
+
+# ttf-parser 0.25.1 (2024-11-29) and rustybuzz 0.20.1 (2024-11-12) are the
+# latest releases and are flagged unmaintained with no fixed version in OSV.
+# They are load-bearing across the whole typst text/render stack
+# (typst-layout, typst-library, typst-render, typst-svg, usvg, fontdb, krilla,
+# pixglyph), so nothing short of an ecosystem-wide migration clears them.
+# Long horizon deliberately.
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0192"
-ignoreUntil = 2026-10-04
-reason = "ttf-parser — transitive via typst-pdf -> krilla-svg -> fontdb; no fixed version published yet"
+ignoreUntil = 2027-06-30
+reason = "ttf-parser unmaintained — 0.25.1 is the latest release (2024-11-29) and OSV lists no fixed version. Reached via 8 paths (typst-layout/-library/-render/-svg, usvg, fontdb, rustybuzz, pixglyph). Informational only; clears only when the typst/resvg ecosystem migrates off it."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0206"
+ignoreUntil = 2027-06-30
+reason = "rustybuzz unmaintained — 0.20.1 is the latest release (2024-11-12) and OSV lists no fixed version. Reached via typst-layout, typst-library, krilla and usvg. Same upstream (RazrFalcon) and same migration blocker as RUSTSEC-2026-0192; re-check together."
 
 # --- npm: transitive via @astrojs/check -> yaml-language-server ---
 
 # Removed GHSA-48c2-rrv3-qjmp suppression: bun overrides force yaml >= 2.8.3
 
-# --- npm: license metadata missing from bun.lock / GitHub Actions pins ---
+# --- npm: GHSA-mh99-v99m-4gvg (brace-expansion) ---
+
+# No suppression needed: cleared by the `brace-expansion: ^5.0.8` override in
+# apps/web/package.json, which lifts both brace-expansion@5.0.7 and the
+# filelist -> minimatch@5 chain's brace-expansion@2.1.2 to 5.0.8.
+
+# --- npm / GitHub Actions: license metadata missing from bun.lock / SHA pins ---
+# All five claims re-verified 2026-07-25 against the npm registry and the
+# upstream GitHub repository license fields.
 
 [[PackageOverrides]]
 name = "astro"
 ecosystem = "npm"
 license.override = ["MIT"]
-reason = "MIT licensed; bun.lock omits license metadata"
+reason = "MIT licensed (verified via npm registry); bun.lock omits license metadata"
 
 [[PackageOverrides]]
 name = "@astrojs/sitemap"
 ecosystem = "npm"
 license.override = ["MIT"]
-reason = "MIT licensed; bun.lock omits license metadata"
+reason = "MIT licensed (verified via npm registry); bun.lock omits license metadata"
 
 [[PackageOverrides]]
 name = "@lgtm-hq/turbo-themes"
 ecosystem = "npm"
 license.override = ["MIT"]
-reason = "MIT licensed; bun.lock omits license metadata"
+reason = "MIT licensed (verified via npm registry); bun.lock omits license metadata"
 
 [[PackageOverrides]]
 name = "actions/download-artifact"
 ecosystem = "GitHub Actions"
 license.override = ["MIT"]
-reason = "MIT licensed GitHub Action pinned by SHA"
+reason = "MIT licensed GitHub Action pinned by SHA; referenced from publish-release-on-tag.yml"
 
 [[PackageOverrides]]
 name = "lgtm-hq/lgtm-ci/.github/actions/setup-node"
 ecosystem = "GitHub Actions"
 license.override = ["MIT"]
-reason = "MIT licensed composite action from lgtm-ci"
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2026-0206"
-ignoreUntil = 2026-10-04
-reason = "rustybuzz — transitive via typst-layout/typst-library/krilla/usvg; informational (unmaintained), no patched version; blocked until typst ecosystem migrates"
+reason = "MIT licensed composite action from lgtm-ci (lgtm-hq/lgtm-ci is MIT). Audit 2026-07-25: no workflow under .github/workflows currently references this action — only secure-checkout, setup-rust and create-github-release — so the override is presently inert. Retained as coverage for when Node CI uses the composite again; drop it if that has not happened by the next audit."

--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -50,6 +50,7 @@
     "@babel/plugin-transform-modules-systemjs": "^8.0.0",
     "@rollup/plugin-terser": "^1.0.0",
     "astro": "^7.1.0",
+    "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "fast-uri": "^4.1.1",
     "h3": "2.0.1-rc.25",
@@ -894,7 +895,7 @@
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "browserslist": ["browserslist@4.28.6", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001803", "electron-to-chromium": "^1.5.389", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw=="],
 
@@ -1822,8 +1823,6 @@
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
-    "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
-
     "hast-util-from-html/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "source-map/whatwg-url/tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
@@ -1843,8 +1842,6 @@
     "@babel/plugin-transform-modules-systemjs/@babel/helper-module-transforms/@babel/traverse/@babel/template": ["@babel/template@8.0.0", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ=="],
 
     "@babel/plugin-transform-modules-systemjs/@babel/helper-module-transforms/@babel/traverse/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
-
-    "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@babel/plugin-transform-modules-systemjs/@babel/helper-module-transforms/@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,6 +59,7 @@
     "typescript": "7.0.2",
     "@rollup/plugin-terser": "^1.0.0",
     "@babel/plugin-transform-modules-systemjs": "^8.0.0",
+    "brace-expansion": "^5.0.8",
     "fast-uri": "^4.1.1",
     "astro": "^7.1.0",
     "esbuild": "^0.28.1",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(deps): clear brace-expansion advisories and re-verify OSV suppressions
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`main` is red at `9c36cd8` on **Security - Dependency Vulnerability Scan** and
**Quality - Lint & Format**, both failing solely on GHSA-mh99-v99m-4gvg. This PR
is the fix, and folds in the suppression/overrides audit from #567.

### osv_scanner counts

Measured with **lintro 0.91.41** (the version #572 pins for CI), run from a clean
lane worktree with no nested `.claude/worktrees/agent-*` checkouts, so the counts
are real repo state and not the inflated ~38 described in #567.

| | Findings | Health |
| --- | --- | --- |
| Before (`9c36cd8`) | **2** | 94/100 |
| After | **0** | 100/100 |

```text
before: [GHSA-mh99-v99m-4gvg] brace-expansion@2.1.2 (fix: 5.0.8)
        [GHSA-mh99-v99m-4gvg] brace-expansion@5.0.7 (fix: 5.0.8)
        ✗ Found 2 issues
after:  ✓ No issues found.
```

Note: #572 (`chore/568-lintro-renovate-pins`) is what pins lintro 0.91.41 for CI and
is not yet merged. This PR deliberately touches none of its files — no `pyproject.toml`,
`uv.lock`, `renovate.json` or workflow changes here.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated — dependency + config change only; gate is the existing suite plus a successful PWA build
- [ ] Docs updated if user-facing — not user-facing
- [x] Local CI passed (`uv run lintro chk`, web + site suites)

## Closes

- Closes #567

## Details

### 1. The bump held — no new suppression needed

Added `"brace-expansion": "^5.0.8"` to `overrides` in `apps/web/package.json`. OSV lists
a single affected range (`introduced: 0` → `fixed: 5.0.8`), so one override clears both
findings. The lockfile diff is minimal and exactly what was intended:

- `brace-expansion@5.0.7` → `5.0.8`
- the nested `filelist/minimatch/brace-expansion@2.1.2` entry (and its `balanced-match@1.0.2`) is gone

Step 2 of the issue (fall back to an `IgnoredVulns` entry if the override breaks the
build) was **not** needed. Evidence the override is safe:

- `bun run build` succeeds; PWA generation still emits `dist/sw.js` (4132 B) and `dist/workbox-6c06881d.js` — this is the at-risk consumer, since the v2 chain is `vite-plugin-pwa → @trickfilm400/rollup-plugin-off-main-thread → ejs → jake → filelist → minimatch@5`
- `bun run test` — **472/472 passing across 58 files**
- `bun run lint` (oxlint, `--max-warnings=0`) and `bun run typecheck` clean
- `apps/site` suite passes unchanged

### 2. IgnoredVulns audit — 7 entries, all blockers still real

The issue says 8; the file actually carries **7**. The 8th (`GHSA-48c2-rrv3-qjmp`) was
already removed in an earlier pass and survives only as a comment.

Every blocker was re-verified against `Cargo.lock`, the crates.io latest release for each
upstream, and the OSV record. **None could be dropped** — but five of the seven are
"unmaintained" notices that OSV publishes with *no fixed version at all*, so they can
never clear by bumping; only an upstream migration retires them. The batch
`ignoreUntil = 2026-10-04` is replaced by per-blocker dates.

| Advisory | Package | Verdict | New date | Why |
| --- | --- | --- | --- | --- |
| RUSTSEC-2024-0320 | yaml-rust | **Kept** | 2027-03-31 | syntect 5.3.0 is the latest release (2025-09-27) and still deps `yaml-rust 0.4.5`. Unmaintained notice, no fixed version. ~10 months since last syntect release → long horizon. |
| RUSTSEC-2025-0141 | bincode | **Kept** | 2027-03-31 | Same upstream: syntect 5.3.0 still deps `bincode 1.3.3`. No fixed version. Re-check with the above. |
| RUSTSEC-2024-0436 | paste | **Kept** | 2026-12-31 | `hayagriva 0.10.1` (latest, 2026-06-14) **and** `biblatex 0.12.0` both dep `paste 1.0.15`. No fixed version, but both crates ship actively → shorter horizon. Old reason named only hayagriva. |
| RUSTSEC-2026-0194 | quick-xml 0.38.4 | **Kept** | 2026-11-30 | **Reason was wrong.** The pin is `citationberg 0.7.0`, not hayagriva: `typst-library → hayagriva 0.10.1 → citationberg 0.7.0 → quick-xml ^0.38`. citationberg 0.7.0 is itself the latest. Fixed in 0.41.0, which is *already in `Cargo.lock`* (via `plist`), so this is a one-line upstream bump. Real DoS + available fix → shortest horizon. |
| RUSTSEC-2026-0195 | quick-xml 0.38.4 | **Kept** | 2026-11-30 | Same chain, same correction, same date. |
| RUSTSEC-2026-0192 | ttf-parser | **Kept** | 2027-06-30 | 0.25.1 is the latest release (2024-11-29); unmaintained, no fixed version. Reached via **8** paths (`typst-layout`/`-library`/`-render`/`-svg`, `usvg`, `fontdb`, `rustybuzz`, `pixglyph`). Old reason said "no fixed version published yet", implying one is coming — it is not. |
| RUSTSEC-2026-0206 | rustybuzz | **Kept** | 2027-06-30 | 0.20.1 is the latest release (2024-11-12); same RazrFalcon upstream and same migration blocker as ttf-parser. Also moved back up with the other `IgnoredVulns` instead of trailing the `PackageOverrides`. |

### 3. PackageOverrides — all 5 license claims verified MIT

Checked against the npm registry and the upstream GitHub repos' license fields:
`astro` MIT, `@astrojs/sitemap` MIT, `@lgtm-hq/turbo-themes` MIT,
`actions/download-artifact` MIT, `lgtm-hq/lgtm-ci` MIT. All claims accurate.

One drift finding: **`lgtm-hq/lgtm-ci/.github/actions/setup-node` is no longer referenced
by any workflow.** The only lgtm-ci composite actions in `.github/workflows` are
`secure-checkout`, `setup-rust` and `create-github-release`. I **kept** the override and
annotated it rather than deleting it — see "Needs a decision" below.

### 4. Overrides audit

Every entry in both `overrides` blocks still maps to a package present in the
corresponding lockfile, so none are dead. `apps/web` carries two extra entries
(`@rollup/plugin-terser`, `@babel/plugin-transform-modules-systemjs`) that have no
counterpart in `apps/site` — correct, as neither package is in the site lockfile.
`apps/site` carries `yaml` that web does not — also correct.

**fast-uri divergence is left alone on purpose:** #557 owns that bump. What the lockfiles
actually resolve to today:

- `apps/web` pins `^4.1.1` → resolves **4.1.1**
- `apps/site` pins `^3.1.4` → resolves **3.1.4**

They do **not** both resolve to 4.1.1 — earlier triage had that wrong. Both are safe
regardless: GHSA-v2hh-gcrm-f6hx has three fixed versions (2.4.3, 3.1.4, 4.1.1), and each
lockfile sits exactly on a patched release, which is why neither fires an advisory. See
"Needs a decision" for a caveat on #557's proposed range.

### Needs a decision (not actioned here)

1. **`setup-node` PackageOverride is inert.** Deleting it is the tidy answer, but I could
   not prove locally that it is harmless: `lintro chk --tools osv_scanner` performs no
   license scanning at either 0.91.41 or the 0.61.0 image CI uses (I verified by removing
   the `actions/download-artifact` override — no license finding appeared). Rather than
   gamble on a P0 unblock PR, I kept it with the audit result recorded in its `reason`.
   Happy to drop it in a follow-up.
2. **#557's `fast-uri: ^4.0.0` for site permits vulnerable versions.** The advisory is
   fixed at 4.1.1, so `^4.0.0` admits vulnerable 4.0.x. Resolution will pick 4.1.1+ in
   practice, so it works, but `^4.1.1` (matching web) states the constraint correctly.

### Why the weekly suppression check never caught this

Confirmed the suspicion in #568's implementation notes: `vuln-suppression-check.yml`
delegates entirely to `lgtm-ci/reusable-vuln-suppression-check` with no repo-side
configuration, and none of the 7 entries had expired (all sat at 2026-10-04, still in the
future). The automation is expiry-driven, so it stays silent for a suppression whose date
is valid but whose blocker has moved — and a batch date makes that the default outcome.
Filed as a follow-up rather than fixed here, since the automation lives in lgtm-ci.

### Not touched

`renovate.json`, `.github/workflows/*`, `pyproject.toml`, `uv.lock` — all owned by #572.
`apps/site/package.json` — fast-uri is owned by #557.

### Unblocks

main, #572, #557, #562, #565, #570.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refreshes dependency-security configuration and upgrades brace-expansion to its patched release.
- Adds a `brace-expansion` override at `^5.0.8` for the web application.
- Updates the Bun lockfile and removes obsolete nested vulnerable resolutions.
- Re-verifies license overrides and assigns advisory-specific suppression review dates.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The patched brace-expansion release remains compatible with its transitive minimatch consumer, and the extended quick-xml suppressions do not cover a parser reachable through the repository’s current templates or resume schema.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .osv-scanner.toml | Reorganizes and documents existing suppressions, assigns advisory-specific expiry dates, and refreshes verified license-override reasons without introducing a reachable security failure. |
| apps/web/package.json | Adds a compatible brace-expansion override that moves vulnerable transitive resolutions onto patched version 5.0.8. |
| apps/web/bun.lock | Resolves brace-expansion at 5.0.8 and removes the obsolete nested 2.1.2 resolution and its balanced-match dependency. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(security): re-verify OSV suppressi..."](https://github.com/lgtm-hq/rustume/commit/1fa6ccbbd42213f32cc3150386107af57d1afe64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47237159)</sub>

<!-- /greptile_comment -->