### PR TITLE
ci: bump lgtm-ci v0.54.0 to v0.59.16 and pin lintro exactly

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, coverage, release automation,
 and publishing. Most workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`31c25ef2e8992960e218524780e34f44f51271b5` (**v0.54.0** release commit; not the annotated
+`240daf3ed1f7475b3f322502035b15994be210a8` (**v0.59.16** release commit; not the annotated
 tag object SHA). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
@@ -83,9 +83,9 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 Use the **release commit SHA**, not the annotated tag object SHA:
 
 ```yaml
-uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
 with:
-  tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0 release commit
+  tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16 release commit
 ```
 
 Sparse `lgtm-hq` tooling checkouts may use `actions/checkout` when `ref:` is quoted and

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -29,12 +29,12 @@ jobs:
   rerun:
     if: github.event.workflow_run.conclusion == 'failure'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       actions: write
       contents: read
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       # run id/attempt are numbers in the event payload; format() passes them
       # as the strings the reusable workflow inputs expect.
       run-id: ${{ format('{0}', github.event.workflow_run.id) }}

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -18,9 +18,9 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: "🏷️ Create Release Tag"
       version-source: cargo
       create-release: false

--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
         with:
           persist-credentials: false
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -68,7 +68,7 @@ jobs:
         # setup-rust cargo-binstall fix for Windows Git Bash
         # (MINGW64_NT-* was "Unsupported OS", skipping release artifacts).
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -42,12 +42,12 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       contents: read # checkout repository sources for lintro analysis
       packages: read # pull the pinned lintro image from GHCR
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: "🛠️ Lintro Code Quality"
       lintro-tool-options: clippy:timeout=300
       timeout-minutes: 30
@@ -65,14 +65,14 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       contents: read # read quality job outputs and artifacts
       pull-requests: write # post or update the quality summary comment
     with:
       exit-code: >-
         ${{ needs.quality.outputs.exit-code != '' && needs.quality.outputs.exit-code || '1' }}
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: "🛠️ Lintro Code Quality PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,9 +34,9 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: "🔬 CodeQL Analysis"
       languages: actions,rust
       language-build-modes: '{"rust":"none","actions":"none"}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,12 +36,12 @@ jobs:
   # instrumented, as a superset of the old dedicated job's filter.
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: "🦀 Rust Coverage"
       coverage: true
       setup-script: scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -54,12 +54,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,11 +15,11 @@ concurrency:
 jobs:
   review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       job-name: "🔍 Dependency Review"
       fail-on-severity: high
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       egress-policy: block
       egress-preset: github-tooling
       # github-tooling preset + api.deps.dev: dependency-review-action

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
       actions: write
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       # Explicit space-separated (folded scalar) allowlists: the reusable
       # workflow's newline block-scalar defaults are mis-parsed by the
@@ -74,7 +74,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -95,7 +95,7 @@ jobs:
       && needs.classify.outputs.pipeline != 'false'
       && needs.classify.outputs.bump-only != 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       contents: read
       packages: write
@@ -103,7 +103,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -40,7 +40,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       contents: read
       packages: write
@@ -48,7 +48,7 @@ jobs:
       package-name: rustume
       min-age-days: ${{ inputs.min_age_days || 7 }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       egress-policy: audit
       runner-image: ubuntu-24.04
     secrets:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
         with:
           persist-credentials: false
 

--- a/.github/workflows/pin-sync-guard.yml
+++ b/.github/workflows/pin-sync-guard.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -13,11 +13,11 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       job-name: "👤 Auto Assign PR Author"
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,12 +12,12 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       job-name: "🏷️ Auto Label PR"
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -108,7 +108,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       job-name: "🛡️ Scorecard Analysis"
       # v0.54.0 hard-cut the no-op tooling-ref / egress-preset /

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -22,12 +22,12 @@ concurrency:
 jobs:
   security-audit:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       contents: read
       packages: read
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: "Scan dependencies"
       runner-image: ubuntu-24.04
       # yamllint disable-line rule:line-length
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+          ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
           sparse-checkout: |
             scripts/ci/
           sparse-checkout-cone-mode: true
@@ -84,12 +84,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs: security-audit
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       contents: read
       pull-requests: write
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: "💬 Post PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       job-name: "📝 Validate PR Title"
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       egress-policy: block
       egress-preset: github-tooling
       comment-marker: "<!-- semantic-pr-title -->"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -50,12 +50,12 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       ecosystems: rust
       auto-merge: true
       max-bump: minor
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       egress-policy: block
       egress-preset: github-tooling
       # Harden-runner pre reads workflow inputs only (not resolved presets)

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -31,12 +31,12 @@ concurrency:
 jobs:
   site-quality:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     permissions:
       contents: read
       pull-requests: write # required: reusable declares this on internal publish job
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: Build and check documentation site
       test-job-name: Test documentation site
       node-version: '22'

--- a/.github/workflows/test-boundary-shell.yml
+++ b/.github/workflows/test-boundary-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: Boundary Shell Tests
       test-path: tests/bats/unit/boundary
       coverage: true

--- a/.github/workflows/test-docker-shell.yml
+++ b/.github/workflows/test-docker-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: Docker Shell Tests
       test-path: tests/bats/unit/docker
       coverage: true

--- a/.github/workflows/test-maintenance-shell.yml
+++ b/.github/workflows/test-maintenance-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       job-name: Maintenance Shell Tests
       test-path: tests/bats/unit/maintenance
       coverage: true

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -29,10 +29,10 @@ jobs:
     # ruleset check name stays rust-build / 🔨 Build Check — an extra nesting
     # hop would prefix build / and break required-status matching.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       job-name: "🔨 Build Check"
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       draft-pr-skip: true
       egress-policy: block
       egress-preset: quality

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       job-name: '📌 Validate Action Pinning'
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5'  # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8'  # v0.59.16
       egress-policy: block
       egress-preset: github-tooling
       fail-on-error: true

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -19,10 +19,10 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
     with:
       job-name: "🔍 Check Vulnerability Suppressions"
-      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ license = "AGPL-3.0-only"
 dependencies = []
 
 [dependency-groups]
-lint = ["lintro>=0.91.41"]
+# Exact pin, not a floor: an open `>=` range is always satisfied under
+# Renovate's `replace` strategy, so it never proposes a bump and the local
+# venv silently drifts behind the `lintro-image:` pin CI runs (#588).
+lint = ["lintro==0.91.52"]
 test = ["pytest>=8.3"]
 
 [tool.lintro]

--- a/uv.lock
+++ b/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "lintro"
-version = "0.91.41"
+version = "0.91.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -144,9 +144,9 @@ dependencies = [
     { name = "rich" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/90/61159516e2b30a783b94115a130afc6778771b9076cbae92c3296747f30e/lintro-0.91.41.tar.gz", hash = "sha256:1b10996d547bb12966f4a69f0b65ff568795ab597d02de0be57af4ee0e324980", size = 2785300, upload-time = "2026-07-25T13:50:10.93Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/04/c7df2c9313f2c40884c143bb01885cf4c7bee2206568c402224d7549c8d3/lintro-0.91.52.tar.gz", hash = "sha256:50f8451cb69c0d4b3dfdcbed0e35c73393703def384bc0e2e00d507277315c95", size = 2822972, upload-time = "2026-07-26T13:18:00.217Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/ef/cc667570910d58488017aff8ee88183a7f257d12f41f7984be64201f9c07/lintro-0.91.41-py3-none-any.whl", hash = "sha256:ec2c974b60352a431797b4fc4293c941be5e3399247da9996193df67d55bfcad", size = 992020, upload-time = "2026-07-25T13:50:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/491c5d9b0492352f6185bc8a2a88b783d39821d09ce882d774019021ec1e/lintro-0.91.52-py3-none-any.whl", hash = "sha256:8f1118b5fc029c141151092ba7ce5ade41dfc6475397a7060c105c77906a76e6", size = 997718, upload-time = "2026-07-26T13:17:58.107Z" },
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ test = [
 [package.metadata]
 
 [package.metadata.requires-dev]
-lint = [{ name = "lintro", specifier = ">=0.91.41" }]
+lint = [{ name = "lintro", specifier = "==0.91.52" }]
 test = [{ name = "pytest", specifier = ">=8.3" }]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci: bump lgtm-ci v0.54.0 to v0.59.16 and pin lintro exactly
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Two things, both mechanical:

1. **lgtm-ci refs move v0.54.0 → v0.59.16.** Every reference in `.github/` now
   points at the v0.59.16 release commit
   `240daf3ed1f7475b3f322502035b15994be210a8` — `uses:` pins, the `tooling-ref:`
   input values that mirror them, the `ref:` on the sparse tooling checkout in
   `security-dependency-review.yml`, and the pin documentation in
   `.github/workflows/README.md`.
2. **The lintro floor closes.** `pyproject.toml`'s lint group carried
   `lintro>=0.91.41`. Under Renovate's `replace` range strategy an open floor is
   always already satisfied, so Renovate could never propose a bump and the local
   venv silently drifted behind the `lintro-image:` pin CI runs. It is now pinned
   exactly at `lintro==0.91.52`, matching the image in `ci-lintro-analysis.yml`
   and `security-dependency-review.yml`, with `uv.lock` refreshed.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #588

## Details

### Changelog review

Read v0.54.1..v0.59.16 and additionally diffed all 23 consumed reusable
workflows at both tags rather than trusting the changelog alone:

- **No inputs removed** — the only additions are `link-report-artifact-name`
  (`reusable-site-quality`) and `coverage-artifact-name` (`reusable-test-node`).
- **No permission declarations changed**, so no caller grant needs widening.
- The one consumer-visible change, v0.59.15's artifact-name default renames,
  does not affect this repo: nothing downloads `lychee-report` by name, and both
  Pages coverage artifacts are already named explicitly
  (`rust-coverage-html` / `web-coverage-html`).

**No new inputs adopted.** The two additions above are overrides for artifact
names this repo does not consume, and the issue explicitly scopes out
opportunistic workflow rewrites.

### Deliberately not touched

Per #588: `ghcr-cleanup.yml`'s inline `prune-tagged` job, `build-binary.yml`, and
`auto-rerun-on-infra-failure.yml`'s trigger shim all keep their current shape —
only their pins moved.

The `# v0.54.0 hard-cut the no-op tooling-ref …` comment in `scorecards.yml`
also keeps its version reference on purpose: it records *when* those inputs were
removed upstream, not the current pin. It is the only `v0.54.0` string left in
`.github/`, and `pin-sync-guard.yml` confirms every real pin agrees.

### Follow-ups this bump unblocks (not done here)

- `coverage.yml`'s `publish-test-summary: false` on `web-coverage` carries a
  TODO on lgtm-ci#511. That is fixed as of v0.54.3 — `reusable-test-node` now
  passes `COVERAGE` to the summary staging step — so the flag can be flipped
  back to `true`. Left alone here because it changes check behaviour, not pins.
- `reusable-test-e2e-playwright` (new in v0.57.0) is now reachable, which is the
  ordering constraint #588 raised for #486 / #490.

### Verification

- `scripts/ci/maintenance/check-tooling-ref-sync.sh` → 24 tooling-ref pins in sync.
- `uv run lintro fmt` then full `uv run lintro chk`: **0 issues, health 100/100**,
  including the newly active **trufflehog** (lintro 0.88 → 0.89+), which found
  **nothing** — the Railway-UUID false positive seen in rustume-ops did not
  recur, so no `trufflehog:ignore` markers or exclusions were needed.
- `pip-audit` reports a local-only tool crash (`ensurepip` `SIGABRT` while
  building its isolated venv on macOS). It reproduces on a clean tree with the
  same lintro version and is not a finding — CI runs lintro from the
  `py-lintro:0.91.52` image, which is already green on `main`.
- `make test` (cargo workspace + web vitest, 499 tests), `make site-test`,
  `bats -r tests/bats` (40 tests), `uv run pytest tests/scripts` (9 tests) — all pass.
- Local CodeRabbit and Greptile runs: Greptile clean; CodeRabbit raised one
  trivial suggestion to annotate pre-existing `permissions:` lines that this PR
  does not modify — skipped as out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI, security, testing, release, deployment, and maintenance workflows to use the latest pinned tooling release.
  * Improved consistency and reliability across automated project checks and publishing processes.
  * Pinned the linting tool to a specific version to ensure consistent results in local and continuous integration environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the repository’s CI tooling pins and aligns the local lint dependency with the CI image.
- Moves lgtm-ci reusable workflows, actions, and mirrored tooling references from v0.54.0 to v0.59.16.
- Pins lintro exactly at 0.91.52 and refreshes the corresponding lockfile.
- Updates workflow documentation to reflect the new pins.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Replaces the open lintro minimum with an exact 0.91.52 pin matching the changed CI image. |
| uv.lock | Refreshes the locked lintro package and dependency-group specifier for the exact 0.91.52 requirement. |
| .github/workflows/ci-lintro-analysis.yml | Updates reusable workflow references and the lintro image consistently to the new pinned versions. |
| .github/workflows/security-dependency-review.yml | Updates reusable workflow, tooling checkout, and lintro image pins consistently. |
| .github/workflows/README.md | Documents the new lgtm-ci release SHA and exact lintro synchronization policy. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): pin lintro exactly at 0.91...."](https://github.com/lgtm-hq/rustume/commit/a0c6aa84c234368f52ce8703542388f647506f29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47374118)</sub>

<!-- /greptile_comment -->