### PR TITLE
ci: fail the run when a release image is not published

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,7 +33,10 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
   **Quality - Documentation Site** on `main`, or `workflow_dispatch`)
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker`
   (`ghcr.io/lgtm-hq/rustume:main`; hosted deploys run from the private
-  rustume-ops repo — this repo ends at the GHCR publish)
+  rustume-ops repo — this repo ends at the GHCR publish). A trailing
+  `🔍 Verify Published Tags` job asserts the contracted tags actually resolve
+  (`scripts/ci/docker/verify-published-tags.sh`), so a skipped manifest merge
+  fails the run instead of passing as "mostly green with skips" (#597)
 
 ## Release
 
@@ -44,7 +47,11 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 - **auto-tag-on-main.yml** — Creates tags when `Cargo.toml` version changes on `main`
   via `reusable-release-auto-tag` (`version-source: cargo`, `create-release: false`)
 - **publish-release-on-tag.yml** — GitHub Release on tag push (inline;
-  `create-github-release` composite)
+  `create-github-release` composite). `📦 Create GitHub Release` is gated on
+  `🔍 Verify Release Image`, which waits for the GHCR tags
+  docker-build-publish.yml is contracted to publish, so a Release is never
+  created without its image (#597). The git tag is created earlier by
+  auto-tag-on-main.yml and is **not** covered by that gate
 - **build-binary.yml** — Cross-platform release binaries (inline; Windows
   `actions/checkout` exception)
 

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -177,3 +177,57 @@ jobs:
         index.crates.io:443
         static.crates.io:443
         registry.npmjs.org:443
+
+  # Publish verification (#597). `Merge Manifests` inside reusable-docker runs
+  # only after EVERY platform succeeds, so one dead runner ("The runner has
+  # received a shutdown signal") skips the merge and publishes NO tags — while
+  # the git tag and GitHub Release may already exist. This job asserts the
+  # contracted tags actually resolve, so the run reads as "the release did not
+  # ship" instead of "one flaky platform".
+  #
+  # `always()` on purpose: when the build fails this job must still run and go
+  # red with an attributable message, not skip. It is required on tag builds
+  # and scoped to :main + :sha- on main builds. It never runs on PRs (nothing
+  # is pushed) and skips exactly when the docker job itself is skipped.
+  verify-images:
+    name: 🔍 Verify Published Tags
+    needs: [classify, docker]
+    if: >-
+      always()
+      && github.event_name != 'pull_request'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/v'))
+      && needs.classify.outputs.pipeline != 'false'
+      && needs.classify.outputs.bump-only != 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            ghcr.io:443
+
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+
+      - name: Verify published tags resolve
+        env:
+          IMAGE_REF: ghcr.io/lgtm-hq/rustume
+          EXPECT_PLATFORMS: linux/amd64,linux/arm64
+          # The manifest merge has already run; retry only long enough to
+          # absorb GHCR read-after-write lag.
+          TIMEOUT_SECONDS: "120"
+          POLL_INTERVAL_SECONDS: "15"
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/docker/verify-published-tags.sh

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -63,9 +63,58 @@ jobs:
     permissions:
       contents: read
 
+  # Release gate (#597). docker-build-publish.yml runs as a separate workflow
+  # on the same tag push, so this job waits for the container tags it is
+  # contracted to publish and fails if they never appear. `release` needs it,
+  # which is what keeps a GitHub Release from existing without its image.
+  #
+  # The wait budget covers the docker job's own timeout-minutes: 120 plus
+  # queueing. WATCH_WORKFLOW short-circuits the wait when that workflow has
+  # already concluded without success, so a dead runner fails in minutes
+  # rather than burning the full budget.
+  verify-image:
+    name: 🔍 Verify Release Image
+    needs: verify-tag
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+      actions: read # WATCH_WORKFLOW reads docker-build-publish run status
+    timeout-minutes: 150
+
+    steps:
+      - name: Harden Runner
+        # Direct step-security invocation: lgtm-ci removed its harden-runner
+        # composite in v0.50.0 (the action pre hook must install the agent).
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            ghcr.io:443
+
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+
+      - name: Wait for the release image to be published
+        env:
+          IMAGE_REF: ghcr.io/lgtm-hq/rustume
+          EXPECT_PLATFORMS: linux/amd64,linux/arm64
+          TIMEOUT_SECONDS: "8100"
+          POLL_INTERVAL_SECONDS: "30"
+          WATCH_WORKFLOW: docker-build-publish.yml
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/docker/verify-published-tags.sh
+
   release:
     name: 📦 Create GitHub Release
-    needs: [verify-tag, build-binaries]
+    needs: [verify-tag, build-binaries, verify-image]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/scripts/ci/docker/verify-published-tags.sh
+++ b/scripts/ci/docker/verify-published-tags.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# verify-published-tags.sh
+#
+# Asserts that the container tags a push/tag build is supposed to publish
+# actually resolve in the registry (#597).
+#
+# Why: `Merge Manifests` in lgtm-ci reusable-docker runs only after EVERY
+# platform build succeeds. When a single platform dies (e.g. "The runner has
+# received a shutdown signal"), the merge is *skipped* and no tag is pushed —
+# while `Release - Auto Tag` and `Publish - GitHub Release` may already have
+# produced a git tag and a GitHub Release. The release looks shipped and is
+# not. This script turns that into a loud, attributable failure.
+#
+# Existence is probed with a HEAD against the registry manifest API (the
+# authoritative answer, no pull required). When EXPECT_PLATFORMS is set the
+# manifest is additionally fetched and its platform list checked, so a
+# single-arch manifest published under a multi-arch tag also fails.
+#
+# Usage:
+#   GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.2.3 GITHUB_SHA=<sha> \
+#     bash scripts/ci/docker/verify-published-tags.sh
+#
+# Environment:
+#   IMAGE_REF              Image without tag (default ghcr.io/lgtm-hq/rustume)
+#   TAGS                   Explicit whitespace-separated tag list. When unset,
+#                          derived from the ref:
+#                            tag  refs/tags/vX.Y.Z -> X.Y.Z latest sha-<short>
+#                            main                 -> main sha-<short>
+#   EXPECT_PLATFORMS       Comma/space separated os/arch list that every tag's
+#                          manifest must contain (default: none)
+#   TIMEOUT_SECONDS        Total time to keep polling for missing tags
+#                          (default 0 = single pass, fail immediately)
+#   POLL_INTERVAL_SECONDS  Delay between polls (default 20)
+#   REGISTRY_USERNAME      Basic-auth user for the registry token endpoint
+#   REGISTRY_PASSWORD      Basic-auth password/token (anonymous pull if unset)
+#   WATCH_WORKFLOW         Optional workflow file name (e.g.
+#                          docker-build-publish.yml). While polling, if that
+#                          workflow's run for GITHUB_SHA has already concluded
+#                          without success, stop waiting and fail immediately.
+#                          Best effort: lookup errors keep polling.
+#   GITHUB_REPOSITORY      owner/repo, required by WATCH_WORKFLOW
+#   GH_TOKEN               Token for the WATCH_WORKFLOW `gh api` lookup
+#   GITHUB_STEP_SUMMARY    When set, a short verdict is appended
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Verify that expected container tags resolve in the registry.
+
+Usage:
+  bash scripts/ci/docker/verify-published-tags.sh
+
+Environment:
+  IMAGE_REF              Image without tag (default ghcr.io/lgtm-hq/rustume)
+  TAGS                   Explicit tag list (default: derived from the ref)
+  EXPECT_PLATFORMS       Platforms every tag's manifest must contain
+  TIMEOUT_SECONDS        Poll budget for missing tags (default 0)
+  POLL_INTERVAL_SECONDS  Delay between polls (default 20)
+  REGISTRY_USERNAME      Basic-auth user for the registry token endpoint
+  REGISTRY_PASSWORD      Basic-auth password/token (anonymous when unset)
+  WATCH_WORKFLOW         Workflow file to fail fast on (best effort)
+  GITHUB_STEP_SUMMARY    Appends a short verdict when set
+
+Exits non-zero when any expected tag is absent or, with EXPECT_PLATFORMS,
+publishes a manifest missing an expected platform.
+EOF
+	exit 0
+fi
+
+IMAGE_REF="${IMAGE_REF:-ghcr.io/lgtm-hq/rustume}"
+EXPECT_PLATFORMS="${EXPECT_PLATFORMS:-}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-0}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-20}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-30}"
+
+MANIFEST_ACCEPT='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
+
+err() { printf '%s\n' "$*" >&2; }
+
+if [[ "$IMAGE_REF" != */* ]]; then
+	err "IMAGE_REF must be <registry>/<repository>, got: ${IMAGE_REF}"
+	exit 2
+fi
+REGISTRY="${IMAGE_REF%%/*}"
+REPOSITORY="${IMAGE_REF#*/}"
+
+# Short SHA must match the length metadata-action uses for its `sha-` tag.
+short_sha() {
+	local sha="${GITHUB_SHA:-}"
+	printf '%s' "${sha:0:7}"
+}
+
+# Tags the publish is contracted to produce for the current ref.
+derive_tags() {
+	local ref_type="${GITHUB_REF_TYPE:-}"
+	local ref_name="${GITHUB_REF_NAME:-}"
+	local ref="${GITHUB_REF:-}"
+	local sha
+	sha="$(short_sha)"
+
+	if [[ "$ref_type" != "tag" && "$ref" == refs/tags/* ]]; then
+		ref_type="tag"
+		ref_name="${ref#refs/tags/}"
+	fi
+
+	if [[ "$ref_type" == "tag" ]]; then
+		# metadata-action `type=semver` strips the leading v.
+		printf '%s\n' "${ref_name#v}" "latest" "sha-${sha}"
+		return 0
+	fi
+
+	printf '%s\n' "${ref_name:-main}" "sha-${sha}"
+}
+
+# Registry pull token. Anonymous unless REGISTRY_PASSWORD is provided.
+fetch_token() {
+	local url="https://${REGISTRY}/token?service=${REGISTRY}"
+	url+="&scope=repository:${REPOSITORY}:pull"
+	local args=(-fsSL --max-time "$CURL_MAX_TIME")
+	if [[ -n "${REGISTRY_PASSWORD:-}" ]]; then
+		args+=(-u "${REGISTRY_USERNAME:-x}:${REGISTRY_PASSWORD}")
+	fi
+	curl "${args[@]}" "$url" 2>/dev/null |
+		jq -r '.token // .access_token // empty' 2>/dev/null
+}
+
+manifest_url() {
+	printf 'https://%s/v2/%s/manifests/%s' "$REGISTRY" "$REPOSITORY" "$1"
+}
+
+# HTTP status of a HEAD against the tag's manifest.
+manifest_status() {
+	local tag="$1" token="$2"
+	curl -sS -o /dev/null -w '%{http_code}' --max-time "$CURL_MAX_TIME" \
+		-I -H "Authorization: Bearer ${token}" -H "Accept: ${MANIFEST_ACCEPT}" \
+		"$(manifest_url "$tag")" 2>/dev/null || printf '000'
+}
+
+# os/arch entries in the tag's manifest index. Attestation manifests carry
+# platform "unknown/unknown" and are filtered out.
+manifest_platforms() {
+	local tag="$1" token="$2"
+	curl -fsSL --max-time "$CURL_MAX_TIME" \
+		-H "Authorization: Bearer ${token}" -H "Accept: ${MANIFEST_ACCEPT}" \
+		"$(manifest_url "$tag")" 2>/dev/null |
+		jq -r '
+			.manifests[]?
+			| select(.platform.architecture != "unknown")
+			| "\(.platform.os)/\(.platform.architecture)"
+		' 2>/dev/null
+}
+
+# Best effort: has the watched build already concluded without success?
+watched_build_failed() {
+	[[ -n "${WATCH_WORKFLOW:-}" && -n "${GITHUB_REPOSITORY:-}" ]] || return 1
+	command -v gh >/dev/null 2>&1 || return 1
+
+	local endpoint runs conclusion
+	endpoint="repos/${GITHUB_REPOSITORY}/actions/workflows/${WATCH_WORKFLOW}"
+	endpoint+="/runs?head_sha=${GITHUB_SHA:-}&per_page=50"
+	runs="$(gh api "$endpoint" 2>/dev/null)" || return 1
+
+	# A release-bump commit is reachable from both `main` and the tag, so the
+	# same head_sha has two runs. Only the run for THIS ref is relevant.
+	conclusion="$(
+		printf '%s' "$runs" | jq -r --arg branch "${GITHUB_REF_NAME:-}" '
+			[.workflow_runs[]? | select($branch == "" or .head_branch == $branch)]
+			| sort_by(.run_number)
+			| last
+			| select(. != null and .status == "completed")
+			| .conclusion // empty
+		' 2>/dev/null
+	)" || return 1
+
+	[[ -n "$conclusion" && "$conclusion" != "success" ]]
+}
+
+write_summary() {
+	[[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+	printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"
+}
+
+expected_tags=()
+if [[ -n "${TAGS:-}" ]]; then
+	# shellcheck disable=SC2206 # deliberate word splitting of the tag list
+	expected_tags=(${TAGS})
+else
+	while IFS= read -r derived_tag; do
+		if [[ -n "$derived_tag" ]]; then
+			expected_tags+=("$derived_tag")
+		fi
+	done < <(derive_tags)
+fi
+
+if [[ ${#expected_tags[@]} -eq 0 ]]; then
+	err "No tags to verify (set TAGS or provide ref metadata)"
+	exit 2
+fi
+
+expected_platforms=()
+if [[ -n "$EXPECT_PLATFORMS" ]]; then
+	# shellcheck disable=SC2206 # comma/space separated input
+	expected_platforms=(${EXPECT_PLATFORMS//,/ })
+fi
+
+printf 'Verifying %s tag(s) on %s: %s\n' \
+	"${#expected_tags[@]}" "$IMAGE_REF" "${expected_tags[*]}"
+
+missing=("${expected_tags[@]}")
+started_at="$SECONDS"
+fail_fast=""
+
+while :; do
+	token="$(fetch_token || true)"
+	if [[ -z "$token" ]]; then
+		err "Warning: could not obtain a ${REGISTRY} pull token; retrying"
+	fi
+
+	remaining=()
+	for tag in "${missing[@]}"; do
+		status="$(manifest_status "$tag" "${token:-}")"
+		if [[ "$status" == "200" ]]; then
+			printf '  present: %s:%s\n' "$IMAGE_REF" "$tag"
+		else
+			printf '  MISSING: %s:%s (HTTP %s)\n' "$IMAGE_REF" "$tag" "$status"
+			remaining+=("$tag")
+		fi
+	done
+	if [[ ${#remaining[@]} -eq 0 ]]; then
+		missing=()
+		break
+	fi
+	missing=("${remaining[@]}")
+
+	if watched_build_failed; then
+		fail_fast="${WATCH_WORKFLOW} already concluded without success"
+		break
+	fi
+
+	elapsed=$((SECONDS - started_at))
+	if [[ "$elapsed" -ge "$TIMEOUT_SECONDS" ]]; then
+		break
+	fi
+
+	printf 'Waiting %ss for %s missing tag(s) (%ss/%ss elapsed)\n' \
+		"$POLL_INTERVAL_SECONDS" "${#missing[@]}" "$elapsed" "$TIMEOUT_SECONDS"
+	sleep "$POLL_INTERVAL_SECONDS"
+done
+
+if [[ ${#missing[@]} -ne 0 ]]; then
+	err "::error::Release image verification failed: ${#missing[@]} expected" \
+		"tag(s) absent from ${IMAGE_REF} — ${missing[*]}"
+	err "The image was NOT published, so this build did not ship."
+	err "A single failed platform skips the manifest merge, which publishes" \
+		"no tags at all — treat this as a failed release, not a flaky job."
+	if [[ -n "$fail_fast" ]]; then
+		err "Stopped waiting: ${fail_fast}"
+	fi
+	write_summary "❌ Image verification failed: missing ${missing[*]} on ${IMAGE_REF}"
+	exit 1
+fi
+
+platform_failures=0
+if [[ ${#expected_platforms[@]} -ne 0 ]]; then
+	token="$(fetch_token || true)"
+	for tag in "${expected_tags[@]}"; do
+		published="$(manifest_platforms "$tag" "${token:-}")"
+		for platform in "${expected_platforms[@]}"; do
+			if ! printf '%s\n' "$published" | grep -qxF "$platform"; then
+				err "::error::${IMAGE_REF}:${tag} is missing platform ${platform}"
+				platform_failures=$((platform_failures + 1))
+			fi
+		done
+	done
+fi
+
+if [[ "$platform_failures" -ne 0 ]]; then
+	err "Published manifests are not multi-arch; this build did not ship."
+	write_summary "❌ Image verification failed: missing platforms on ${IMAGE_REF}"
+	exit 1
+fi
+
+printf 'All expected tags resolve on %s\n' "$IMAGE_REF"
+write_summary "✅ Image verification passed: ${expected_tags[*]} on ${IMAGE_REF}"

--- a/scripts/ci/docker/verify-published-tags.sh
+++ b/scripts/ci/docker/verify-published-tags.sh
@@ -139,14 +139,26 @@ manifest_url() {
 
 # HTTP status of a HEAD against the tag's manifest.
 manifest_status() {
-	local tag="$1" token="$2"
-	curl -sS -o /dev/null -w '%{http_code}' --max-time "$CURL_MAX_TIME" \
-		-I -H "Authorization: Bearer ${token}" -H "Accept: ${MANIFEST_ACCEPT}" \
-		"$(manifest_url "$tag")" 2>/dev/null || printf '000'
+	local tag="$1" token="$2" code=""
+	# curl still emits its -w output on transport errors, so capture first and
+	# only substitute a placeholder when nothing came back — otherwise a
+	# timeout logs the concatenated "000000".
+	code="$(
+		curl -sS -o /dev/null -w '%{http_code}' --max-time "$CURL_MAX_TIME" \
+			-I -H "Authorization: Bearer ${token}" \
+			-H "Accept: ${MANIFEST_ACCEPT}" \
+			"$(manifest_url "$tag")" 2>/dev/null || true
+	)"
+	printf '%s' "${code:-000}"
 }
 
 # os/arch entries in the tag's manifest index. Attestation manifests carry
 # platform "unknown/unknown" and are filtered out.
+#
+# Every tag reusable-docker publishes — including sha-<short> — points at the
+# merged OCI index, not a per-platform digest, so EXPECT_PLATFORMS is valid for
+# the whole tag set (verified against ghcr.io/lgtm-hq/rustume for :latest,
+# :main, :0.46.0 and :sha-89ce2bf).
 manifest_platforms() {
 	local tag="$1" token="$2"
 	curl -fsSL --max-time "$CURL_MAX_TIME" \

--- a/scripts/ci/docker/verify-published-tags.sh
+++ b/scripts/ci/docker/verify-published-tags.sh
@@ -79,6 +79,13 @@ MANIFEST_ACCEPT='application/vnd.oci.image.index.v1+json,application/vnd.docker.
 
 err() { printf '%s\n' "$*" >&2; }
 
+for required_command in curl jq; do
+	if ! command -v "$required_command" >/dev/null 2>&1; then
+		err "Required command not found: ${required_command}"
+		exit 2
+	fi
+done
+
 if [[ "$IMAGE_REF" != */* ]]; then
 	err "IMAGE_REF must be <registry>/<repository>, got: ${IMAGE_REF}"
 	exit 2
@@ -149,7 +156,9 @@ manifest_platforms() {
 			.manifests[]?
 			| select(.platform.architecture != "unknown")
 			| "\(.platform.os)/\(.platform.architecture)"
-		' 2>/dev/null
+		' 2>/dev/null || true
+	# `|| true`: a fetch/parse failure must surface as "missing platform X",
+	# not as a set -e abort that loses the attributable message.
 }
 
 # Best effort: has the watched build already concluded without success?
@@ -160,7 +169,14 @@ watched_build_failed() {
 	local endpoint runs conclusion
 	endpoint="repos/${GITHUB_REPOSITORY}/actions/workflows/${WATCH_WORKFLOW}"
 	endpoint+="/runs?head_sha=${GITHUB_SHA:-}&per_page=50"
-	runs="$(gh api "$endpoint" 2>/dev/null)" || return 1
+
+	# Bound the lookup so a hung API call cannot stall the poll loop.
+	local bounded=()
+	if command -v timeout >/dev/null 2>&1; then
+		bounded=(timeout "$CURL_MAX_TIME")
+	fi
+	runs="$(${bounded[@]+"${bounded[@]}"} gh api "$endpoint" 2>/dev/null)" ||
+		return 1
 
 	# A release-bump commit is reachable from both `main` and the tag, so the
 	# same head_sha has two runs. Only the run for THIS ref is relevant.

--- a/tests/bats/unit/docker/test_verify_published_tags.bats
+++ b/tests/bats/unit/docker/test_verify_published_tags.bats
@@ -211,6 +211,25 @@ JSON
 	assert_output --partial "did not ship"
 }
 
+@test "a manifest body that cannot be fetched fails cleanly" {
+	# HEAD says the tag exists but the GET fails (auth expiry, timeout). The
+	# script must report the platform verdict, not abort mid-run.
+	mock_command_script "curl" '
+url="${@: -1}"
+if [[ "$url" == *"/token?"* ]]; then printf "{\"token\":\"tok\"}\n"; exit 0; fi
+for arg in "$@"; do
+	if [[ "$arg" == "-I" ]]; then printf "200"; exit 0; fi
+done
+exit 22
+'
+	export TAGS=latest EXPECT_PLATFORMS="linux/amd64"
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_equal "1" "${status}"
+	assert_output --partial "is missing platform linux/amd64"
+}
+
 @test "attestation manifests are not treated as platforms" {
 	mock_registry "latest" "$(multi_arch_manifest)"
 	export TAGS=latest EXPECT_PLATFORMS="unknown/unknown"

--- a/tests/bats/unit/docker/test_verify_published_tags.bats
+++ b/tests/bats/unit/docker/test_verify_published_tags.bats
@@ -1,0 +1,330 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/docker/verify-published-tags.sh (#597)
+
+# `run !` is a silent no-op below this version (BW02 = dead assertion).
+bats_require_minimum_version 1.5.0
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/docker/verify-published-tags.sh"
+
+setup() {
+	setup_temp_dir
+	export SCRIPT
+	export GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/step_summary"
+	: >"${GITHUB_STEP_SUMMARY}"
+	# Never wait for real time in unit tests.
+	mock_command_script "sleep" 'exit 0'
+	unset TAGS EXPECT_PLATFORMS TIMEOUT_SECONDS WATCH_WORKFLOW || true
+	unset REGISTRY_USERNAME REGISTRY_PASSWORD || true
+	export TIMEOUT_SECONDS=0
+	export POLL_INTERVAL_SECONDS=0
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+# A curl stand-in that answers the three request shapes the script makes:
+# the registry token endpoint, a HEAD manifest probe, and a GET manifest body.
+#
+# $1 - space separated tags that resolve (HTTP 200); everything else 404s
+# $2 - optional manifest JSON returned by the GET probe
+mock_registry() {
+	local present="$1"
+	local manifest="${2:-}"
+	local present_file="${BATS_TEST_TMPDIR}/present"
+	local manifest_file="${BATS_TEST_TMPDIR}/manifest.json"
+	printf '%s\n' "${present}" >"${present_file}"
+	printf '%s\n' "${manifest}" >"${manifest_file}"
+
+	mock_command_script "curl" '
+url="${@: -1}"
+if [[ "$url" == *"/token?"* ]]; then
+	printf "{\"token\":\"tok\"}\n"
+	exit 0
+fi
+tag="${url##*/manifests/}"
+present="$(cat "'"${present_file}"'")"
+found=1
+for candidate in $present; do
+	if [[ "$candidate" == "$tag" ]]; then found=0; fi
+done
+for arg in "$@"; do
+	if [[ "$arg" == "-I" ]]; then
+		if [[ $found -eq 0 ]]; then printf "200"; else printf "404"; fi
+		exit 0
+	fi
+done
+if [[ $found -ne 0 ]]; then exit 22; fi
+cat "'"${manifest_file}"'"
+'
+}
+
+multi_arch_manifest() {
+	cat <<'JSON'
+{
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {"platform": {"os": "linux", "architecture": "amd64"}},
+    {"platform": {"os": "unknown", "architecture": "unknown"}},
+    {"platform": {"os": "linux", "architecture": "arm64"}},
+    {"platform": {"os": "unknown", "architecture": "unknown"}}
+  ]
+}
+JSON
+}
+
+single_arch_manifest() {
+	cat <<'JSON'
+{
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {"platform": {"os": "linux", "architecture": "arm64"}},
+    {"platform": {"os": "unknown", "architecture": "unknown"}}
+  ]
+}
+JSON
+}
+
+# =============================================================================
+# Tag derivation
+# =============================================================================
+
+@test "tag build verifies version, latest and sha- tags" {
+	mock_registry "0.46.0 latest sha-abc1234"
+	export GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.46.0
+	export GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "present: ghcr.io/lgtm-hq/rustume:0.46.0"
+	assert_output --partial "present: ghcr.io/lgtm-hq/rustume:latest"
+	assert_output --partial "present: ghcr.io/lgtm-hq/rustume:sha-abc1234"
+	assert_output --partial "All expected tags resolve"
+}
+
+@test "tag build derives the tag from refs/tags when GITHUB_REF_TYPE is unset" {
+	mock_registry "0.46.0 latest sha-abc1234"
+	export GITHUB_REF=refs/tags/v0.46.0
+	export GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "ghcr.io/lgtm-hq/rustume: 0.46.0 latest sha-abc1234"
+}
+
+@test "non-tag main build is scoped to :main and :sha- only" {
+	mock_registry "main sha-abc1234"
+	export GITHUB_REF_TYPE=branch GITHUB_REF_NAME=main
+	export GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "ghcr.io/lgtm-hq/rustume: main sha-abc1234"
+	[[ "${output}" != *"latest"* ]] || fail "main build must not require :latest"
+}
+
+@test "explicit TAGS overrides ref derivation" {
+	mock_registry "custom-a custom-b"
+	export TAGS="custom-a custom-b"
+	export GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v9.9.9 GITHUB_SHA=deadbeef123
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "Verifying 2 tag(s)"
+	[[ "${output}" != *"9.9.9"* ]] || fail "explicit TAGS must win"
+}
+
+# =============================================================================
+# Missing-tag failure (the #597 regression)
+# =============================================================================
+
+@test "a skipped manifest merge fails the job loudly" {
+	# Nothing published: exactly what a single dead platform produces.
+	mock_registry ""
+	export GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.46.0
+	export GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_equal "1" "${status}"
+	assert_output --partial "::error::Release image verification failed"
+	assert_output --partial "The image was NOT published"
+	assert_output --partial "0.46.0 latest sha-abc1234"
+}
+
+@test "a partially published tag set still fails" {
+	mock_registry "latest sha-abc1234"
+	export GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.46.0
+	export GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_output --partial "MISSING: ghcr.io/lgtm-hq/rustume:0.46.0"
+}
+
+@test "failure is recorded in the step summary" {
+	mock_registry ""
+	export GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.46.0
+	export GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_failure
+	run cat "${GITHUB_STEP_SUMMARY}"
+	assert_output --partial "Image verification failed"
+}
+
+@test "success is recorded in the step summary" {
+	mock_registry "0.46.0 latest sha-abc1234"
+	export GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.46.0
+	export GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_success
+	run cat "${GITHUB_STEP_SUMMARY}"
+	assert_output --partial "Image verification passed"
+}
+
+# =============================================================================
+# Platform assertions
+# =============================================================================
+
+@test "multi-arch manifest satisfies EXPECT_PLATFORMS" {
+	mock_registry "latest" "$(multi_arch_manifest)"
+	export TAGS=latest EXPECT_PLATFORMS="linux/amd64,linux/arm64"
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "All expected tags resolve"
+}
+
+@test "single-arch manifest under a multi-arch tag fails" {
+	mock_registry "latest" "$(single_arch_manifest)"
+	export TAGS=latest EXPECT_PLATFORMS="linux/amd64,linux/arm64"
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_output --partial "is missing platform linux/amd64"
+	assert_output --partial "did not ship"
+}
+
+@test "attestation manifests are not treated as platforms" {
+	mock_registry "latest" "$(multi_arch_manifest)"
+	export TAGS=latest EXPECT_PLATFORMS="unknown/unknown"
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_output --partial "is missing platform unknown/unknown"
+}
+
+# =============================================================================
+# Polling and fail-fast
+# =============================================================================
+
+@test "a tag that appears on a later poll passes" {
+	local counter="${BATS_TEST_TMPDIR}/calls"
+	printf '0\n' >"${counter}"
+	mock_command_script "curl" '
+url="${@: -1}"
+if [[ "$url" == *"/token?"* ]]; then printf "{\"token\":\"tok\"}\n"; exit 0; fi
+count=$(cat "'"${counter}"'")
+count=$((count + 1))
+printf "%s\n" "$count" > "'"${counter}"'"
+if [[ $count -le 1 ]]; then printf "404"; else printf "200"; fi
+'
+	export TAGS=latest TIMEOUT_SECONDS=60 POLL_INTERVAL_SECONDS=0
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "MISSING"
+	assert_output --partial "All expected tags resolve"
+}
+
+@test "fail-fast when the watched build already concluded in failure" {
+	mock_registry ""
+	mock_command "gh" '{"workflow_runs":[{"run_number":1,"head_branch":"v0.46.0","status":"completed","conclusion":"failure"}]}'
+	export TAGS=latest TIMEOUT_SECONDS=9000 POLL_INTERVAL_SECONDS=0
+	export WATCH_WORKFLOW=docker-build-publish.yml
+	export GITHUB_REPOSITORY=lgtm-hq/Rustume
+	export GITHUB_REF_NAME=v0.46.0 GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_output --partial "Stopped waiting: docker-build-publish.yml"
+}
+
+@test "an in-progress watched build does not trigger fail-fast" {
+	mock_registry ""
+	mock_command "gh" '{"workflow_runs":[{"run_number":1,"head_branch":"v0.46.0","status":"in_progress","conclusion":null}]}'
+	export TAGS=latest TIMEOUT_SECONDS=0 POLL_INTERVAL_SECONDS=0
+	export WATCH_WORKFLOW=docker-build-publish.yml
+	export GITHUB_REPOSITORY=lgtm-hq/Rustume
+	export GITHUB_REF_NAME=v0.46.0 GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_failure
+	[[ "${output}" != *"Stopped waiting"* ]] ||
+		fail "in-progress build must not short-circuit the wait"
+}
+
+@test "a run on another ref does not trigger fail-fast" {
+	# The release-bump commit is reachable from both main and the tag, so the
+	# same head_sha has a main run that must be ignored.
+	mock_registry ""
+	mock_command "gh" '{"workflow_runs":[{"run_number":1,"head_branch":"main","status":"completed","conclusion":"failure"}]}'
+	export TAGS=latest TIMEOUT_SECONDS=0 POLL_INTERVAL_SECONDS=0
+	export WATCH_WORKFLOW=docker-build-publish.yml
+	export GITHUB_REPOSITORY=lgtm-hq/Rustume
+	export GITHUB_REF_NAME=v0.46.0 GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_failure
+	[[ "${output}" != *"Stopped waiting"* ]] ||
+		fail "a run for a different ref must be ignored"
+}
+
+@test "a successful watched build does not trigger fail-fast" {
+	mock_registry ""
+	mock_command "gh" '{"workflow_runs":[{"run_number":1,"head_branch":"v0.46.0","status":"completed","conclusion":"success"}]}'
+	export TAGS=latest TIMEOUT_SECONDS=0 POLL_INTERVAL_SECONDS=0
+	export WATCH_WORKFLOW=docker-build-publish.yml
+	export GITHUB_REPOSITORY=lgtm-hq/Rustume
+	export GITHUB_REF_NAME=v0.46.0 GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_failure
+	[[ "${output}" != *"Stopped waiting"* ]] ||
+		fail "a successful watched build must not short-circuit"
+}
+
+# =============================================================================
+# Input handling
+# =============================================================================
+
+@test "--help exits zero and documents the contract" {
+	run bash "${SCRIPT}" --help
+	assert_success
+	assert_output --partial "Verify that expected container tags resolve"
+}
+
+@test "a registry-less IMAGE_REF is rejected" {
+	export IMAGE_REF=rustume TAGS=latest
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_equal "2" "${status}"
+	assert_output --partial "IMAGE_REF must be"
+}
+
+@test "an empty tag list is rejected" {
+	export TAGS=" "
+	export GITHUB_REF_TYPE=branch GITHUB_REF_NAME="" GITHUB_SHA=""
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_equal "2" "${status}"
+	assert_output --partial "No tags to verify"
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci: fail the run when a release image is not published
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`Merge Manifests` inside lgtm-ci `reusable-docker` runs only after **every**
platform build succeeds. When one platform dies on infrastructure ("The runner
has received a shutdown signal"), the merge is *skipped* and **no tags are
pushed at all** — while `Release - Auto Tag` and `Publish - GitHub Release`
have already produced a git tag and a published GitHub Release. The release
looks shipped and is not, and nothing reports the discrepancy.

This is live and recurring, not a one-off: it hit the v0.46.0 release (run
`30202736613`, `linux/amd64`) and again on PR #601's `linux/amd64` build while
its `arm64` twin passed on identical code.

Two changes, per the owner decision on #597 to take the stronger fix:

1. A verification job in `docker-build-publish.yml` that asserts the contracted
   tags actually resolve, so the run reads as "the release did not ship"
   instead of "one flaky platform, mostly green with skips".
2. `📦 Create GitHub Release` is gated behind a matching verification job in
   `publish-release-on-tag.yml`, so a GitHub Release can no longer exist
   without its image.

### What the ordering now guarantees — exactly

`Release - Auto Tag` runs on the `main` push that bumps `Cargo.toml`, i.e.
**before** any of this. It is deliberately not covered by the gate. After this
PR, when the image build fails:

| Artifact | Can still exist? | Why |
| --- | --- | --- |
| The `vX.Y.Z` **git tag** | **Yes** | Created by `auto-tag-on-main.yml` on the preceding `main` push, before the tag build starts. Nothing here revokes it. |
| Release **binaries** (build-binary.yml artifacts) | **Yes** | `🔨 Build Binaries` runs in parallel; its workflow artifacts are produced regardless. |
| The **GitHub Release** (and its attached binaries) | **No** | `release` now `needs: [verify-tag, build-binaries, verify-image]`. |
| The **container image** | No | That is the failure being detected. |

So the post-change guarantee is precisely: **a published GitHub Release implies
a published multi-arch image**. It does *not* guarantee that a git tag implies
an image — a dangling tag with no release remains possible, and is now the
visible, red-CI signal instead of a silent one. Closing that last gap would
mean deferring tag creation to after the build, which is a separate change to
`auto-tag-on-main.yml` and out of scope here.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #597
- Relates to #596

## Details

### `scripts/ci/docker/verify-published-tags.sh`

Shell logic lives in a dedicated script per `stand-ci`; the workflows only pass
environment. It:

- Derives the tag set from the ref rather than hardcoding it in YAML —
  tag builds → `<semver>`, `latest`, `sha-<short>`; `main` builds → `main`,
  `sha-<short>`. This is how requirement (a)'s "skip it or scope it to
  `:main` + `:sha-`" is satisfied: the job runs on `main` but only asserts the
  two tags a `main` build is actually contracted to publish.
- `HEAD`s the registry manifest API for each tag (authoritative, no pull).
- Optionally asserts the manifest index carries every expected platform, so a
  single-arch manifest published under a multi-arch tag also fails.
  Attestation manifests (`unknown/unknown`) are filtered out. Verified against
  the live registry that `:latest`, `:main`, `:0.46.0` and `:sha-89ce2bf` are
  all merged OCI indexes, so this is valid for the whole tag set.
- Supports a bounded poll (`TIMEOUT_SECONDS`) with token refresh per pass, and
  an optional `WATCH_WORKFLOW` fail-fast.

### `docker-build-publish.yml` — `🔍 Verify Published Tags`

`needs: [classify, docker]`, and deliberately `if: always()` so that a **failed**
build still runs it and goes red with an attributable message rather than
skipping. It is scoped to non-PR `main`/tag refs and skips exactly when the
`docker` job itself is skipped (docs-only or release-bump-only), so it is safe
to make required on tag builds. Retry budget is only 120 s — the merge has
already run, this just absorbs GHCR read-after-write lag.

### `publish-release-on-tag.yml` — `🔍 Verify Release Image`

`docker-build-publish.yml` is a separate workflow on the same tag push, so the
gate is a job that waits for the tags rather than a `needs:` edge. Budget is
8100 s, covering the docker job's own `timeout-minutes: 120` plus queueing.
`WATCH_WORKFLOW: docker-build-publish.yml` short-circuits that wait once the
docker run **for this ref** has concluded without success, so the dead-runner
case fails in minutes instead of burning the full budget. The lookup filters on
`head_branch` because a release-bump commit is reachable from both `main` and
the tag and therefore has two runs for one `head_sha`. It is best-effort: any
lookup error keeps polling rather than failing early.

### Testing

`tests/bats/unit/docker/test_verify_published_tags.bats` — 20 cases, run by the
existing `test-docker-shell.yml`. `bats_require_minimum_version 1.5.0` is set;
no `run !` assertions are used, and the suite reports no `BW02` warning.

- **Simulated single-platform failure** — the registry mock publishes *nothing*
  (exactly what a skipped manifest merge produces): script exits 1, emits
  `::error::Release image verification failed`, names the missing tags, and
  writes the failure to the step summary. Because `release` now `needs`
  this job, no GitHub Release is published. A partial tag set is covered
  separately.
- **Successful multi-arch build** — all three tags resolve and the manifest
  carries both platforms: exit 0. Also exercised against the **live** registry
  (`ghcr.io/lgtm-hq/rustume` at `v0.46.0` / `sha-89ce2bf`), which passes, and
  against a deliberately absent `sha-` tag, which fails.
- **Non-tag `main` build** — asserts only `:main` and `:sha-`, and asserts
  `latest` is never required.
- Plus: ref-derivation fallbacks, explicit `TAGS` override, single-arch
  manifest rejection, unfetchable manifest body, a tag that appears on a later
  poll, and all four `WATCH_WORKFLOW` fail-fast branches (concluded-failure,
  in-progress, other-ref, success).

Full local run: `bats --recursive tests/bats/` (60 pass), `make test`
(Rust workspace + 537 web tests), `uv run lintro chk` → 0 issues / 100 health.

### Pre-push AI review

CodeRabbit and Greptile CLIs both ran to completion. Applied: up-front
`curl`/`jq` dependency check; `manifest_platforms` no longer aborts under
`set -e` on a failed GET (it now surfaces as a missing platform, with a
regression test); the `gh api` lookup is bounded by `timeout` when available;
`manifest_status` no longer logs a concatenated `000000` on transport errors.
Greptile's `sha-` single-arch concern was checked against the live registry and
is unfounded (documented in the script). Its `GITHUB_REPOSITORY` casing note is
incorrect — `lgtm-hq/Rustume` is the real slug.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds post-build container-tag verification and gates GitHub Release creation on successful publication of the expected multi-architecture image.
- Adds a reusable shell verifier for expected GHCR tags and platforms.
- Runs short verification after main and release-image builds.
- Waits for release images before publishing GitHub Releases.
- Adds BATS coverage and documents the updated release workflow.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is safe to merge, with a non-blocking issue that delays failure reporting for tag-triggered image builds.

The release gate still blocks publication when image tags remain absent, but its workflow-run filter excludes tag-triggered Docker runs and therefore waits the full polling budget instead of failing promptly.

**Files Needing Attention:** scripts/ci/docker/verify-published-tags.sh and tests/bats/unit/docker/test_verify_published_tags.bats

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/docker/verify-published-tags.sh | Adds bounded GHCR verification, but its workflow-run filter excludes tag-triggered runs and prevents failure short-circuiting. |
| .github/workflows/docker-build-publish.yml | Adds verification of the expected main or release tags after the reusable multi-platform Docker build. |
| .github/workflows/publish-release-on-tag.yml | Gates GitHub Release creation on image verification, with failed Docker runs currently consuming the full polling budget. |
| tests/bats/unit/docker/test_verify_published_tags.bats | Covers verification behavior, but models tag workflow runs with a non-null head_branch and therefore misses the fail-fast issue. |
| .github/workflows/README.md | Documents the new image-verification jobs and the resulting release guarantee. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Tag as Tag Push
  participant Docker as Docker Build Workflow
  participant GHCR
  participant Gate as Release Image Verification
  participant Release as GitHub Release
  Tag->>Docker: Start multi-platform build
  Tag->>Gate: Start release workflow
  Docker->>GHCR: Publish merged tags
  Gate->>GHCR: Poll expected tags and platforms
  GHCR-->>Gate: Multi-arch manifests resolve
  Gate->>Release: Allow release creation
  Note over Gate,Release: Missing tags or platforms prevent publication
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fdocker%2Fverify-published-tags.sh%3A197%0A**Tag%20runs%20bypass%20fail-fast**%0A%0AFor%20tag-triggered%20workflow%20runs%2C%20%60head_branch%60%20is%20null%20rather%20than%20the%20tag%20name%2C%20so%20filtering%20it%20against%20%60GITHUB_REF_NAME%60%20excludes%20the%20Docker%20run%20that%20this%20gate%20watches.%20A%20failed%20image%20build%20therefore%20remains%20undetected%20until%20the%20full%208%2C100-second%20polling%20budget%20expires%3B%20match%20the%20run%20by%20its%20tag%20ref%20instead%2C%20and%20update%20the%20tests%20that%20currently%20model%20%60head_branch%60%20as%20%60v0.46.0%60.%0A%0A&pr=607&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fdocker%2Fverify-published-tags.sh%3A197%0A**Tag%20runs%20bypass%20fail-fast**%0A%0AFor%20tag-triggered%20workflow%20runs%2C%20%60head_branch%60%20is%20null%20rather%20than%20the%20tag%20name%2C%20so%20filtering%20it%20against%20%60GITHUB_REF_NAME%60%20excludes%20the%20Docker%20run%20that%20this%20gate%20watches.%20A%20failed%20image%20build%20therefore%20remains%20undetected%20until%20the%20full%208%2C100-second%20polling%20budget%20expires%3B%20match%20the%20run%20by%20its%20tag%20ref%20instead%2C%20and%20update%20the%20tests%20that%20currently%20model%20%60head_branch%60%20as%20%60v0.46.0%60.%0A%0A&repo=lgtm-hq%2Frustume&pr=607&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Frustume%22%20on%20the%20existing%20branch%20%22fix%2F597-release-image-verification%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F597-release-image-verification%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fdocker%2Fverify-published-tags.sh%3A197%0A**Tag%20runs%20bypass%20fail-fast**%0A%0AFor%20tag-triggered%20workflow%20runs%2C%20%60head_branch%60%20is%20null%20rather%20than%20the%20tag%20name%2C%20so%20filtering%20it%20against%20%60GITHUB_REF_NAME%60%20excludes%20the%20Docker%20run%20that%20this%20gate%20watches.%20A%20failed%20image%20build%20therefore%20remains%20undetected%20until%20the%20full%208%2C100-second%20polling%20budget%20expires%3B%20match%20the%20run%20by%20its%20tag%20ref%20instead%2C%20and%20update%20the%20tests%20that%20currently%20model%20%60head_branch%60%20as%20%60v0.46.0%60.%0A%0A&repo=lgtm-hq%2Frustume&pr=607&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci: report a single 000 status on regist..."](https://github.com/lgtm-hq/rustume/commit/8cbb550c1cc0d87a5f17c6ee97dad17673fae925) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47407334)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->