### PR TITLE
feat(web): add folder scopes to the library sidebar

### DIFF
--- a/apps/web/src/lib/__tests__/homeFolders.test.ts
+++ b/apps/web/src/lib/__tests__/homeFolders.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getStoredFolders,
+  HOME_FOLDERS_STORAGE_KEY,
+  MAX_FOLDER_NAME_LENGTH,
+  mergeFolderNames,
+  normalizeFolderName,
+  setStoredFolders,
+} from "../homeFolders";
+
+describe("normalizeFolderName", () => {
+  it.each([
+    { input: "  Applications  ", expected: "Applications" },
+    { input: "Job  Search", expected: "Job Search" },
+    { input: "Job\tSearch", expected: "Job Search" },
+    { input: "   ", expected: "" },
+    { input: "", expected: "" },
+  ])("normalizes '$input' to '$expected'", ({ input, expected }) => {
+    expect(normalizeFolderName(input)).toBe(expected);
+  });
+
+  it("caps names at the maximum length so one folder stays one rail row", () => {
+    const name = normalizeFolderName("x".repeat(MAX_FOLDER_NAME_LENGTH + 25));
+    expect(name).toHaveLength(MAX_FOLDER_NAME_LENGTH);
+  });
+});
+
+describe("mergeFolderNames", () => {
+  it("unions the remembered names with the ones resumes are filed into", () => {
+    expect(mergeFolderNames(["Consulting"], ["Applications"])).toEqual([
+      "Applications",
+      "Consulting",
+    ]);
+  });
+
+  it("dedupes case-insensitively, keeping the first spelling seen", () => {
+    expect(mergeFolderNames(["Applications"], ["applications", "APPLICATIONS"])).toEqual([
+      "Applications",
+    ]);
+  });
+
+  it("drops blank entries rather than offering an unnameable folder", () => {
+    expect(mergeFolderNames(["", "   ", "Applications"])).toEqual(["Applications"]);
+  });
+
+  it("sorts for a stable rail order regardless of source order", () => {
+    expect(mergeFolderNames(["Zeta", "alpha"], ["Mid"])).toEqual(["alpha", "Mid", "Zeta"]);
+  });
+});
+
+describe("folder name storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("round-trips remembered folders", () => {
+    setStoredFolders(["Applications", "Consulting"]);
+    expect(getStoredFolders()).toEqual(["Applications", "Consulting"]);
+  });
+
+  it("reads no folders when nothing has been stored", () => {
+    expect(getStoredFolders()).toEqual([]);
+  });
+
+  it("falls back to no folders when the stored value is corrupt", () => {
+    localStorage.setItem(HOME_FOLDERS_STORAGE_KEY, "{not json");
+    expect(getStoredFolders()).toEqual([]);
+  });
+
+  it("ignores non-string entries rather than surfacing them as folders", () => {
+    localStorage.setItem(HOME_FOLDERS_STORAGE_KEY, JSON.stringify(["Applications", 7, null]));
+    expect(getStoredFolders()).toEqual(["Applications"]);
+  });
+});

--- a/apps/web/src/lib/__tests__/homeScope.test.ts
+++ b/apps/web/src/lib/__tests__/homeScope.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  folderScope,
   isSameScope,
   matchesScope,
   scopeLabel,
@@ -35,6 +36,25 @@ describe("homeScope membership", () => {
     expect(matchesScope(resume({ tags: ["design"] }), tagScope("backend"))).toBe(false);
     expect(matchesScope(resume(), tagScope("backend"))).toBe(false);
   });
+
+  it("keeps only resumes filed in a folder in that folder scope", () => {
+    expect(matchesScope(resume({ folder: "Applications" }), folderScope("Applications"))).toBe(
+      true,
+    );
+    expect(matchesScope(resume({ folder: "Consulting" }), folderScope("Applications"))).toBe(false);
+    // Unfiled resumes belong to no folder scope, only to All.
+    expect(matchesScope(resume(), folderScope("Applications"))).toBe(false);
+    expect(matchesScope(resume(), SCOPE_ALL)).toBe(true);
+  });
+
+  it("treats folders as mutually exclusive rather than tag-shaped", () => {
+    const filed = resume({ folder: "Applications", tags: ["backend", "design"] });
+    // A resume carries many tags but exactly one folder.
+    expect(matchesScope(filed, tagScope("backend"))).toBe(true);
+    expect(matchesScope(filed, tagScope("design"))).toBe(true);
+    expect(matchesScope(filed, folderScope("Applications"))).toBe(true);
+    expect(matchesScope(filed, folderScope("Consulting"))).toBe(false);
+  });
 });
 
 describe("homeScope identity", () => {
@@ -45,6 +65,11 @@ describe("homeScope identity", () => {
     { a: tagScope("backend"), b: tagScope("backend"), expected: true },
     { a: tagScope("backend"), b: tagScope("design"), expected: false },
     { a: tagScope("backend"), b: SCOPE_ALL, expected: false },
+    { a: folderScope("Applications"), b: folderScope("Applications"), expected: true },
+    { a: folderScope("Applications"), b: folderScope("Consulting"), expected: false },
+    { a: folderScope("Applications"), b: SCOPE_ALL, expected: false },
+    // A folder and a tag of the same name are different scopes.
+    { a: folderScope("backend"), b: tagScope("backend"), expected: false },
   ])("compares $a.kind with $b.kind as $expected", ({ a, b, expected }) => {
     expect(isSameScope(a, b)).toBe(expected);
   });
@@ -55,6 +80,7 @@ describe("homeScope labels", () => {
     { scope: SCOPE_ALL, expected: "all" },
     { scope: SCOPE_LOCKED, expected: "locked" },
     { scope: tagScope("backend"), expected: "#backend" },
+    { scope: folderScope("Applications"), expected: "/Applications" },
   ])("labels $scope.kind as $expected", ({ scope, expected }) => {
     expect(scopeLabel(scope)).toBe(expected);
   });

--- a/apps/web/src/lib/__tests__/homeScope.test.ts
+++ b/apps/web/src/lib/__tests__/homeScope.test.ts
@@ -47,6 +47,17 @@ describe("homeScope membership", () => {
     expect(matchesScope(resume(), SCOPE_ALL)).toBe(true);
   });
 
+  it("matches a folder however the assignment happens to be capitalised", () => {
+    // The rail collapses these into one row, so matching must collapse too or
+    // the row's count and its contents disagree.
+    expect(matchesScope(resume({ folder: "applications" }), folderScope("Applications"))).toBe(
+      true,
+    );
+    expect(matchesScope(resume({ folder: "  Applications " }), folderScope("Applications"))).toBe(
+      true,
+    );
+  });
+
   it("treats folders as mutually exclusive rather than tag-shaped", () => {
     const filed = resume({ folder: "Applications", tags: ["backend", "design"] });
     // A resume carries many tags but exactly one folder.
@@ -67,6 +78,7 @@ describe("homeScope identity", () => {
     { a: tagScope("backend"), b: SCOPE_ALL, expected: false },
     { a: folderScope("Applications"), b: folderScope("Applications"), expected: true },
     { a: folderScope("Applications"), b: folderScope("Consulting"), expected: false },
+    { a: folderScope("Applications"), b: folderScope("applications"), expected: true },
     { a: folderScope("Applications"), b: SCOPE_ALL, expected: false },
     // A folder and a tag of the same name are different scopes.
     { a: folderScope("backend"), b: tagScope("backend"), expected: false },

--- a/apps/web/src/lib/homeFolders.ts
+++ b/apps/web/src/lib/homeFolders.ts
@@ -1,0 +1,71 @@
+/**
+ * The set of folders offered in the scope rail.
+ *
+ * Folder *assignment* lives on the resume itself (`metadata.folder`), so it
+ * travels with the resume through both the local and the cloud save path. That
+ * alone cannot represent a folder nobody has filed anything into yet, so the
+ * names are additionally remembered here: without it, `+ New folder` would
+ * create something that vanishes on the next render.
+ *
+ * The two sources are unioned on read, which keeps assignments authoritative —
+ * a folder arriving from another device still appears even though this device
+ * never stored its name.
+ */
+export const HOME_FOLDERS_STORAGE_KEY = "rustume:home-folders";
+
+/** Long enough for a real label, short enough to stay one rail row. */
+export const MAX_FOLDER_NAME_LENGTH = 60;
+
+/**
+ * Canonical form of a user-typed folder name.
+ *
+ * Interior runs of whitespace collapse so "Job  Search" and "Job Search" are
+ * one folder rather than two that look identical in the rail.
+ */
+export function normalizeFolderName(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim().slice(0, MAX_FOLDER_NAME_LENGTH);
+}
+
+/** Read the remembered folder names. Unusable storage reads as "none". */
+export function getStoredFolders(): string[] {
+  if (typeof localStorage === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(HOME_FOLDERS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is string => typeof entry === "string");
+  } catch {
+    // Corrupt or unavailable storage (private browsing, tests) — fall back to
+    // the folders derivable from assignments rather than throwing on mount.
+    return [];
+  }
+}
+
+export function setStoredFolders(folders: readonly string[]): void {
+  try {
+    localStorage.setItem(HOME_FOLDERS_STORAGE_KEY, JSON.stringify([...folders]));
+  } catch {
+    // localStorage may be unavailable in private browsing or tests
+  }
+}
+
+/**
+ * Union folder names into one display order.
+ *
+ * Dedupes case-insensitively so "Applications" and "applications" collapse to
+ * the first spelling seen rather than presenting the user two rows they cannot
+ * tell apart. Sorted case-insensitively for the same reason.
+ */
+export function mergeFolderNames(...sources: readonly (readonly string[])[]): string[] {
+  const seen = new Map<string, string>();
+  for (const source of sources) {
+    for (const entry of source) {
+      const name = normalizeFolderName(entry);
+      if (!name) continue;
+      const key = name.toLocaleLowerCase();
+      if (!seen.has(key)) seen.set(key, name);
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.localeCompare(b));
+}

--- a/apps/web/src/lib/homeFolders.ts
+++ b/apps/web/src/lib/homeFolders.ts
@@ -26,6 +26,16 @@ export function normalizeFolderName(raw: string): string {
   return raw.replace(/\s+/g, " ").trim().slice(0, MAX_FOLDER_NAME_LENGTH);
 }
 
+/**
+ * Identity of a folder, independent of how it happens to be capitalised.
+ *
+ * Two spellings that differ only in case are one folder everywhere: in the
+ * rail, in the counts, and in what a folder scope matches.
+ */
+export function folderKey(name: string): string {
+  return normalizeFolderName(name).toLocaleLowerCase();
+}
+
 /** Read the remembered folder names. Unusable storage reads as "none". */
 export function getStoredFolders(): string[] {
   if (typeof localStorage === "undefined") return [];
@@ -63,7 +73,7 @@ export function mergeFolderNames(...sources: readonly (readonly string[])[]): st
     for (const entry of source) {
       const name = normalizeFolderName(entry);
       if (!name) continue;
-      const key = name.toLocaleLowerCase();
+      const key = folderKey(name);
       if (!seen.has(key)) seen.set(key, name);
     }
   }

--- a/apps/web/src/lib/homeScope.ts
+++ b/apps/web/src/lib/homeScope.ts
@@ -10,7 +10,8 @@ import type { ResumeListItem } from "../stores/persistence";
 export type HomeScope =
   | { readonly kind: "all" }
   | { readonly kind: "locked" }
-  | { readonly kind: "tag"; readonly tag: string };
+  | { readonly kind: "tag"; readonly tag: string }
+  | { readonly kind: "folder"; readonly folder: string };
 
 /** The whole library — the default, and the state every other scope clears to. */
 export const SCOPE_ALL: HomeScope = { kind: "all" };
@@ -23,12 +24,27 @@ export function tagScope(tag: string): HomeScope {
   return { kind: "tag", tag };
 }
 
+/**
+ * Narrow the library to a single folder.
+ *
+ * Folders are mutually exclusive — a resume is in exactly one or none — which is
+ * what separates them from tags rather than a second flavour of the same thing.
+ */
+export function folderScope(folder: string): HomeScope {
+  return { kind: "folder", folder };
+}
+
 /** Structural equality, so a control can tell whether it is the active scope. */
 export function isSameScope(a: HomeScope, b: HomeScope): boolean {
-  if (a.kind === "tag" || b.kind === "tag") {
-    return a.kind === "tag" && b.kind === "tag" && a.tag === b.tag;
+  if (a.kind !== b.kind) return false;
+  switch (a.kind) {
+    case "tag":
+      return a.tag === (b as Extract<HomeScope, { kind: "tag" }>).tag;
+    case "folder":
+      return a.folder === (b as Extract<HomeScope, { kind: "folder" }>).folder;
+    default:
+      return true;
   }
-  return a.kind === b.kind;
 }
 
 /** Whether a resume belongs to the given scope. */
@@ -40,6 +56,8 @@ export function matchesScope(resume: ResumeListItem, scope: HomeScope): boolean 
       return Boolean(resume.locked);
     case "tag":
       return (resume.tags ?? []).includes(scope.tag);
+    case "folder":
+      return resume.folder === scope.folder;
   }
 }
 
@@ -52,5 +70,7 @@ export function scopeLabel(scope: HomeScope): string {
       return "locked";
     case "tag":
       return `#${scope.tag}`;
+    case "folder":
+      return `/${scope.folder}`;
   }
 }

--- a/apps/web/src/lib/homeScope.ts
+++ b/apps/web/src/lib/homeScope.ts
@@ -1,3 +1,4 @@
+import { folderKey } from "./homeFolders";
 import type { ResumeListItem } from "../stores/persistence";
 
 /**
@@ -41,7 +42,9 @@ export function isSameScope(a: HomeScope, b: HomeScope): boolean {
     case "tag":
       return a.tag === (b as Extract<HomeScope, { kind: "tag" }>).tag;
     case "folder":
-      return a.folder === (b as Extract<HomeScope, { kind: "folder" }>).folder;
+      return (
+        folderKey(a.folder) === folderKey((b as Extract<HomeScope, { kind: "folder" }>).folder)
+      );
     default:
       return true;
   }
@@ -57,7 +60,10 @@ export function matchesScope(resume: ResumeListItem, scope: HomeScope): boolean 
     case "tag":
       return (resume.tags ?? []).includes(scope.tag);
     case "folder":
-      return resume.folder === scope.folder;
+      // Compared by canonical key: the rail collapses folders that differ only
+      // in case into one row, so matching must collapse them the same way or a
+      // row's count and its contents disagree.
+      return Boolean(resume.folder) && folderKey(resume.folder ?? "") === folderKey(scope.folder);
   }
 }
 

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -928,6 +928,7 @@ describe("Home folder scopes", () => {
   it("carries every filed resume across when a folder is renamed", async () => {
     openRail();
 
+    fireEvent.click(screen.getByTestId("home-scope-folder-Applications"));
     fireEvent.click(screen.getByTestId("home-scope-folder-rename-Applications"));
     const input = screen.getByTestId("home-scope-folder-rename-input");
     fireEvent.input(input, { target: { value: "Job Search" } });
@@ -939,6 +940,8 @@ describe("Home folder scopes", () => {
     // Rename preserves assignment: both filed resumes move, the unfiled one does not.
     expect(patchResumeListMetaMock).toHaveBeenCalledWith("2", { folder: "Job Search" });
     expect(patchResumeListMetaMock).not.toHaveBeenCalledWith("3", expect.anything());
+    // The active scope follows the rename rather than dumping the user in All.
+    expect(screen.getByTestId("home-status-view")).toHaveTextContent("scope: /Job Search");
   });
 
   it("unfiles rather than deletes the resumes in a deleted folder", async () => {
@@ -954,9 +957,11 @@ describe("Home folder scopes", () => {
       expect(patchResumeListMetaMock).toHaveBeenCalledWith("1", { folder: null });
     });
     expect(patchResumeListMetaMock).toHaveBeenCalledWith("2", { folder: null });
-    // The whole point: the resumes survive.
+    // The whole point: unfiling is the only write, the resumes are never deleted.
     expect(resumeListMock.deleteResume).not.toHaveBeenCalled();
-    expect(screen.getAllByTestId("resume-card")).toHaveLength(3);
+    for (const [, patch] of patchResumeListMetaMock.mock.calls) {
+      expect(patch).toEqual({ folder: null });
+    }
   });
 
   it("keeps the folder when the delete confirmation is declined", () => {
@@ -992,6 +997,49 @@ describe("Home folder scopes", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Show all resumes" }));
     expect(screen.getAllByTestId("resume-card")).toHaveLength(3);
+  });
+
+  it("refuses a rename onto a folder that already exists", async () => {
+    openRail();
+
+    fireEvent.click(screen.getByTestId("home-scope-folder-new"));
+    const create = screen.getByTestId("home-scope-folder-input");
+    fireEvent.input(create, { target: { value: "Consulting" } });
+    fireEvent.submit(create);
+    await waitFor(() => {
+      expect(screen.getByTestId("home-scope-folder-Consulting")).toBeInTheDocument();
+    });
+
+    // Differs only in case, so it would read as a second identical row.
+    fireEvent.click(screen.getByTestId("home-scope-folder-rename-Applications"));
+    const rename = screen.getByTestId("home-scope-folder-rename-input");
+    fireEvent.input(rename, { target: { value: "consulting" } });
+    fireEvent.submit(rename);
+
+    expect(patchResumeListMetaMock).not.toHaveBeenCalled();
+    // The editor stays open on the rejected name so it can be corrected.
+    expect(screen.getByTestId("home-scope-folder-rename-input")).toBeInTheDocument();
+  });
+
+  it("counts and filters a folder the same way when casing differs", () => {
+    listState.items = [
+      { id: "1", name: "One", updatedAt: new Date("2025-01-01"), folder: "Applications" },
+      { id: "2", name: "Two", updatedAt: new Date("2025-02-01"), folder: "applications" },
+    ];
+    openRail();
+
+    // One row, and its count must match what selecting it actually shows.
+    expect(screen.getByTestId("home-scope-folder-count-Applications")).toHaveTextContent("2");
+    fireEvent.click(screen.getByTestId("home-scope-folder-Applications"));
+    expect(screen.getAllByTestId("resume-card")).toHaveLength(2);
+  });
+
+  it("hides the card folder control until a folder exists to file into", () => {
+    listState.items = [{ id: "1", name: "One", updatedAt: new Date("2025-01-01") }];
+
+    renderHome();
+
+    expect(screen.queryByTestId("resume-folder-select")).not.toBeInTheDocument();
   });
 
   it("has no axe violations with folders in the rail", async () => {

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -1042,6 +1042,25 @@ describe("Home folder scopes", () => {
     expect(screen.queryByTestId("resume-folder-select")).not.toBeInTheDocument();
   });
 
+  it("keeps Tab inside the drawer when the folder field is the last control", () => {
+    // No tags, so nothing focusable follows the folder field in the rail.
+    listState.items = [{ id: "1", name: "One", updatedAt: new Date("2025-01-01") }];
+    stubNarrowViewport();
+    renderHome();
+    fireEvent.click(screen.getByTestId("home-sidebar-toggle"));
+
+    fireEvent.click(screen.getByTestId("home-scope-folder-new"));
+    const input = screen.getByTestId("home-scope-folder-input");
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    // Tabbing off the last focusable element wraps to the first one rather
+    // than escaping into the app behind the scrim.
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(document.activeElement).toBe(screen.getByTestId("home-sidebar-new"));
+  });
+
   it("has no axe violations with folders in the rail", async () => {
     localStorage.setItem(HOME_SIDEBAR_STORAGE_KEY, HomeSidebarState.Open);
 

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -5,6 +5,7 @@ import { axeConfig } from "../../test/a11y";
 import { Route, Router } from "@solidjs/router";
 import { HOME_LAYOUT_STORAGE_KEY, HomeLayout } from "../../lib/homeLayout";
 import { HOME_SIDEBAR_STORAGE_KEY, HomeSidebarState } from "../../lib/homeSidebar";
+import { HOME_FOLDERS_STORAGE_KEY } from "../../lib/homeFolders";
 import type { ResumeListItem } from "../../stores/persistence";
 import Home from "../Home";
 
@@ -26,8 +27,15 @@ const mockResumes = vi.hoisted(() => {
       updatedAt: new Date("2025-01-01"),
       headline: "Staff Platform Engineer",
       tags: ["backend"],
+      folder: "Applications",
     },
-    { id: "2", name: "Product Manager", updatedAt: new Date("2025-02-01"), locked: true },
+    {
+      id: "2",
+      name: "Product Manager",
+      updatedAt: new Date("2025-02-01"),
+      locked: true,
+      folder: "Applications",
+    },
     {
       id: "3",
       name: "Jane Doe — Designer",
@@ -106,6 +114,7 @@ function resetHomeState() {
   sessionStorage.clear();
   localStorage.removeItem(HOME_LAYOUT_STORAGE_KEY);
   localStorage.removeItem(HOME_SIDEBAR_STORAGE_KEY);
+  localStorage.removeItem(HOME_FOLDERS_STORAGE_KEY);
   listState.items = mockResumes;
   openModalMock.mockClear();
   patchResumeListMetaMock.mockClear();
@@ -828,6 +837,147 @@ describe("Home accessibility", () => {
     const { container } = renderHome();
 
     expect(screen.getByTestId("home-scope-rail")).toBeInTheDocument();
+    expect(await axe(container, axeConfig)).toHaveNoViolations();
+  });
+});
+
+describe("Home folder scopes", () => {
+  beforeEach(resetHomeState);
+
+  function openRail() {
+    localStorage.setItem(HOME_SIDEBAR_STORAGE_KEY, HomeSidebarState.Open);
+    renderHome();
+    return screen.getByTestId("home-scope-rail");
+  }
+
+  it("lists folders derived from what resumes are filed into, with counts", () => {
+    openRail();
+
+    expect(screen.getByTestId("home-scope-folder-Applications")).toHaveTextContent("/Applications");
+    expect(screen.getByTestId("home-scope-folder-count-Applications")).toHaveTextContent("2");
+  });
+
+  it("reports the resumes that are in no folder at all", () => {
+    openRail();
+
+    expect(screen.getByTestId("home-scope-folder-unfiled")).toHaveTextContent("1 unfiled");
+  });
+
+  it("narrows the library to exactly one folder and reports it in the status strip", () => {
+    openRail();
+
+    fireEvent.click(screen.getByTestId("home-scope-folder-Applications"));
+
+    expect(screen.getAllByTestId("resume-card")).toHaveLength(2);
+    expect(screen.getByTestId("home-status-view")).toHaveTextContent("scope: /Applications");
+    expect(screen.getByTestId("home-scope-folder-Applications")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("clears back to the whole library when the active folder is picked again", () => {
+    openRail();
+
+    fireEvent.click(screen.getByTestId("home-scope-folder-Applications"));
+    fireEvent.click(screen.getByTestId("home-scope-folder-Applications"));
+
+    expect(screen.getAllByTestId("resume-card")).toHaveLength(3);
+    expect(screen.getByTestId("home-status-view")).toHaveTextContent("scope: all");
+  });
+
+  it("creates an empty folder without touching any resume", async () => {
+    openRail();
+
+    fireEvent.click(screen.getByTestId("home-scope-folder-new"));
+    const input = screen.getByTestId("home-scope-folder-input");
+    fireEvent.input(input, { target: { value: "Consulting" } });
+    fireEvent.submit(input);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("home-scope-folder-Consulting")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("home-scope-folder-count-Consulting")).toHaveTextContent("0");
+    // Creating a folder is not a write to any resume.
+    expect(patchResumeListMetaMock).not.toHaveBeenCalled();
+  });
+
+  it("files a resume into a folder from the card control", async () => {
+    renderHome();
+
+    // By label rather than position: cards render in sort order, not array order.
+    const select = screen.getByLabelText("Folder for Jane Doe — Designer");
+    fireEvent.change(select, { target: { value: "Applications" } });
+
+    await waitFor(() => {
+      expect(patchResumeListMetaMock).toHaveBeenCalledWith("3", { folder: "Applications" });
+    });
+  });
+
+  it("unfiles a resume when the card control is set back to Unfiled", async () => {
+    renderHome();
+
+    const select = screen.getByLabelText("Folder for Software Engineer");
+    fireEvent.change(select, { target: { value: "" } });
+
+    await waitFor(() => {
+      expect(patchResumeListMetaMock).toHaveBeenCalledWith("1", { folder: null });
+    });
+  });
+
+  it("carries every filed resume across when a folder is renamed", async () => {
+    openRail();
+
+    fireEvent.click(screen.getByTestId("home-scope-folder-rename-Applications"));
+    const input = screen.getByTestId("home-scope-folder-rename-input");
+    fireEvent.input(input, { target: { value: "Job Search" } });
+    fireEvent.submit(input);
+
+    await waitFor(() => {
+      expect(patchResumeListMetaMock).toHaveBeenCalledWith("1", { folder: "Job Search" });
+    });
+    // Rename preserves assignment: both filed resumes move, the unfiled one does not.
+    expect(patchResumeListMetaMock).toHaveBeenCalledWith("2", { folder: "Job Search" });
+    expect(patchResumeListMetaMock).not.toHaveBeenCalledWith("3", expect.anything());
+  });
+
+  it("unfiles rather than deletes the resumes in a deleted folder", async () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true),
+    );
+    openRail();
+
+    fireEvent.click(screen.getByTestId("home-scope-folder-delete-Applications"));
+
+    await waitFor(() => {
+      expect(patchResumeListMetaMock).toHaveBeenCalledWith("1", { folder: null });
+    });
+    expect(patchResumeListMetaMock).toHaveBeenCalledWith("2", { folder: null });
+    // The whole point: the resumes survive.
+    expect(resumeListMock.deleteResume).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId("resume-card")).toHaveLength(3);
+  });
+
+  it("keeps the folder when the delete confirmation is declined", () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => false),
+    );
+    openRail();
+
+    fireEvent.click(screen.getByTestId("home-scope-folder-delete-Applications"));
+
+    expect(patchResumeListMetaMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("home-scope-folder-Applications")).toBeInTheDocument();
+  });
+
+  it("has no axe violations with folders in the rail", async () => {
+    localStorage.setItem(HOME_SIDEBAR_STORAGE_KEY, HomeSidebarState.Open);
+
+    const { container } = renderHome();
+
+    expect(screen.getByTestId("home-scope-folder-Applications")).toBeInTheDocument();
     expect(await axe(container, axeConfig)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/pages/__tests__/Home.test.tsx
+++ b/apps/web/src/pages/__tests__/Home.test.tsx
@@ -972,6 +972,28 @@ describe("Home folder scopes", () => {
     expect(screen.getByTestId("home-scope-folder-Applications")).toBeInTheDocument();
   });
 
+  it("explains an empty folder instead of blaming a search nobody made", async () => {
+    openRail();
+
+    fireEvent.click(screen.getByTestId("home-scope-folder-new"));
+    const input = screen.getByTestId("home-scope-folder-input");
+    fireEvent.input(input, { target: { value: "Consulting" } });
+    fireEvent.submit(input);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("home-scope-folder-Consulting")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("home-scope-folder-Consulting"));
+
+    const empty = screen.getByTestId("home-empty-scope");
+    expect(empty).toHaveTextContent("/Consulting");
+    // The search-specific copy would read: Nothing matches "" in /Consulting.
+    expect(screen.queryByTestId("resume-search-empty")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show all resumes" }));
+    expect(screen.getAllByTestId("resume-card")).toHaveLength(3);
+  });
+
   it("has no axe violations with folders in the rail", async () => {
     localStorage.setItem(HOME_SIDEBAR_STORAGE_KEY, HomeSidebarState.Open);
 

--- a/apps/web/src/pages/home/HomeLayouts.tsx
+++ b/apps/web/src/pages/home/HomeLayouts.tsx
@@ -279,6 +279,33 @@ function NoSearchMatches(props: { home: HomePageModel }) {
   );
 }
 
+/**
+ * A scope with nothing in it and no search to blame.
+ *
+ * Only reachable since folders can exist while empty — every other scope is
+ * derived from resumes and so always has at least one.
+ */
+function EmptyScope(props: { home: HomePageModel }) {
+  const { home } = props;
+  return (
+    <div
+      class="rounded-xl border border-dashed border-border bg-surface/40 px-6 py-16 text-center"
+      data-testid="home-empty-scope"
+    >
+      <h3 class="font-display text-2xl font-semibold text-ink mb-2">Nothing here yet</h3>
+      <p class="mx-auto max-w-sm text-sm text-stone">
+        No resumes are in <span class="font-mono text-ink">{home.activeScopeLabel()}</span>. Use the
+        folder control on a resume to file one here.
+      </p>
+      <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <Button variant="secondary" onClick={() => home.setScope(SCOPE_ALL)}>
+          Show all resumes
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 const LAYOUT_CONTAINERS: Record<HomeLayout, { class: string; testId: string }> = {
   [HomeLayout.List]: { class: "grid w-full gap-2.5 stagger-children", testId: "home-resume-list" },
   [HomeLayout.Grid]: {
@@ -307,7 +334,14 @@ function ResumeListBody(props: { home: HomePageModel }) {
       }
     >
       <Show when={home.resumes()?.length} fallback={<EmptyLibrary home={home} />}>
-        <Show when={home.filteredResumes().length > 0} fallback={<NoSearchMatches home={home} />}>
+        <Show
+          when={home.filteredResumes().length > 0}
+          fallback={
+            <Show when={home.searchQuery().trim()} fallback={<EmptyScope home={home} />}>
+              <NoSearchMatches home={home} />
+            </Show>
+          }
+        >
           <div class={container().class} data-testid={container().testId}>
             <For each={home.filteredResumes()}>
               {({ resume, nameSegments }) => (

--- a/apps/web/src/pages/home/HomeResumeCard.tsx
+++ b/apps/web/src/pages/home/HomeResumeCard.tsx
@@ -177,6 +177,37 @@ export function HomeResumeCard(props: {
   const isGallery = () => props.variant === HomeLayout.Gallery;
   const isList = () => props.variant === HomeLayout.List;
 
+  /**
+   * Filing control. A select rather than the freeform input tags use, because a
+   * resume is in exactly one folder or none — the control should not suggest
+   * otherwise.
+   */
+  const folderSelect = () => (
+    <select
+      class={`max-w-[9rem] border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px]
+        text-stone transition-colors motion-reduce:transition-none hover:border-accent
+        hover:text-ink disabled:opacity-50 disabled:pointer-events-none focus:outline-none
+        focus-visible:ring-2 focus-visible:ring-accent ${isList() ? "rounded-full" : "rounded-sm"}`}
+      aria-label={`Folder for ${resume().name}`}
+      title={resume().locked ? "Unlock to change folder" : "Folder"}
+      disabled={Boolean(resume().locked) || home.metaBusyId() === resume().id || home.actionsBusy()}
+      data-testid="resume-folder-select"
+      onClick={(e) => e.stopPropagation()}
+      onChange={(e) => void home.handleAssignFolder(resume().id, e.currentTarget.value || null)}
+    >
+      <option value="" selected={!resume().folder}>
+        Unfiled
+      </option>
+      <For each={home.allFolders()}>
+        {(folder) => (
+          <option value={folder} selected={resume().folder === folder}>
+            /{folder}
+          </option>
+        )}
+      </For>
+    </select>
+  );
+
   const tagRow = (opts?: { trailing?: "updated" }) => (
     <div
       class={
@@ -187,6 +218,7 @@ export function HomeResumeCard(props: {
       data-testid="resume-card-tags"
       onClick={(e) => e.stopPropagation()}
     >
+      {folderSelect()}
       <For each={resume().tags ?? []}>
         {(tag) => (
           <span

--- a/apps/web/src/pages/home/HomeResumeCard.tsx
+++ b/apps/web/src/pages/home/HomeResumeCard.tsx
@@ -183,29 +183,33 @@ export function HomeResumeCard(props: {
    * otherwise.
    */
   const folderSelect = () => (
-    <select
-      class={`max-w-[9rem] border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px]
+    <Show when={home.allFolders().length > 0}>
+      <select
+        class={`max-w-[9rem] border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px]
         text-stone transition-colors motion-reduce:transition-none hover:border-accent
         hover:text-ink disabled:opacity-50 disabled:pointer-events-none focus:outline-none
         focus-visible:ring-2 focus-visible:ring-accent ${isList() ? "rounded-full" : "rounded-sm"}`}
-      aria-label={`Folder for ${resume().name}`}
-      title={resume().locked ? "Unlock to change folder" : "Folder"}
-      disabled={Boolean(resume().locked) || home.metaBusyId() === resume().id || home.actionsBusy()}
-      data-testid="resume-folder-select"
-      onClick={(e) => e.stopPropagation()}
-      onChange={(e) => void home.handleAssignFolder(resume().id, e.currentTarget.value || null)}
-    >
-      <option value="" selected={!resume().folder}>
-        Unfiled
-      </option>
-      <For each={home.allFolders()}>
-        {(folder) => (
-          <option value={folder} selected={resume().folder === folder}>
-            /{folder}
-          </option>
-        )}
-      </For>
-    </select>
+        aria-label={`Folder for ${resume().name}`}
+        title={resume().locked ? "Unlock to change folder" : "Folder"}
+        disabled={
+          Boolean(resume().locked) || home.metaBusyId() === resume().id || home.actionsBusy()
+        }
+        data-testid="resume-folder-select"
+        onClick={(e) => e.stopPropagation()}
+        onChange={(e) => void home.handleAssignFolder(resume().id, e.currentTarget.value || null)}
+      >
+        <option value="" selected={!resume().folder}>
+          Unfiled
+        </option>
+        <For each={home.allFolders()}>
+          {(folder) => (
+            <option value={folder} selected={resume().folder === folder}>
+              /{folder}
+            </option>
+          )}
+        </For>
+      </select>
+    </Show>
   );
 
   const tagRow = (opts?: { trailing?: "updated" }) => (

--- a/apps/web/src/pages/home/HomeSidebar.tsx
+++ b/apps/web/src/pages/home/HomeSidebar.tsx
@@ -376,7 +376,7 @@ export function HomeSidebar(props: { home: HomePageModel; isDrawer: () => boolea
               >
                 <FolderRow
                   folder={folder}
-                  count={home.scopeCounts().folders.get(folder) ?? 0}
+                  count={home.folderCount(folder)}
                   active={isSameScope(home.scope(), folderScope(folder))}
                   busy={home.folderBusy()}
                   onSelect={() => select(folderScope(folder))}

--- a/apps/web/src/pages/home/HomeSidebar.tsx
+++ b/apps/web/src/pages/home/HomeSidebar.tsx
@@ -1,12 +1,14 @@
 import { For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { Button } from "../../components/ui";
 import {
+  folderScope,
   isSameScope,
   SCOPE_ALL,
   SCOPE_LOCKED,
   tagScope,
   type HomeScope,
 } from "../../lib/homeScope";
+import { MAX_FOLDER_NAME_LENGTH } from "../../lib/homeFolders";
 import { HOME_SIDEBAR_ID } from "../../stores/homeSidebar";
 import type { HomePageModel } from "./useHomePage";
 
@@ -79,6 +81,167 @@ function ScopeRow(props: {
       <span class="truncate">{props.label}</span>
       <span class="flex-shrink-0 font-mono text-[10px] text-stone">{props.count}</span>
     </button>
+  );
+}
+
+/** Dashed mono affordance, matching the card's `+ Tag` control. */
+function DashedRailButton(props: {
+  label: string;
+  testId: string;
+  ariaLabel?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      class="mt-0.5 inline-flex w-full items-center rounded-md border border-dashed border-border
+        px-2 py-1 font-mono text-[10px] text-stone transition-colors motion-reduce:transition-none
+        hover:border-accent hover:bg-accent-light hover:text-ink focus:outline-none
+        focus-visible:ring-2 focus-visible:ring-accent"
+      onClick={props.onClick}
+      aria-label={props.ariaLabel}
+      data-testid={props.testId}
+    >
+      {props.label}
+    </button>
+  );
+}
+
+/** Inline mono field shared by folder creation and folder rename. */
+function FolderNameField(props: {
+  value: string;
+  placeholder: string;
+  ariaLabel: string;
+  testId: string;
+  onInput: (value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <form
+      class="mt-0.5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        props.onSubmit();
+      }}
+    >
+      <input
+        type="text"
+        class="w-full rounded-md border border-accent/40 bg-surface px-2 py-1 font-mono text-[10px]
+          text-ink placeholder:text-stone/70 focus:border-accent focus:outline-none
+          focus:ring-1 focus:ring-accent/30"
+        placeholder={props.placeholder}
+        aria-label={props.ariaLabel}
+        maxLength={MAX_FOLDER_NAME_LENGTH}
+        value={props.value}
+        data-testid={props.testId}
+        onInput={(event) => props.onInput(event.currentTarget.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            props.onCancel();
+          }
+        }}
+        ref={(el) => setTimeout(() => el?.focus(), 0)}
+      />
+    </form>
+  );
+}
+
+/**
+ * One folder in the rail.
+ *
+ * The row itself scopes the library; rename and delete replace the count on
+ * hover or keyboard focus, so the resting state stays identical to a tag row.
+ */
+function FolderRow(props: {
+  folder: string;
+  count: number;
+  active: boolean;
+  busy: boolean;
+  onSelect: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div class="group/folder relative flex items-center">
+      <button
+        type="button"
+        class={rowClass(props.active)}
+        aria-pressed={props.active}
+        onClick={props.onSelect}
+        data-testid={`home-scope-folder-${props.folder}`}
+      >
+        <span class="truncate">/{props.folder}</span>
+        <span
+          class="flex-shrink-0 pr-11 font-mono text-[10px] text-stone transition-opacity
+            motion-reduce:transition-none group-hover/folder:opacity-0
+            group-focus-within/folder:opacity-0"
+          data-testid={`home-scope-folder-count-${props.folder}`}
+        >
+          {props.count}
+        </span>
+      </button>
+      <div
+        class="pointer-events-none absolute right-1.5 flex items-center gap-0.5 opacity-0
+          transition-opacity motion-reduce:transition-none group-hover/folder:pointer-events-auto
+          group-hover/folder:opacity-100 group-focus-within/folder:pointer-events-auto
+          group-focus-within/folder:opacity-100"
+      >
+        <button
+          type="button"
+          class="rounded p-1 text-stone transition-colors motion-reduce:transition-none
+            hover:bg-accent/10 hover:text-ink disabled:opacity-50 focus:outline-none
+            focus-visible:ring-2 focus-visible:ring-accent"
+          onClick={props.onRename}
+          disabled={props.busy}
+          title={`Rename folder ${props.folder}`}
+          aria-label={`Rename folder ${props.folder}`}
+          data-testid={`home-scope-folder-rename-${props.folder}`}
+        >
+          <svg
+            class="h-3 w-3"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+            />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="rounded p-1 text-stone transition-colors motion-reduce:transition-none
+            hover:bg-red-50 hover:text-red-600 disabled:opacity-50 focus:outline-none
+            focus-visible:ring-2 focus-visible:ring-accent"
+          onClick={props.onDelete}
+          disabled={props.busy}
+          title={`Delete folder ${props.folder}`}
+          aria-label={`Delete folder ${props.folder}`}
+          data-testid={`home-scope-folder-delete-${props.folder}`}
+        >
+          <svg
+            class="h-3 w-3"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -191,6 +354,71 @@ export function HomeSidebar(props: { home: HomePageModel; isDrawer: () => boolea
             testId="home-scope-locked"
             onSelect={() => select(SCOPE_LOCKED)}
           />
+        </div>
+
+        <GroupHeading id="home-scope-group-folders">Folders</GroupHeading>
+        <div role="group" aria-labelledby="home-scope-group-folders" class="flex flex-col gap-px">
+          <For each={home.allFolders()}>
+            {(folder) => (
+              <Show
+                when={home.renamingFolder() !== folder}
+                fallback={
+                  <FolderNameField
+                    value={home.folderRenameValue()}
+                    placeholder="Folder name"
+                    ariaLabel={`Rename folder ${folder}`}
+                    testId="home-scope-folder-rename-input"
+                    onInput={home.setFolderRenameValue}
+                    onSubmit={() => void home.confirmFolderRename(folder)}
+                    onCancel={home.cancelFolderRename}
+                  />
+                }
+              >
+                <FolderRow
+                  folder={folder}
+                  count={home.scopeCounts().folders.get(folder) ?? 0}
+                  active={isSameScope(home.scope(), folderScope(folder))}
+                  busy={home.folderBusy()}
+                  onSelect={() => select(folderScope(folder))}
+                  onRename={() => home.startFolderRename(folder)}
+                  onDelete={() => void home.handleDeleteFolder(folder)}
+                />
+              </Show>
+            )}
+          </For>
+
+          <Show
+            when={home.folderCreating()}
+            fallback={
+              <DashedRailButton
+                label="+ New folder"
+                ariaLabel="Create folder"
+                testId="home-scope-folder-new"
+                onClick={home.openFolderCreator}
+              />
+            }
+          >
+            <FolderNameField
+              value={home.folderDraft()}
+              placeholder="Folder name"
+              ariaLabel="New folder name"
+              testId="home-scope-folder-input"
+              onInput={home.setFolderDraft}
+              onSubmit={() => home.handleCreateFolder()}
+              onCancel={home.closeFolderCreator}
+            />
+          </Show>
+
+          {/* Unfiled is a count, not a scope: resumes without a folder are
+              already exactly what All shows minus the filed ones. */}
+          <Show when={home.scopeCounts().unfiled > 0 && home.allFolders().length > 0}>
+            <p
+              class="px-2 pt-1 font-mono text-[10px] text-stone"
+              data-testid="home-scope-folder-unfiled"
+            >
+              {home.scopeCounts().unfiled} unfiled
+            </p>
+          </Show>
         </div>
 
         <Show

--- a/apps/web/src/pages/home/HomeSidebar.tsx
+++ b/apps/web/src/pages/home/HomeSidebar.tsx
@@ -22,8 +22,14 @@ function rowClass(active: boolean): string {
     }`;
 }
 
-/** Everything inside the rail a Tab can land on; the rail itself is tabindex -1. */
-const FOCUSABLE_SELECTOR = 'button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])';
+/**
+ * Everything inside the rail a Tab can land on; the rail itself is tabindex -1.
+ *
+ * Includes inputs: the folder name field can be the last focusable thing in the
+ * rail, and omitting it lets Tab escape the drawer it is meant to trap.
+ */
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), a[href], input:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
  * Keep Tab inside the open drawer.

--- a/apps/web/src/pages/home/HomeSidebar.tsx
+++ b/apps/web/src/pages/home/HomeSidebar.tsx
@@ -174,7 +174,7 @@ function FolderRow(props: {
       >
         <span class="truncate">/{props.folder}</span>
         <span
-          class="flex-shrink-0 pr-11 font-mono text-[10px] text-stone transition-opacity
+          class="flex-shrink-0 font-mono text-[10px] text-stone transition-opacity
             motion-reduce:transition-none group-hover/folder:opacity-0
             group-focus-within/folder:opacity-0"
           data-testid={`home-scope-folder-count-${props.folder}`}

--- a/apps/web/src/pages/home/useHomePage.ts
+++ b/apps/web/src/pages/home/useHomePage.ts
@@ -25,6 +25,7 @@ import {
   type HomeScope,
 } from "../../lib/homeScope";
 import {
+  folderKey,
   getStoredFolders,
   mergeFolderNames,
   normalizeFolderName,
@@ -140,18 +141,28 @@ export function useHomePage() {
   const scopeCounts = createMemo(() => {
     const all = resumes() ?? [];
     const tags = new Map<string, number>();
-    const folders = new Map<string, number>();
+    // Keyed by canonical folder key, carrying a display name, so folders that
+    // differ only in case are counted as the one folder the rail shows.
+    const folders = new Map<string, { name: string; count: number }>();
     let locked = 0;
     let unfiled = 0;
     for (const resume of all) {
       if (resume.locked) locked += 1;
       for (const tag of resume.tags ?? []) tags.set(tag, (tags.get(tag) ?? 0) + 1);
-      const folder = resume.folder;
-      if (folder) folders.set(folder, (folders.get(folder) ?? 0) + 1);
-      else unfiled += 1;
+      const folder = normalizeFolderName(resume.folder ?? "");
+      if (!folder) {
+        unfiled += 1;
+        continue;
+      }
+      const existing = folders.get(folderKey(folder));
+      if (existing) existing.count += 1;
+      else folders.set(folderKey(folder), { name: folder, count: 1 });
     }
     return { total: all.length, locked, tags, folders, unfiled };
   });
+
+  /** Count for a folder, matched however it happens to be capitalised. */
+  const folderCount = (folder: string) => scopeCounts().folders.get(folderKey(folder))?.count ?? 0;
 
   const allTags = createMemo(() =>
     [...scopeCounts().tags.keys()].sort((a, b) => a.localeCompare(b)),
@@ -163,7 +174,10 @@ export function useHomePage() {
    * where assignments arrive with the resumes but the name list does not.
    */
   const allFolders = createMemo(() =>
-    mergeFolderNames(knownFolders(), [...scopeCounts().folders.keys()]),
+    mergeFolderNames(
+      knownFolders(),
+      [...scopeCounts().folders.values()].map((entry) => entry.name),
+    ),
   );
 
   /** Live status-strip state — the trust signals the old marketing footer used to assert. */
@@ -276,9 +290,18 @@ export function useHomePage() {
     setStoredFolders(next);
   };
 
-  /** Resumes currently filed under a folder, matched exactly. */
+  /** Resumes currently filed under a folder, however it is capitalised. */
   const resumesInFolder = (folder: string) =>
-    (resumes() ?? []).filter((resume) => resume.folder === folder);
+    (resumes() ?? []).filter(
+      (resume) => resume.folder && folderKey(resume.folder) === folderKey(folder),
+    );
+
+  /** An existing folder that differs from `name` only in case, if any. */
+  const conflictingFolder = (name: string, ignore?: string) =>
+    allFolders().find(
+      (existing) =>
+        folderKey(existing) !== folderKey(ignore ?? "") && folderKey(existing) === folderKey(name),
+    );
 
   const openFolderCreator = () => {
     setFolderDraft("");
@@ -303,7 +326,7 @@ export function useHomePage() {
       closeFolderCreator();
       return;
     }
-    const existing = allFolders().find((f) => f.toLocaleLowerCase() === name.toLocaleLowerCase());
+    const existing = conflictingFolder(name);
     if (existing) {
       toast.error(`Folder "${existing}" already exists`);
       return;
@@ -338,35 +361,70 @@ export function useHomePage() {
     setFolderRenameValue("");
   };
 
+  /**
+   * Re-file every given resume, reporting how many actually moved.
+   *
+   * Settled rather than all-or-nothing: one failed write must not discard the
+   * writes that already succeeded, because those resumes really have moved and
+   * pretending otherwise leaves the rail describing a library that no longer
+   * exists.
+   */
+  const refileResumes = async (
+    ids: readonly string[],
+    folder: string | null,
+  ): Promise<{ moved: number; failed: number }> => {
+    const results = await Promise.allSettled(
+      ids.map((id) =>
+        enqueueResumeMeta(id, async () => {
+          await patchResumeListMeta(id, { folder });
+        }),
+      ),
+    );
+    const failures = results.filter((result) => result.status === "rejected");
+    for (const failure of failures) console.error(failure.reason);
+    return { moved: results.length - failures.length, failed: failures.length };
+  };
+
   /** Rename a folder, carrying every resume filed under it across. */
   const confirmFolderRename = async (folder: string) => {
     const next = normalizeFolderName(folderRenameValue());
-    if (!next || next === folder) {
+    if (!next || folderKey(next) === folderKey(folder)) {
       cancelFolderRename();
       return;
     }
+    // Same guard as creating one: two folders the user cannot tell apart are
+    // worse than a rejected rename.
+    const conflict = conflictingFolder(next, folder);
+    if (conflict) {
+      toast.error(`Folder "${conflict}" already exists`);
+      return;
+    }
+
     const affected = resumesInFolder(folder);
     setFolderBusy(true);
     try {
-      await Promise.all(
-        affected.map((resume) =>
-          enqueueResumeMeta(resume.id, async () => {
-            await patchResumeListMeta(resume.id, { folder: next });
-          }),
-        ),
+      const { failed } = await refileResumes(
+        affected.map((resume) => resume.id),
+        next,
       );
+      // Keep the old name listed while any resume is still filed under it, so
+      // the stragglers stay reachable and the rename can be retried.
+      const remaining = failed > 0 ? [folder] : [];
       persistKnownFolders(
         mergeFolderNames(
-          knownFolders().filter((f) => f !== folder),
+          knownFolders().filter((f) => folderKey(f) !== folderKey(folder)),
+          remaining,
           [next],
         ),
       );
       // Follow the folder rather than dropping the user back to All.
       if (isSameScope(scope(), folderScope(folder))) setScopeSignal(folderScope(next));
       cancelFolderRename();
-    } catch (e) {
-      console.error(e);
-      toast.error("Failed to rename folder");
+      if (failed > 0) {
+        toast.error(
+          `${failed} ${failed === 1 ? "resume" : "resumes"} stayed in "${folder}" — try again`,
+        );
+      }
     } finally {
       setFolderBusy(false);
     }
@@ -380,6 +438,10 @@ export function useHomePage() {
    * resume is not.
    */
   const handleDeleteFolder = async (folder: string) => {
+    // A second click while the first delete is in flight would re-confirm and
+    // re-issue writes for resumes that are already being unfiled.
+    if (folderBusy()) return;
+
     const affected = resumesInFolder(folder);
     const detail = affected.length
       ? `${affected.length} ${affected.length === 1 ? "resume" : "resumes"} will be unfiled, not deleted.`
@@ -388,23 +450,25 @@ export function useHomePage() {
 
     setFolderBusy(true);
     try {
-      await Promise.all(
-        affected.map((resume) =>
-          enqueueResumeMeta(resume.id, async () => {
-            await patchResumeListMeta(resume.id, { folder: null });
-          }),
-        ),
+      const { moved, failed } = await refileResumes(
+        affected.map((resume) => resume.id),
+        null,
       );
-      persistKnownFolders(knownFolders().filter((f) => f !== folder));
-      if (isSameScope(scope(), folderScope(folder))) setScopeSignal(SCOPE_ALL);
-      toast.success(
-        affected.length
-          ? `Folder deleted — ${affected.length} ${affected.length === 1 ? "resume" : "resumes"} unfiled`
-          : "Folder deleted",
-      );
-    } catch (e) {
-      console.error(e);
-      toast.error("Failed to delete folder");
+      // Only forget the folder once nothing is left in it; otherwise the
+      // stragglers would have no row to reach them by.
+      if (failed === 0) {
+        persistKnownFolders(knownFolders().filter((f) => folderKey(f) !== folderKey(folder)));
+        if (isSameScope(scope(), folderScope(folder))) setScopeSignal(SCOPE_ALL);
+        toast.success(
+          moved
+            ? `Folder deleted — ${moved} ${moved === 1 ? "resume" : "resumes"} unfiled`
+            : "Folder deleted",
+        );
+      } else {
+        toast.error(
+          `${failed} ${failed === 1 ? "resume" : "resumes"} could not be unfiled — try again`,
+        );
+      }
     } finally {
       setFolderBusy(false);
     }
@@ -510,6 +574,7 @@ export function useHomePage() {
     filteredResumes,
     allTags,
     allFolders,
+    folderCount,
     folderDraft,
     setFolderDraft,
     folderCreating,

--- a/apps/web/src/pages/home/useHomePage.ts
+++ b/apps/web/src/pages/home/useHomePage.ts
@@ -16,6 +16,7 @@ import {
 } from "../../lib/resumeSort";
 import { getStoredHomeLayout, setStoredHomeLayout, type HomeLayout } from "../../lib/homeLayout";
 import {
+  folderScope,
   isSameScope,
   matchesScope,
   scopeLabel,
@@ -23,6 +24,12 @@ import {
   tagScope,
   type HomeScope,
 } from "../../lib/homeScope";
+import {
+  getStoredFolders,
+  mergeFolderNames,
+  normalizeFolderName,
+  setStoredFolders,
+} from "../../lib/homeFolders";
 import { formatRelativeTime } from "../../lib/formatRelativeTime";
 import { authStore } from "../../stores/auth";
 import {
@@ -55,6 +62,14 @@ export function useHomePage() {
   const [scope, setScopeSignal] = createSignal<HomeScope>(SCOPE_ALL);
   const [tagDrafts, setTagDrafts] = createSignal<Record<string, string>>({});
   const [tagEditorId, setTagEditorId] = createSignal<string | null>(null);
+  // Folder names the user created. Assignments live on the resumes themselves;
+  // this only additionally remembers folders nothing is filed into yet.
+  const [knownFolders, setKnownFolders] = createSignal<string[]>(getStoredFolders());
+  const [folderDraft, setFolderDraft] = createSignal("");
+  const [folderCreating, setFolderCreating] = createSignal(false);
+  const [renamingFolder, setRenamingFolder] = createSignal<string | null>(null);
+  const [folderRenameValue, setFolderRenameValue] = createSignal("");
+  const [folderBusy, setFolderBusy] = createSignal(false);
 
   // The rail's open state outlives this page, so re-read it on every mount.
   restoreHomeSidebarOpen();
@@ -125,16 +140,30 @@ export function useHomePage() {
   const scopeCounts = createMemo(() => {
     const all = resumes() ?? [];
     const tags = new Map<string, number>();
+    const folders = new Map<string, number>();
     let locked = 0;
+    let unfiled = 0;
     for (const resume of all) {
       if (resume.locked) locked += 1;
       for (const tag of resume.tags ?? []) tags.set(tag, (tags.get(tag) ?? 0) + 1);
+      const folder = resume.folder;
+      if (folder) folders.set(folder, (folders.get(folder) ?? 0) + 1);
+      else unfiled += 1;
     }
-    return { total: all.length, locked, tags };
+    return { total: all.length, locked, tags, folders, unfiled };
   });
 
   const allTags = createMemo(() =>
     [...scopeCounts().tags.keys()].sort((a, b) => a.localeCompare(b)),
+  );
+
+  /**
+   * Folders offered in the rail: the ones created here, unioned with the ones
+   * resumes are actually filed into. The union matters on a second device,
+   * where assignments arrive with the resumes but the name list does not.
+   */
+  const allFolders = createMemo(() =>
+    mergeFolderNames(knownFolders(), [...scopeCounts().folders.keys()]),
   );
 
   /** Live status-strip state — the trust signals the old marketing footer used to assert. */
@@ -242,6 +271,145 @@ export function useHomePage() {
     }
   };
 
+  const persistKnownFolders = (next: string[]) => {
+    setKnownFolders(next);
+    setStoredFolders(next);
+  };
+
+  /** Resumes currently filed under a folder, matched exactly. */
+  const resumesInFolder = (folder: string) =>
+    (resumes() ?? []).filter((resume) => resume.folder === folder);
+
+  const openFolderCreator = () => {
+    setFolderDraft("");
+    setFolderCreating(true);
+  };
+
+  const closeFolderCreator = () => {
+    setFolderCreating(false);
+    setFolderDraft("");
+  };
+
+  /**
+   * Create an empty folder.
+   *
+   * Nothing is written to any resume — a folder only reaches a resume when the
+   * user files one into it.
+   */
+  const handleCreateFolder = (event?: Event) => {
+    event?.preventDefault();
+    const name = normalizeFolderName(folderDraft());
+    if (!name) {
+      closeFolderCreator();
+      return;
+    }
+    const existing = allFolders().find((f) => f.toLocaleLowerCase() === name.toLocaleLowerCase());
+    if (existing) {
+      toast.error(`Folder "${existing}" already exists`);
+      return;
+    }
+    persistKnownFolders(mergeFolderNames(knownFolders(), [name]));
+    closeFolderCreator();
+  };
+
+  /** File a resume into a folder, or unfile it when `folder` is null. */
+  const handleAssignFolder = async (id: string, folder: string | null) => {
+    const next = folder === null ? null : normalizeFolderName(folder) || null;
+    try {
+      await enqueueResumeMeta(id, async () => {
+        await patchResumeListMeta(id, { folder: next });
+        // Filing into a folder the rail has not heard of yet keeps it listed
+        // even if the resume later moves out.
+        if (next) persistKnownFolders(mergeFolderNames(knownFolders(), [next]));
+      });
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to update folder");
+    }
+  };
+
+  const startFolderRename = (folder: string) => {
+    setRenamingFolder(folder);
+    setFolderRenameValue(folder);
+  };
+
+  const cancelFolderRename = () => {
+    setRenamingFolder(null);
+    setFolderRenameValue("");
+  };
+
+  /** Rename a folder, carrying every resume filed under it across. */
+  const confirmFolderRename = async (folder: string) => {
+    const next = normalizeFolderName(folderRenameValue());
+    if (!next || next === folder) {
+      cancelFolderRename();
+      return;
+    }
+    const affected = resumesInFolder(folder);
+    setFolderBusy(true);
+    try {
+      await Promise.all(
+        affected.map((resume) =>
+          enqueueResumeMeta(resume.id, async () => {
+            await patchResumeListMeta(resume.id, { folder: next });
+          }),
+        ),
+      );
+      persistKnownFolders(
+        mergeFolderNames(
+          knownFolders().filter((f) => f !== folder),
+          [next],
+        ),
+      );
+      // Follow the folder rather than dropping the user back to All.
+      if (isSameScope(scope(), folderScope(folder))) setScopeSignal(folderScope(next));
+      cancelFolderRename();
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to rename folder");
+    } finally {
+      setFolderBusy(false);
+    }
+  };
+
+  /**
+   * Delete a folder without deleting anything filed in it.
+   *
+   * Every affected resume is unfiled, so it stays in the library and remains
+   * visible under All. Losing a filing decision is recoverable; losing the
+   * resume is not.
+   */
+  const handleDeleteFolder = async (folder: string) => {
+    const affected = resumesInFolder(folder);
+    const detail = affected.length
+      ? `${affected.length} ${affected.length === 1 ? "resume" : "resumes"} will be unfiled, not deleted.`
+      : "It is empty.";
+    if (!confirm(`Delete the folder "${folder}"? ${detail}`)) return;
+
+    setFolderBusy(true);
+    try {
+      await Promise.all(
+        affected.map((resume) =>
+          enqueueResumeMeta(resume.id, async () => {
+            await patchResumeListMeta(resume.id, { folder: null });
+          }),
+        ),
+      );
+      persistKnownFolders(knownFolders().filter((f) => f !== folder));
+      if (isSameScope(scope(), folderScope(folder))) setScopeSignal(SCOPE_ALL);
+      toast.success(
+        affected.length
+          ? `Folder deleted — ${affected.length} ${affected.length === 1 ? "resume" : "resumes"} unfiled`
+          : "Folder deleted",
+      );
+    } catch (e) {
+      console.error(e);
+      toast.error("Failed to delete folder");
+    } finally {
+      setFolderBusy(false);
+    }
+  };
+
   const handleDelete = async (id: string, event: Event) => {
     event.preventDefault();
     event.stopPropagation();
@@ -309,7 +477,8 @@ export function useHomePage() {
     duplicatingId() !== null ||
     renamingId() !== null ||
     lockingId() !== null ||
-    metaBusyId() !== null;
+    metaBusyId() !== null ||
+    folderBusy();
 
   return {
     layout,
@@ -340,6 +509,22 @@ export function useHomePage() {
     toggleSidebar: toggleHomeSidebar,
     filteredResumes,
     allTags,
+    allFolders,
+    folderDraft,
+    setFolderDraft,
+    folderCreating,
+    openFolderCreator,
+    closeFolderCreator,
+    handleCreateFolder,
+    handleAssignFolder,
+    renamingFolder,
+    folderRenameValue,
+    setFolderRenameValue,
+    startFolderRename,
+    cancelFolderRename,
+    confirmFolderRename,
+    handleDeleteFolder,
+    folderBusy,
     resumeCount,
     lastEditedAt,
     lastEditLabel,

--- a/apps/web/src/stores/__tests__/persistence-folder.test.ts
+++ b/apps/web/src/stores/__tests__/persistence-folder.test.ts
@@ -1,0 +1,245 @@
+import type { CloudResumeRow } from "../../api/resumes";
+import { createDefaultResume } from "../../wasm/defaults";
+import type { ResumeData } from "../../wasm/types";
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear() {
+      store = {};
+    },
+    getItem(key: string) {
+      return key in store ? store[key] : null;
+    },
+    key(index: number) {
+      const keys = Object.keys(store);
+      return keys[index] ?? null;
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+  };
+}
+
+const mockStorage = createMockStorage();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: mockStorage,
+  writable: true,
+  configurable: true,
+});
+
+const { mockAuthState, resumeApiMocks, toastMocks } = vi.hoisted(() => ({
+  mockAuthState: {
+    loading: false,
+    cloudEnabled: false,
+    user: null as { id: string; plan: string } | null,
+  },
+  resumeApiMocks: {
+    listCloudResumes: vi.fn(),
+    getCloudResume: vi.fn(),
+    createCloudResume: vi.fn(),
+    updateCloudResume: vi.fn(),
+    deleteCloudResume: vi.fn(),
+    upsertCloudResume: vi.fn(),
+  },
+  toastMocks: {
+    error: vi.fn(),
+    warning: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("../auth", () => ({
+  authStore: {
+    get state() {
+      return mockAuthState;
+    },
+  },
+}));
+
+vi.mock("../../api/resumes", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/resumes")>();
+  return {
+    ...actual,
+    ...resumeApiMocks,
+  };
+});
+
+// WASM never becomes ready, so the local path falls back to localStorage.
+vi.mock("../../wasm", () => ({
+  listResumes: vi.fn().mockRejectedValue(new Error("WASM not ready")),
+  deleteResume: vi.fn().mockRejectedValue(new Error("WASM not ready")),
+  getResume: vi.fn().mockRejectedValue(new Error("WASM not ready")),
+  saveResume: vi.fn().mockRejectedValue(new Error("WASM not ready")),
+  resumeExists: vi.fn().mockResolvedValue(false),
+  isWasmReady: () => false,
+  ensureWasmReady: async () => false,
+}));
+
+vi.mock("../../components/ui", () => ({
+  toast: toastMocks,
+}));
+
+import { getResumeMeta, patchResumeListMeta } from "../persistence";
+
+const RESUME_ID = "resume-1";
+
+function testResume(): ResumeData {
+  const resume = createDefaultResume();
+  resume.basics.name = "Jane Doe";
+  return resume;
+}
+
+function mockRow(data: ResumeData): CloudResumeRow {
+  return {
+    id: RESUME_ID,
+    title: "My Resume",
+    updated_at: "2026-01-01T00:00:00Z",
+    user_id: "user-1",
+    data,
+    is_public: false,
+    public_slug: null,
+    version: 1,
+    created_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+/** Seed a resume into the localStorage-backed store. */
+function seedLocalResume(data: ResumeData): void {
+  localStorage.setItem(`rustume:${RESUME_ID}`, JSON.stringify(data));
+  localStorage.setItem("rustume:_ids", JSON.stringify([RESUME_ID]));
+}
+
+/** Re-read the resume exactly as a fresh page load would. */
+function readLocalResume(): ResumeData {
+  return JSON.parse(localStorage.getItem(`rustume:${RESUME_ID}`) ?? "{}") as ResumeData;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStorage.clear();
+  mockAuthState.loading = false;
+  mockAuthState.cloudEnabled = false;
+  mockAuthState.user = null;
+});
+
+describe("folder assignment - local storage", () => {
+  it("files a resume into a folder that survives a reload", async () => {
+    seedLocalResume(testResume());
+
+    await patchResumeListMeta(RESUME_ID, { folder: "Applications" });
+
+    // On the resume itself, so it travels with the resume...
+    expect(readLocalResume().metadata.folder).toBe("Applications");
+    // ...and in the list metadata the home page reads.
+    expect(getResumeMeta(RESUME_ID)?.folder).toBe("Applications");
+  });
+
+  it("unfiles a resume without deleting it when the folder is cleared", async () => {
+    const resume = testResume();
+    resume.metadata.folder = "Applications";
+    seedLocalResume(resume);
+
+    await patchResumeListMeta(RESUME_ID, { folder: null });
+
+    // Absent rather than an empty string: unfiled is the absence of a folder.
+    expect(readLocalResume().metadata.folder).toBeUndefined();
+    expect(getResumeMeta(RESUME_ID)?.folder).toBeUndefined();
+    // The resume itself is untouched.
+    expect(readLocalResume().basics.name).toBe("Jane Doe");
+  });
+
+  it("reassigns a filed resume to a different folder", async () => {
+    const resume = testResume();
+    resume.metadata.folder = "Applications";
+    seedLocalResume(resume);
+
+    await patchResumeListMeta(RESUME_ID, { folder: "Consulting" });
+
+    expect(readLocalResume().metadata.folder).toBe("Consulting");
+    expect(getResumeMeta(RESUME_ID)?.folder).toBe("Consulting");
+  });
+
+  it("leaves the folder alone when patching an unrelated field", async () => {
+    const resume = testResume();
+    resume.metadata.folder = "Applications";
+    seedLocalResume(resume);
+
+    await patchResumeListMeta(RESUME_ID, { locked: true });
+
+    expect(readLocalResume().metadata.folder).toBe("Applications");
+    expect(getResumeMeta(RESUME_ID)?.folder).toBe("Applications");
+  });
+
+  it("keeps folders independent of tags", async () => {
+    seedLocalResume(testResume());
+
+    await patchResumeListMeta(RESUME_ID, { folder: "Applications" });
+    await patchResumeListMeta(RESUME_ID, { tags: ["backend", "design"] });
+
+    const stored = readLocalResume();
+    expect(stored.metadata.folder).toBe("Applications");
+    expect(stored.metadata.tags).toEqual(["backend", "design"]);
+  });
+});
+
+describe("folder assignment - cloud metadata path", () => {
+  beforeEach(() => {
+    mockAuthState.cloudEnabled = true;
+    mockAuthState.user = { id: "user-1", plan: "free" };
+  });
+
+  it("sends the folder to the cloud so it is not stranded on one device", async () => {
+    const remote = testResume();
+    resumeApiMocks.getCloudResume.mockResolvedValue(mockRow(remote));
+    resumeApiMocks.upsertCloudResume.mockImplementation((_id, data: ResumeData) =>
+      Promise.resolve(mockRow(data)),
+    );
+
+    await patchResumeListMeta(RESUME_ID, { folder: "Applications" });
+
+    expect(resumeApiMocks.upsertCloudResume).toHaveBeenCalledTimes(1);
+    const [, sent] = resumeApiMocks.upsertCloudResume.mock.calls[0] as [string, ResumeData];
+    expect(sent.metadata.folder).toBe("Applications");
+  });
+
+  it("reads a folder assigned on another device back off the cloud resume", async () => {
+    const remote = testResume();
+    remote.metadata.folder = "Consulting";
+    resumeApiMocks.getCloudResume.mockResolvedValue(mockRow(remote));
+    resumeApiMocks.upsertCloudResume.mockImplementation((_id, data: ResumeData) =>
+      Promise.resolve(mockRow(data)),
+    );
+
+    // Touching an unrelated field must preserve the folder that arrived remotely.
+    await patchResumeListMeta(RESUME_ID, { locked: true });
+
+    const [, sent] = resumeApiMocks.upsertCloudResume.mock.calls[0] as [string, ResumeData];
+    expect(sent.metadata.folder).toBe("Consulting");
+    // ...and it lands in the list metadata the rail counts from.
+    expect(getResumeMeta(RESUME_ID)?.folder).toBe("Consulting");
+  });
+
+  it("clears the folder in the cloud when a resume is unfiled", async () => {
+    const remote = testResume();
+    remote.metadata.folder = "Applications";
+    resumeApiMocks.getCloudResume.mockResolvedValue(mockRow(remote));
+    resumeApiMocks.upsertCloudResume.mockImplementation((_id, data: ResumeData) =>
+      Promise.resolve(mockRow(data)),
+    );
+
+    await patchResumeListMeta(RESUME_ID, { folder: null });
+
+    const [, sent] = resumeApiMocks.upsertCloudResume.mock.calls[0] as [string, ResumeData];
+    expect(sent.metadata.folder).toBeUndefined();
+    expect(getResumeMeta(RESUME_ID)?.folder).toBeUndefined();
+  });
+});

--- a/apps/web/src/stores/__tests__/persistence-folder.test.ts
+++ b/apps/web/src/stores/__tests__/persistence-folder.test.ts
@@ -88,7 +88,8 @@ vi.mock("../../components/ui", () => ({
   toast: toastMocks,
 }));
 
-import { getResumeMeta, patchResumeListMeta } from "../persistence";
+import { createRoot } from "solid-js";
+import { getResumeMeta, patchResumeListMeta, useResumeList } from "../persistence";
 
 const RESUME_ID = "resume-1";
 
@@ -188,6 +189,32 @@ describe("folder assignment - local storage", () => {
     const stored = readLocalResume();
     expect(stored.metadata.folder).toBe("Applications");
     expect(stored.metadata.tags).toEqual(["backend", "design"]);
+  });
+});
+
+describe("folder recovery from the resume itself", () => {
+  it("rebuilds a lost metadata cache from the folder stored on the resume", async () => {
+    const resume = testResume();
+    resume.metadata.folder = "Applications";
+    seedLocalResume(resume);
+
+    // Simulate a cleared metadata cache with the resume still on disk.
+    localStorage.removeItem("rustume:_meta");
+    expect(getResumeMeta(RESUME_ID)).toBeNull();
+
+    await createRoot(async (dispose) => {
+      try {
+        const store = useResumeList();
+        await store.refresh();
+        const items = store.resumes();
+        expect(items?.[0]?.folder).toBe("Applications");
+      } finally {
+        dispose();
+      }
+    });
+
+    // ...and the recovered folder is written back to the cache.
+    expect(getResumeMeta(RESUME_ID)?.folder).toBe("Applications");
   });
 });
 

--- a/apps/web/src/stores/persistence.ts
+++ b/apps/web/src/stores/persistence.ts
@@ -39,6 +39,8 @@ export interface ResumeListItem {
   headline?: string;
   locked?: boolean;
   tags?: string[];
+  /** Single folder this resume is filed under; absent means unfiled. */
+  folder?: string;
 }
 
 /** Serialized form stored in localStorage under the `_meta` key. */
@@ -53,6 +55,8 @@ export interface ResumeMetaEntry {
   headline?: string;
   locked?: boolean;
   tags?: string[];
+  /** Single folder this resume is filed under; absent means unfiled. */
+  folder?: string;
 }
 
 /** Searchable fields snapshotted from resume data into metadata. */
@@ -74,6 +78,7 @@ function isValidMetaEntry(v: unknown): v is ResumeMetaEntry {
   if (typeof obj.updatedAt !== "string") return false;
   if (obj.basicsName !== undefined && typeof obj.basicsName !== "string") return false;
   if (obj.headline !== undefined && typeof obj.headline !== "string") return false;
+  if (obj.folder !== undefined && typeof obj.folder !== "string") return false;
   return !Number.isNaN(Date.parse(obj.updatedAt));
 }
 
@@ -119,7 +124,7 @@ export function setResumeMeta(
   title: string,
   updatedAt?: Date,
   search?: ResumeSearchMeta,
-  extras?: Pick<ResumeMetaEntry, "locked" | "tags">,
+  extras?: Pick<ResumeMetaEntry, "locked" | "tags" | "folder">,
 ): void {
   const map = getMetaMap();
   const existing = map[id];
@@ -132,6 +137,9 @@ export function setResumeMeta(
     headline: search ? search.headline : existing?.headline,
     locked: extras?.locked ?? existing?.locked,
     tags: extras?.tags ?? existing?.tags,
+    // Not `??`: unfiling sets folder to undefined, and coalescing would
+    // resurrect the folder the user just cleared.
+    folder: extras ? extras.folder : existing?.folder,
   };
   setMetaMap(map);
 }
@@ -175,12 +183,20 @@ function resolveResumeTitle(id: string, data: ResumeData): string {
   return deriveTitleFromResume(data);
 }
 
+/** Folder as stored on the resume; blank or non-string reads as unfiled. */
+function readResumeFolder(data: ResumeData): string | undefined {
+  const folder = data.metadata?.folder;
+  if (typeof folder !== "string") return undefined;
+  return folder.trim() || undefined;
+}
+
 function maybeUpdateResumeMeta(id: string, title: string, data?: ResumeData): void {
   const search = data ? deriveSearchMetaFromResume(data) : undefined;
   const extras = data
     ? {
         locked: Boolean(data.metadata?.locked),
         tags: Array.isArray(data.metadata?.tags) ? data.metadata.tags : [],
+        folder: readResumeFolder(data),
       }
     : undefined;
   // Always touch updatedAt on save so the home list reflects recent edits.
@@ -198,6 +214,8 @@ export interface ResumesChangedDetail {
   name?: string;
   locked?: boolean;
   tags?: string[];
+  /** `null` unfiles the resume; omitted leaves the current folder alone. */
+  folder?: string | null;
 }
 
 /** Update list metadata after a resume save (shared by editor + persistence paths). */
@@ -210,6 +228,7 @@ export function notifyResumeSaved(id: string, data: ResumeData): void {
       name: title,
       locked: Boolean(data.metadata?.locked),
       tags: Array.isArray(data.metadata?.tags) ? data.metadata.tags : [],
+      folder: readResumeFolder(data) ?? null,
     };
     window.dispatchEvent(new CustomEvent("rustume:resumes-changed", { detail }));
   }
@@ -391,6 +410,7 @@ async function fetchResumeList(): Promise<ResumeListItem[]> {
         headline: cachedMeta[row.id]?.headline,
         locked: cachedMeta[row.id]?.locked,
         tags: cachedMeta[row.id]?.tags,
+        folder: cachedMeta[row.id]?.folder,
       }));
     }
 
@@ -446,6 +466,7 @@ async function fetchResumeList(): Promise<ResumeListItem[]> {
         headline: meta.headline,
         locked: meta.locked,
         tags: meta.tags,
+        folder: meta.folder,
       };
     });
   } catch (e) {
@@ -473,6 +494,7 @@ export function useResumeList() {
           ...(detail.name !== undefined ? { name: detail.name } : {}),
           ...(detail.locked !== undefined ? { locked: detail.locked } : {}),
           ...(detail.tags !== undefined ? { tags: detail.tags } : {}),
+          ...(detail.folder !== undefined ? { folder: detail.folder ?? undefined } : {}),
           updatedAt: new Date(),
         };
       });
@@ -637,12 +659,17 @@ export async function getStoredResume(id: string): Promise<ResumeData> {
 }
 
 /**
- * Patch lock/tags on a stored resume and refresh list metadata.
+ * Patch lock/tags/folder on a stored resume and refresh list metadata.
  * Works in local and cloud modes via the shared save path.
+ *
+ * `folder: null` unfiles the resume. It is written onto the resume itself
+ * rather than only into the local metadata cache, so the assignment travels
+ * with the resume through the cloud save path instead of being stranded on
+ * whichever device made the change.
  */
 export async function patchResumeListMeta(
   id: string,
-  patch: { locked?: boolean; tags?: string[] },
+  patch: { locked?: boolean; tags?: string[]; folder?: string | null },
 ): Promise<void> {
   const data = await getResume(id);
   if (patch.locked !== undefined) {
@@ -650,6 +677,13 @@ export async function patchResumeListMeta(
   }
   if (patch.tags !== undefined) {
     data.metadata.tags = patch.tags;
+  }
+  if (patch.folder !== undefined) {
+    if (patch.folder === null) {
+      delete data.metadata.folder;
+    } else {
+      data.metadata.folder = patch.folder;
+    }
   }
   await saveResume(id, data);
 }

--- a/apps/web/src/stores/persistence.ts
+++ b/apps/web/src/stores/persistence.ts
@@ -432,12 +432,16 @@ async function fetchResumeList(): Promise<ResumeListItem[]> {
         const result = migrationResults[i];
         let title = "Untitled Resume";
         let search: ResumeSearchMeta = {};
+        let folder: string | undefined;
         if (result.status === "fulfilled") {
           title = deriveTitleFromResume(result.value.data);
           search = deriveSearchMetaFromResume(result.value.data);
+          // The resume itself is the source of truth for the folder, so a
+          // cleared metadata cache recovers the filing rather than losing it.
+          folder = readResumeFolder(result.value.data);
           // Persist the derived metadata so future loads are instant
           try {
-            setResumeMeta(id, title, undefined, search);
+            setResumeMeta(id, title, undefined, search, { folder });
           } catch (metaErr) {
             console.error("Failed to persist metadata for resume:", id, metaErr);
           }
@@ -448,6 +452,7 @@ async function fetchResumeList(): Promise<ResumeListItem[]> {
           updatedAt: new Date(),
           createdAt: new Date(),
           ...search,
+          folder,
         });
       }
     }

--- a/apps/web/src/wasm/types.ts
+++ b/apps/web/src/wasm/types.ts
@@ -286,6 +286,11 @@ export interface Metadata {
   locked?: boolean;
   /** User-defined organization labels (never rendered on the PDF). */
   tags?: string[];
+  /**
+   * Single folder this resume is filed under (never rendered on the PDF).
+   * Mutually exclusive, unlike `tags`; absent means unfiled.
+   */
+  folder?: string;
 }
 
 export interface ResumeData {

--- a/crates/parser/src/reactive_resume_v3.rs
+++ b/crates/parser/src/reactive_resume_v3.rs
@@ -1115,6 +1115,7 @@ fn convert_metadata(v3: &V3Metadata) -> Metadata {
         level_display: LevelDisplay::TemplateDefault,
         locked: false,
         tags: Vec::new(),
+        folder: None,
     }
 }
 

--- a/crates/schema/src/metadata.rs
+++ b/crates/schema/src/metadata.rs
@@ -57,6 +57,14 @@ pub struct Metadata {
     /// User-defined organization labels (never rendered on the PDF).
     #[serde(default)]
     pub tags: Vec<String>,
+
+    /// Single folder this resume is filed under (never rendered on the PDF).
+    ///
+    /// Folders are mutually exclusive, unlike `tags`. Omitted when unset so an
+    /// absent field reads as "unfiled" rather than an explicit null clients
+    /// have to special-case — no migration is needed for existing resumes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub folder: Option<String>,
 }
 
 impl Default for Metadata {
@@ -72,6 +80,7 @@ impl Default for Metadata {
             level_display: LevelDisplay::TemplateDefault,
             locked: false,
             tags: Vec::new(),
+            folder: None,
         }
     }
 }
@@ -369,5 +378,30 @@ mod tests {
     fn metadata_defaults_missing_level_display_to_template_default() {
         let metadata: Metadata = serde_json::from_value(json!({})).unwrap();
         assert_eq!(metadata.level_display, LevelDisplay::TemplateDefault);
+    }
+
+    #[test]
+    fn metadata_treats_absent_folder_as_unfiled() {
+        let metadata: Metadata = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(metadata.folder, None);
+    }
+
+    #[test]
+    fn metadata_omits_unset_folder_when_serialized() {
+        let json = serde_json::to_value(Metadata::default()).unwrap();
+        assert!(json.get("folder").is_none());
+    }
+
+    #[test]
+    fn metadata_round_trips_folder_assignment() {
+        // The local WASM storage path deserializes into this struct and
+        // re-serializes it, so a folder that does not survive here is silently
+        // dropped for every offline user.
+        let metadata: Metadata =
+            serde_json::from_value(json!({ "folder": "Applications" })).unwrap();
+        assert_eq!(metadata.folder.as_deref(), Some("Applications"));
+
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert_eq!(json["folder"], json!("Applications"));
     }
 }


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add folder scopes to the library sidebar
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Gives resumes a folder and surfaces folders as a group in the Home scope rail,
completing the sidebar #580 shipped with Scope + Tags only.

Folders are flat and single-assignment — a resume is in exactly one or none.
That is the whole point versus tags, which are many-per-resume and freeform, so
the filing control is a select rather than the freeform input tags use. Nesting,
drag-between-folders, and multi-folder assignment are out of scope.

**Deleting a folder unfiles its resumes rather than deleting them.** They stay in
the library and remain visible under All. Losing a filing decision is
recoverable; losing the resume is not.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #581
- Relates to #566

## Details

### Data model

`folder?: string` on `ResumeListItem` / `ResumeMetaEntry`, persisted through the
existing `patchResumeListMeta` path tags already use. Absent means unfiled, so no
migration is needed.

The field is also added to the Rust `Metadata` struct. This is load-bearing, not
incidental: the local WASM storage path deserializes resumes into that struct and
re-serializes them, so a folder known only to TypeScript would be silently
dropped for every offline user. A test pins the round-trip.

### Cloud round-trip

Assignment is written onto the resume itself, so it goes through `saveCloudResume`
and is stored in the resume JSON server-side — the server persists the blob
without deserializing it through the typed struct, so the field survives. Tests
assert the folder reaches `upsertCloudResume` and that a folder assigned remotely
survives an unrelated local edit.

Note the honest limitation, shared with `tags` and `locked` today: cloud list
summaries carry only id/title/updated_at, so the *library list* hydrates these
fields from the local metadata cache. A folder is fully stored and travels with
the resume, but a brand-new device won't show it in the list until the resume is
opened. Widening the summary contract would fix this for all three fields at once
and is worth a follow-up rather than a folder-only change here.

### Folder registry

Assignments live on resumes, which cannot represent a folder nothing is filed
into yet. Folder *names* are additionally remembered in localStorage so
`+ New folder` creates something that persists. The rail unions the two, keeping
assignments authoritative — a folder arriving from another device still appears
even though this device never stored its name.

### Scope model

One union variant (`{ kind: "folder"; folder: string }`) plus one case in each of
the two exhaustive switches. Folder identity is a single canonical
(trimmed, case-folded) key used by the rail, the counts, and scope matching
alike, so folders differing only in case cannot show a count that disagrees with
what selecting them returns. Unfiled is reported as a count, not a scope — it is
just All minus the filed resumes.

### Design

Follows the language #580 established rather than introducing a second one:
folder rows reuse the existing row styling, with `/name` reading against tags'
`#name`, and rename/delete replacing the count on hover or keyboard focus so the
resting state matches a tag row. `+ New folder` uses the same dashed mono
affordance as the card's `+ Tag`.

### Testing

- Assignment persists across reload (localStorage) and through the cloud path
- Selecting a folder scope filters to exactly that folder
- Deleting a folder unfiles rather than deletes; resumes stay under All
- Rename preserves assignment and the active scope follows it
- Counts are correct, including the unfiled case and mixed casing
- Focus stays trapped in the drawer around the new folder field

Pre-push review: CodeRabbit and Greptile CLIs. Both flagged real issues that are
fixed in this branch — non-atomic rename/delete losing partially-succeeded
writes, a missing duplicate guard on rename, folder loss when rebuilding a
cleared metadata cache, case-inconsistent counting, and a focus-trap gap. The
final Greptile pass reports no review comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added folder organization for resumes in the Home library.
  * Create, rename, delete, assign, and unassign folders.
  * Browse resumes by folder, including unfiled items and folder counts.
  * Folder assignments persist across reloads and cloud synchronization.
  * Added clearer empty-state messaging for empty scopes.

* **Bug Fixes**
  * Improved folder name normalization, duplicate handling, and case-insensitive matching.
  * Preserved folder assignments when updating unrelated resume details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds single-assignment folders to the home library.
- Persists folder assignment through TypeScript, Rust schema, local storage, and cloud resume data.
- Adds folder creation, rename, deletion, counts, filtering, and card assignment controls.
- Adds folder-aware persistence, scope, UI, accessibility, and schema round-trip tests.
</details>


<h3>Confidence Score: 3/5</h3>

The folder feature should not merge until cloud copies retain visible folder metadata and card controls consistently display canonical folder assignments.

Cloud duplication creates a mismatch between persisted resume data and list metadata, while differently cased folder spellings can make filed resumes appear unfiled; the new empty-state fallback also gives incorrect guidance outside folder scopes.

**Files Needing Attention:** apps/web/src/stores/persistence.ts, apps/web/src/pages/home/HomeResumeCard.tsx, apps/web/src/pages/home/HomeLayouts.tsx

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/pages/home/useHomePage.ts | Adds folder state, canonical counts, assignment, rename, and deletion orchestration; existing non-folder scopes can still reach the new folder-specific empty state. |
| apps/web/src/stores/persistence.ts | Propagates folders through resume and list metadata, but cloud duplication omits the copied folder from the cache used by cloud summaries. |
| apps/web/src/pages/home/HomeResumeCard.tsx | Adds the folder select, whose strict selected-value comparison disagrees with canonical folder identity. |
| apps/web/src/pages/home/HomeSidebar.tsx | Adds folder rows, creation and rename fields, destructive controls, and input-aware drawer focus trapping. |
| apps/web/src/lib/homeFolders.ts | Defines folder normalization, canonical identity, local registry persistence, unioning, and stable sorting. |
| crates/schema/src/metadata.rs | Adds an optional, omitted-when-unset folder field with defaults and serialization round-trip coverage. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Card[Resume folder select] --> Patch[patchResumeListMeta]
  Patch --> Resume[Resume metadata.folder]
  Resume --> Local[WASM or local storage]
  Resume --> Cloud[Cloud resume JSON]
  Local --> Cache[Local list metadata]
  Cloud --> Summary[Cloud list summary]
  Summary --> Cache
  Cache --> Rail[Folder rail counts and scopes]
  Rail --> Filter[Canonical folder filtering]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/stores/persistence.ts`, line 581 ([link](https://github.com/lgtm-hq/rustume/blob/81950fe3c187d448eefd841c6a18f11a44c6a223/apps/web/src/stores/persistence.ts#L581)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cloud copies lose visible folders**

   When a cloud user duplicates a filed resume, the cloned cloud data retains the folder but `setResumeMeta` omits it. The following refetch can only obtain the folder from this local cache because cloud summaries do not include it, causing the copy to appear unfiled in the library and folder counts.

   **Knowledge Base Used:** [Web App (apps/web)](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/rustume/-/docs/web-app.md)
   
   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fstores%2Fpersistence.ts%0ALine%3A%20581%0A%0AComment%3A%0A**Cloud%20copies%20lose%20visible%20folders**%0A%0AWhen%20a%20cloud%20user%20duplicates%20a%20filed%20resume%2C%20the%20cloned%20cloud%20data%20retains%20the%20folder%20but%20%60setResumeMeta%60%20omits%20it.%20The%20following%20refetch%20can%20only%20obtain%20the%20folder%20from%20this%20local%20cache%20because%20cloud%20summaries%20do%20not%20include%20it%2C%20causing%20the%20copy%20to%20appear%20unfiled%20in%20the%20library%20and%20folder%20counts.%0A%0A**Knowledge%20Base%20Used%3A**%20%5BWeb%20App%20%28apps%2Fweb%29%5D%28https%3A%2F%2Fapp.greptile.com%2Flgtm-hq%2F-%2Fcustom-context%2Fknowledge-base%2Flgtm-hq%2Frustume%2F-%2Fdocs%2Fweb-app.md%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=606&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fstores%2Fpersistence.ts%0ALine%3A%20581%0A%0AComment%3A%0A**Cloud%20copies%20lose%20visible%20folders**%0A%0AWhen%20a%20cloud%20user%20duplicates%20a%20filed%20resume%2C%20the%20cloned%20cloud%20data%20retains%20the%20folder%20but%20%60setResumeMeta%60%20omits%20it.%20The%20following%20refetch%20can%20only%20obtain%20the%20folder%20from%20this%20local%20cache%20because%20cloud%20summaries%20do%20not%20include%20it%2C%20causing%20the%20copy%20to%20appear%20unfiled%20in%20the%20library%20and%20folder%20counts.%0A%0A**Knowledge%20Base%20Used%3A**%20%5BWeb%20App%20%28apps%2Fweb%29%5D%28https%3A%2F%2Fapp.greptile.com%2Flgtm-hq%2F-%2Fcustom-context%2Fknowledge-base%2Flgtm-hq%2Frustume%2F-%2Fdocs%2Fweb-app.md%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=606&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22feat%2F581-folder-scopes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F581-folder-scopes%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fstores%2Fpersistence.ts%0ALine%3A%20581%0A%0AComment%3A%0A**Cloud%20copies%20lose%20visible%20folders**%0A%0AWhen%20a%20cloud%20user%20duplicates%20a%20filed%20resume%2C%20the%20cloned%20cloud%20data%20retains%20the%20folder%20but%20%60setResumeMeta%60%20omits%20it.%20The%20following%20refetch%20can%20only%20obtain%20the%20folder%20from%20this%20local%20cache%20because%20cloud%20summaries%20do%20not%20include%20it%2C%20causing%20the%20copy%20to%20appear%20unfiled%20in%20the%20library%20and%20folder%20counts.%0A%0A**Knowledge%20Base%20Used%3A**%20%5BWeb%20App%20%28apps%2Fweb%29%5D%28https%3A%2F%2Fapp.greptile.com%2Flgtm-hq%2F-%2Fcustom-context%2Fknowledge-base%2Flgtm-hq%2Frustume%2F-%2Fdocs%2Fweb-app.md%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Frustume&pr=606&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fstores%2Fpersistence.ts%3A581%0A**Cloud%20copies%20lose%20visible%20folders**%0A%0AWhen%20a%20cloud%20user%20duplicates%20a%20filed%20resume%2C%20the%20cloned%20cloud%20data%20retains%20the%20folder%20but%20%60setResumeMeta%60%20omits%20it.%20The%20following%20refetch%20can%20only%20obtain%20the%20folder%20from%20this%20local%20cache%20because%20cloud%20summaries%20do%20not%20include%20it%2C%20causing%20the%20copy%20to%20appear%20unfiled%20in%20the%20library%20and%20folder%20counts.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fpages%2Fhome%2FHomeResumeCard.tsx%3A206%0A**Canonical%20folders%20display%20as%20unfiled**%0A%0AWhen%20a%20persisted%20assignment%20differs%20in%20case%20or%20normalized%20whitespace%20from%20the%20spelling%20retained%20by%20%60allFolders%60%2C%20this%20strict%20comparison%20selects%20no%20folder%20option%20even%20though%20counts%20and%20filtering%20treat%20the%20names%20as%20identical.%20The%20browser%20then%20displays%20the%20first%20%E2%80%9CUnfiled%E2%80%9D%20option%2C%20and%20subsequent%20interaction%20can%20overwrite%20or%20clear%20the%20actual%20assignment.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fpages%2Fhome%2FHomeLayouts.tsx%3A340%0A**Empty%20state%20assumes%20folder%20scope**%0A%0AThis%20fallback%20applies%20to%20every%20blank-search%20scope%2C%20but%20%60EmptyScope%60%20always%20instructs%20users%20to%20file%20a%20resume%20with%20the%20folder%20control.%20Unlocking%20or%20deleting%20the%20final%20result%20can%20leave%20a%20locked%20or%20tag%20scope%20empty%2C%20where%20that%20instruction%20cannot%20repopulate%20the%20active%20scope.%0A%0A&pr=606&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fstores%2Fpersistence.ts%3A581%0A**Cloud%20copies%20lose%20visible%20folders**%0A%0AWhen%20a%20cloud%20user%20duplicates%20a%20filed%20resume%2C%20the%20cloned%20cloud%20data%20retains%20the%20folder%20but%20%60setResumeMeta%60%20omits%20it.%20The%20following%20refetch%20can%20only%20obtain%20the%20folder%20from%20this%20local%20cache%20because%20cloud%20summaries%20do%20not%20include%20it%2C%20causing%20the%20copy%20to%20appear%20unfiled%20in%20the%20library%20and%20folder%20counts.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fpages%2Fhome%2FHomeResumeCard.tsx%3A206%0A**Canonical%20folders%20display%20as%20unfiled**%0A%0AWhen%20a%20persisted%20assignment%20differs%20in%20case%20or%20normalized%20whitespace%20from%20the%20spelling%20retained%20by%20%60allFolders%60%2C%20this%20strict%20comparison%20selects%20no%20folder%20option%20even%20though%20counts%20and%20filtering%20treat%20the%20names%20as%20identical.%20The%20browser%20then%20displays%20the%20first%20%E2%80%9CUnfiled%E2%80%9D%20option%2C%20and%20subsequent%20interaction%20can%20overwrite%20or%20clear%20the%20actual%20assignment.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fpages%2Fhome%2FHomeLayouts.tsx%3A340%0A**Empty%20state%20assumes%20folder%20scope**%0A%0AThis%20fallback%20applies%20to%20every%20blank-search%20scope%2C%20but%20%60EmptyScope%60%20always%20instructs%20users%20to%20file%20a%20resume%20with%20the%20folder%20control.%20Unlocking%20or%20deleting%20the%20final%20result%20can%20leave%20a%20locked%20or%20tag%20scope%20empty%2C%20where%20that%20instruction%20cannot%20repopulate%20the%20active%20scope.%0A%0A&repo=lgtm-hq%2Frustume&pr=606&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22feat%2F581-folder-scopes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F581-folder-scopes%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fweb%2Fsrc%2Fstores%2Fpersistence.ts%3A581%0A**Cloud%20copies%20lose%20visible%20folders**%0A%0AWhen%20a%20cloud%20user%20duplicates%20a%20filed%20resume%2C%20the%20cloned%20cloud%20data%20retains%20the%20folder%20but%20%60setResumeMeta%60%20omits%20it.%20The%20following%20refetch%20can%20only%20obtain%20the%20folder%20from%20this%20local%20cache%20because%20cloud%20summaries%20do%20not%20include%20it%2C%20causing%20the%20copy%20to%20appear%20unfiled%20in%20the%20library%20and%20folder%20counts.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fweb%2Fsrc%2Fpages%2Fhome%2FHomeResumeCard.tsx%3A206%0A**Canonical%20folders%20display%20as%20unfiled**%0A%0AWhen%20a%20persisted%20assignment%20differs%20in%20case%20or%20normalized%20whitespace%20from%20the%20spelling%20retained%20by%20%60allFolders%60%2C%20this%20strict%20comparison%20selects%20no%20folder%20option%20even%20though%20counts%20and%20filtering%20treat%20the%20names%20as%20identical.%20The%20browser%20then%20displays%20the%20first%20%E2%80%9CUnfiled%E2%80%9D%20option%2C%20and%20subsequent%20interaction%20can%20overwrite%20or%20clear%20the%20actual%20assignment.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fweb%2Fsrc%2Fpages%2Fhome%2FHomeLayouts.tsx%3A340%0A**Empty%20state%20assumes%20folder%20scope**%0A%0AThis%20fallback%20applies%20to%20every%20blank-search%20scope%2C%20but%20%60EmptyScope%60%20always%20instructs%20users%20to%20file%20a%20resume%20with%20the%20folder%20control.%20Unlocking%20or%20deleting%20the%20final%20result%20can%20leave%20a%20locked%20or%20tag%20scope%20empty%2C%20where%20that%20instruction%20cannot%20repopulate%20the%20active%20scope.%0A%0A&repo=lgtm-hq%2Frustume&pr=606&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(web): keep Tab trapped in the drawer..."](https://github.com/lgtm-hq/rustume/commit/81950fe3c187d448eefd841c6a18f11a44c6a223) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47403033)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/rustume/-/docs/web-app.md)
- Knowledge Base — [WASM Bindings: Rust Core to Web App](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/rustume/-/docs/wasm-bindings.md)
- Knowledge Base — [Schema: the resume data model](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/rustume/-/docs/schema.md)
</details>


<!-- /greptile_comment -->