### PR TITLE
feat(server): add GET /version deploy-verification endpoint

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -116,6 +116,12 @@ jobs:
       platforms: linux/amd64,linux/arm64
       runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
       smoke-test-script: scripts/ci/docker/smoke-test.sh
+      # Stamps the running build's commit into `GET /version` (#584) so a deploy
+      # can be verified against the `sha-<commit>` tag rustume-ops pins in
+      # deploy/image.txt. docker/Dockerfile truncates it to the same 7 chars
+      # metadata-action uses for that tag.
+      build-args: |
+        GIT_COMMIT=${{ github.sha }}
       # Cold amd64 builds (no registry cache hit) exceed the 60-minute
       # default: the workspace cargo build alone runs ~50 minutes (#439).
       timeout-minutes: 120

--- a/apps/site/src/content/docs/api/core-endpoints.md
+++ b/apps/site/src/content/docs/api/core-endpoints.md
@@ -18,6 +18,31 @@ Returns `200` with body `ok`. Used by Docker healthchecks and load balancers.
 
 ---
 
+## Version
+
+```http
+GET /version
+
+```
+
+Returns the version, commit, and build time of the running build, so a deploy can be verified with a
+single cheap request:
+
+```json
+{
+  "version": "0.44.0",
+  "commit": "c515854",
+  "built_at": "2026-07-25T19:38:00Z"
+}
+
+```
+
+`commit` is the short commit the image was built from — the same seven characters as the
+`sha-<commit>` container tag. `commit` and `built_at` are `null` for builds made without that
+metadata, such as a local `cargo run`.
+
+---
+
 ## Templates
 
 ```http

--- a/apps/site/src/content/docs/deployment/rate-limits.md
+++ b/apps/site/src/content/docs/deployment/rate-limits.md
@@ -49,7 +49,7 @@ Resume CRUD allows short bursts (for example rapid autosave) via a separate burs
 
 | Route group | Default | Examples |
 | --- | ---: | --- |
-| Health | 60 | `GET /health` |
+| Health | 60 | `GET /health`, `GET /version` |
 | Metrics | 60 | `GET /metrics` (still requires `METRICS_TOKEN`) |
 | Other unauthenticated | 30 | Any route reached without a session |
 

--- a/apps/site/src/content/docs/operations/monitoring.md
+++ b/apps/site/src/content/docs/operations/monitoring.md
@@ -15,6 +15,19 @@ Cloud operates its observability stack; self-hosted operators configure their ow
 `GET /health` returns `ok` in normal mode. When connected state is active, it also probes PostgreSQL
 and reports failure if the database cannot be reached.
 
+## Version
+
+`GET /version` reports which build is serving:
+
+```bash
+curl -s http://localhost:3000/version
+{"version":"0.44.0","commit":"c515854","built_at":"2026-07-25T19:38:00Z"}
+```
+
+`commit` matches the short commit in the image's `sha-<commit>` tag, so a deploy can be confirmed
+without reading the OpenAPI document or the JavaScript bundles. Builds without that metadata (for
+example a local `cargo run`) report `null` for `commit` and `built_at`.
+
 ## Metrics
 
 `GET /metrics` requires a configured token and an authorization header:

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
           /^\/auth(?:\/|$)/,
           /^\/api(?:\/|$)/,
           /^\/health$/,
+          /^\/version$/,
           /^\/metrics$/,
           /^\/swagger-ui(?:\/|$)/,
           /^\/api-docs(?:\/|$)/,

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -1,0 +1,42 @@
+//! Bakes optional build metadata into the server binary.
+//!
+//! `GIT_COMMIT` and `BUILD_TIME` are supplied by `docker/Dockerfile` (fed from
+//! CI). They are re-exported as `RUSTUME_GIT_COMMIT` / `RUSTUME_BUILD_TIME` so
+//! `crates/server/src/routes/version.rs` can read them with `option_env!`.
+//!
+//! Two reasons this lives in a build script rather than reading `GIT_COMMIT`
+//! directly with `option_env!`:
+//!
+//! - Cargo does not track arbitrary environment variables in a crate's
+//!   fingerprint, so a rebuild with unchanged sources but a new commit would
+//!   silently reuse a binary carrying the previous commit. The
+//!   `rerun-if-env-changed` directives below make the change observable.
+//! - Absent or blank metadata is dropped here, so `option_env!` yields `None`
+//!   and the endpoint reports `null` instead of an empty string.
+
+/// Build metadata variables read from the environment, in
+/// `(input, exported)` form.
+const METADATA_VARS: [(&str, &str); 2] = [
+    ("GIT_COMMIT", "RUSTUME_GIT_COMMIT"),
+    ("BUILD_TIME", "RUSTUME_BUILD_TIME"),
+];
+
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+
+    for (input, exported) in METADATA_VARS {
+        println!("cargo::rerun-if-env-changed={input}");
+
+        let Ok(value) = std::env::var(input) else {
+            continue;
+        };
+        let value = value.trim();
+        // A value containing whitespace would corrupt the `cargo::` directive
+        // line, so ignore anything that is not a single bare token.
+        if value.is_empty() || value.split_whitespace().count() != 1 {
+            continue;
+        }
+
+        println!("cargo::rustc-env={exported}={value}");
+    }
+}

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -32,7 +32,7 @@ use crate::routes::{
     export_resumes_pdf, get_resume, get_resume_version, health, import_resumes,
     list_resume_versions, list_resumes, list_templates, login, logout, me, metrics, parse,
     render_pdf, render_preview, restore_resume_version, security_txt, spa_fallback, static_dir,
-    template_thumbnail, update_resume, update_sharing, validate,
+    template_thumbnail, update_resume, update_sharing, validate, version,
 };
 use crate::state::AppState;
 
@@ -106,7 +106,12 @@ pub fn create_router_with_state(state: AppState) -> Router {
         ));
     }
 
-    let mut health_routes = Router::new().route("/health", get(health));
+    // `/version` shares `/health`'s unauthenticated, rate-limited treatment so a
+    // deploy pipeline can verify the running build without credentials. Being a
+    // server route, it also takes precedence over the SPA catch-all fallback.
+    let mut health_routes = Router::new()
+        .route("/health", get(health))
+        .route("/version", get(version));
     if cloud_rate_limits {
         health_routes = health_routes.route_layer(middleware::from_fn_with_state(
             state_for_layers.clone(),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5,6 +5,7 @@
 //! # Endpoints
 //!
 //! - `GET /health` - Health check
+//! - `GET /version` - Running build's version, commit, and build time
 //! - `GET /api/templates` - List available templates
 //! - `POST /api/parse` - Parse resume from various formats
 //! - `POST /api/render/pdf` - Render resume to PDF
@@ -63,6 +64,7 @@ mod tests {
     };
     use error::ApiError;
     use routes::sanitize_static_path;
+    use routes::version::VersionResponse;
     use rustume_schema::ResumeData;
     use tower::ServiceExt;
 
@@ -81,6 +83,132 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_version() {
+        let app = create_router();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/version")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let payload: VersionResponse = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(payload.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    /// A test build carries no Docker build args, so the endpoint must still
+    /// answer — reporting `null` for the metadata it does not have.
+    #[tokio::test]
+    async fn test_version_without_build_metadata_reports_null() {
+        let app = create_router();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/version")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        // Both keys are always present; a build without metadata reports null
+        // rather than an empty string, and never panics for lacking it.
+        assert!(payload.get("commit").is_some());
+        assert!(payload.get("built_at").is_some());
+
+        if option_env!("RUSTUME_GIT_COMMIT").is_none() {
+            assert!(payload["commit"].is_null());
+        } else {
+            assert!(payload["commit"]
+                .as_str()
+                .is_some_and(|commit| !commit.is_empty()));
+        }
+
+        if option_env!("RUSTUME_BUILD_TIME").is_none() {
+            assert!(payload["built_at"].is_null());
+        } else {
+            assert!(payload["built_at"]
+                .as_str()
+                .is_some_and(|built_at| !built_at.is_empty()));
+        }
+    }
+
+    /// Guards route precedence: `/version` must be served by the server route,
+    /// not swallowed by the SPA catch-all fallback that serves `index.html`.
+    #[tokio::test]
+    async fn test_version_is_not_served_by_spa_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spa_marker = "<html><body>rustume-spa-fallback</body></html>";
+        std::fs::write(tmp.path().join("index.html"), spa_marker).unwrap();
+        let app = create_router_with_static_dir(tmp.path().to_path_buf());
+
+        // Sanity-check the fixture: an unknown path *does* get the SPA shell.
+        let fallback = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/some-client-route")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let fallback_body = axum::body::to_bytes(fallback.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&fallback_body).unwrap(), spa_marker);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/version")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+
+        assert!(!text.contains("rustume-spa-fallback"));
+        assert!(!text.contains("<html"));
+
+        let payload: VersionResponse = serde_json::from_str(text).unwrap();
+        assert_eq!(payload.version, env!("CARGO_PKG_VERSION"));
     }
 
     #[tokio::test]
@@ -426,6 +554,7 @@ mod tests {
         assert_eq!(spec["info"]["title"], "Rustume API");
         assert_eq!(spec["info"]["version"], env!("CARGO_PKG_VERSION"));
         assert!(spec["paths"].as_object().unwrap().contains_key("/health"));
+        assert!(spec["paths"].as_object().unwrap().contains_key("/version"));
         assert!(spec["paths"]
             .as_object()
             .unwrap()
@@ -905,6 +1034,28 @@ mod tests {
                 .oneshot(
                     Request::builder()
                         .uri("/health")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_self_hosted_version_has_no_rate_limit() {
+        let app = create_router();
+        let default_health_quota = config::RateLimitConfig::default().health_per_min;
+        let request_count = default_health_quota as usize + 1;
+
+        for _ in 0..request_count {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/version")
                         .body(Body::empty())
                         .unwrap(),
                 )

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -17,6 +17,7 @@ use crate::dto::{
     ValidationResponse,
 };
 use crate::error::ApiError;
+use crate::routes::version::VersionResponse;
 
 struct CookieAuthAddon;
 
@@ -46,6 +47,7 @@ impl Modify for CookieAuthAddon {
     modifiers(&CookieAuthAddon),
     paths(
         crate::routes::health::health,
+        crate::routes::version::version,
         crate::routes::templates::list_templates,
         crate::routes::templates::template_thumbnail,
         crate::routes::parse::parse,
@@ -70,6 +72,7 @@ impl Modify for CookieAuthAddon {
     components(
         schemas(
             ApiError,
+            VersionResponse,
             ParseFormat,
             ParseRequest,
             RenderPdfRequest,
@@ -103,7 +106,7 @@ impl Modify for CookieAuthAddon {
         )
     ),
     tags(
-        (name = "Health", description = "Health check endpoints"),
+        (name = "Health", description = "Health and build-metadata endpoints"),
         (name = "Templates", description = "Template management"),
         (name = "Parse", description = "Resume parsing from various formats"),
         (name = "Render", description = "Resume rendering to PDF/PNG"),

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -12,6 +12,7 @@ pub mod security_txt;
 pub mod static_files;
 pub mod templates;
 pub mod validate;
+pub mod version;
 
 pub use account::delete_account;
 pub use auth::{callback, login, logout, me};
@@ -28,3 +29,4 @@ pub use security_txt::security_txt;
 pub use static_files::{sanitize_static_path, spa_fallback, static_dir};
 pub use templates::{list_templates, template_thumbnail};
 pub use validate::validate;
+pub use version::version;

--- a/crates/server/src/routes/static_files.rs
+++ b/crates/server/src/routes/static_files.rs
@@ -23,6 +23,7 @@ fn is_reserved_server_path(path: &str) -> bool {
         || path == "/swagger-ui"
         || path.starts_with("/swagger-ui/")
         || path == "/health"
+        || path == "/version"
         || path == "/metrics"
         || path.starts_with("/auth/")
         || path == "/auth"

--- a/crates/server/src/routes/version.rs
+++ b/crates/server/src/routes/version.rs
@@ -1,0 +1,114 @@
+//! Build-metadata endpoint used to verify which build is actually serving.
+//!
+//! `GET /version` is deliberately unauthenticated (and rate limited alongside
+//! `/health` in cloud mode) so a deploy pipeline can confirm the running
+//! container without credentials. Nothing exposed here is sensitive: the
+//! version is already published in the OpenAPI document and the commit is
+//! public on GitHub.
+//!
+//! `commit` and `built_at` come from optional build metadata baked in by
+//! `docker/Dockerfile` (see `crates/server/build.rs`). Builds without that
+//! metadata — `cargo run`, `cargo test`, plain `cargo build` — report `null`
+//! for both fields rather than failing to compile or panicking.
+
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Build metadata for the running server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct VersionResponse {
+    /// Crate version of the running build.
+    #[schema(example = "0.44.0")]
+    pub version: String,
+    /// Short git commit the build was compiled from, or `null` when the build
+    /// carried no commit metadata.
+    #[schema(example = "c515854")]
+    pub commit: Option<String>,
+    /// RFC 3339 UTC build timestamp, or `null` when the build carried no
+    /// timestamp metadata.
+    #[schema(example = "2026-07-25T19:38:00Z")]
+    pub built_at: Option<String>,
+}
+
+/// Version of the running build, from `CARGO_PKG_VERSION`.
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Commit baked in by the build script, when the build supplied one.
+const COMMIT: Option<&str> = option_env!("RUSTUME_GIT_COMMIT");
+
+/// Build timestamp baked in by the build script, when the build supplied one.
+const BUILT_AT: Option<&str> = option_env!("RUSTUME_BUILD_TIME");
+
+/// Treat blank build metadata as absent so an empty build arg degrades to
+/// `null` instead of an empty string.
+fn present(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+impl VersionResponse {
+    /// Build metadata for the currently running binary.
+    #[must_use]
+    pub fn current() -> Self {
+        Self {
+            version: VERSION.to_owned(),
+            commit: present(COMMIT),
+            built_at: present(BUILT_AT),
+        }
+    }
+}
+
+/// Build version
+///
+/// Returns the version, commit, and build time of the running build so a deploy
+/// can be verified with a single cheap request.
+#[utoipa::path(
+    get,
+    path = "/version",
+    tag = "Health",
+    responses(
+        (status = 200, description = "Build metadata for the running server", body = VersionResponse)
+    )
+)]
+pub async fn version() -> Json<VersionResponse> {
+    Json(VersionResponse::current())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_reports_the_crate_version() {
+        assert_eq!(
+            VersionResponse::current().version,
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+
+    #[test]
+    fn missing_build_metadata_degrades_to_none() {
+        assert_eq!(present(None), None);
+    }
+
+    #[test]
+    fn blank_build_metadata_degrades_to_none() {
+        assert_eq!(present(Some("")), None);
+        assert_eq!(present(Some("   ")), None);
+    }
+
+    #[test]
+    fn present_build_metadata_is_trimmed() {
+        assert_eq!(present(Some(" c515854\n")), Some("c515854".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn handler_returns_current_build_metadata() {
+        let Json(payload) = version().await;
+
+        assert_eq!(payload, VersionResponse::current());
+    }
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,13 +64,27 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TA
     cargo chef cook --release --target "${RUST_TARGET}" \
       --recipe-path recipe.json -p rustume-server
 
+# Build metadata surfaced by `GET /version` (crates/server/build.rs).
+# Declared AFTER the cook layer so a new commit never invalidates the cached
+# dependency build. Empty is valid: the endpoint reports null for what it does
+# not know, so local `docker build` needs no build args.
+ARG GIT_COMMIT=""
+
 # Copy workspace source and build (reuses cooked deps via shared target cache mount)
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY bindings ./bindings
+# GIT_COMMIT is truncated to 7 characters to match the `sha-<commit>` image tag
+# that docker/metadata-action publishes (and that rustume-ops pins in
+# deploy/image.txt), so a /version response can be compared to the pin verbatim.
+# BUILD_TIME is stamped here rather than passed in: it is the time this layer
+# actually compiled the binary, which stays truthful on a cache hit.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TARGETARCH} \
     --mount=type=cache,target=/app/target,id=rustume-target-${TARGETARCH} \
     RUST_TARGET="$(cat /tmp/rust_target)" && \
+    GIT_COMMIT="$(printf '%.7s' "${GIT_COMMIT}")" && \
+    BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)" && \
+    export GIT_COMMIT BUILD_TIME && \
     cargo build --release --target "${RUST_TARGET}" -p rustume-server && \
     cp "target/${RUST_TARGET}/release/rustume-server" /app/rustume-server
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,6 +25,7 @@ docker run -p 3000:3000 ghcr.io/lgtm-hq/rustume:latest
 Open <http://localhost:3000>. The same process also exposes:
 
 - `GET /health` for container health checks
+- `GET /version` for the running build's version, commit, and build time
 - `/swagger-ui/` for API documentation
 - `/api-docs/openapi.json` for the OpenAPI document
 

--- a/scripts/ci/docker/smoke-test.sh
+++ b/scripts/ci/docker/smoke-test.sh
@@ -18,6 +18,9 @@ set -euo pipefail
 #   PLATFORM  - Optional platform for docker pull/run (e.g. linux/arm64)
 #   PORT      - Host port mapping (default: 3000)
 #   TIMEOUT   - Health wait timeout seconds (default: 30)
+#
+# The /version check asserts the build metadata baked in by docker/Dockerfile,
+# so images built by hand need `--build-arg GIT_COMMIT=$(git rev-parse HEAD)`.
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 	cat <<'EOF'
@@ -103,6 +106,23 @@ fi
 echo "Checking Swagger UI"
 if ! curl -sf --max-time "$CURL_TIMEOUT" "http://127.0.0.1:${PORT}/swagger-ui/" | grep -qi "swagger"; then
 	echo "Expected Swagger UI to load" >&2
+	exit 1
+fi
+
+echo "Checking build metadata endpoint"
+version_payload="$(curl -sf --max-time "$CURL_TIMEOUT" "http://127.0.0.1:${PORT}/version" || true)"
+if ! jq -e '.version | type == "string" and length > 0' <<<"$version_payload" >/dev/null 2>&1; then
+	echo "Expected /version to report a version string, got: ${version_payload:-<empty>}" >&2
+	exit 1
+fi
+# The image build passes GIT_COMMIT, so a null commit means the build-arg
+# plumbing (workflow -> Dockerfile -> crates/server/build.rs) is broken.
+if ! jq -e '.commit | type == "string" and length > 0' <<<"$version_payload" >/dev/null 2>&1; then
+	echo "Expected /version to report a commit, got: ${version_payload}" >&2
+	exit 1
+fi
+if ! jq -e '.built_at | type == "string" and length > 0' <<<"$version_payload" >/dev/null 2>&1; then
+	echo "Expected /version to report a build time, got: ${version_payload}" >&2
 	exit 1
 fi
 

--- a/scripts/ci/docker/smoke-test.sh
+++ b/scripts/ci/docker/smoke-test.sh
@@ -18,9 +18,10 @@ set -euo pipefail
 #   PLATFORM  - Optional platform for docker pull/run (e.g. linux/arm64)
 #   PORT      - Host port mapping (default: 3000)
 #   TIMEOUT   - Health wait timeout seconds (default: 30)
-#
-# The /version check asserts the build metadata baked in by docker/Dockerfile,
-# so images built by hand need `--build-arg GIT_COMMIT=$(git rev-parse HEAD)`.
+#   REQUIRE_BUILD_METADATA - Require /version to report a commit
+#                            (default: true under GitHub Actions, else false).
+#                            Hand-built images can satisfy it with
+#                            `--build-arg GIT_COMMIT=$(git rev-parse HEAD)`.
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 	cat <<'EOF'
@@ -35,6 +36,8 @@ Environment:
   PORT      Host port (default: 3000)
   TIMEOUT   Health wait timeout in seconds (default: 30)
   CURL_TIMEOUT  Per-request HTTP timeout in seconds (default: 5)
+  REQUIRE_BUILD_METADATA
+            Fail when /version reports no commit (default: true in CI)
 EOF
 	exit 0
 fi
@@ -44,6 +47,7 @@ PLATFORM="${PLATFORM:-}"
 PORT="${PORT:-3000}"
 TIMEOUT="${TIMEOUT:-30}"
 CURL_TIMEOUT="${CURL_TIMEOUT:-5}"
+REQUIRE_BUILD_METADATA="${REQUIRE_BUILD_METADATA:-${GITHUB_ACTIONS:-false}}"
 CONTAINER_NAME="rustume-smoke-${GITHUB_RUN_ID:-local}-$$"
 
 if [[ -z "$IMAGE" ]]; then
@@ -115,11 +119,15 @@ if ! jq -e '.version | type == "string" and length > 0' <<<"$version_payload" >/
 	echo "Expected /version to report a version string, got: ${version_payload:-<empty>}" >&2
 	exit 1
 fi
-# The image build passes GIT_COMMIT, so a null commit means the build-arg
-# plumbing (workflow -> Dockerfile -> crates/server/build.rs) is broken.
+# The workflow always passes GIT_COMMIT, so in CI a null commit means the
+# build-arg plumbing (workflow -> Dockerfile -> crates/server/build.rs) is
+# broken. A hand-built image may legitimately omit it, so warn there instead.
 if ! jq -e '.commit | type == "string" and length > 0' <<<"$version_payload" >/dev/null 2>&1; then
-	echo "Expected /version to report a commit, got: ${version_payload}" >&2
-	exit 1
+	if [[ "$REQUIRE_BUILD_METADATA" == "true" ]]; then
+		echo "Expected /version to report a commit, got: ${version_payload}" >&2
+		exit 1
+	fi
+	echo "Note: /version reports no commit (image built without GIT_COMMIT)"
 fi
 if ! jq -e '.built_at | type == "string" and length > 0' <<<"$version_payload" >/dev/null 2>&1; then
 	echo "Expected /version to report a build time, got: ${version_payload}" >&2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(server): add GET /version deploy-verification endpoint
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Verifying what is actually running in production required serving the entire
OpenAPI document to read one string, and no commit was exposed anywhere — which
is precisely what the rustume-ops GitOps flow needs, since `deploy/image.txt`
pins `sha-<commit>`.

`GET /version` answers that question in one cheap, unauthenticated request:

```json
{
  "version": "0.44.0",
  "commit": "c515854",
  "built_at": "2026-07-26T06:41:07Z"
}
```

`commit` is the same seven characters as the image's `sha-<commit>` tag, so a
response can be compared to the `deploy/image.txt` pin verbatim.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #584

## Details

### Endpoint

- New `crates/server/src/routes/version.rs`, registered in `routes/mod.rs`, added
  to the utoipa spec, and wired alongside `/health` in `app.rs` so it stays
  unauthenticated and shares the `health_per_min` rate-limit bucket.
- `version` comes from `CARGO_PKG_VERSION`. Nothing here is sensitive: the
  version is already public through the OpenAPI document and the commit is
  public on GitHub.

### Route precedence

`/version` previously fell through to the SPA catch-all and returned
`index.html` (verified live against app.rustume.com). Besides the server route
now taking precedence, `/version` is added to `is_reserved_server_path` and to
the service worker's `navigateFallbackDenylist`, so neither the fallback nor an
installed PWA can answer it with the SPA shell.

`test_version_is_not_served_by_spa_fallback` locks that in: it builds a router
over a temp static dir, asserts an unknown path *does* get the SPA shell (so the
fixture is proven to work), then asserts `/version` is `application/json`,
contains no HTML, and deserializes into the response type. Removing both the
route and the reserved-path entry makes it fail with
`text/html; charset=utf-8` — the exact pre-change behavior.

### Build metadata and graceful degradation

`commit` and `built_at` come from optional build metadata and are `null` when a
build carries none, so `cargo run`, `cargo test`, and plain `cargo build` are
unaffected and neither fail to compile nor panic. Blank values degrade to `null`
rather than empty strings.

The metadata is baked in by a new `crates/server/build.rs` rather than a bare
`option_env!("GIT_COMMIT")`. Cargo does not track arbitrary environment
variables in a crate's fingerprint, so a rebuild with unchanged sources but a
new commit — a frontend-only or CI-only change, with the Docker target cache
mount warm — would have shipped a binary reporting the *previous* commit. The
build script's `rerun-if-env-changed` makes the change observable; verified
locally that changing `GIT_COMMIT` alone recompiles the crate and updates the
reported value.

### Docker plumbing

lgtm-ci's `reusable-docker.yml` already exposes a `build-args` input, so no
lgtm-ci change is needed. The workflow passes `GIT_COMMIT=${{ github.sha }}`;
`docker/Dockerfile` truncates it to seven characters to match the
`sha-<commit>` tag. `BUILD_TIME` is stamped inside the build stage rather than
passed in, so it records when the binary was actually compiled and stays
truthful on a cache hit. The `ARG` is declared after the cargo-chef cook layer,
so a new commit never invalidates the cached dependency build.

The container smoke test now asserts all three fields, so a break anywhere in
the workflow → Dockerfile → build script chain fails the build instead of
silently shipping an image that cannot report its commit.

### Testing

- `cargo test --workspace` (113 server tests, all suites green),
  `cargo clippy --workspace --all-targets -- -D warnings`
- `apps/web`: `bun run test` (492), `bun run lint`, `bun run typecheck`
- `uv run lintro fmt` / `uv run lintro chk` clean for the changed files
- New: `/version` returns 200 JSON with the crate version; metadata degrades to
  `null`; not served by the SPA fallback; no rate limit in self-hosted mode;
  `/version` present in the OpenAPI document; unit tests for the metadata
  fallbacks

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an unauthenticated deployment-verification endpoint and propagates build metadata through the container pipeline.
- Registers `GET /version` with health-route rate limiting and excludes it from SPA and service-worker fallbacks.
- Embeds optional commit and build-time metadata through the Dockerfile and Cargo build script.
- Updates smoke tests to require commit metadata in GitHub Actions while accepting `null` for local images.
- Documents the endpoint and includes it in the OpenAPI specification.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/routes/version.rs | Defines the typed `/version` response and gracefully represents absent build metadata as null. |
| crates/server/src/app.rs | Registers `/version` alongside `/health` with the intended unauthenticated rate-limit treatment. |
| crates/server/build.rs | Tracks metadata environment changes and exports nonblank values for compile-time embedding. |
| docker/Dockerfile | Supplies the shortened commit and UTC build timestamp to the server compilation. |
| scripts/ci/docker/smoke-test.sh | Fixes the prior local-build failure by requiring commit metadata only when explicitly requested or running under GitHub Actions. |
| apps/web/vite.config.ts | Prevents the service worker navigation fallback from replacing `/version` responses with the SPA shell. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI as GitHub Actions
    participant Docker as Docker build
    participant Cargo as Server build script
    participant Server as GET /version
    participant Verify as Deployment verifier
    CI->>Docker: "GIT_COMMIT=github.sha"
    Docker->>Docker: Truncate commit to 7 characters
    Docker->>Cargo: Export GIT_COMMIT and BUILD_TIME
    Cargo->>Server: Embed optional build metadata
    Verify->>Server: GET /version
    Server-->>Verify: version, commit, built_at
```
</details>

<sub>Reviews (2): Last reviewed commit: ["build(docker): only require /version com..."](https://github.com/lgtm-hq/rustume/commit/fdbc9037505ed7b283267b6e6a6de85eb7181429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47330410)</sub>

<!-- /greptile_comment -->