### PR TITLE
docs(design): define Rustume brand story and design language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,11 @@ Rustume is a Rust + SolidJS monorepo (privacy-first, offline-first resume builde
 Standard commands live in the `Makefile`, `README.md`, and `CONTRIBUTING.md`; prefer
 those. Notes below capture only non-obvious environment caveats for cloud agents.
 
+For any UI, copy, or template change, read
+[`docs/design/BRAND.md`](docs/design/BRAND.md) first — it is the authoritative
+brand story, design language, voice, and anti-pattern list, and UI changes are
+reviewed against it.
+
 ### Toolchain / dependencies
 
 - Requires **Rust >= 1.85** (a transitive dependency needs the `edition2024`

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ uv run lintro chk        # Check for issues
 uv run lintro fmt        # Auto-fix formatting
 ```
 
+### Design language
+
+Before changing UI, copy, or templates, read
+[docs/design/BRAND.md](docs/design/BRAND.md) — Rustume's brand story, design
+principles, voice, and anti-patterns.
+
 ## 🙏 Acknowledgements
 
 <!-- markdownlint-disable MD033 MD013 -->

--- a/docs/design/BRAND.md
+++ b/docs/design/BRAND.md
@@ -9,11 +9,13 @@ this document, it is the change that is wrong, or this document needs an argued 
 Rustume makes one document, and makes it well. A resume is the most consequential page most
 people ever write, and the tools for writing it are rented: you create an account, you paste
 your employment history into someone else's database, and when you want the PDF you find the
-export behind a paywall. Rustume inverts that. The engine is Rust compiled to WebAssembly and
-runs in your browser; the layouts are Typst, not a headless Chrome print hack; the default
-deployment is stateless, needs no database and no sign-in, and the whole thing runs from a
-Docker image you own. There is a CLI that does the same work from a shell, so your resume can
-live in a repo next to everything else you version.
+export behind a paywall. Rustume inverts that. The engine is Rust: compiled to WebAssembly for
+the parsing and editing that happen in your browser, and compiled native for the Typst renderer
+that turns a resume into a PDF or preview PNG — that render runs on the server you point the app
+at, not in a headless Chrome print hack. The default deployment is stateless, needs no database
+and no sign-in, and the whole thing runs from a Docker image you own. There is a CLI that does
+the same work entirely locally, so your resume can live in a repo next to everything else you
+version.
 
 The point is not that Rustume is private in the abstract. It is that the thing you are making
 is a document, not a row in a service — and Rustume is a workbench, not a landlord.
@@ -73,6 +75,10 @@ user rather than acting on the document.
 `Fraunces` display, `Source Serif 4` body, `JetBrains Mono` for anything the machine owns —
 identifiers, shortcuts, scope names, file names, versions. Serif body text is unusual in an app
 and it is deliberate: it makes the editor read like the document it produces.
+
+This is the target, and `apps/site` does not meet it yet: its craft theme loads `Archivo` for
+body copy and its other themes inherit the turbo sans tokens. Treat that as a pending migration,
+not as licence to add more sans body copy.
 
 **Rules out:** substituting a geometric or neo-grotesque sans (Inter, Geist, system-ui) for
 body copy; using the display face for controls and labels; using mono decoratively for prose
@@ -140,7 +146,7 @@ that fills it.
 | Where | Now | Should be |
 | --- | --- | --- |
 | `ExportModal` PDF-export toast | "Failed to export PDF" | "Could not export the PDF. Your resume is unchanged. Try again." — and where the failure reason is known, say it instead: "…the render service is unreachable. Check that the server is running." |
-| `AppErrorFallback` boundary | "An unexpected error occurred." | "Rustume could not render this page. Your resume is saved and unchanged. Reload, or try again." |
+| `AppErrorFallback` boundary | "An unexpected error occurred." | "Rustume could not render this page. Reload, or try again." — a boundary that catches any render error has no view of what was saved, so it must not say the resume is safe |
 | `useHomePage` bulk-unfile toast | "3 resumes could not be unfiled — try again" | "Could not unfile 3 resumes. They are still in their folders. Try again." |
 | `EmptyScope` heading in `HomeLayouts` | "Nothing here yet" | "No resumes in Drafts" — the body already names the fix, the heading should too |
 

--- a/docs/design/BRAND.md
+++ b/docs/design/BRAND.md
@@ -1,0 +1,172 @@
+# Rustume Brand and Design Language
+
+Direction for anyone — human or agent — making a visual, copy, or interaction decision in
+`apps/web`, `apps/site`, or the resume templates. If a change cannot be defended against
+this document, it is the change that is wrong, or this document needs an argued update.
+
+## Story
+
+Rustume makes one document, and makes it well. A resume is the most consequential page most
+people ever write, and the tools for writing it are rented: you create an account, you paste
+your employment history into someone else's database, and when you want the PDF you find the
+export behind a paywall. Rustume inverts that. The engine is Rust compiled to WebAssembly and
+runs in your browser; the layouts are Typst, not a headless Chrome print hack; the default
+deployment is stateless, needs no database and no sign-in, and the whole thing runs from a
+Docker image you own. There is a CLI that does the same work from a shell, so your resume can
+live in a repo next to everything else you version.
+
+The point is not that Rustume is private in the abstract. It is that the thing you are making
+is a document, not a row in a service — and Rustume is a workbench, not a landlord.
+
+## Audience
+
+People who write their own resume and dislike being processed while they do it. In practice:
+software and technical people (the repo hands them a CLI, a Docker image, JSON Resume,
+LinkedIn and Reactive Resume V3 importers), and privacy-conscious job seekers who would rather
+not create an account to edit a text file. They are usually mid-search, under time pressure,
+and editing an existing document rather than starting one.
+
+What they already believe when they arrive, and what the interface has to answer:
+
+- **"This will be slow."** Every keystroke will round-trip to a server and the preview will lag.
+- **"This is harvesting me."** The free tier is the data-collection tier, and the export is
+  the upsell.
+- **"The output will look like everyone else's."** Templates that are recognisably a template.
+
+Answer these by demonstration, not by claim. A preview that repaints instantly is the argument
+for speed; a working editor before any sign-in prompt is the argument for privacy.
+
+## Design language
+
+The metaphor is already in the repo and it is the right one: a **workshop**. `craft-theme.css`
+sets ember on near-black with brass headings; the site says "Forge resumes with quiet craft" and
+"Build like a workshop — warm, precise, entirely yours"; the app names its colours `--color-ink`,
+`--color-paper`, `--color-sheet` and animates with `ink-drop`. This document makes that explicit
+and adds the part that was implicit: **the workshop is dark and quiet so the paper on the bench
+is the brightest thing in the room.**
+
+One honest caution. A near-black surface with a single warm accent is, on its own, the most
+common look generated tooling produces. The palette alone is not the identity. What makes an
+interface recognisably Rustume is the paper/ink material split, serif-set body text, and the
+absence of dashboard furniture. Spend effort there, not on the accent hue.
+
+### 1. The sheet is the hero
+
+The resume preview is a printed sheet: light, warm-white, ink-dark, the same in every theme
+(`--color-sheet` / `--color-sheet-ink`). Everything around it is bench — recessive, dark, matte.
+
+**Rules out:** theming, tinting, or dark-moding the preview surface; gradients, glows, or
+saturated fills anywhere adjacent to it; decorative illustration or stock imagery inside the
+app; a preview that is smaller than the editor by default.
+
+### 2. Chrome is tools, not a dashboard
+
+The surrounding UI exists to hold instruments within reach. Controls sit at the edges, label
+themselves in plain words, and go quiet when unused.
+
+**Rules out:** stat tiles, metric rows, progress rings, completeness scores, "resume strength"
+gauges, streaks, badges, confetti, onboarding checklists, and any widget that reports on the
+user rather than acting on the document.
+
+### 3. Serif for reading, mono for machine facts
+
+`Fraunces` display, `Source Serif 4` body, `JetBrains Mono` for anything the machine owns —
+identifiers, shortcuts, scope names, file names, versions. Serif body text is unusual in an app
+and it is deliberate: it makes the editor read like the document it produces.
+
+**Rules out:** substituting a geometric or neo-grotesque sans (Inter, Geist, system-ui) for
+body copy; using the display face for controls and labels; using mono decoratively for prose
+or headings; more than three families on a surface.
+
+### 4. Speed is demonstrated, never advertised
+
+Sub-second work gets no spinner. Show the result. If an operation genuinely takes time (server
+render, batch export), show determinate progress and say what is running.
+
+**Rules out:** skeleton shimmer used as ambience rather than as a real pending state; artificial
+delay or staged "processing" theatre; spinners on operations that complete in under ~300ms;
+performance boasts inside the product UI, and any speed number the repo does not measure.
+
+### 5. Claims are scoped to the surface making them
+
+Privacy language must be true of the build the user is looking at. The codebase already
+enforces this — `CloudEntry.tsx` carries a comment explaining that "No accounts, no tracking"
+was true of a local-only home page and false above a sign-in button, and the empty-library copy
+in `HomeLayouts.tsx` branches on `syncEnabled()` before promising anything stays on-device. Note
+also that PDF/PNG rendering and template thumbnails are server-side (`POST /api/render/pdf`);
+"nothing ever leaves your machine" is not a sentence Rustume can write unqualified.
+
+**Rules out:** blanket privacy or encryption claims not conditioned on deployment mode; padlock
+and shield iconography implying guarantees the deployment does not make; marketing superlatives
+in product surfaces.
+
+### 6. Contrast is a design constraint, not a QA step
+
+WCAG 2.2 AA is the floor, and it binds at the moment a colour is chosen, not at review. Body
+text ≥ 4.5:1, large text and UI/focus indicators ≥ 3:1, against the actual background it lands
+on. The app's palette is user-selectable via `@lgtm-hq/turbo-themes` and is normalised through
+the `--a11y-*` derived tokens in `apps/web/src/index.css`; the site's craft theme is
+hand-authored and is not yet normalised. Resume templates must hold contrast in print and in
+grayscale as well as on screen.
+
+**Rules out:** introducing a raw hex value that has not been checked against its background;
+low-contrast placeholder, helper, or disabled text used for visual calm; colour as the only
+carrier of state; text over a gradient ramp whose whole range has not been audited; text on the
+brand accent without a verified on-brand foreground token.
+
+### 7. Motion is small, purposeful, and skippable
+
+Motion confirms that something happened — a save landed, a panel opened. It is short, it does
+not move the sheet, and every animation has a `prefers-reduced-motion: reduce` path.
+
+**Rules out:** parallax, scroll-jacking, entrance animation on lists and data, looping ambient
+effects, hover transforms that shift layout, and any motion that runs before the user acts.
+
+## Voice and tone
+
+Plain, specific, second person, active voice. State what happened and what to do next. Never
+apologise, never exclaim, never blame the user, never use "we". Sentence case everywhere; an
+action keeps the same verb from button to confirmation.
+
+Errors say **what failed, why, and what is still safe.** The repo already contains the model
+sentence — `"Failed to load resume — your data has not been modified"` — and the model
+validation message, `"Add cover letter content before exporting"`. Match those.
+
+Empty states are invitations. The heading names what is missing; the body names the one action
+that fills it.
+
+**Before → after**, from real strings:
+
+| Where | Now | Should be |
+| --- | --- | --- |
+| `components/export/ExportModal.tsx:51` | "Failed to export PDF" | "PDF export failed. The render service did not return a file — check that the server is reachable, then export again." |
+| `components/errors/AppErrorFallback.tsx:11` | "An unexpected error occurred." | "Rustume could not render this page. Your resume is saved and unchanged. Reload, or try again." |
+| `pages/home/useHomePage.ts:469` | "3 resumes could not be unfiled — try again" | "Could not unfile 3 resumes. They are still in their folders. Try again." |
+| `pages/home/HomeLayouts.tsx:295` | "Nothing here yet" | "No resumes in Drafts" (body already names the fix — the heading should too) |
+
+Note what the rewrites share: the failure is named as a thing that happened to an object, the
+user's data is accounted for, and the next action is a verb they can take now.
+
+## Anti-patterns
+
+Rustume must never look or sound like the category it is arguing with.
+
+**Never looks like:** a purple-to-blue SaaS gradient hero; rounded-blob illustrations of
+diverse people at laptops; an ATS-score dial or "your resume is 68% complete" meter; a
+testimonial carousel or logo wall; an upgrade banner, trial countdown, or paywalled export; a
+modal that interrupts editing to sell something; a template preview that does not match the
+rendered PDF; glassmorphism, neon glow, or a bright accent used as a large fill.
+
+**Never sounds like:** "Oops! Something went wrong 😕"; "We're sorry, but…"; "Let's get you set
+up!"; "AI-powered"; "Land your dream job"; interview-rate statistics; emoji in product UI copy;
+"Submit" on a button whose action has a real name; any sentence whose only content is enthusiasm.
+
+**Never does:** ask for an account before the editor works; collect anything it does not need to
+render a document; hide the export; ship a colour that has not been contrast-checked.
+
+## Related
+
+- Parent epic: [#352](https://github.com/lgtm-hq/Rustume/issues/352) — WCAG 2.2 AA and design
+  language for app and site
+- Evidence this document is built on: `apps/site/src/styles/craft-theme.css`,
+  `apps/web/src/index.css`, `apps/site/src/pages/index.astro`, [README](../../README.md)

--- a/docs/design/BRAND.md
+++ b/docs/design/BRAND.md
@@ -139,13 +139,15 @@ that fills it.
 
 | Where | Now | Should be |
 | --- | --- | --- |
-| `components/export/ExportModal.tsx:51` | "Failed to export PDF" | "PDF export failed. The render service did not return a file — check that the server is reachable, then export again." |
-| `components/errors/AppErrorFallback.tsx:11` | "An unexpected error occurred." | "Rustume could not render this page. Your resume is saved and unchanged. Reload, or try again." |
-| `pages/home/useHomePage.ts:469` | "3 resumes could not be unfiled — try again" | "Could not unfile 3 resumes. They are still in their folders. Try again." |
-| `pages/home/HomeLayouts.tsx:295` | "Nothing here yet" | "No resumes in Drafts" (body already names the fix — the heading should too) |
+| `ExportModal` PDF-export toast | "Failed to export PDF" | "Could not export the PDF. Your resume is unchanged. Try again." — and where the failure reason is known, say it instead: "…the render service is unreachable. Check that the server is running." |
+| `AppErrorFallback` boundary | "An unexpected error occurred." | "Rustume could not render this page. Your resume is saved and unchanged. Reload, or try again." |
+| `useHomePage` bulk-unfile toast | "3 resumes could not be unfiled — try again" | "Could not unfile 3 resumes. They are still in their folders. Try again." |
+| `EmptyScope` heading in `HomeLayouts` | "Nothing here yet" | "No resumes in Drafts" — the body already names the fix, the heading should too |
 
-Note what the rewrites share: the failure is named as a thing that happened to an object, the
-user's data is accounted for, and the next action is a verb they can take now.
+Note what the rewrites share: the failure is named as something that happened to a specific
+object, the user's data is accounted for, and the next action is a verb they can take now. Note
+also what they avoid — a generic handler must not assert a cause it has not established. Attach
+the specific sentence to the specific error, and keep the neutral one as the fallback.
 
 ## Anti-patterns
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `docs(design): define Rustume brand story and design language`

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Nothing in the repo stated what Rustume is meant to feel like, who it is for, or why it
looks the way it does. The one strong signal — `apps/site/src/styles/craft-theme.css` —
existed only as hex values. This adds `docs/design/BRAND.md` (174 lines, deliberately
short enough to paste into agent context) and links it from `README.md` and `AGENTS.md`.

Docs-only. No application code, CSS, or tests touched.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (docs-only)
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` — 0 issues, markdownlint included)

## Closes

- Closes #625
- Relates to #352

## Details

`docs/design/BRAND.md` covers, in order:

- **Story** — the local-first, no-account, Rust/WASM/Typst position, in prose.
- **Audience** — technical and privacy-conscious job seekers, and the three things they
  already believe about resume builders (slow, harvesting, generic output).
- **Design language** — seven principles, each stating explicitly what it **rules out**.
  The workshop metaphor already implicit in the palette is made explicit and extended:
  the bench is dark and quiet so the paper on it is the brightest thing in the room.
  Includes the honest caveat that near-black-plus-one-warm-accent is the generic default,
  so the identity has to live in the paper/ink split and serif-on-serif type instead.
- **Voice and tone** — with before/after rewrites of four real `apps/web` strings.
- **Anti-patterns** — never-looks-like / never-sounds-like / never-does.

WCAG 2.2 AA is stated as design-language principle 6, binding at the moment a colour is
chosen rather than at review, so aesthetic choices cannot quietly undercut #617/#618/#619.

### Claims deliberately not made

- **"Your data never leaves your machine"** is not written unqualified. PDF/PNG rendering
  and template thumbnails go through `POST /api/render/pdf` (`apps/web/src/api/render.ts`),
  so the document says so and turns it into a voice rule instead. The codebase already
  agrees: `CloudEntry.tsx` carries a comment about exactly this, and `HomeLayouts.tsx`
  branches its empty-state copy on `syncEnabled()`.
- **Native desktop shells** (README "native UI shells", the "Install the desktop build"
  link in `CloudEntry.tsx`) — no desktop shell exists in this repo, so it is left out.
- **Speed numbers** — nothing in the repo benchmarks them, so the doc forbids claiming them.

### Review

Ran CodeRabbit and Greptile locally against the branch before pushing. Both had one
finding each and both were valid and fixed in the follow-up commit: hardcoded `file:line`
references in the voice table would drift (now file + landmark), and the PDF-export
rewrite asserted a cause a generic handler has not established (now neutral, with the
specific sentence attached to the specific error).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive brand and design-language guidance covering visual style, typography, accessibility, motion, privacy, performance, voice, and error states.
  * Updated development documentation with instructions to consult the design guidance before changing UI, copy, or templates.
  * Added agent guidance to ensure design principles are reviewed before making related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR establishes Rustume’s brand and design guidance.
- Adds the brand story, audience, visual principles, voice guidance, and anti-patterns in `docs/design/BRAND.md`.
- Links the new guidance from `README.md` and `AGENTS.md` for contributors and coding agents.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, although the remaining browser-engine wording should be clarified to keep the architectural guidance precise.

The rendering boundary is now accurately described, but the authoritative story still attributes browser editing to the WebAssembly compilation even though the WASM interface does not implement the editor UI.

**Files Needing Attention:** docs/design/BRAND.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/design/BRAND.md | Adds the authoritative brand story, design language, accessibility principles, voice examples, and anti-patterns. |
| README.md | Adds a development-section link to the new design-language guide. |
| AGENTS.md | Directs agents to consult the brand guide before changing UI, copy, or templates. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(design): scope brand claims to what..."](https://github.com/lgtm-hq/rustume/commit/702dbdec51ef35d68dd516ae2c52813cf8b5fdc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47593424)</sub>

<!-- /greptile_comment -->