### PR TITLE
feat(site): audit craft theme tokens against WCAG AA with a contrast checker

### DIFF
--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -29,6 +29,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  craft-contrast:
+    name: Craft theme contrast (WCAG AA)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        with:
+          persist-credentials: false
+
+      - name: Check craft theme contrast
+        run: bash scripts/ci/site/check-contrast.sh
+
   site-quality:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -13,6 +13,7 @@
     "preview": "bash ../../scripts/ci/site/preview-serve.sh",
     "test": "vitest run --coverage",
     "check": "astro check",
+    "check:contrast": "node scripts/check-craft-contrast.mjs",
     "astro": "astro"
   },
   "dependencies": {

--- a/apps/site/scripts/check-craft-contrast.mjs
+++ b/apps/site/scripts/check-craft-contrast.mjs
@@ -1,0 +1,367 @@
+/**
+ * Gate the hand-authored craft theme against WCAG 2.x AA contrast.
+ *
+ * `apps/site/src/styles/craft-theme.css` is the one theme Rustume authors
+ * itself, so it never passes through turbo-themes' token normalizer. This
+ * script is the audit that stands in for it. It is modelled on turbo-themes'
+ * `scripts/normalize-wcag-aa-tokens.mjs` (same luminance/ratio maths, same
+ * gradient sampling rationale) with one deliberate difference: it CHECKS and
+ * fails, it never rewrites. The CSS is hand-authored and its palette is a
+ * design statement — drift must be fixed by a human, not silently averaged
+ * toward black or white.
+ *
+ * Retires once lgtm-hq/turbo-themes#840 promotes Craft to a first-class theme
+ * family and the site consumes the published, already-normalized tokens.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { argv, exit } from "node:process";
+
+/**
+ * Contrast floor. Deliberately above the 4.5:1 axe/WCAG threshold so rounding,
+ * gradient sampling granularity and future nudges keep real headroom.
+ */
+export const AA_FLOOR = 4.75;
+
+/** Interior steps taken along `--gradient-primary`; 20 steps = 21 samples. */
+export const GRADIENT_STEPS = 20;
+
+/** Backgrounds every ink token must stay readable on. */
+export const BACKDROP_TOKENS = ["--turbo-bg-base", "--turbo-bg-surface"];
+
+/**
+ * Tokens painted as ink on the page backdrop.
+ *
+ * State fills (`--turbo-state-*`) and `--turbo-bg-overlay` are intentionally
+ * absent: those are fills, not ink, and gating them here would audit a pair
+ * that is never rendered. Fill/ink pairs that ARE rendered together are
+ * declared in `TOKEN_PAIRS` instead.
+ */
+export const INK_TOKENS = [
+  "--turbo-text-primary",
+  "--turbo-text-secondary",
+  "--turbo-body-primary",
+  "--turbo-body-secondary",
+  "--turbo-accent-link",
+  "--turbo-link-default",
+  "--turbo-heading-h1",
+  "--turbo-heading-h2",
+  "--turbo-heading-h3",
+  "--turbo-heading-h4",
+  "--turbo-heading-h5",
+  "--turbo-heading-h6",
+  "--site-accent",
+  "--site-accent-light",
+];
+
+/** Explicit ink-on-fill pairs the theme declares together. */
+export const TOKEN_PAIRS = [
+  ["--turbo-code-inline-fg", "--turbo-code-inline-bg"],
+  ["--turbo-code-block-fg", "--turbo-code-block-bg"],
+  ["--turbo-table-header-fg", "--turbo-table-thead-bg"],
+  ["--turbo-table-header-fg", "--turbo-table-cell-bg"],
+  ["--turbo-table-header-fg", "--turbo-table-stripe"],
+  ["--turbo-panel-header-fg", "--turbo-panel-header-bg"],
+  ["--turbo-message-body-fg", "--turbo-message-bg"],
+  ["--turbo-message-body-fg", "--turbo-message-header-bg"],
+  ["--turbo-text-inverse", "--turbo-brand-primary"],
+  ["--turbo-text-primary", "--turbo-dropdown-item-hover"],
+  ["--turbo-body-primary", "--turbo-dropdown-item-hover"],
+];
+
+/** Ink painted on top of `--gradient-primary` (CTA fills). */
+export const GRADIENT_TOKEN = "--gradient-primary";
+
+/** Ink token gated against the whole gradient ramp. */
+export const GRADIENT_INK_TOKEN = "--turbo-text-on-brand";
+
+const HEX_RE = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/**
+ * Parse `--custom-property: value;` declarations out of a CSS source.
+ *
+ * @param {string} css
+ * @returns {Record<string, string>}
+ */
+export function parseCustomProperties(css) {
+  /** @type {Record<string, string>} */
+  const properties = {};
+  for (const match of css.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/gi)) {
+    properties[match[1]] = match[2].trim();
+  }
+  return properties;
+}
+
+/**
+ * Convert a hex colour to RGB channels.
+ *
+ * Anything else — 8-digit alpha hex, `rgb()`, `color-mix()`, a colour name —
+ * would parse to NaN and silently report a bogus ratio, so it is rejected.
+ *
+ * @param {string} hex
+ * @returns {[number, number, number]}
+ */
+export function hexToRgb(hex) {
+  const value = String(hex).trim();
+  if (!HEX_RE.test(value)) {
+    throw new Error(`unsupported color value: ${hex} (only #rgb / #rrggbb are supported)`);
+  }
+  const digits = value.slice(1);
+  const full =
+    digits.length === 3
+      ? digits
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : digits;
+  return /** @type {[number, number, number]} */ (
+    [0, 2, 4].map((i) => parseInt(full.slice(i, i + 2), 16))
+  );
+}
+
+/**
+ * Convert RGB channels back to a hex colour.
+ *
+ * @param {number[]} rgb
+ * @returns {string}
+ */
+export function rgbToHex(rgb) {
+  return `#${rgb
+    .map((v) =>
+      Math.max(0, Math.min(255, Math.round(v)))
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+/**
+ * WCAG relative luminance.
+ *
+ * @param {string} hex
+ * @returns {number}
+ */
+export function relativeLuminance(hex) {
+  const [r, g, b] = hexToRgb(hex).map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * WCAG contrast ratio between two colours.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function contrastRatio(a, b) {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Blend `hex` toward `target` by `t` (0..1) in sRGB, the way a browser paints a
+ * linear gradient.
+ *
+ * @param {string} hex
+ * @param {string} target
+ * @param {number} t
+ * @returns {string}
+ */
+export function mixToward(hex, target, t) {
+  const from = hexToRgb(hex);
+  const to = hexToRgb(target);
+  return rgbToHex(from.map((v, i) => v + (to[i] - v) * t));
+}
+
+/**
+ * Sample a two-stop linear gradient into discrete backgrounds.
+ *
+ * Clearing the floor at both stops is NOT sufficient. sRGB blending is linear
+ * per channel but luminance is not, so the interior of a ramp sits below the
+ * chord between its endpoints and contrast dips there. turbo-themes#774 caught
+ * gruvbox-light-soft doing exactly that: 4.75:1 and 4.79:1 at the ends, 4.46:1
+ * at 60% along. Sampling the ramp is what makes the audit match what a reader
+ * actually sees on a button.
+ *
+ * @param {string} from
+ * @param {string} to
+ * @param {number} [steps]
+ * @returns {string[]}
+ */
+export function gradientRamp(from, to, steps = GRADIENT_STEPS) {
+  if (!to) {
+    return [from];
+  }
+  const samples = [];
+  for (let i = 0; i <= steps; i++) {
+    samples.push(mixToward(from, to, i / steps));
+  }
+  return samples;
+}
+
+/**
+ * Extract the hex stops of a two-stop `linear-gradient(...)` value.
+ *
+ * @param {string} value
+ * @returns {[string, string]}
+ */
+export function parseGradientStops(value) {
+  const stops = [...String(value).matchAll(/#[0-9a-f]{3,8}\b/gi)].map((match) => match[0]);
+  if (stops.length !== 2) {
+    throw new Error(`expected exactly 2 hex stops in gradient, found ${stops.length}: ${value}`);
+  }
+  // Force the hex guard so an 8-digit alpha stop fails loudly here.
+  stops.forEach((stop) => hexToRgb(stop));
+  return /** @type {[string, string]} */ (stops);
+}
+
+/**
+ * Read a token, failing loudly when it is missing.
+ *
+ * @param {Record<string, string>} tokens
+ * @param {string} name
+ * @returns {string}
+ */
+function requireToken(tokens, name) {
+  const value = tokens[name];
+  if (!value) {
+    throw new Error(`missing required token ${name} in craft-theme.css`);
+  }
+  return value;
+}
+
+/**
+ * @typedef {object} ContrastFailure
+ * @property {string} token Foreground token that failed.
+ * @property {string} foreground Foreground colour compared.
+ * @property {string} against Background token (or gradient description).
+ * @property {string} background Background colour compared.
+ * @property {number} ratio Measured contrast ratio.
+ * @property {number} required Required floor.
+ */
+
+/**
+ * Audit every gated pair in a parsed craft theme.
+ *
+ * @param {Record<string, string>} tokens
+ * @param {number} [floor]
+ * @returns {ContrastFailure[]}
+ */
+export function auditTheme(tokens, floor = AA_FLOOR) {
+  /** @type {ContrastFailure[]} */
+  const failures = [];
+
+  /**
+   * @param {string} token
+   * @param {string} foreground
+   * @param {string} against
+   * @param {string} background
+   */
+  const gate = (token, foreground, against, background) => {
+    const ratio = contrastRatio(foreground, background);
+    if (ratio < floor) {
+      failures.push({ token, foreground, against, background, ratio, required: floor });
+    }
+  };
+
+  for (const backdrop of BACKDROP_TOKENS) {
+    const background = requireToken(tokens, backdrop);
+    for (const token of INK_TOKENS) {
+      gate(token, requireToken(tokens, token), backdrop, background);
+    }
+  }
+
+  for (const [fgToken, bgToken] of TOKEN_PAIRS) {
+    gate(fgToken, requireToken(tokens, fgToken), bgToken, requireToken(tokens, bgToken));
+  }
+
+  // The whole ramp, not just its ends — see gradientRamp().
+  const [from, to] = parseGradientStops(requireToken(tokens, GRADIENT_TOKEN));
+  const ink = requireToken(tokens, GRADIENT_INK_TOKEN);
+  const ramp = gradientRamp(from, to);
+  let worstSample = ramp[0];
+  let worstRatio = Number.POSITIVE_INFINITY;
+  for (const sample of ramp) {
+    const ratio = contrastRatio(ink, sample);
+    if (ratio < worstRatio) {
+      worstRatio = ratio;
+      worstSample = sample;
+    }
+  }
+  if (worstRatio < floor) {
+    failures.push({
+      token: GRADIENT_INK_TOKEN,
+      foreground: ink,
+      against: `${GRADIENT_TOKEN} ramp ${from} -> ${to}`,
+      background: worstSample,
+      ratio: worstRatio,
+      required: floor,
+    });
+  }
+
+  return failures;
+}
+
+/**
+ * Render one failure as a CI log line.
+ *
+ * @param {ContrastFailure} failure
+ * @returns {string}
+ */
+export function formatFailure(failure) {
+  return (
+    `${failure.token} ${failure.foreground} on ${failure.against} ${failure.background}: ` +
+    `${failure.ratio.toFixed(2)}:1 (needs ${failure.required}:1)`
+  );
+}
+
+/** Default location of the theme this script audits. */
+export const CRAFT_THEME_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "src",
+  "styles",
+  "craft-theme.css",
+);
+
+/**
+ * Audit the craft theme file and report to stdout.
+ *
+ * @param {string} [path]
+ * @returns {number} Process exit code.
+ */
+export function main(path = CRAFT_THEME_PATH) {
+  const prefix = "[check-craft-contrast]";
+  /** @type {ContrastFailure[]} */
+  let failures;
+  try {
+    failures = auditTheme(parseCustomProperties(readFileSync(path, "utf8")));
+  } catch (error) {
+    console.error(`${prefix} ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`${prefix} FAIL ${formatFailure(failure)}`);
+    }
+    console.error(
+      `${prefix} ${failures.length} contrast failure(s) in ${path}. ` +
+        "Fix the palette by hand — this checker never rewrites the theme.",
+    );
+    return 1;
+  }
+
+  console.log(`${prefix} craft theme clears ${AA_FLOOR}:1 on every gated pair`);
+  return 0;
+}
+
+if (argv[1] && fileURLToPath(import.meta.url) === resolve(argv[1])) {
+  exit(main());
+}

--- a/apps/site/scripts/check-craft-contrast.mjs
+++ b/apps/site/scripts/check-craft-contrast.mjs
@@ -27,16 +27,22 @@ export const AA_FLOOR = 4.75;
 /** Interior steps taken along `--gradient-primary`; 20 steps = 21 samples. */
 export const GRADIENT_STEPS = 20;
 
-/** Backgrounds every ink token must stay readable on. */
-export const BACKDROP_TOKENS = ["--turbo-bg-base", "--turbo-bg-surface"];
+/**
+ * Backgrounds every ink token must stay readable on.
+ *
+ * `--turbo-bg-overlay` belongs here, not in the excluded set: `global.css`
+ * paints it as the fill behind real prose (feature tile bodies, sidebar link
+ * hover/active, docs section nav) and behind the search dropdown, so any ink
+ * the site can place on the page can land on it.
+ */
+export const BACKDROP_TOKENS = ["--turbo-bg-base", "--turbo-bg-surface", "--turbo-bg-overlay"];
 
 /**
  * Tokens painted as ink on the page backdrop.
  *
- * State fills (`--turbo-state-*`) and `--turbo-bg-overlay` are intentionally
- * absent: those are fills, not ink, and gating them here would audit a pair
- * that is never rendered. Fill/ink pairs that ARE rendered together are
- * declared in `TOKEN_PAIRS` instead.
+ * State fills (`--turbo-state-*`) are intentionally absent: those are fills,
+ * not ink. Fill/ink pairs that ARE rendered together are declared in
+ * `TOKEN_PAIRS` or `GRADIENT_RAMPS` instead.
  */
 export const INK_TOKENS = [
   "--turbo-text-primary",
@@ -75,6 +81,31 @@ export const GRADIENT_TOKEN = "--gradient-primary";
 
 /** Ink token gated against the whole gradient ramp. */
 export const GRADIENT_INK_TOKEN = "--turbo-text-on-brand";
+
+/**
+ * Every gradient the site paints ink on, sampled end to end.
+ *
+ * A ramp is either declared whole in one token (`--gradient-primary`) or
+ * assembled in `global.css` from two separate tokens — `.feature-tile-bubble`
+ * builds `linear-gradient(135deg, --site-accent, --turbo-state-info)` and puts
+ * `--turbo-text-inverse` on it, which is why a state fill still has to be
+ * audited even though it is not a backdrop.
+ *
+ * @type {{ ink: string, gradient?: string, from?: string, to?: string, label: string }[]}
+ */
+export const GRADIENT_RAMPS = [
+  {
+    ink: GRADIENT_INK_TOKEN,
+    gradient: GRADIENT_TOKEN,
+    label: GRADIENT_TOKEN,
+  },
+  {
+    ink: "--turbo-text-inverse",
+    from: "--site-accent",
+    to: "--turbo-state-info",
+    label: ".feature-tile-bubble gradient",
+  },
+];
 
 /** Selector whose declarations are audited. */
 export const CRAFT_SELECTOR = '[data-theme="craft"]';
@@ -320,27 +351,33 @@ export function auditTheme(tokens, floor = AA_FLOOR) {
   }
 
   // The whole ramp, not just its ends — see gradientRamp().
-  const [from, to] = parseGradientStops(requireToken(tokens, GRADIENT_TOKEN));
-  const ink = requireToken(tokens, GRADIENT_INK_TOKEN);
-  const ramp = gradientRamp(from, to);
-  let worstSample = ramp[0];
-  let worstRatio = Number.POSITIVE_INFINITY;
-  for (const sample of ramp) {
-    const ratio = contrastRatio(ink, sample);
-    if (ratio < worstRatio) {
-      worstRatio = ratio;
-      worstSample = sample;
+  for (const spec of GRADIENT_RAMPS) {
+    const [from, to] = spec.gradient
+      ? parseGradientStops(requireToken(tokens, spec.gradient))
+      : [
+          requireToken(tokens, /** @type {string} */ (spec.from)),
+          requireToken(tokens, /** @type {string} */ (spec.to)),
+        ];
+    const ink = requireToken(tokens, spec.ink);
+    let worstSample = from;
+    let worstRatio = Number.POSITIVE_INFINITY;
+    for (const sample of gradientRamp(from, to)) {
+      const ratio = contrastRatio(ink, sample);
+      if (ratio < worstRatio) {
+        worstRatio = ratio;
+        worstSample = sample;
+      }
     }
-  }
-  if (worstRatio < floor) {
-    failures.push({
-      token: GRADIENT_INK_TOKEN,
-      foreground: ink,
-      against: `${GRADIENT_TOKEN} ramp ${from} -> ${to}`,
-      background: worstSample,
-      ratio: worstRatio,
-      required: floor,
-    });
+    if (worstRatio < floor) {
+      failures.push({
+        token: spec.ink,
+        foreground: ink,
+        against: `${spec.label} ramp ${from} -> ${to}`,
+        background: worstSample,
+        ratio: worstRatio,
+        required: floor,
+      });
+    }
   }
 
   return failures;

--- a/apps/site/scripts/check-craft-contrast.mjs
+++ b/apps/site/scripts/check-craft-contrast.mjs
@@ -76,18 +76,56 @@ export const GRADIENT_TOKEN = "--gradient-primary";
 /** Ink token gated against the whole gradient ramp. */
 export const GRADIENT_INK_TOKEN = "--turbo-text-on-brand";
 
+/** Selector whose declarations are audited. */
+export const CRAFT_SELECTOR = '[data-theme="craft"]';
+
 const HEX_RE = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
 
 /**
- * Parse `--custom-property: value;` declarations out of a CSS source.
+ * Return the body of the rule introduced by `selector`.
+ *
+ * Scoping matters: a future light variant or a `:root` block redefining the
+ * same tokens would otherwise shadow the craft values and the audit would
+ * silently measure colours the craft theme never paints.
  *
  * @param {string} css
+ * @param {string} selector
+ * @returns {string}
+ */
+function extractRuleBody(css, selector) {
+  const start = css.indexOf(selector);
+  if (start === -1) {
+    throw new Error(`selector ${selector} not found in theme stylesheet`);
+  }
+  const open = css.indexOf("{", start + selector.length);
+  if (open === -1) {
+    throw new Error(`selector ${selector} has no rule body`);
+  }
+  let depth = 0;
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === "{") {
+      depth++;
+    } else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        return css.slice(open + 1, i);
+      }
+    }
+  }
+  throw new Error(`selector ${selector} has an unterminated rule body`);
+}
+
+/**
+ * Parse the `--custom-property: value;` declarations of one CSS rule.
+ *
+ * @param {string} css
+ * @param {string} [selector]
  * @returns {Record<string, string>}
  */
-export function parseCustomProperties(css) {
+export function parseCustomProperties(css, selector = CRAFT_SELECTOR) {
   /** @type {Record<string, string>} */
   const properties = {};
-  for (const match of css.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/gi)) {
+  for (const match of extractRuleBody(css, selector).matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/gi)) {
     properties[match[1]] = match[2].trim();
   }
   return properties;

--- a/apps/site/scripts/check-craft-contrast.test.mjs
+++ b/apps/site/scripts/check-craft-contrast.test.mjs
@@ -142,6 +142,22 @@ describe("parseCustomProperties", () => {
       "--font-body": '"Archivo", sans-serif',
     });
   });
+
+  it("ignores declarations from other selectors", () => {
+    const css = [
+      ":root {\n  --turbo-bg-base: #ffffff;\n}",
+      '[data-theme="craft"] {\n  --turbo-bg-base: #14110e;\n}',
+      '[data-theme="craft-light"] {\n  --turbo-bg-base: #f5efe4;\n}',
+    ].join("\n");
+
+    expect(parseCustomProperties(css)).toEqual({ "--turbo-bg-base": "#14110e" });
+  });
+
+  it("fails when the audited selector is absent", () => {
+    expect(() => parseCustomProperties(":root {\n  --turbo-bg-base: #14110e;\n}")).toThrow(
+      /selector \[data-theme="craft"\] not found/,
+    );
+  });
 });
 
 describe("parseGradientStops", () => {

--- a/apps/site/scripts/check-craft-contrast.test.mjs
+++ b/apps/site/scripts/check-craft-contrast.test.mjs
@@ -19,6 +19,7 @@ import {
 const PASSING_TOKENS = {
   "--turbo-bg-base": "#14110e",
   "--turbo-bg-surface": "#1a1612",
+  "--turbo-bg-overlay": "#221c17",
   "--turbo-text-primary": "#f0ebe3",
   "--turbo-text-secondary": "#b8aa98",
   "--turbo-body-primary": "#f0ebe3",
@@ -50,6 +51,7 @@ const PASSING_TOKENS = {
   "--turbo-brand-primary": "#e8622a",
   "--turbo-dropdown-item-hover": "#221c17",
   "--turbo-text-on-brand": "#14110e",
+  "--turbo-state-info": "#83a598",
   "--gradient-primary": "linear-gradient(135deg, #e8622a 0%, #dd581d 100%)",
 };
 
@@ -187,7 +189,13 @@ describe("auditTheme", () => {
   it("reports the token, ratio and pair for ink that fails on a backdrop", () => {
     const failures = auditTheme({ ...PASSING_TOKENS, "--turbo-text-secondary": "#8a7d6c" });
 
-    expect(failures).toHaveLength(2);
+    // One failure per backdrop: base, surface and overlay.
+    expect(failures).toHaveLength(3);
+    expect(failures.map((failure) => failure.against)).toEqual([
+      "--turbo-bg-base",
+      "--turbo-bg-surface",
+      "--turbo-bg-overlay",
+    ]);
     expect(failures[0]).toMatchObject({
       token: "--turbo-text-secondary",
       foreground: "#8a7d6c",
@@ -211,6 +219,17 @@ describe("auditTheme", () => {
     expect(failures[0].against).toContain("#129d8d -> #c16e31");
     expect(failures[0].background).not.toBe("#129d8d");
     expect(failures[0].background).not.toBe("#c16e31");
+  });
+
+  it("gates the feature-tile bubble ramp assembled outside the theme file", () => {
+    const failures = auditTheme({ ...PASSING_TOKENS, "--turbo-state-info": "#4a5f57" });
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      token: "--turbo-text-inverse",
+      foreground: "#14110e",
+    });
+    expect(failures[0].against).toContain(".feature-tile-bubble gradient");
   });
 
   it("fails loudly when a gated token is missing", () => {

--- a/apps/site/scripts/check-craft-contrast.test.mjs
+++ b/apps/site/scripts/check-craft-contrast.test.mjs
@@ -1,0 +1,217 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  AA_FLOOR,
+  CRAFT_THEME_PATH,
+  GRADIENT_STEPS,
+  auditTheme,
+  contrastRatio,
+  formatFailure,
+  gradientRamp,
+  hexToRgb,
+  mixToward,
+  parseCustomProperties,
+  parseGradientStops,
+  relativeLuminance,
+} from "./check-craft-contrast.mjs";
+
+/** Minimal token set that clears the floor everywhere. */
+const PASSING_TOKENS = {
+  "--turbo-bg-base": "#14110e",
+  "--turbo-bg-surface": "#1a1612",
+  "--turbo-text-primary": "#f0ebe3",
+  "--turbo-text-secondary": "#b8aa98",
+  "--turbo-body-primary": "#f0ebe3",
+  "--turbo-body-secondary": "#b8aa98",
+  "--turbo-accent-link": "#e8622a",
+  "--turbo-link-default": "#e8622a",
+  "--turbo-heading-h1": "#f0ebe3",
+  "--turbo-heading-h2": "#e8dcc8",
+  "--turbo-heading-h3": "#d4b86a",
+  "--turbo-heading-h4": "#e8622a",
+  "--turbo-heading-h5": "#b8943f",
+  "--turbo-heading-h6": "#c4b8a8",
+  "--site-accent": "#e8622a",
+  "--site-accent-light": "#d4b86a",
+  "--turbo-code-inline-fg": "#d4b86a",
+  "--turbo-code-inline-bg": "#2a2318",
+  "--turbo-code-block-fg": "#f0ebe3",
+  "--turbo-code-block-bg": "#221c17",
+  "--turbo-table-header-fg": "#d4b86a",
+  "--turbo-table-thead-bg": "#221c17",
+  "--turbo-table-cell-bg": "#1a1612",
+  "--turbo-table-stripe": "#1f1a15",
+  "--turbo-panel-header-fg": "#f0ebe3",
+  "--turbo-panel-header-bg": "#14110e",
+  "--turbo-message-body-fg": "#f0ebe3",
+  "--turbo-message-bg": "#1a1612",
+  "--turbo-message-header-bg": "#221c17",
+  "--turbo-text-inverse": "#14110e",
+  "--turbo-brand-primary": "#e8622a",
+  "--turbo-dropdown-item-hover": "#221c17",
+  "--turbo-text-on-brand": "#14110e",
+  "--gradient-primary": "linear-gradient(135deg, #e8622a 0%, #dd581d 100%)",
+};
+
+describe("hexToRgb", () => {
+  it("expands shorthand hex", () => {
+    expect(hexToRgb("#abc")).toEqual([0xaa, 0xbb, 0xcc]);
+  });
+
+  it.each(["rgb(20, 17, 14)", "#14110eff", "chocolate", "color-mix(in srgb, #fff 50%, #000)", ""])(
+    "rejects non-hex value %s",
+    (value) => {
+      expect(() => hexToRgb(value)).toThrow(/unsupported color value/);
+    },
+  );
+});
+
+describe("contrastRatio", () => {
+  it("is 21:1 for black on white", () => {
+    expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 5);
+  });
+
+  it("is symmetric", () => {
+    expect(contrastRatio("#e8622a", "#14110e")).toBeCloseTo(
+      contrastRatio("#14110e", "#e8622a"),
+      10,
+    );
+  });
+
+  it.each([
+    ["#f0ebe3", "#14110e", 15.85],
+    ["#e8622a", "#1a1612", 5.32],
+    ["#d4b86a", "#2a2318", 8.04],
+  ])("clears the floor for known-pass pair %s on %s", (fg, bg, expected) => {
+    expect(contrastRatio(fg, bg)).toBeCloseTo(expected, 1);
+    expect(contrastRatio(fg, bg)).toBeGreaterThanOrEqual(AA_FLOOR);
+  });
+
+  it.each([
+    ["#c44e1a", "#14110e", 3.99],
+    ["#8a7d6c", "#1a1612", 4.48],
+    ["#e8622a", "#c44e1a", 1.39],
+  ])("stays below the floor for known-fail pair %s on %s", (fg, bg, expected) => {
+    expect(contrastRatio(fg, bg)).toBeCloseTo(expected, 1);
+    expect(contrastRatio(fg, bg)).toBeLessThan(AA_FLOOR);
+  });
+
+  it("matches the WCAG luminance of pure channels", () => {
+    expect(relativeLuminance("#ffffff")).toBeCloseTo(1, 10);
+    expect(relativeLuminance("#000000")).toBeCloseTo(0, 10);
+  });
+});
+
+describe("gradientRamp", () => {
+  it("samples 21 points inclusive of both stops", () => {
+    const ramp = gradientRamp("#000000", "#ffffff");
+
+    expect(ramp).toHaveLength(GRADIENT_STEPS + 1);
+    expect(ramp[0]).toBe("#000000");
+    expect(ramp.at(-1)).toBe("#ffffff");
+    expect(ramp[10]).toBe(mixToward("#000000", "#ffffff", 0.5));
+  });
+
+  it("returns a single sample when there is no second stop", () => {
+    expect(gradientRamp("#e8622a", undefined)).toEqual(["#e8622a"]);
+  });
+
+  it("catches a ramp that passes at both stops but fails mid-ramp", () => {
+    // sRGB blends linearly per channel, luminance does not: the interior of
+    // this teal -> copper ramp sits below the chord between its endpoints.
+    const ink = "#14110e";
+    const from = "#129d8d";
+    const to = "#c16e31";
+
+    expect(contrastRatio(ink, from)).toBeGreaterThanOrEqual(AA_FLOOR);
+    expect(contrastRatio(ink, to)).toBeGreaterThanOrEqual(AA_FLOOR);
+
+    const ratios = gradientRamp(from, to).map((sample) => contrastRatio(ink, sample));
+
+    expect(Math.min(...ratios)).toBeLessThan(AA_FLOOR);
+    expect(Math.min(...ratios)).toBeCloseTo(4.55, 1);
+  });
+});
+
+describe("parseCustomProperties", () => {
+  it("extracts declarations from a theme block", () => {
+    const css = `[data-theme="craft"] {\n  --turbo-bg-base: #14110e;\n  --font-body: "Archivo", sans-serif;\n}`;
+
+    expect(parseCustomProperties(css)).toEqual({
+      "--turbo-bg-base": "#14110e",
+      "--font-body": '"Archivo", sans-serif',
+    });
+  });
+});
+
+describe("parseGradientStops", () => {
+  it("returns both stops", () => {
+    expect(parseGradientStops("linear-gradient(135deg, #e8622a 0%, #dd581d 100%)")).toEqual([
+      "#e8622a",
+      "#dd581d",
+    ]);
+  });
+
+  it("rejects gradients that are not two-stop", () => {
+    expect(() => parseGradientStops("linear-gradient(135deg, #e8622a 0%)")).toThrow(/found 1/);
+  });
+
+  it("rejects alpha hex stops", () => {
+    expect(() => parseGradientStops("linear-gradient(135deg, #e8622aff 0%, #dd581d 100%)")).toThrow(
+      /unsupported color value/,
+    );
+  });
+});
+
+describe("auditTheme", () => {
+  it("passes a compliant token set", () => {
+    expect(auditTheme(PASSING_TOKENS)).toEqual([]);
+  });
+
+  it("reports the token, ratio and pair for ink that fails on a backdrop", () => {
+    const failures = auditTheme({ ...PASSING_TOKENS, "--turbo-text-secondary": "#8a7d6c" });
+
+    expect(failures).toHaveLength(2);
+    expect(failures[0]).toMatchObject({
+      token: "--turbo-text-secondary",
+      foreground: "#8a7d6c",
+      against: "--turbo-bg-base",
+      background: "#14110e",
+    });
+    expect(failures[0].ratio).toBeLessThan(AA_FLOOR);
+    expect(formatFailure(failures[0])).toContain(
+      "--turbo-text-secondary #8a7d6c on --turbo-bg-base #14110e",
+    );
+  });
+
+  it("reports a gradient that fails only in its interior", () => {
+    const failures = auditTheme({
+      ...PASSING_TOKENS,
+      "--gradient-primary": "linear-gradient(135deg, #129d8d 0%, #c16e31 100%)",
+    });
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0].token).toBe("--turbo-text-on-brand");
+    expect(failures[0].against).toContain("#129d8d -> #c16e31");
+    expect(failures[0].background).not.toBe("#129d8d");
+    expect(failures[0].background).not.toBe("#c16e31");
+  });
+
+  it("fails loudly when a gated token is missing", () => {
+    const { "--turbo-text-on-brand": _omitted, ...tokens } = PASSING_TOKENS;
+
+    expect(() => auditTheme(tokens)).toThrow(/missing required token --turbo-text-on-brand/);
+  });
+
+  it("rejects a non-hex token value", () => {
+    expect(() =>
+      auditTheme({ ...PASSING_TOKENS, "--turbo-text-primary": "rgb(240, 235, 227)" }),
+    ).toThrow(/unsupported color value/);
+  });
+
+  it("keeps the shipped craft theme compliant", () => {
+    const tokens = parseCustomProperties(readFileSync(CRAFT_THEME_PATH, "utf8"));
+
+    expect(auditTheme(tokens)).toEqual([]);
+  });
+});

--- a/apps/site/src/styles/craft-theme.css
+++ b/apps/site/src/styles/craft-theme.css
@@ -1,4 +1,10 @@
-/* Native Craftforge theme — warm workshop palette without turbo theme CSS files. */
+/*
+ * Native Craftforge theme — warm workshop palette without turbo theme CSS files.
+ *
+ * Every ink/fill pair below is gated at 4.75:1 by
+ * `scripts/check-craft-contrast.mjs` (`bun run check:contrast`). Edit colours
+ * here by hand and re-run the checker; it never rewrites this file.
+ */
 
 [data-theme="craft"] {
   --turbo-bg-base: #14110e;
@@ -7,6 +13,8 @@
   --turbo-text-primary: #f0ebe3;
   --turbo-text-secondary: #b8aa98;
   --turbo-text-inverse: #14110e;
+  /* Ink for anything painted on --gradient-primary (CTA fills). */
+  --turbo-text-on-brand: #14110e;
   --turbo-brand-primary: #e8622a;
   --turbo-accent-link: #e8622a;
   --turbo-state-info: #83a598;
@@ -47,7 +55,14 @@
   --turbo-dropdown-bg: #1a1612;
   --turbo-dropdown-border: #3d342a;
   --turbo-dropdown-item-hover: #221c17;
-  --gradient-primary: linear-gradient(135deg, #e8622a 0%, #c44e1a 100%);
+  /*
+   * The old #c44e1a end stop could host no readable ink at all: the best
+   * possible ink (pure black) reached only 4.45:1 there, below even the 4.5
+   * axe threshold. The deep end is raised to #dd581d — still a rust-deepened
+   * ember ramp — so the warm near-black --turbo-text-on-brand clears 4.75:1
+   * at every sampled point (worst 4.92:1 at the 100% stop).
+   */
+  --gradient-primary: linear-gradient(135deg, #e8622a 0%, #dd581d 100%);
   --shadow-md: 0 4px 16px rgba(20, 16, 10, 0.35);
   --shadow-lg: 0 8px 32px rgba(20, 16, 10, 0.45);
   --shadow-glow: 0 0 0 3px color-mix(in srgb, #e8622a 30%, transparent);

--- a/scripts/ci/site/README.md
+++ b/scripts/ci/site/README.md
@@ -4,6 +4,7 @@
 | --- | --- |
 | `build.sh` | Build Astro site (`ASTRO_BASE` defaults from `defaults.env`) |
 | `check.sh` | `astro check` and dependency install |
+| `check-contrast.sh` | WCAG AA contrast gate for `src/styles/craft-theme.css` |
 | `test.sh` | Vitest with coverage |
 | `test-python.sh` | Pytest for `tests/scripts/ci/` |
 | `test-all.sh` | `test.sh` + `test-python.sh` |

--- a/scripts/ci/site/check-contrast.sh
+++ b/scripts/ci/site/check-contrast.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Gate the hand-authored craft theme against the WCAG AA contrast floor.
+#
+# Runs the checker with plain node (it has no dependencies) so the job needs
+# neither a bun install nor the site build.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SITE_DIR="${ROOT}/apps/site"
+
+cd "${SITE_DIR}"
+
+node scripts/check-craft-contrast.mjs


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(site): audit craft theme tokens against WCAG AA with a contrast checker
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`apps/site/src/styles/craft-theme.css` is the one theme Rustume authors itself, so it
never passes through turbo-themes' WCAG normalizer. This adds the audit that stands in
for it and fixes the one real defect it found.

`apps/site/scripts/check-craft-contrast.mjs` is modelled on turbo-themes'
`scripts/normalize-wcag-aa-tokens.mjs` (same luminance/ratio maths, same gradient
sampling rationale) with one deliberate difference: it **checks and fails, it never
rewrites**. The palette is a hand-authored design statement — drift gets fixed by a
human, not silently averaged toward black or white.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #617
- Relates to #352

## Details

### Checker

- Parses only the `[data-theme="craft"]` rule body (a future light variant or `:root`
  block must not shadow the audited values)
- Gates every ink token against **both** `--turbo-bg-base` and `--turbo-bg-surface`,
  plus the ink/fill pairs the theme declares together (code inline/block, table header,
  panel header, message body, dropdown hover, `--turbo-text-inverse` on brand)
- Samples `--gradient-primary` at **21 points along the ramp**, not just its two stops.
  sRGB blends linearly per channel but luminance does not, so a ramp can clear the floor
  at both ends and collapse in the interior (turbo-themes#774: gruvbox-light-soft
  measured 4.75/4.79 at the ends and 4.46 at 60% along)
- Floor is **4.75:1**, deliberately above the 4.5 axe threshold, for headroom
- Rejects non-hex values (8-digit alpha hex, `rgb()`, `color-mix()`, colour names) rather
  than parsing them to `NaN` and reporting a bogus ratio
- Exits non-zero naming the offending token, the measured ratio and the pair compared

### Palette findings

Every text/link/heading token already cleared 4.75:1 on both backdrops (worst was
`--turbo-link-default` / `--turbo-heading-h4` ember `#e8622a` at 5.32:1 on surface), so
ember, brass and the near-black base are untouched.

The gradient was the real defect. `--gradient-primary` ended at `#c44e1a`, where the
**best possible ink** — pure black — reached only **4.45:1**, below even the plain 4.5
axe threshold. No `--turbo-text-on-brand` value could have fixed that, so the ink token
alone was not enough:

| | before | after |
| --- | --- | --- |
| `--gradient-primary` end stop | `#c44e1a` | `#dd581d` |
| best achievable ink on the ramp | 4.45:1 (pure black) | — |
| `--turbo-text-on-brand` `#14110e` worst sample | 3.99:1 | **4.92:1** |

The new end stop is still a rust-deepened ember ramp; the start stop stays `#e8622a`.
`--turbo-text-on-brand` is added as the warm near-black CTA ink and is itself gated
against all 21 samples, so the token can never claim to be audited without being so.

State fills (`--turbo-state-*`) and `--turbo-bg-overlay` are intentionally out of scope:
they are fills, not ink, and gating them against the backdrop would audit a pair the site
never renders. Their paired-ink handling belongs upstream.

### Wiring

- `bun run check:contrast` in `apps/site/package.json`
- A dedicated `Craft theme contrast (WCAG AA)` job in `.github/workflows/site-quality.yml`
  running `scripts/ci/site/check-contrast.sh` (shell logic in a `.sh` file, actions pinned
  to SHAs, egress blocked). The checker has no dependencies, so the job needs neither a
  `bun install` nor the site build.

### Tests

`apps/site/scripts/check-craft-contrast.test.mjs` (30 cases, Vitest): known-pass and
known-fail pairs against published ratios, non-hex rejection, selector scoping, missing
token, 21-point ramp shape, and specifically **a gradient that passes at both stops and
fails mid-ramp** — plus a live assertion that the shipped `craft-theme.css` is compliant.

### Eventual retirement

lgtm-hq/turbo-themes#840 will promote Craft to a first-class theme family. When it ships,
`craft-theme.css` and this checker both retire in favour of the published, already
normalized tokens. This interim in-place audit lands anyway because #618, #619 and #620
all need an audited palette to point at.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an automated WCAG contrast audit for the hand-authored Craft theme.
- Introduces token-pair and sampled-gradient contrast checks with Vitest coverage.
- Updates the Craft palette and adds dedicated on-brand text.
- Runs the checker through a dependency-free CI job and documents the command.
</details>

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because the contrast gate still misses a foreground currently rendered on the overlay backdrop.

The feature-tile description uses `--a11y-text-secondary` on `--turbo-bg-overlay`, but the checker only audits its fixed `INK_TOKENS` list and does not include that foreground, leaving the previously reported coverage gap outstanding.

**Files Needing Attention:** apps/site/scripts/check-craft-contrast.mjs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/site/scripts/check-craft-contrast.mjs | Adds the contrast engine and expands coverage for the previously reported overlay and feature-tile gradient, but the overlay foreground inventory remains incomplete. |
| apps/site/scripts/check-craft-contrast.test.mjs | Covers color conversion, selector scoping, malformed values, token pairs, sampled gradients, and the shipped theme. |
| apps/site/src/styles/craft-theme.css | Adds dedicated gradient ink and raises the gradient endpoint to satisfy the configured contrast floor. |
| .github/workflows/site-quality.yml | Adds a minimally privileged, dependency-free Craft contrast job. |
| scripts/ci/site/check-contrast.sh | Invokes the Node-based checker from a repository-root-independent site path. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Theme[craft-theme.css] --> Parse[Parse Craft tokens]
  Parse --> Backdrops[Check ink against base, surface, and overlay]
  Parse --> Pairs[Check explicit ink/fill pairs]
  Parse --> Gradients[Sample rendered gradients]
  Backdrops --> Gate{All ratios at least 4.75}
  Pairs --> Gate
  Gradients --> Gate
  Gate -->|Yes| Pass[CI passes]
  Gate -->|No| Fail[CI reports token and ratio]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(site): gate the overlay backdrop an..."](https://github.com/lgtm-hq/rustume/commit/9213d509a9a68096e9503ad8a1fdb7e16aa44cc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47597588)</sub>

<!-- /greptile_comment -->