### PR TITLE
ci: auto-rerun infra failures on Publish - GitHub Release

### DIFF
--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -22,6 +22,12 @@ name: Auto Rerun on Infra Failure
       - Deploy - GitHub Pages
       - Rust Build (workspace)
       - Quality - Lint & Format
+      # Release gate. verify-image idles on a runner for up to 8100s polling
+      # GHCR for docker-build-publish's tags, which makes it the job most
+      # exposed to runner reclamation — and the only one whose loss withholds
+      # a published GitHub Release. v0.50.1 hit exactly that (run 30289961951
+      # attempt 1, exit 143 at 680s of budget) and needed a manual rerun. #639
+      - Publish - GitHub Release
     types: [completed]
 
 permissions: {}


### PR DESCRIPTION
## Summary

Adds `Publish - GitHub Release` to the `workflow_run` trigger list in
`.github/workflows/auto-rerun-on-infra-failure.yml`.

That workflow already exists to rerun jobs killed by GitHub-side infra faults, and its header
comment names "runner shutdown signals" as a covered signature — but the release publish
workflow was never on its watch list. It is the one workflow whose infra failure withholds a
user-visible release, and it was the one without the net.

Closes #639

## Why now

**v0.50.1 hit this today.** Run `30289961951`, attempt 1, job `🔍 Verify Release Image`:

```
Waiting 30s for 2 missing tag(s) (680s/8100s elapsed)
##[error]Process completed with exit code 143.
##[error]The runner has received a shutdown signal. …
```

The poll budget did not expire — 680s into 8100s. The runner was reclaimed. Because `release`
`needs: verify-image`, the GitHub Release was blocked while the GHCR tags published normally,
leaving a tag and images with no Release. A human reran it manually and attempt 2 succeeded, so
v0.50.1 is published and nothing is currently broken. This PR is about the missing recovery.

`verify-image` idles on a runner for up to 8100s polling GHCR for a sibling workflow's output,
which makes it the job most exposed to runner reclamation in the repo.

This was the third `runner has received a shutdown signal` failure in the repo today; the other
two were `rust-build` on #630 and #632. Those were PR branches, which the auto-rerun guard
excludes by design.

## Scope

One entry added to the trigger list. No logic change:

- The job's `if` guard already admits tag pushes via `startsWith(…head_branch, 'v')`, and the
  file's own comment says branch filtering was deliberately avoided for exactly this case.
- The name matches `publish-release-on-tag.yml:3` exactly — `workflow_run` matches on the
  workflow's `name:`, so a mismatch would silently no-op.
- The reusable workflow carries a run-attempt guard upstream, so it reruns once and cannot loop.

## Verification

`uv run lintro chk` — 100/100, clean.

**This cannot be validated on the PR branch.** `workflow_run` triggers only run from the
definition on the default branch, as the file's own comment states, so it takes effect only
after merging. Confirming it works means waiting for the next infra-flaked release run to pick
up an automatic attempt 2 — there is nothing to observe until such a failure occurs naturally.

## Not in scope

- Whether `Test - Web E2E` and the `Security - *` workflows also belong on the list.
- Whether `verify-image` should poll on a runner at all versus being triggered by the docker
  workflow's completion. #597 chose the current shape deliberately; changing it is a larger
  design question, noted in #639.