### PR TITLE
feat(server)!: require authentication on all cloud deployments

### DIFF
--- a/apps/site/src/content/docs/deployment/env-reference.md
+++ b/apps/site/src/content/docs/deployment/env-reference.md
@@ -44,6 +44,13 @@ enabled, these identity and persistence settings are required:
 | `RESEND_API_KEY` | Resend API key; required together with `EMAIL_FROM` to enable transactional email |
 | `EMAIL_FROM` | Sender address for outbound mail (for example `noreply@rustume.com`) |
 
+Connected mode always requires authentication. Render, template, resume, and account
+routes return `401` without a valid session, and there is no setting that re-opens them
+anonymously. Run without `RUSTUME_CLOUD` for an open, self-hosted deployment.
+
+`RUSTUME_REQUIRE_AUTH` was removed and is no longer read. Connected deployments that
+previously left it unset served those routes anonymously and will now return `401`.
+
 Set `TRUSTED_PROXY=true` only when the server is behind a trusted proxy and may rely on
 `X-Forwarded-For` when calling WorkOS. The same flag enables `X-Real-IP` and append-mode
 `X-Forwarded-For` for rate-limit key extraction — see [Rate

--- a/apps/site/src/content/docs/deployment/rate-limits.md
+++ b/apps/site/src/content/docs/deployment/rate-limits.md
@@ -53,8 +53,9 @@ Resume CRUD allows short bursts (for example rapid autosave) via a separate burs
 | Metrics | 60 | `GET /metrics` (still requires `METRICS_TOKEN`) |
 | Other unauthenticated | 30 | Any route reached without a session |
 
-When `RUSTUME_REQUIRE_AUTH=true` (hosted Rustume Cloud), unauthenticated clients cannot reach
-render or connected API routes; the unauthenticated bucket mainly covers probes and stray traffic.
+On cloud deployments (`RUSTUME_CLOUD=true`), authentication is mandatory, so unauthenticated
+clients cannot reach render or connected API routes; the unauthenticated bucket mainly covers
+probes and stray traffic.
 
 ## Bulk export cap
 

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -171,18 +171,13 @@ pub fn cloud_enabled() -> bool {
             .is_some_and(|url| !url.trim().is_empty())
 }
 
-/// Returns `true` when hosted Rustume Cloud should reject anonymous billable API use.
+/// Returns `true` when the server must reject anonymous billable API use.
 ///
-/// Only meaningful when [`cloud_enabled`] is also true.
+/// Cloud implies auth: every cloud deployment is a billable, account-backed
+/// service, so authentication is mandatory and not configurable. Self-hosted
+/// deployments ([`cloud_enabled`] is false) have no accounts and no gate.
 pub fn require_auth_enabled() -> bool {
-    require_auth_from_env(
-        cloud_enabled(),
-        std::env::var("RUSTUME_REQUIRE_AUTH").ok().as_deref(),
-    )
-}
-
-fn require_auth_from_env(cloud: bool, value: Option<&str>) -> bool {
-    cloud && matches!(value.map(str::trim), Some("true" | "1"))
+    cloud_enabled()
 }
 
 /// Shared cloud services (database, auth providers).
@@ -240,17 +235,39 @@ pub async fn init_cloud(config: CloudConfig) -> anyhow::Result<Arc<CloudState>> 
     }))
 }
 
+/// Build a [`CloudState`] backed by a lazy (never-connected) pool for tests that
+/// only need cloud mode to be *on*, not reachable.
+#[cfg(test)]
+pub(crate) fn test_cloud_state() -> Arc<CloudState> {
+    let pool = PgPoolOptions::new()
+        .connect_lazy("postgres://localhost/rustume_test")
+        .expect("lazy pool");
+    Arc::new(CloudState {
+        db: pool.clone(),
+        workos: WorkOsClient::new("client_test".to_string(), "api_key_test".to_string()),
+        sessions: SessionService::new(
+            pool,
+            "test-session-secret-at-least-32-chars".to_string(),
+            false,
+        ),
+        workos_redirect_uri: "http://localhost/auth/callback".to_string(),
+        email: Some(EmailService::new(
+            "re_test_key".to_string(),
+            "noreply@rustume.com".to_string(),
+        )),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn require_auth_from_env_requires_cloud_and_truthy_flag() {
-        assert!(!require_auth_from_env(false, Some("true")));
-        assert!(!require_auth_from_env(true, None));
-        assert!(!require_auth_from_env(true, Some("false")));
-        assert!(require_auth_from_env(true, Some("true")));
-        assert!(require_auth_from_env(true, Some("1")));
+    fn require_auth_is_exactly_cloud_mode() {
+        // Cloud implies auth; self-hosted never gates. There is no configuration
+        // in between, so the two predicates must stay identical. Enforcement is
+        // covered end to end by the router tests in `lib.rs`.
+        assert_eq!(require_auth_enabled(), cloud_enabled());
     }
 
     #[test]

--- a/crates/server/src/cloud.rs
+++ b/crates/server/src/cloud.rs
@@ -264,9 +264,12 @@ mod tests {
 
     #[test]
     fn require_auth_is_exactly_cloud_mode() {
-        // Cloud implies auth; self-hosted never gates. There is no configuration
-        // in between, so the two predicates must stay identical. Enforcement is
-        // covered end to end by the router tests in `lib.rs`.
+        // A parity guard, not a behavioural test: the assertion holds by
+        // construction today and exists to fail the moment anyone reintroduces
+        // a condition between the two — an env flag, a config field, an opt-out.
+        // Cloud implies auth and self-hosted never gates, with nothing in
+        // between. The behaviour itself is covered end to end by the router
+        // tests in `lib.rs` and `middleware::subscription`.
         assert_eq!(require_auth_enabled(), cloud_enabled());
     }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -58,6 +58,7 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
+    use cloud::test_cloud_state;
     use dto::{
         ParseFormat, ParseRequest, RenderPdfRequest, RenderPreviewRequest, TemplateInfo,
         ValidationResponse,
@@ -866,30 +867,6 @@ mod tests {
         );
     }
 
-    fn test_cloud_state() -> std::sync::Arc<cloud::CloudState> {
-        use auth::{session::SessionService, workos::WorkOsClient};
-        use email::EmailService;
-        use sqlx::postgres::PgPoolOptions;
-
-        let pool = PgPoolOptions::new()
-            .connect_lazy("postgres://localhost/rustume_test")
-            .expect("lazy pool");
-        std::sync::Arc::new(cloud::CloudState {
-            db: pool.clone(),
-            workos: WorkOsClient::new("client_test".to_string(), "api_key_test".to_string()),
-            sessions: SessionService::new(
-                pool,
-                "test-session-secret-at-least-32-chars".to_string(),
-                false,
-            ),
-            workos_redirect_uri: "http://localhost/auth/callback".to_string(),
-            email: Some(EmailService::new(
-                "re_test_key".to_string(),
-                "noreply@rustume.com".to_string(),
-            )),
-        })
-    }
-
     fn sample_render_pdf_request() -> RenderPdfRequest {
         RenderPdfRequest {
             resume: serde_json::to_value(ResumeData::default()).unwrap(),
@@ -897,8 +874,12 @@ mod tests {
         }
     }
 
+    /// Cloud mode gates billable routes on cloud presence, not on a flag, so a
+    /// state that advertises `require_auth: false` still rejects anonymous
+    /// requests. This pins the removal of `RUSTUME_REQUIRE_AUTH`: no
+    /// configuration can re-open a cloud deployment.
     #[tokio::test]
-    async fn test_render_pdf_anonymous_ok_when_require_auth_disabled() {
+    async fn test_render_pdf_anonymous_401_on_cloud_even_when_flag_is_off() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
             Some(test_cloud_state()),
@@ -920,11 +901,15 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    // Self-hosted deployments have no accounts and stay open anonymously:
+    // covered by `test_render_pdf` and `test_templates`, which build a
+    // `create_router()` (cloud-less) app and assert 200.
+
     #[tokio::test]
-    async fn test_render_pdf_anonymous_401_when_require_auth_enabled() {
+    async fn test_render_pdf_anonymous_401_on_cloud() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
             Some(test_cloud_state()),
@@ -950,7 +935,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_templates_anonymous_401_when_require_auth_enabled() {
+    async fn test_templates_anonymous_401_on_cloud() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
             Some(test_cloud_state()),
@@ -972,7 +957,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resumes_anonymous_401_when_require_auth_enabled() {
+    async fn test_resumes_anonymous_401_on_cloud() {
         let state = state::AppState::with_require_auth(
             std::sync::Arc::new(routes::static_dir()),
             Some(test_cloud_state()),

--- a/crates/server/src/middleware/auth.rs
+++ b/crates/server/src/middleware/auth.rs
@@ -52,13 +52,18 @@ fn unauthorized(message: &str) -> ApiError {
     ApiError::unauthorized(message)
 }
 
-/// Require a session on billable routes when hosted require-auth mode is enabled.
+/// Require a session on billable routes for every cloud deployment.
+///
+/// Self-hosted deployments have no accounts, so requests pass straight through.
+/// The gate is keyed on cloud presence rather than a configuration flag: on a
+/// billable hosted service, authentication must not be something a missing
+/// environment variable can switch off.
 pub async fn require_auth_when_enabled(
     State(state): State<AppState>,
     request: Request,
     next: Next,
 ) -> Result<Response, ApiError> {
-    if !state.require_auth {
+    if state.cloud.is_none() {
         return Ok(next.run(request).await);
     }
 

--- a/crates/server/src/middleware/subscription.rs
+++ b/crates/server/src/middleware/subscription.rs
@@ -21,14 +21,13 @@ pub async fn require_subscription_render(
     request: Request,
     next: Next,
 ) -> Result<Response, ApiError> {
-    if state.cloud.is_none() {
+    let Some(cloud) = state.cloud.clone() else {
         return Ok(next.run(request).await);
-    }
+    };
 
     let (mut parts, body) = request.into_parts();
     let AuthUser(user) = AuthUser::from_request_parts(&mut parts, &state).await?;
 
-    let cloud = state.cloud()?;
     let access = subscription::load_access(&cloud.db, user.id).await?;
     access.ensure_render()?;
 

--- a/crates/server/src/middleware/subscription.rs
+++ b/crates/server/src/middleware/subscription.rs
@@ -5,9 +5,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
-use axum_extra::extract::CookieJar;
 
-use crate::auth::session::SESSION_COOKIE;
 use crate::error::ApiError;
 use crate::middleware::auth::AuthUser;
 use crate::state::AppState;
@@ -15,9 +13,9 @@ use crate::subscription;
 
 /// Enforce subscription render access for signed-in cloud users.
 ///
-/// Anonymous requests pass through when hosted require-auth is disabled.
-/// Stale session cookies on open deployments also pass through so render stays
-/// available without manual cookie clearing.
+/// Self-hosted deployments have no accounts and pass straight through. On cloud
+/// every request must carry a valid session, so there is no anonymous or
+/// stale-cookie relaxation path.
 pub async fn require_subscription_render(
     State(state): State<AppState>,
     request: Request,
@@ -28,25 +26,66 @@ pub async fn require_subscription_render(
     }
 
     let (mut parts, body) = request.into_parts();
-    let jar = CookieJar::from_request_parts(&mut parts, &state)
-        .await
-        .map_err(|_| ApiError::internal("failed to read cookies"))?;
-
-    if jar.get(SESSION_COOKIE).is_none() && !state.require_auth {
-        return Ok(next.run(Request::from_parts(parts, body)).await);
-    }
-
-    let user = match AuthUser::from_request_parts(&mut parts, &state).await {
-        Ok(AuthUser(user)) => user,
-        Err(_err) if !state.require_auth => {
-            return Ok(next.run(Request::from_parts(parts, body)).await);
-        }
-        Err(err) => return Err(err),
-    };
+    let AuthUser(user) = AuthUser::from_request_parts(&mut parts, &state).await?;
 
     let cloud = state.cloud()?;
     let access = subscription::load_access(&cloud.db, user.id).await?;
     access.ensure_render()?;
 
     Ok(next.run(Request::from_parts(parts, body)).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request as HttpRequest, StatusCode};
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::cloud::test_cloud_state;
+    use crate::routes::static_dir;
+
+    fn app(state: AppState) -> Router {
+        Router::new()
+            .route("/render", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                require_subscription_render,
+            ))
+            .with_state(state)
+    }
+
+    async fn status_for(state: AppState) -> StatusCode {
+        app(state)
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/render")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("router response")
+            .status()
+    }
+
+    /// No anonymous relaxation path survives under cloud, even for a state that
+    /// advertises `require_auth: false`.
+    #[tokio::test]
+    async fn anonymous_cloud_request_is_rejected_even_when_flag_is_off() {
+        let state =
+            AppState::with_require_auth(Arc::new(static_dir()), Some(test_cloud_state()), false);
+
+        assert_eq!(status_for(state).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn anonymous_self_hosted_request_passes_through() {
+        let state = AppState::with_require_auth(Arc::new(static_dir()), None, false);
+
+        assert_eq!(status_for(state).await, StatusCode::OK);
+    }
 }

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -13,7 +13,11 @@ pub struct AppState {
     pub static_dir: Arc<PathBuf>,
     pub cloud: Option<Arc<CloudState>>,
     pub renderer: Arc<TypstRenderer>,
-    /// When true, billable API routes require a valid session (hosted Rustume Cloud).
+    /// Whether this deployment requires a session, as advertised to clients via
+    /// `/auth/me`. Always mirrors cloud mode in production.
+    ///
+    /// This is a reporting value, not the enforcement switch: the middleware
+    /// gates on cloud presence so no flag can re-open a billable deployment.
     pub require_auth: bool,
     /// In-memory rate limiters (cloud mode only).
     pub rate_limits: Option<Arc<RateLimitState>>,
@@ -35,7 +39,7 @@ impl AppState {
         }
     }
 
-    /// Build application state with an explicit require-auth flag (tests).
+    /// Build application state with an explicit advertised require-auth flag (tests).
     #[cfg(test)]
     pub fn with_require_auth(
         static_dir: Arc<PathBuf>,


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(server)!: require authentication on all cloud deployments
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [x] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Cloud deployments permitted anonymous billable API use unless
`RUSTUME_REQUIRE_AUTH` was explicitly set to `true`/`1`. With the variable unset,
`require_auth_from_env` returned `false`, `require_auth_when_enabled`
short-circuited before any session check, and every guarded route — render,
templates, resumes, account — was reachable with no session. Forgetting one
environment variable silently disabled authentication on a billable hosted
service. The safe default was inverted.

Cloud now implies auth. `require_auth_enabled()` is `cloud_enabled()`, and
`RUSTUME_REQUIRE_AUTH` is removed rather than deprecated (owner decision recorded
on #591): a flag that can only weaken security does not stay.

Self-hosted deployments (`RUSTUME_CLOUD` unset) are untouched — no accounts, no
gate.

### Reproduced before fixing

Against `main`, with `RUSTUME_CLOUD=true` and `DATABASE_URL` set but
`RUSTUME_REQUIRE_AUTH` unset, an anonymous `POST /api/render/pdf` returned
**200**. With this branch the same request returns **401**.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #591

## Details

### The `!state.require_auth` short-circuit — dropped

Issue #591 asks which choice was made and why. **Both short-circuits were dropped
and replaced with a cloud-presence check** (`state.cloud.is_none()`):

- `middleware/auth.rs` — a pass-through is still required, otherwise self-hosted
  requests would hit `state.cloud()` and get a 404 on every guarded route. But
  keying it to `state.cloud` rather than a boolean makes the gate structural: no
  flag, env var, or misconfiguration can re-open a cloud deployment. Keeping it
  keyed on `require_auth` would have preserved exactly the shape of switch this
  issue exists to delete.
- `middleware/subscription.rs` — both relaxation branches are gone outright. The
  existing `cloud.is_none()` guard above them already covers self-hosted, so the
  anonymous and stale-cookie paths were only reachable under
  cloud-without-auth — impossible under the new contract.

`AppState::require_auth` is retained, along with `with_require_auth` /
`with_options` taking an explicit flag, per the issue's scope note. It is now
purely the value advertised to clients via `/auth/me` (which the web app reads);
it no longer controls enforcement, and its doc comment says so.

### Breaking change

**Affected group: self-hosters running cloud mode without auth.** A deployment
with `RUSTUME_CLOUD=true` that never set `RUSTUME_REQUIRE_AUTH` (or set it to
`false`) served render, template, resume, and account routes anonymously. Those
routes now return `401`. Operators who want an open deployment should run
self-hosted mode (`RUSTUME_CLOUD` unset) instead.

`app.rustume.com` already sets the flag, so production behaviour does not change.

`CHANGELOG.md` is not edited here — it is generated by `lgtm-release-bot` from
conventional commits, so the `BREAKING CHANGE:` footer on the implementing commit
is the input. The operator-facing warning is added to the environment reference
doc instead.

### Testing strategy

Rewritten rather than deleted, per the issue:

- `cloud.rs` — the `require_auth_from_env` table encoded the old contract. It is
  replaced by a parity guard asserting `require_auth_enabled() == cloud_enabled()`,
  which fails the moment anyone reintroduces a condition between the two.
- `lib.rs` — `test_render_pdf_anonymous_ok_when_require_auth_disabled` asserted
  the vulnerability (cloud + flag off → 200). It now asserts **401** for the same
  state, pinning that the removed variable cannot re-open the gate.
- `middleware/subscription.rs` — new isolation tests: anonymous cloud request is
  rejected even when the state advertises `require_auth: false`; anonymous
  self-hosted request passes through.
- Self-hosted anonymous access staying at 200 is covered by the existing
  `test_render_pdf` and `test_templates`, which build a cloud-less router.

`test_cloud_state` moved from `lib.rs` into `cloud.rs` as `pub(crate)` so the
subscription tests reuse it rather than adding a fourth copy.

### Local verification

- `make test` — exit 0 (Rust workspace + 499 web tests)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `uv run lintro chk` — 0 issues, health 100/100
- Local AI review: Greptile (5/5, no comments) and CodeRabbit, run via CLI rather
  than the CI bots

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Cloud deployments now require authentication based on cloud-state presence rather than an optional environment flag.
- Removes `RUSTUME_REQUIRE_AUTH` from authentication enforcement.
- Rejects anonymous and stale-session requests on cloud render routes while preserving anonymous self-hosted access.
- Retains `AppState.require_auth` only as a client-facing reporting value.
- Updates regression tests and deployment documentation for the new mandatory-authentication contract.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with cloud authentication consistently enforced and self-hosted anonymous access preserved.

The changed middleware derives enforcement from the same cloud-state boundary used during production startup, and the updated tests cover anonymous cloud rejection and self-hosted pass-through without revealing a concrete regression.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/server/src/cloud.rs | Makes cloud mode and mandatory authentication share the same activation predicate and adds reusable cloud test state. |
| crates/server/src/middleware/auth.rs | Enforces sessions whenever cloud state exists while continuing to bypass authentication for self-hosted mode. |
| crates/server/src/middleware/subscription.rs | Removes cloud-mode anonymous and stale-cookie relaxation paths while retaining the self-hosted bypass. |
| crates/server/src/state.rs | Clarifies that require_auth is client-facing state rather than the middleware enforcement switch. |
| crates/server/src/lib.rs | Replaces opt-out behavior tests with regression coverage proving cloud routes reject anonymous requests. |
| apps/site/src/content/docs/deployment/env-reference.md | Documents mandatory authentication in connected mode and removal of RUSTUME_REQUIRE_AUTH. |
| apps/site/src/content/docs/deployment/rate-limits.md | Aligns rate-limit documentation with mandatory cloud authentication. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    R[Incoming guarded request] --> C{Cloud state present?}
    C -- No --> S[Allow self-hosted request]
    C -- Yes --> A[Resolve session cookie]
    A --> V{Valid authenticated user?}
    V -- No --> U[Return 401 Unauthorized]
    V -- Yes --> G{Subscription-gated render route?}
    G -- No --> H[Run route handler]
    G -- Yes --> P[Load subscription access]
    P --> E{Render access allowed?}
    E -- No --> F[Return 403 Forbidden]
    E -- Yes --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(deployment): document that connecte..."](https://github.com/lgtm-hq/rustume/commit/e3b3e681d81ac0f0351f9d14b1247ac24cd97d13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47377419)</sub>

<!-- /greptile_comment -->