### PR TITLE
fix(web): re-enable the axe color-contrast rule and fix failing surfaces

### DIFF
--- a/apps/web/e2e/accessibility.spec.ts
+++ b/apps/web/e2e/accessibility.spec.ts
@@ -5,16 +5,6 @@ import { test, expect, DEFAULT_TEMPLATE_ID } from "./support/fixtures";
 /** WCAG 2.1 AA scan scope (also includes the 2.0 A/AA baseline). */
 const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
 
-/**
- * Known pre-existing failures, excluded so the suite guards against
- * regressions on everything else.
- *
- * TODO(#352): re-enable color-contrast once the design-audit palette fixes
- * land — the stone-on-paper secondary text currently sits below the 4.5:1
- * AA ratio across all pages.
- */
-const KNOWN_FAILING_RULES = ["color-contrast"];
-
 /** Human-readable summary so failures state the rule, impact, and targets. */
 interface ViolationSummary {
   rule: string;
@@ -24,7 +14,7 @@ interface ViolationSummary {
 }
 
 async function scanForViolations(page: Page, include?: string): Promise<ViolationSummary[]> {
-  let builder = new AxeBuilder({ page }).withTags(WCAG_TAGS).disableRules(KNOWN_FAILING_RULES);
+  let builder = new AxeBuilder({ page }).withTags(WCAG_TAGS);
   if (include) {
     builder = builder.include(include);
   }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -80,7 +80,16 @@
   --animate-pulse-subtle: pulse-subtle 2s ease-in-out infinite;
 }
 
-/* Keyframes */
+/*
+ * Keyframes.
+ *
+ * Entrance animations that carry text (`slide-up`, `stagger-in`) move only —
+ * they must not interpolate opacity. A partially transparent element is
+ * composited toward whatever sits behind it, so its text and background blend
+ * together and the pair drops below the AA contrast ratio for the duration of
+ * the animation. `fade-in` keeps its opacity ramp because it is only applied
+ * to text-free scrims and overlays.
+ */
 @keyframes fade-in {
   from {
     opacity: 0;
@@ -92,11 +101,9 @@
 
 @keyframes slide-up {
   from {
-    opacity: 0;
     transform: translateY(20px);
   }
   to {
-    opacity: 1;
     transform: translateY(0);
   }
 }
@@ -128,11 +135,9 @@
 
 @keyframes stagger-in {
   from {
-    opacity: 0;
     transform: translateY(8px);
   }
   to {
-    opacity: 1;
     transform: translateY(0);
   }
 }
@@ -153,6 +158,29 @@ body {
 
 #root {
   min-height: 100vh;
+}
+
+/*
+ * Reduced motion.
+ *
+ * Entrance animations (fade-in, slide-up, stagger-in) interpolate opacity,
+ * which composites text and its background toward each other mid-flight —
+ * a transient contrast failure as well as a motion-sensitivity problem.
+ * Components already opt out of their own transitions via
+ * `motion-reduce:transition-none`; this is the global counterpart that also
+ * covers the keyframe animations.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-delay: -0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* Focus States */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -163,12 +163,11 @@ body {
 /*
  * Reduced motion.
  *
- * Entrance animations (fade-in, slide-up, stagger-in) interpolate opacity,
- * which composites text and its background toward each other mid-flight —
- * a transient contrast failure as well as a motion-sensitivity problem.
- * Components already opt out of their own transitions via
- * `motion-reduce:transition-none`; this is the global counterpart that also
- * covers the keyframe animations.
+ * Now that `slide-up` and `stagger-in` animate transform alone, movement is
+ * the only entrance cue they offer — which is exactly the cue a motion-
+ * sensitive reader needs suppressed. Components already opt out of their own
+ * transitions via `motion-reduce:transition-none`; this is the global
+ * counterpart that also covers the keyframe animations.
  */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/apps/web/src/pages/home/HomeLayouts.tsx
+++ b/apps/web/src/pages/home/HomeLayouts.tsx
@@ -240,7 +240,9 @@ function EmptyLibrary(props: { home: HomePageModel }) {
           Import Resume
         </Button>
       </div>
-      <p class="mt-6 font-mono text-[10px] uppercase tracking-[0.14em] text-stone/70">
+      {/* No alpha modifier on the text colour: `text-stone` is derived to sit
+          just above AA, and diluting it drops this hint below 4.5:1. */}
+      <p class="mt-6 font-mono text-[10px] uppercase tracking-[0.14em] text-stone">
         press ⌘K for commands
       </p>
     </div>


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(web): re-enable the axe color-contrast rule and fix failing surfaces
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`apps/web/e2e/accessibility.spec.ts` disabled axe's `color-contrast` rule on all five
scanned surfaces, so the single most common WCAG failure mode was unguarded. The
suppression is gone and the surfaces behind it are fixed.

Measuring with the rule enabled — before touching a single colour value — turned up two
unrelated problems wearing the same costume.

**Motion, not palette.** `slide-up` and `stagger-in` interpolated `opacity`, so every
element they animated was composited toward whatever sat behind it. Text and background
blend toward each other for the duration, and the pair falls below 4.5:1 while they do.
That is what made the suite non-deterministic: the same dialog title, rendered in
unmodified primary ink against an unchanging background, measured 4.42:1, 4.23:1, and
3.70:1 on three consecutive runs. A DOM probe confirmed the mechanism — the dialog
container sat at `opacity: 0.28` at scan time and settled to the correct
`rgb(76, 79, 105)` a second later. Both keyframes now animate `transform` alone.
`fade-in` keeps its opacity ramp; it is only applied to text-free scrims and overlays.

**A real contrast failure.** The home page's "press ⌘K for commands" hint diluted
`text-stone` with a `/70` alpha modifier and measured 2.74:1 — stable across every run,
so genuinely broken rather than mid-flight. `--a11y-text-secondary` is already derived to
clear AA; the modifier undid that work at the use site, so it is gone.

Since transform is now the only entrance cue those two keyframes offer — and transform is
the cue a motion-sensitive reader most needs suppressed — a global
`prefers-reduced-motion` block joins them, matching the `motion-reduce:` opt-outs
components already carry individually.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Related Issues

Closes #618

## Details

### Measured violations

Every `color-contrast` violation found with the rule enabled, with the ratio axe
measured. "Transient" means the value moved run to run while the element's colours never
changed — the opacity blend described above.

| Surface | Target | Before | Cause | After |
| --- | --- | --- | --- | --- |
| Home | `p.mt-6` — "press ⌘K for commands" | **2.74:1** (stable) | `text-stone/70` | **4.78:1** |
| Home | `.px-4.active\:bg-border.inline-flex` | 3.71 – 4.39:1 (transient) | `stagger-in` opacity | passes |
| Home | `.truncate` — command palette trigger | 4.45:1 (transient) | `stagger-in` opacity | passes |
| Home | `.group-hover\:text-accent…` — "JSON Data" | 3.70 – 3.91:1 (transient) | `stagger-in` opacity | passes |
| Template picker | `#dialog-…-title` — "Choose Template" | 3.70 – 4.42:1 (transient) | `slide-up` opacity | passes |
| Template picker | `#dialog-…-description` | 2.94 – 3.58:1 (transient) | `slide-up` opacity | passes |
| Template picker | `.capitalize` — Rhyhorn / Azurill / Onyx | 3.59 – 4.23:1 (transient) | `slide-up` opacity | passes |
| Export dialog | `#dialog-…-title` — "Export Resume" | 3.70 – 3.91:1 (transient) | `slide-up` opacity | passes |
| Export dialog | `#dialog-…-description` | 2.90 – 4.02:1 (transient) | `slide-up` opacity | passes |

The editor and account scans were already clean.

### Why the existing `--a11y-*` layer wasn't enough

It was not, in fact, insufficient — `#618` asked us to establish that before extending it,
and the answer is that it should be left alone. `--a11y-text-secondary` resolves to
`#64677e` under Catppuccin Latte, which clears AA on both backgrounds it is used against
(4.91:1 on `--color-paper`, 4.57:1 on `--color-surface`). Every apparent token failure was
either the opacity blend or a use-site `/70` modifier diluting a token that was already
correct. No palette values are changed by this PR.

Worth flagging as follow-up rather than fixing here: the surface margin above is thin
(4.57:1), and `text-stone` is still diluted by alpha modifiers in unscanned surfaces —
`CommandPalette.tsx:233`, `Sidebar.tsx:134`, `ImageUpload.tsx:338` and the `/50`–`/60`
uses in the layout editor. They will fail the moment a scan reaches them.

### Testing strategy

- `bun run test:e2e` in `apps/web`, three full-suite runs: 26 passed, 0 flaky. The
  accessibility spec alone was run six more times during measurement.
- `bun run test` (585 unit tests), `bun run lint`, `bun run typecheck`.
- `uv run lintro fmt` then `uv run lintro chk` from the repo root: 0 issues. `pip-audit`
  errors out locally on a `ensurepip` bootstrap crash unrelated to this diff.
- Pre-push review by CodeRabbit and Greptile; both raised the same single P2 (a stale
  comment), fixed in `f8e0166`.

Note for review: `home-empty.png` covers the "press ⌘K" hint, so its Linux baseline shifts
by a few hundred pixels of 10px text — well inside the 2% `maxDiffPixelRatio`. The
keyframe change does not affect any baseline, since `toHaveScreenshot` already disables
animations.

Playwright's `reducedMotion: "reduce"` emulation was tried first and rejected: it does not
reach the page in this setup (`matchMedia` still reports `no-preference` under
Playwright 1.61 + `devices["Desktop Chrome"]`), and papering over a mid-flight blend with
emulation or waits would have left the motion bug in the product.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Re-enables browser-based color-contrast checks and corrects the identified accessibility failures.
- Removes opacity interpolation from text-bearing entrance animations.
- Globally minimizes animation and transition motion when reduced motion is preferred.
- Restores full-opacity secondary text for the home-page command hint.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the changed behavior.

The changes consistently restore browser contrast coverage, prevent transient text contrast degradation, and suppress entrance motion for users who request reduced motion.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/e2e/accessibility.spec.ts | Re-enables axe's color-contrast rule for all browser accessibility scans. |
| apps/web/src/index.css | Makes text-bearing entrance animations transform-only and adds a global reduced-motion override. |
| apps/web/src/pages/home/HomeLayouts.tsx | Removes the alpha modifier that caused the command hint to fall below AA contrast. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(web): correct the reduced-motion ra..."](https://github.com/lgtm-hq/rustume/commit/f8e016692866e7aa196a295edabddfcb3ce4cf3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47596978)</sub>

<!-- /greptile_comment -->