### PR TITLE
fix(templates): contrast-audit the 12 resume templates for screen and print

### DIFF
--- a/apps/web/e2e/support/contrast.ts
+++ b/apps/web/e2e/support/contrast.ts
@@ -1,0 +1,168 @@
+/**
+ * Colour maths for the template contrast audit.
+ *
+ * Mirrors `apps/site/scripts/check-craft-contrast.mjs` (same luminance and
+ * ratio maths) with the additions this audit needs: Typst's `lighten`/`darken`
+ * operators, and a print surface model. Gradient ramp sampling is deliberately
+ * not duplicated here — no template paints ink on a gradient, and the guard in
+ * `template-contrast.spec.ts` fails if one appears.
+ *
+ * The two surfaces exist because the 12 resume templates are a single Typst
+ * document rendered by two backends — `typst-render` to PNG for the on-screen
+ * preview and `typst-pdf` for the export. The colour VALUES are identical, so
+ * the surfaces only diverge in how a reader's device resolves them: a monitor
+ * shows sRGB, and a monochrome office printer — the overwhelmingly common way a
+ * resume actually reaches a human — collapses hue to a single ink. Two colours
+ * that separate on screen can converge to the same grey on paper, which is the
+ * failure class the print surface exists to catch. It is NOT uniformly stricter
+ * than the screen surface; it is a different projection.
+ */
+
+/** Contrast floor for text, WCAG 2.1 SC 1.4.3 (AA, normal size). */
+export const TEXT_FLOOR = 4.5;
+
+/**
+ * Contrast floor for non-text content, WCAG 2.1 SC 1.4.11.
+ *
+ * Applies to rules, borders, bullets and rating indicators — marks that carry
+ * meaning (a section boundary, a proficiency level) rather than prose.
+ */
+export const NON_TEXT_FLOOR = 3;
+
+const HEX_RE = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/** A colour role, which selects the floor a pair is gated against. */
+export const ContrastRole = {
+  Text: "text",
+  NonText: "non-text",
+} as const;
+
+export type ContrastRole = (typeof ContrastRole)[keyof typeof ContrastRole];
+
+/** Render target a pair is measured on. */
+export const Surface = {
+  Screen: "screen",
+  Print: "print",
+} as const;
+
+export type Surface = (typeof Surface)[keyof typeof Surface];
+
+/** Every surface the audit measures, in report order. */
+export const SURFACES = [Surface.Screen, Surface.Print] as const;
+
+/** The floor a role must clear, regardless of surface. */
+export function floorFor(role: ContrastRole): number {
+  return role === ContrastRole.Text ? TEXT_FLOOR : NON_TEXT_FLOOR;
+}
+
+/**
+ * Convert a hex colour to RGB channels.
+ *
+ * Anything else — 8-digit alpha hex, `rgb()`, a colour name — would parse to
+ * NaN and silently report a bogus ratio, so it is rejected.
+ */
+export function hexToRgb(hex: string): [number, number, number] {
+  const value = hex.trim();
+  if (!HEX_RE.test(value)) {
+    throw new Error(`unsupported color value: ${hex} (only #rgb / #rrggbb are supported)`);
+  }
+  const digits = value.slice(1);
+  const full =
+    digits.length === 3
+      ? digits
+          .split("")
+          .map((channel) => channel + channel)
+          .join("")
+      : digits;
+  return [0, 2, 4].map((offset) => parseInt(full.slice(offset, offset + 2), 16)) as [
+    number,
+    number,
+    number,
+  ];
+}
+
+/** Convert RGB channels back to a hex colour. */
+export function rgbToHex(rgb: readonly number[]): string {
+  return `#${rgb
+    .map((channel) =>
+      Math.max(0, Math.min(255, Math.round(channel)))
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+/** WCAG relative luminance of a hex colour. */
+export function relativeLuminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex).map((channel) => {
+    const s = channel / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG contrast ratio between two hex colours. */
+export function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Typst's `color.lighten(factor)` for an `rgb()` colour.
+ *
+ * Typst stores `rgb("#…")` as `palette::rgb::Rgba<Srgb, f32>` and delegates to
+ * palette's `Lighten`, which raises each GAMMA-ENCODED channel toward its
+ * maximum: `c + (1 - c) * factor`. Doing this in linear light instead would
+ * produce visibly different colours, so the encoding matters.
+ */
+export function lighten(hex: string, factor: number): string {
+  return rgbToHex(
+    hexToRgb(hex).map((channel) => {
+      const c = channel / 255;
+      return (c + (1 - c) * factor) * 255;
+    }),
+  );
+}
+
+/**
+ * Typst's `color.darken(factor)` for an `rgb()` colour.
+ *
+ * palette's `Darken` lowers each gamma-encoded channel toward its minimum,
+ * which for RGB is zero: `c - c * factor`.
+ */
+export function darken(hex: string, factor: number): string {
+  return rgbToHex(
+    hexToRgb(hex).map((channel) => {
+      const c = channel / 255;
+      return c * (1 - factor) * 255;
+    }),
+  );
+}
+
+/**
+ * Project a colour onto a monochrome printer's single ink.
+ *
+ * Uses BT.601 luma over the gamma-encoded channels, which is what a greyscale
+ * print driver applies. This is deliberately NOT WCAG relative luminance: that
+ * would be a no-op, because the contrast ratio is already luminance-only, and
+ * the print surface would then be an exact copy of the screen surface. BT.601
+ * weights hue differently, so hues that separate on screen can converge here —
+ * the thing worth gating.
+ */
+export function toPrintGrey(hex: string): string {
+  const [r, g, b] = hexToRgb(hex);
+  const luma = 0.299 * r + 0.587 * g + 0.114 * b;
+  return rgbToHex([luma, luma, luma]);
+}
+
+/** Project a colour onto a render surface. */
+export function project(hex: string, surface: Surface): string {
+  return surface === Surface.Print ? toPrintGrey(hex) : hex;
+}
+
+/** Contrast ratio between two colours as resolved on a given surface. */
+export function surfaceRatio(foreground: string, background: string, surface: Surface): number {
+  return contrastRatio(project(foreground, surface), project(background, surface));
+}

--- a/apps/web/e2e/support/templateContrastMatrix.ts
+++ b/apps/web/e2e/support/templateContrastMatrix.ts
@@ -1,0 +1,238 @@
+/**
+ * The template x surface contrast matrix.
+ *
+ * Each entry names an ink and the backdrop it is painted on, as Typst colour
+ * expressions resolved against the template's own source. Nothing here is a
+ * copied hex value: rename a binding or retune a tint in
+ * `crates/render/src/typst_engine/templates/` and the matrix fails rather than
+ * quietly measuring a colour the template no longer paints.
+ *
+ * Pairs were derived by walking every `fill:`, `stroke:` and `line()` in all 12
+ * templates and `_common.typ`, recording which enclosing `box`/`rect`/`grid`
+ * fill each piece of ink actually lands on. Text that inherits the page-level
+ * `set text(fill: text-color)` is covered by the `text-color` rows.
+ */
+import { ContrastRole } from "./contrast";
+
+/** One ink-on-backdrop relationship a template paints. */
+export interface ContrastPair {
+  /** What the pair is, in the report and in failure output. */
+  readonly label: string;
+  /** Typst colour expression for the ink. */
+  readonly ink: string;
+  /** Typst colour expression for what sits behind it. */
+  readonly backdrop: string;
+  /** Selects the WCAG floor; text unless stated. */
+  readonly role?: ContrastRole;
+}
+
+/**
+ * Pairs every template paints, wherever its layout puts them.
+ *
+ * The profile badge comes from `_common.typ`, which fills the icon chip with
+ * `fill.lighten(82%)` and then writes the icon mark in `fill` itself — a
+ * self-referential pair that is easy to miss because no template declares it.
+ */
+const UNIVERSAL_PAIRS: readonly ContrastPair[] = [
+  { label: "body text on page", ink: "text-color", backdrop: "bg-color" },
+  { label: "muted text on page", ink: "muted-color", backdrop: "bg-color" },
+  { label: "accent ink on page", ink: "accent-color", backdrop: "bg-color" },
+  {
+    label: "section rule on page",
+    ink: "accent-color",
+    backdrop: "bg-color",
+    role: ContrastRole.NonText,
+  },
+  {
+    label: "profile badge mark on its own chip",
+    ink: "accent-color",
+    backdrop: "accent-color.lighten(82%)",
+  },
+  {
+    label: "profile icon fallback ink on page",
+    ink: "#333333",
+    backdrop: "bg-color",
+  },
+  {
+    label: "rating indicator outline on page",
+    ink: "accent-color",
+    backdrop: "bg-color",
+    role: ContrastRole.NonText,
+  },
+];
+
+/**
+ * Per-template pairs: tinted panels, chips, coloured bars and any ink a
+ * template paints on something other than the bare page.
+ */
+const TEMPLATE_PAIRS: Readonly<Record<string, readonly ContrastPair[]>> = {
+  azurill: [
+    { label: "keyword chip ink", ink: "accent-color", backdrop: "light-bg" },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "bar-empty",
+      role: ContrastRole.NonText,
+    },
+  ],
+  bronzor: [
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "bg-color.darken(10%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+  chikorita: [
+    { label: "sidebar panel heading", ink: "accent-color", backdrop: "light-bg" },
+    { label: "sidebar panel body text", ink: "text-color", backdrop: "light-bg" },
+    { label: "sidebar panel muted text", ink: "muted-color", backdrop: "light-bg" },
+    { label: "keyword chip ink", ink: "accent-color", backdrop: "accent-bg" },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "border-color",
+      role: ContrastRole.NonText,
+    },
+  ],
+  ditto: [
+    { label: "sidebar heading", ink: "accent-color", backdrop: "sidebar-bg" },
+    { label: "sidebar body text", ink: "text-color", backdrop: "sidebar-bg" },
+    { label: "sidebar muted text", ink: "muted-color", backdrop: "sidebar-bg" },
+    { label: "keyword chip ink", ink: "accent-color", backdrop: "light-bg" },
+    { label: "header name on accent bar", ink: "white", backdrop: "accent-color" },
+    {
+      label: "header headline on accent bar",
+      ink: "accent-color.lighten(80%)",
+      backdrop: "accent-color",
+    },
+    {
+      label: "header contact line on accent bar",
+      ink: "accent-color.lighten(85%)",
+      backdrop: "accent-color",
+    },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "bg-color.darken(10%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+  gengar: [
+    { label: "sidebar heading", ink: "accent-color", backdrop: "sidebar-bg" },
+    { label: "sidebar body text", ink: "sidebar-text", backdrop: "sidebar-bg" },
+    { label: "sidebar muted text", ink: "muted-color", backdrop: "sidebar-bg" },
+    { label: "project tag ink", ink: "accent-color", backdrop: "sidebar-bg" },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "bg-color.darken(10%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+  glalie: [
+    { label: "sidebar heading", ink: "accent-color", backdrop: "sidebar-bg" },
+    { label: "sidebar body text", ink: "text-color", backdrop: "sidebar-bg" },
+    { label: "sidebar muted text", ink: "muted-color", backdrop: "sidebar-bg" },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "accent-color.lighten(70%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+  kakuna: [
+    { label: "keyword chip ink", ink: "accent-color", backdrop: "light-bg" },
+    {
+      label: "header box border on page",
+      ink: "border-color",
+      backdrop: "bg-color",
+      role: ContrastRole.NonText,
+    },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "bg-color.darken(10%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+  leafish: [
+    { label: "header name on header band", ink: "accent-color", backdrop: "header-bg" },
+    { label: "header headline on header band", ink: "header-text-color", backdrop: "header-bg" },
+    { label: "contact bar ink", ink: "#ffffff", backdrop: "contact-bar-bg" },
+    {
+      label: "contact bar separator",
+      ink: "separator-color",
+      backdrop: "contact-bar-bg",
+      role: ContrastRole.NonText,
+    },
+    { label: "keyword chip ink", ink: "accent-color", backdrop: "tag-bg" },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "bg-color.darken(10%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+  nosepass: [
+    { label: "date badge muted ink", ink: "muted-color", backdrop: "light-gray" },
+    { label: "keyword chip body text", ink: "text-color", backdrop: "light-gray" },
+    {
+      label: "section rule and skill box border",
+      ink: "border-color",
+      backdrop: "bg-color",
+      role: ContrastRole.NonText,
+    },
+    {
+      label: "skill bullet filled vs hollow outline",
+      ink: "accent-color",
+      backdrop: "bg-color",
+      role: ContrastRole.NonText,
+    },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "bg-color.darken(10%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+  onyx: [
+    { label: "keyword chip ink", ink: "accent-color", backdrop: "accent-color.lighten(92%)" },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "bg-color.darken(10%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+  pikachu: [
+    { label: "sidebar heading", ink: "accent-color", backdrop: "sidebar-bg" },
+    { label: "sidebar body text", ink: "sidebar-text-color", backdrop: "sidebar-bg" },
+    { label: "sidebar muted text", ink: "muted-color", backdrop: "sidebar-bg" },
+    { label: "section pill ink on accent", ink: "white", backdrop: "accent-color" },
+    { label: "avatar initials on accent", ink: "white", backdrop: "accent-color" },
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "sidebar-bg.darken(15%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+  rhyhorn: [
+    {
+      label: "rating indicator fill vs empty",
+      ink: "accent-color",
+      backdrop: "bg-color.darken(10%)",
+      role: ContrastRole.NonText,
+    },
+  ],
+};
+
+/** Every pair audited for one template. */
+export function pairsFor(templateId: string): readonly ContrastPair[] {
+  const specific = TEMPLATE_PAIRS[templateId];
+  if (!specific) {
+    throw new Error(`no contrast matrix entry for template ${templateId}`);
+  }
+  return [...UNIVERSAL_PAIRS, ...specific];
+}

--- a/apps/web/e2e/support/typstPalette.ts
+++ b/apps/web/e2e/support/typstPalette.ts
@@ -1,0 +1,135 @@
+/**
+ * Read the colour palette a Typst resume template actually declares.
+ *
+ * The audit gates colours parsed from `crates/render/src/typst_engine/templates/`
+ * rather than a hand-copied table, so a template that changes its accent, its
+ * muted ink or a fill tint cannot drift away from the matrix that guards it.
+ * The matrix only declares RELATIONSHIPS (which ink lands on which backdrop);
+ * the values always come from the source.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { darken, lighten } from "./contrast";
+
+/** Directory holding the 12 Typst templates and their shared `_common.typ`. */
+export const TEMPLATE_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+  "crates",
+  "render",
+  "src",
+  "typst_engine",
+  "templates",
+);
+
+/**
+ * Every shipped template id, in the order `TEMPLATES` lists them in
+ * `crates/render/src/typst_engine/engine.rs`.
+ */
+export const TEMPLATE_IDS = [
+  "azurill",
+  "bronzor",
+  "chikorita",
+  "ditto",
+  "gengar",
+  "glalie",
+  "kakuna",
+  "leafish",
+  "nosepass",
+  "onyx",
+  "pikachu",
+  "rhyhorn",
+] as const;
+
+export type TemplateId = (typeof TEMPLATE_IDS)[number];
+
+/** Resolved colour bindings of one template, keyed by their Typst names. */
+export type Palette = Readonly<Record<string, string>>;
+
+const LET_RE = /^\s*(?:#)?let\s+([a-z][a-z0-9-]*)\s*=\s*(.+?)\s*$/gim;
+const THEME_DEFAULT_RE =
+  /^rgb\(\s*data\.metadata\.theme\.at\([^,]+,\s*default:\s*"(#[0-9a-f]{3,6})"\s*\)\s*\)$/i;
+const RGB_LITERAL_RE = /^rgb\(\s*"(#[0-9a-f]{3,6})"\s*\)$/i;
+const HEX_LITERAL_RE = /^(#[0-9a-f]{3}|#[0-9a-f]{6})$/i;
+const MODIFIER_RE = /^(.+?)\.(lighten|darken)\(\s*(\d+(?:\.\d+)?)%\s*\)$/i;
+
+/**
+ * Evaluate one Typst colour expression against already-resolved bindings.
+ *
+ * Returns `null` for anything outside the grammar the templates use — a
+ * conditional, a helper call, an alpha hex — so the caller can skip a binding
+ * that carries no auditable colour instead of inventing a number for it.
+ */
+export function evaluateExpression(expression: string, resolved: Palette): string | null {
+  const expr = expression.trim();
+
+  const modifier = MODIFIER_RE.exec(expr);
+  if (modifier) {
+    const base = evaluateExpression(modifier[1], resolved);
+    if (base === null) {
+      return null;
+    }
+    const factor = Number(modifier[3]) / 100;
+    return modifier[2].toLowerCase() === "lighten" ? lighten(base, factor) : darken(base, factor);
+  }
+
+  const themed = THEME_DEFAULT_RE.exec(expr);
+  if (themed) {
+    return themed[1].toLowerCase();
+  }
+
+  const literal = RGB_LITERAL_RE.exec(expr) ?? HEX_LITERAL_RE.exec(expr);
+  if (literal) {
+    return literal[1].toLowerCase();
+  }
+
+  if (Object.hasOwn(resolved, expr)) {
+    return resolved[expr];
+  }
+
+  return null;
+}
+
+/**
+ * Parse the colour bindings of a Typst template source.
+ *
+ * Bindings are resolved in source order, which is also dependency order: a
+ * template declares `primary-color` before the tints derived from it.
+ */
+export function parsePalette(source: string): Palette {
+  const resolved: Record<string, string> = {};
+  for (const match of source.matchAll(LET_RE)) {
+    const [, name, expression] = match;
+    const value = evaluateExpression(expression, resolved);
+    if (value !== null) {
+      resolved[name] = value;
+    }
+  }
+  return resolved;
+}
+
+/** Read and parse one template's palette from disk. */
+export function readPalette(templateId: TemplateId, templateDir = TEMPLATE_DIR): Palette {
+  return parsePalette(readFileSync(join(templateDir, `${templateId}.typ`), "utf8"));
+}
+
+/**
+ * Resolve an arbitrary Typst colour expression against a template's palette.
+ *
+ * The matrix uses this for backdrops a template composes inline rather than
+ * binding to a name — `accent-color.lighten(92%)` chips, for instance.
+ */
+export function resolveColor(palette: Palette, expression: string, templateId: string): string {
+  const value = evaluateExpression(expression, palette);
+  if (value === null) {
+    throw new Error(
+      `template ${templateId} cannot resolve the colour expression "${expression}" — ` +
+        "the contrast matrix and the Typst source have drifted apart",
+    );
+  }
+  return value;
+}

--- a/apps/web/e2e/template-contrast.spec.ts
+++ b/apps/web/e2e/template-contrast.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * Contrast audit of the 12 resume templates across screen and print.
+ *
+ * ## Why this is not an axe scan of the preview
+ *
+ * A resume template is a Typst document, not DOM. `crates/render` compiles it
+ * once and hands it to two backends — `typst-render` rasterises a PNG for the
+ * on-screen preview, `typst-pdf` writes the export — so the preview the user
+ * sees in the editor is an `<img>`, and every glyph inside it is opaque to axe.
+ * Running the colour-contrast rule against the preview would report a clean
+ * page while the resume inside it failed, which is the exact false negative
+ * this audit exists to prevent.
+ *
+ * So the matrix gates the source of both renders: every ink/backdrop pair the
+ * templates can paint, resolved from the Typst sources themselves
+ * (`support/templateContrastMatrix.ts`). That is content-independent — it holds
+ * for every resume a template can render, not just whichever fixture a scan
+ * happened to load — and it covers the PDF path, which no browser-side check
+ * can reach because `renderPdf` in `src/api/render.ts` POSTs to a server.
+ *
+ * axe still runs, per template, over the editor chrome that frames the preview:
+ * that surface IS DOM, and it is where a template switch could regress the app.
+ */
+import AxeBuilder from "@axe-core/playwright";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Page } from "@playwright/test";
+import { test, expect, DEFAULT_TEMPLATE_ID, TEMPLATES_ROUTE } from "./support/fixtures";
+import { ContrastRole, SURFACES, floorFor, surfaceRatio, type Surface } from "./support/contrast";
+import { pairsFor } from "./support/templateContrastMatrix";
+import {
+  TEMPLATE_DIR,
+  TEMPLATE_IDS,
+  readPalette,
+  resolveColor,
+  type TemplateId,
+} from "./support/typstPalette";
+
+/** WCAG 2.1 AA scan scope, matching the rest of the suite. */
+const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+
+/** Display name the template catalog exposes for a template id. */
+function displayName(templateId: string): string {
+  return templateId.charAt(0).toUpperCase() + templateId.slice(1);
+}
+
+/**
+ * The full 12-template catalog.
+ *
+ * The shared fixture serves a deliberately small three-template catalog that
+ * other suites screenshot; this route override widens it to the real shipped
+ * set for this spec only, so the picker can be driven across every template
+ * without moving anyone else's visual baseline. Only the ids and names matter
+ * here — the picker shows a stubbed thumbnail, and the colours a template
+ * paints are gated by the matrix above, not by this catalog.
+ */
+const FULL_TEMPLATE_CATALOG = TEMPLATE_IDS.map((id) => ({
+  id,
+  name: displayName(id),
+  theme: { background: "#ffffff", text: "#000000", primary: "#65a30d" },
+}));
+
+/** One measured cell of the matrix. */
+interface Measurement {
+  readonly label: string;
+  readonly ink: string;
+  readonly backdrop: string;
+  readonly ratio: number;
+  readonly required: number;
+}
+
+/** Measure every pair a template paints, on one surface. */
+function measure(templateId: TemplateId, surface: Surface): Measurement[] {
+  const palette = readPalette(templateId);
+  return pairsFor(templateId).map((pair) => {
+    const ink = resolveColor(palette, pair.ink, templateId);
+    const backdrop = resolveColor(palette, pair.backdrop, templateId);
+    const role = pair.role ?? ContrastRole.Text;
+    return {
+      label: pair.label,
+      ink,
+      backdrop,
+      ratio: surfaceRatio(ink, backdrop, surface),
+      required: floorFor(role),
+    };
+  });
+}
+
+/** Render a failing cell as an assertion message line. */
+function describeFailure(templateId: TemplateId, surface: Surface, cell: Measurement): string {
+  return (
+    `${templateId} [${surface}] ${cell.label}: ${cell.ink} on ${cell.backdrop} ` +
+    `= ${cell.ratio.toFixed(2)}:1 (needs ${cell.required}:1)`
+  );
+}
+
+test.describe("template contrast matrix", () => {
+  TEMPLATE_IDS.forEach((templateId) => {
+    SURFACES.forEach((surface) => {
+      test(`${templateId} clears WCAG AA on ${surface}`, () => {
+        const failures = measure(templateId, surface)
+          .filter((cell) => cell.ratio < cell.required)
+          .map((cell) => describeFailure(templateId, surface, cell));
+        expect(failures).toEqual([]);
+      });
+    });
+  });
+
+  test("every template declares an audited accent ink", () => {
+    // The accent is what makes headings, links and rules readable; a template
+    // that drops the binding would silently fall back to the raw brand seed,
+    // which is the failure this whole audit started from.
+    const missing = TEMPLATE_IDS.filter((templateId) => !readPalette(templateId)["accent-color"]);
+    expect(missing).toEqual([]);
+  });
+
+  test("no template paints ink over an unaudited gradient", () => {
+    // axe flattens a gradient to a single colour and misses one-end failures,
+    // and so would the flat pair matrix above: sRGB blending is linear per
+    // channel but luminance is not, so a ramp dips below the chord between its
+    // endpoints and both stops can clear the floor while the middle does not.
+    // No template uses a Typst gradient today. If one appears, its ink has to
+    // be gated against every sample of the ramp — `gradientRamp` in
+    // `apps/site/scripts/check-craft-contrast.mjs` already does the sampling —
+    // rather than against a single stop, and this guard is what says so.
+    const withGradients = [...TEMPLATE_IDS, "_common"].filter((name) =>
+      /\bgradient\s*[.(]/.test(readFileSync(join(TEMPLATE_DIR, `${name}.typ`), "utf8")),
+    );
+    expect(withGradients).toEqual([]);
+  });
+});
+
+test.describe("template rendering surfaces", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(TEMPLATES_ROUTE, (route) =>
+      route.fulfill({ status: 200, json: FULL_TEMPLATE_CATALOG }),
+    );
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unroute(TEMPLATES_ROUTE);
+  });
+
+  TEMPLATE_IDS.forEach((templateId) => {
+    test(`${templateId} preview and PDF export are free of WCAG 2.1 AA violations`, async ({
+      page,
+      homePage,
+      builderPage,
+      templatePickerModal,
+      exportModal,
+    }) => {
+      await homePage.open();
+      await homePage.createResume();
+      await builderPage.assertEditorOpen();
+      await builderPage.assertSaved();
+
+      await test.step("select the template", async () => {
+        await builderPage.openTemplatePicker(DEFAULT_TEMPLATE_ID);
+        await templatePickerModal.assertOpen();
+        await templatePickerModal.selectTemplate(displayName(templateId));
+        await templatePickerModal.assertClosed();
+        await builderPage.assertSelectedTemplate(templateId);
+        await builderPage.assertPreviewVisible();
+      });
+
+      await test.step("scan the editor chrome framing the preview", async () => {
+        // The transient creation toast would otherwise be scanned mid-flight.
+        await expect(page.getByText("New resume created")).toBeHidden({ timeout: 15_000 });
+        expect(await scanForViolations(page)).toEqual([]);
+      });
+
+      await test.step("the PDF export carries this template", async () => {
+        // Ties the print half of the matrix to the artefact a user actually
+        // sends: the export asks the server for THIS template, so the colours
+        // gated above are the colours the PDF is built from.
+        await builderPage.openExportModal();
+        await exportModal.assertOpen();
+        const renderRequest = page.waitForRequest(
+          (request) =>
+            request.url().includes("/api/render/pdf") &&
+            (request.postData() ?? "").includes(`"template":"${templateId}"`),
+        );
+        const download = page.waitForEvent("download");
+        await exportModal.exportPdf();
+        await renderRequest;
+        await download;
+        await exportModal.assertClosed();
+      });
+    });
+  });
+});
+
+/** Human-readable summary so failures state the rule, impact, and targets. */
+interface ViolationSummary {
+  rule: string;
+  impact: string;
+  description: string;
+  targets: string[];
+}
+
+async function scanForViolations(page: Page): Promise<ViolationSummary[]> {
+  const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+  return results.violations.map((violation) => ({
+    rule: violation.id,
+    impact: violation.impact ?? "unknown",
+    description: violation.description,
+    targets: violation.nodes.flatMap((node) => node.target.map(String)),
+  }));
+}

--- a/crates/render/src/typst_engine/templates/_common.typ
+++ b/crates/render/src/typst_engine/templates/_common.typ
@@ -117,12 +117,27 @@
 /// - `filled-color`, `empty-color`: fill for active/inactive indicators
 /// - `radius`: border radius (50% for circles, 0pt–2pt for squares/rounded)
 /// - `spacing`: horizontal gap between indicators
+///
+/// Every indicator carries a `filled-color` outline, empty ones included. A
+/// rating is a graphical object that conveys information, so WCAG 2.1 SC 1.4.11
+/// asks for 3:1 twice over: between the filled and empty states, AND between an
+/// empty indicator and the page, so a reader can tell how many steps the scale
+/// has. Those two demands pull in opposite directions when both states are
+/// solid — a tint pale enough to read as "empty" against a filled accent is
+/// nearly invisible on white. The outline breaks the tie the way a radio button
+/// does: the ring carries visibility, the fill carries state.
 #let rating-indicators(level, width, height, filled-color, empty-color, radius, spacing) = {
   let level = clamp-level(level)
   for i in range(5) {
     if i > 0 { h(spacing) }
     let color = if i < level { filled-color } else { empty-color }
-    box(width: width, height: height, fill: color, radius: radius)
+    box(
+      width: width,
+      height: height,
+      fill: color,
+      radius: radius,
+      stroke: 0.5pt + filled-color,
+    )
   }
 }
 
@@ -164,6 +179,9 @@
       height: track-height,
       fill: empty-color,
       radius: track-height / 2,
+      // Same reasoning as rating-indicators: the track outline is what makes
+      // the unfilled remainder of the bar visible against the page.
+      stroke: 0.5pt + filled-color,
       place(top + left, box(
         width: track-width * level / 5,
         height: track-height,
@@ -193,7 +211,7 @@
 }
 
 /// Render a clickable URL link for an item, if present.
-/// Uses primary-color for styling — caller must have it in scope.
+/// `color` is link ink, so callers pass their audited `accent-color`.
 #let render-url(item, color) = {
   if has-url(item) {
     v(2pt)

--- a/crates/render/src/typst_engine/templates/azurill.typ
+++ b/crates/render/src/typst_engine/templates/azurill.typ
@@ -11,7 +11,12 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = text-color.lighten(40%)
+  let muted-color = text-color.lighten(30%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(35%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
@@ -21,18 +26,18 @@
   // Section heading for main content area (right column)
   let main-section-heading(title) = {
     v(14pt)
-    text(weight: "bold", size: 11pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+    text(weight: "bold", size: 11pt, fill: accent-color, tracking: 0.06em)[#upper(title)]
     v(2pt)
-    line(length: 100%, stroke: 1.5pt + primary-color)
+    line(length: 100%, stroke: 1.5pt + accent-color)
     v(8pt)
   }
 
   // Section heading for sidebar (left column) - smaller, different style
   let sidebar-section-heading(title) = {
     v(12pt)
-    text(weight: "semibold", size: 9pt, fill: primary-color, tracking: 0.1em)[#upper(title)]
+    text(weight: "semibold", size: 9pt, fill: accent-color, tracking: 0.1em)[#upper(title)]
     v(2pt)
-    line(length: 100%, stroke: 0.75pt + primary-color)
+    line(length: 100%, stroke: 0.75pt + accent-color)
     v(6pt)
   }
 
@@ -40,11 +45,11 @@
   let rating-bars(level) = {
     let level = clamp-level(level)
     if level-display == "template-default" {
-      rating-indicators(level, 14pt, 4pt, primary-color, bar-empty, 2pt, 2pt)
+      rating-indicators(level, 14pt, 4pt, accent-color, bar-empty, 2pt, 2pt)
     } else if level-display == "progress-bar" {
-      render-level(level, level-display, primary-color, bar-empty, track-width: 70pt)
+      render-level(level, level-display, accent-color, bar-empty, track-width: 70pt)
     } else {
-      render-level(level, level-display, primary-color, bar-empty)
+      render-level(level, level-display, accent-color, bar-empty)
     }
   }
 
@@ -165,7 +170,7 @@
       item,
       size: 9pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: "username",
     )
     v(6pt)
@@ -198,7 +203,7 @@
           fill: light-bg,
           radius: 3pt,
           inset: (x: 5pt, y: 2pt),
-          text(size: 8pt, fill: primary-color)[#keyword]
+          text(size: 8pt, fill: accent-color)[#keyword]
         )
         h(3pt)
       }
@@ -267,7 +272,7 @@
           fill: light-bg,
           radius: 3pt,
           inset: (x: 5pt, y: 2pt),
-          text(size: 8pt, fill: primary-color)[#keyword]
+          text(size: 8pt, fill: accent-color)[#keyword]
         )
         h(3pt)
       }
@@ -379,7 +384,7 @@
       text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(10pt)
   }
 
@@ -422,7 +427,7 @@
     // ── Header - centered, above columns ──
     align(center)[
       #if has-visible-picture(data.basics) {
-        render-picture(data.basics, primary-color)
+        render-picture(data.basics, accent-color)
         v(8pt)
       }
 
@@ -430,7 +435,7 @@
 
       #if data.basics.headline != "" {
         v(4pt)
-        text(size: 11pt, fill: primary-color)[#data.basics.headline]
+        text(size: 11pt, fill: accent-color)[#data.basics.headline]
       }
 
       #v(8pt)
@@ -446,7 +451,7 @@
     ]
 
     v(16pt)
-    line(length: 100%, stroke: 1pt + primary-color)
+    line(length: 100%, stroke: 1pt + accent-color)
     v(12pt)
 
     // Column indices match the Layout Editor labels: 0 = Main, 1 = Sidebar.

--- a/crates/render/src/typst_engine/templates/bronzor.typ
+++ b/crates/render/src/typst_engine/templates/bronzor.typ
@@ -12,15 +12,20 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#6b7280")
+  let muted-color = text-color.lighten(30%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(30%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
   let section-heading(title) = {
     v(12pt)
-    text(weight: "bold", size: 11pt, fill: primary-color)[#upper(title)]
+    text(weight: "bold", size: 11pt, fill: accent-color)[#upper(title)]
     v(2pt)
-    line(length: 100%, stroke: 0.5pt + primary-color)
+    line(length: 100%, stroke: 0.5pt + accent-color)
     v(6pt)
   }
 
@@ -39,10 +44,10 @@
     let level = clamp-level(level)
     if level-display == "template-default" {
       h(4pt)
-      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
+      rating-indicators(level, 8pt, 8pt, accent-color, bg-color.darken(10%), 2pt, 2pt)
     } else if should-render-level(level, level-display) {
       h(4pt)
-      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+      render-level(level, level-display, accent-color, bg-color.darken(10%), width: 8pt, height: 8pt)
     }
   }
 
@@ -145,7 +150,7 @@
       item,
       size: 10pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: if has-url(item) { "username" } else { "network-username" },
     )
     v(4pt)
@@ -323,7 +328,7 @@
       text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(8pt)
   }
 
@@ -366,7 +371,7 @@
     align(center)[
       // Picture area
       #if has-visible-picture(data.basics) {
-        render-picture(data.basics, primary-color)
+        render-picture(data.basics, accent-color)
         v(8pt)
       }
 
@@ -384,14 +389,14 @@
       // Contact items - wrapped horizontally
       #let contact-items = build-contact-items(data.basics)
       #if has-url(data.basics) {
-        contact-items = contact-items + (link(data.basics.url.href)[#text(fill: primary-color)[#url-display-label(data.basics.url)]],)
+        contact-items = contact-items + (link(data.basics.url.href)[#text(fill: accent-color)[#url-display-label(data.basics.url)]],)
       }
 
       #text(size: 9pt)[#contact-items.join([#h(10pt)#text(fill: muted-color)[|]#h(10pt)])]
     ]
 
     v(8pt)
-    line(length: 100%, stroke: 0.5pt + primary-color)
+    line(length: 100%, stroke: 0.5pt + accent-color)
     v(8pt)
 
     render-resume(data, (

--- a/crates/render/src/typst_engine/templates/chikorita.typ
+++ b/crates/render/src/typst_engine/templates/chikorita.typ
@@ -11,7 +11,12 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#6b7280")
+  let muted-color = text-color.lighten(10%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(35%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
@@ -23,27 +28,27 @@
     v(14pt)
     box(
       width: 100%,
-      stroke: (bottom: 2pt + primary-color),
+      stroke: (bottom: 2pt + accent-color),
       inset: (bottom: 4pt),
-      text(weight: "bold", size: 10pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+      text(weight: "bold", size: 10pt, fill: accent-color, tracking: 0.06em)[#upper(title)]
     )
     v(10pt)
   }
 
   let sidebar-section(title) = {
     v(12pt)
-    text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.08em)[#upper(title)]
+    text(weight: "bold", size: 9pt, fill: accent-color, tracking: 0.08em)[#upper(title)]
     v(2pt)
-    line(length: 100%, stroke: 0.5pt + border-color)
+    line(length: 100%, stroke: 0.5pt + accent-color)
     v(6pt)
   }
 
   let rating-dots(level) = {
     let level = clamp-level(level)
     if level-display == "template-default" {
-      rating-indicators(level, 6pt, 6pt, primary-color, border-color, 50%, 3pt)
+      rating-indicators(level, 6pt, 6pt, accent-color, border-color, 50%, 3pt)
     } else {
-      render-level(level, level-display, primary-color, border-color, spacing: 3pt)
+      render-level(level, level-display, accent-color, border-color, spacing: 3pt)
     }
   }
 
@@ -56,7 +61,7 @@
       [
         #text(weight: "bold", size: 11pt)[#item.company]
         #v(2pt)
-        #text(size: 10pt, fill: primary-color)[#item.position]
+        #text(size: 10pt, fill: accent-color)[#item.position]
       ],
       align(right)[
         #text(size: 9pt, fill: muted-color)[#item.date]
@@ -157,7 +162,7 @@
       item,
       size: 9pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: "network-username",
       weight: "medium",
     )
@@ -191,7 +196,7 @@
           fill: accent-bg,
           radius: 3pt,
           inset: (x: 6pt, y: 2pt),
-          text(size: 8pt, fill: primary-color)[#keyword]
+          text(size: 8pt, fill: accent-color)[#keyword]
         )
         h(4pt)
       }
@@ -291,7 +296,7 @@
       [
         #text(weight: "bold", size: 11pt)[#item.organization]
         #v(2pt)
-        #text(size: 10pt, fill: primary-color)[#item.position]
+        #text(size: 10pt, fill: accent-color)[#item.position]
       ],
       align(right)[
         #text(size: 9pt, fill: muted-color)[#item.date]
@@ -323,7 +328,7 @@
     if item.summary != "" {
       v(4pt)
       box(
-        stroke: (left: 2pt + primary-color),
+        stroke: (left: 2pt + accent-color),
         inset: (left: 10pt, y: 2pt),
         render-rich-text(item.summary, size: 9pt, style: "italic", fill: muted-color)
       )
@@ -367,13 +372,13 @@
           fill: accent-bg,
           radius: 3pt,
           inset: (x: 6pt, y: 2pt),
-          text(size: 8pt, fill: primary-color)[#keyword]
+          text(size: 8pt, fill: accent-color)[#keyword]
         )
         h(4pt)
       }
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(12pt)
   }
 
@@ -414,7 +419,7 @@
   if has-resume-body(data) {
     // Header - above columns, left-aligned
     if has-visible-picture(data.basics) {
-      render-picture(data.basics, primary-color)
+      render-picture(data.basics, accent-color)
       v(8pt)
     }
 
@@ -422,7 +427,7 @@
 
     if data.basics.headline != "" {
       v(4pt)
-      text(size: 12pt, fill: primary-color)[#data.basics.headline]
+      text(size: 12pt, fill: accent-color)[#data.basics.headline]
     }
 
     v(10pt)
@@ -436,7 +441,7 @@
     }
 
     v(16pt)
-    line(length: 100%, stroke: 1pt + border-color)
+    line(length: 100%, stroke: 1pt + accent-color)
     v(12pt)
 
     let right-wrapper(body) = {

--- a/crates/render/src/typst_engine/templates/ditto.typ
+++ b/crates/render/src/typst_engine/templates/ditto.typ
@@ -11,7 +11,12 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#6b7280")
+  let muted-color = text-color.lighten(30%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(30%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
@@ -21,9 +26,9 @@
 
   let sidebar-heading(title) = {
     v(10pt)
-    text(weight: "bold", size: 8pt, fill: primary-color, tracking: 0.08em)[#upper(title)]
+    text(weight: "bold", size: 8pt, fill: accent-color, tracking: 0.08em)[#upper(title)]
     v(2pt)
-    line(length: 100%, stroke: 0.5pt + primary-color)
+    line(length: 100%, stroke: 0.5pt + accent-color)
     v(6pt)
   }
 
@@ -31,9 +36,9 @@
     v(10pt)
     box(
       width: 100%,
-      stroke: (bottom: 1.5pt + primary-color),
+      stroke: (bottom: 1.5pt + accent-color),
       inset: (bottom: 3pt),
-      text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+      text(weight: "bold", size: 9pt, fill: accent-color, tracking: 0.06em)[#upper(title)]
     )
     v(8pt)
   }
@@ -46,7 +51,7 @@
       column-gutter: 8pt,
       [
         #if has-url(item) {
-          link(item.url.href)[#text(weight: "bold", size: 9pt, fill: primary-color)[#item.company]]
+          link(item.url.href)[#text(weight: "bold", size: 9pt, fill: accent-color)[#item.company]]
         } else {
           text(weight: "bold", size: 9pt)[#item.company]
         }
@@ -110,10 +115,10 @@
     let level = clamp-level(item.level)
     if level-display == "template-default" and level > 0 {
       v(2pt)
-      rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+      rating-indicators(level, 6pt, 6pt, accent-color, bg-color.darken(10%), 50%, 2pt)
     } else if should-render-level(level, level-display) {
       v(2pt)
-      render-level(level, level-display, primary-color, bg-color.darken(10%))
+      render-level(level, level-display, accent-color, bg-color.darken(10%))
     }
 
     if has-keywords(item) {
@@ -136,10 +141,10 @@
     let level = clamp-level(item.level)
     if level-display == "template-default" and level > 0 {
       v(2pt)
-      rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+      rating-indicators(level, 6pt, 6pt, accent-color, bg-color.darken(10%), 50%, 2pt)
     } else if should-render-level(level, level-display) {
       v(2pt)
-      render-level(level, level-display, primary-color, bg-color.darken(10%))
+      render-level(level, level-display, accent-color, bg-color.darken(10%))
     }
 
     v(6pt)
@@ -153,7 +158,7 @@
       item,
       size: 8pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: "network-username",
       weight: "medium",
     )
@@ -187,7 +192,7 @@
           fill: light-bg,
           radius: 2pt,
           inset: (x: 4pt, y: 1pt),
-          text(size: 7pt, fill: primary-color)[#keyword]
+          text(size: 7pt, fill: accent-color)[#keyword]
         )
         h(3pt)
       }
@@ -254,7 +259,7 @@
           fill: light-bg,
           radius: 2pt,
           inset: (x: 4pt, y: 1pt),
-          text(size: 7pt, fill: primary-color)[#keyword]
+          text(size: 7pt, fill: accent-color)[#keyword]
         )
         h(3pt)
       }
@@ -366,13 +371,13 @@
           fill: light-bg,
           radius: 2pt,
           inset: (x: 4pt, y: 1pt),
-          text(size: 7pt, fill: primary-color)[#keyword]
+          text(size: 7pt, fill: accent-color)[#keyword]
         )
         h(3pt)
       }
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(8pt)
   }
 
@@ -414,11 +419,11 @@
     // Header - full width teal background bar
     box(
       width: 100%,
-      fill: primary-color,
+      fill: accent-color,
       inset: (x: 24pt, y: 18pt),
       [
         #if has-visible-picture(data.basics) {
-          render-picture(data.basics, primary-color)
+          render-picture(data.basics, accent-color)
           v(8pt)
         }
 
@@ -426,7 +431,7 @@
 
         #if data.basics.headline != "" {
           v(4pt)
-          text(size: 11pt, fill: primary-color.lighten(80%))[#data.basics.headline]
+          text(size: 11pt, fill: accent-color.lighten(80%))[#data.basics.headline]
         }
 
         #v(8pt)
@@ -434,7 +439,7 @@
         #let contact-items = build-contact-items(data.basics)
         #if has-url(data.basics) { contact-items = contact-items + (link(data.basics.url.href)[#text(fill: white)[#url-display-label(data.basics.url)]],) }
 
-        #text(size: 8pt, fill: primary-color.lighten(85%))[#contact-items.join("  |  ")]
+        #text(size: 8pt, fill: accent-color.lighten(85%))[#contact-items.join("  |  ")]
       ]
     )
 

--- a/crates/render/src/typst_engine/templates/gengar.typ
+++ b/crates/render/src/typst_engine/templates/gengar.typ
@@ -12,7 +12,12 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#6b7280")
+  let muted-color = text-color.lighten(30%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(45%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
@@ -21,9 +26,9 @@
 
   let sidebar-section-heading(title) = {
     v(12pt)
-    text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.05em)[#upper(title)]
+    text(weight: "bold", size: 9pt, fill: accent-color, tracking: 0.05em)[#upper(title)]
     v(2pt)
-    line(length: 100%, stroke: 1pt + primary-color)
+    line(length: 100%, stroke: 1pt + accent-color)
     v(8pt)
   }
 
@@ -31,7 +36,7 @@
     v(14pt)
     text(weight: "bold", size: 11pt, fill: text-color, tracking: 0.04em)[#upper(title)]
     v(3pt)
-    line(length: 100%, stroke: 1.5pt + primary-color)
+    line(length: 100%, stroke: 1.5pt + accent-color)
     v(10pt)
   }
 
@@ -49,9 +54,9 @@
   let rating-boxes(level) = {
     let level = clamp-level(level)
     if level-display == "template-default" {
-      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 1pt, 2pt)
+      rating-indicators(level, 8pt, 8pt, accent-color, bg-color.darken(10%), 1pt, 2pt)
     } else {
-      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+      render-level(level, level-display, accent-color, bg-color.darken(10%), width: 8pt, height: 8pt)
     }
   }
 
@@ -165,7 +170,7 @@
       item,
       size: 9pt,
       fill: sidebar-text,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: "network-username",
       weight: "medium",
     )
@@ -202,7 +207,7 @@
           fill: sidebar-bg,
           radius: 3pt,
           inset: (x: 5pt, y: 2pt),
-          text(size: 8pt, fill: primary-color)[#keyword]
+          text(size: 8pt, fill: accent-color)[#keyword]
         )
         h(4pt)
       }
@@ -363,7 +368,7 @@
       text(size: 8pt, fill: muted-color)[#item.keywords.join(", ")]
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(8pt)
   }
 
@@ -410,7 +415,7 @@
     let sidebar-before = () => [
       #if has-visible-picture(data.basics) {
         align(center)[
-          #render-picture(data.basics, primary-color, default-size: 80pt)
+          #render-picture(data.basics, accent-color, default-size: 80pt)
         ]
         v(12pt)
       }
@@ -439,7 +444,7 @@
         v(4pt)
       }
       #if has-url(data.basics) {
-        link(data.basics.url.href)[#text(size: 8pt, fill: primary-color)[#url-display-label(data.basics.url)]]
+        link(data.basics.url.href)[#text(size: 8pt, fill: accent-color)[#url-display-label(data.basics.url)]]
         v(4pt)
       }
     ]

--- a/crates/render/src/typst_engine/templates/glalie.typ
+++ b/crates/render/src/typst_engine/templates/glalie.typ
@@ -14,33 +14,38 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#64748b")
+  let muted-color = text-color.lighten(35%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(45%)
   let sidebar-bg = primary-color.lighten(90%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
   let section-heading(title) = {
     v(14pt)
-    text(weight: "bold", size: 11pt, fill: primary-color)[#title]
+    text(weight: "bold", size: 11pt, fill: accent-color)[#title]
     v(3pt)
-    line(length: 100%, stroke: 1pt + primary-color)
+    line(length: 100%, stroke: 1pt + accent-color)
     v(8pt)
   }
 
   let sidebar-heading(title) = {
     v(12pt)
-    text(weight: "bold", size: 10pt, fill: primary-color)[#title]
+    text(weight: "bold", size: 10pt, fill: accent-color)[#title]
     v(2pt)
-    line(length: 100%, stroke: 0.75pt + primary-color)
+    line(length: 100%, stroke: 0.75pt + accent-color)
     v(6pt)
   }
 
   let skill-dots(level) = {
     let level = clamp-level(level)
     if level-display == "template-default" {
-      rating-indicators(level, 6pt, 6pt, primary-color, primary-color.lighten(70%), 50%, 2pt)
+      rating-indicators(level, 6pt, 6pt, accent-color, accent-color.lighten(70%), 50%, 2pt)
     } else {
-      render-level(level, level-display, primary-color, primary-color.lighten(70%))
+      render-level(level, level-display, accent-color, accent-color.lighten(70%))
     }
   }
 
@@ -158,7 +163,7 @@
       item,
       size: 9pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: "network-username",
       weight: "bold",
     )
@@ -354,7 +359,7 @@
     }
 
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(8pt)
   }
 
@@ -397,7 +402,7 @@
     let sidebar-before = () => [
       #if has-visible-picture(data.basics) {
         align(center)[
-          #render-picture(data.basics, primary-color, default-size: 80pt)
+          #render-picture(data.basics, accent-color, default-size: 80pt)
         ]
         v(12pt)
       }
@@ -426,7 +431,7 @@
         v(3pt)
       }
       #if has-url(data.basics) {
-        link(data.basics.url.href)[#text(size: 8pt, fill: primary-color)[#url-display-label(data.basics.url)]]
+        link(data.basics.url.href)[#text(size: 8pt, fill: accent-color)[#url-display-label(data.basics.url)]]
         v(3pt)
       }
     ]

--- a/crates/render/src/typst_engine/templates/kakuna.typ
+++ b/crates/render/src/typst_engine/templates/kakuna.typ
@@ -12,20 +12,28 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = text-color.lighten(40%)
+  let muted-color = text-color.lighten(30%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(15%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
   let light-bg = primary-color.lighten(92%)
-  let border-color = bg-color.darken(15%)
+  // Neutral rule/border ink. `darken(15%)` was #d9d9d9 — 1.41:1 on white,
+  // effectively invisible; this clears the 3:1 that WCAG 2.1 SC 1.4.11
+  // asks of a boundary that separates content.
+  let border-color = bg-color.darken(45%)
 
   let section-heading(title) = {
     v(16pt)
     grid(
       columns: (auto, 1fr),
       column-gutter: 10pt,
-      text(weight: "semibold", size: 10pt, fill: primary-color, tracking: 0.06em)[#upper(title)],
-      line(start: (0pt, 5pt), length: 100%, stroke: 0.75pt + primary-color)
+      text(weight: "semibold", size: 10pt, fill: accent-color, tracking: 0.06em)[#upper(title)],
+      line(start: (0pt, 5pt), length: 100%, stroke: 0.75pt + accent-color)
     )
     v(10pt)
   }
@@ -34,10 +42,10 @@
     let level = clamp-level(level)
     if level-display == "template-default" {
       h(4pt)
-      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+      rating-indicators(level, 8pt, 8pt, accent-color, bg-color.darken(10%), 50%, 2pt)
     } else if should-render-level(level, level-display) {
       h(4pt)
-      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+      render-level(level, level-display, accent-color, bg-color.darken(10%), width: 8pt, height: 8pt)
     }
   }
 
@@ -153,7 +161,7 @@
       item,
       size: 10pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: "network-username",
     )
     h(14pt)
@@ -184,7 +192,7 @@
           fill: light-bg,
           radius: 3pt,
           inset: (x: 6pt, y: 2pt),
-          text(size: 8pt, fill: primary-color)[#keyword]
+          text(size: 8pt, fill: accent-color)[#keyword]
         )
         h(4pt)
       }
@@ -342,7 +350,7 @@
       text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(8pt)
   }
 
@@ -390,7 +398,7 @@
         inset: (x: 24pt, y: 20pt),
         [
           #if has-visible-picture(data.basics) {
-            render-picture(data.basics, primary-color)
+            render-picture(data.basics, accent-color)
             v(8pt)
           }
 
@@ -398,7 +406,7 @@
 
           #if data.basics.headline != "" {
             v(6pt)
-            text(size: 11pt, fill: primary-color)[#data.basics.headline]
+            text(size: 11pt, fill: accent-color)[#data.basics.headline]
           }
 
           #v(10pt)

--- a/crates/render/src/typst_engine/templates/leafish.typ
+++ b/crates/render/src/typst_engine/templates/leafish.typ
@@ -11,7 +11,13 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = text-color.lighten(40%)
+  let muted-color = text-color.lighten(25%)
+  // Accent ink: the ink for headings, links and rules. Every other template
+  // has to darken `primary-color` to clear WCAG AA (4.5:1) on the backdrops
+  // it paints; this crimson already clears 4.79:1 at its worst, so the seed
+  // is used as-is. The alias keeps the ink and the decorative tints below
+  // distinguishable, so a future palette change has an obvious place to go.
+  let accent-color = primary-color
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
@@ -25,9 +31,9 @@
     v(10pt)
     box(
       width: 100%,
-      stroke: (bottom: 1.5pt + primary-color),
+      stroke: (bottom: 1.5pt + accent-color),
       inset: (bottom: 4pt),
-      text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+      text(weight: "bold", size: 9pt, fill: accent-color, tracking: 0.06em)[#upper(title)]
     )
     v(8pt)
   }
@@ -35,9 +41,9 @@
   let rating-dots(level) = {
     let level = clamp-level(level)
     if level-display == "template-default" {
-      rating-indicators(level, 6pt, 6pt, primary-color, bg-color.darken(10%), 50%, 2pt)
+      rating-indicators(level, 6pt, 6pt, accent-color, bg-color.darken(10%), 50%, 2pt)
     } else {
-      render-level(level, level-display, primary-color, bg-color.darken(10%))
+      render-level(level, level-display, accent-color, bg-color.darken(10%))
     }
   }
 
@@ -49,7 +55,7 @@
       column-gutter: 8pt,
       [
         #if has-url(item) {
-          link(item.url.href)[#text(weight: "bold", size: 10pt, fill: primary-color)[#item.company]]
+          link(item.url.href)[#text(weight: "bold", size: 10pt, fill: accent-color)[#item.company]]
         } else {
           text(weight: "bold", size: 10pt)[#item.company]
         }
@@ -130,7 +136,7 @@
           fill: tag-bg,
           radius: 3pt,
           inset: (x: 5pt, y: 2pt),
-          text(size: 7.5pt, fill: primary-color)[#keyword]
+          text(size: 7.5pt, fill: accent-color)[#keyword]
         )
         h(3pt)
       }
@@ -166,7 +172,7 @@
       item,
       size: 9pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: "network-username",
       weight: "medium",
     )
@@ -200,7 +206,7 @@
           fill: tag-bg,
           radius: 3pt,
           inset: (x: 5pt, y: 2pt),
-          text(size: 7.5pt, fill: primary-color)[#keyword]
+          text(size: 7.5pt, fill: accent-color)[#keyword]
         )
         h(3pt)
       }
@@ -268,7 +274,7 @@
           fill: tag-bg,
           radius: 3pt,
           inset: (x: 5pt, y: 2pt),
-          text(size: 7.5pt, fill: primary-color)[#keyword]
+          text(size: 7.5pt, fill: accent-color)[#keyword]
         )
         h(3pt)
       }
@@ -379,13 +385,13 @@
           fill: tag-bg,
           radius: 3pt,
           inset: (x: 5pt, y: 2pt),
-          text(size: 7.5pt, fill: primary-color)[#keyword]
+          text(size: 7.5pt, fill: accent-color)[#keyword]
         )
         h(3pt)
       }
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(8pt)
   }
 
@@ -436,7 +442,7 @@
         columns: (1fr, auto),
         column-gutter: 16pt,
         [
-          #text(size: 24pt, weight: "bold", fill: primary-color)[#data.basics.name]
+          #text(size: 24pt, weight: "bold", fill: accent-color)[#data.basics.name]
           #if data.basics.headline != "" {
             v(4pt)
             text(size: 11pt, fill: header-text-color)[#data.basics.headline]
@@ -444,11 +450,11 @@
         ],
         align(right + horizon)[
           #if has-visible-picture(data.basics) {
-            render-picture(data.basics, primary-color)
+            render-picture(data.basics, accent-color)
             if has-url(data.basics) { v(6pt) }
           }
           #if has-url(data.basics) {
-            link(data.basics.url.href)[#text(size: 9pt, fill: primary-color)[#url-display-label(data.basics.url)]]
+            link(data.basics.url.href)[#text(size: 9pt, fill: accent-color)[#url-display-label(data.basics.url)]]
           }
         ]
       )

--- a/crates/render/src/typst_engine/templates/nosepass.typ
+++ b/crates/render/src/typst_engine/templates/nosepass.typ
@@ -12,18 +12,26 @@
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
   let muted-color = text-color.lighten(30%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(30%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
   let light-gray = bg-color.darken(5%)
-  let border-color = bg-color.darken(15%)
+  // Neutral rule/border ink. `darken(15%)` was #d9d9d9 — 1.41:1 on white,
+  // effectively invisible; this clears the 3:1 that WCAG 2.1 SC 1.4.11
+  // asks of a boundary that separates content.
+  let border-color = bg-color.darken(45%)
 
   let section-heading(title) = {
     v(14pt)
     grid(
       columns: (auto, 1fr),
       column-gutter: 12pt,
-      text(weight: "bold", size: 11pt, fill: primary-color)[#title],
+      text(weight: "bold", size: 11pt, fill: accent-color)[#title],
       line(start: (0pt, 6pt), length: 100%, stroke: 1pt + border-color)
     )
     v(10pt)
@@ -45,7 +53,7 @@
       columns: (1fr, auto),
       column-gutter: 12pt,
       [
-        #text(weight: "bold", size: 11pt, fill: primary-color)[#item.position]
+        #text(weight: "bold", size: 11pt, fill: accent-color)[#item.position]
         #v(2pt)
         #text(size: 10pt)[#item.company]
         #if item.location != "" {
@@ -70,7 +78,7 @@
       columns: (1fr, auto),
       column-gutter: 12pt,
       [
-        #text(weight: "bold", size: 11pt, fill: primary-color)[#item.institution]
+        #text(weight: "bold", size: 11pt, fill: accent-color)[#item.institution]
         #v(2pt)
         #if item.studyType != "" or item.area != "" {
           let degree = format-degree(item.studyType, item.area)
@@ -99,14 +107,14 @@
         #if level-display == "template-default" and level > 0 {
           h(4pt)
           for i in range(level) {
-            text(fill: primary-color)[●]
+            text(fill: accent-color)[●]
           }
           for i in range(5 - level) {
-            text(fill: border-color)[●]
+            text(fill: bg-color, stroke: 0.4pt + accent-color)[●]
           }
         } else if should-render-level(level, level-display) {
           h(4pt)
-          render-level(level, level-display, primary-color, border-color)
+          render-level(level, level-display, accent-color, bg-color.darken(10%))
         }
       ]
     )
@@ -134,7 +142,7 @@
       item,
       size: 10pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: "network-username",
     )
     v(4pt)
@@ -143,7 +151,7 @@
   let render-project(item) = {
     if item.visible == false { return }
 
-    text(weight: "bold", size: 10pt, fill: primary-color)[#item.name]
+    text(weight: "bold", size: 10pt, fill: accent-color)[#item.name]
 
     if item.description != "" {
       v(4pt)
@@ -225,7 +233,7 @@
       columns: (1fr, auto),
       column-gutter: 12pt,
       [
-        #text(weight: "bold", size: 10pt, fill: primary-color)[#item.name]
+        #text(weight: "bold", size: 10pt, fill: accent-color)[#item.name]
         #if item.publisher != "" {
           v(2pt)
           text(size: 9pt, fill: muted-color)[#item.publisher]
@@ -249,7 +257,7 @@
       columns: (1fr, auto),
       column-gutter: 12pt,
       [
-        #text(weight: "bold", size: 11pt, fill: primary-color)[#item.organization]
+        #text(weight: "bold", size: 11pt, fill: accent-color)[#item.organization]
         #if item.position != "" {
           v(2pt)
           text(size: 10pt)[#item.position]
@@ -272,7 +280,7 @@
   let render-reference(item) = {
     if item.visible == false { return }
 
-    text(weight: "bold", size: 10pt, fill: primary-color)[#item.name]
+    text(weight: "bold", size: 10pt, fill: accent-color)[#item.name]
 
     if item.description != "" {
       v(4pt)
@@ -294,7 +302,7 @@
       columns: (1fr, auto),
       column-gutter: 12pt,
       [
-        #text(weight: "bold", size: 10pt, fill: primary-color)[#item.name]
+        #text(weight: "bold", size: 10pt, fill: accent-color)[#item.name]
         #if item.description != "" {
           v(2pt)
           render-rich-text(item.description, size: 10pt)
@@ -326,7 +334,7 @@
       }
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(10pt)
   }
 
@@ -369,15 +377,15 @@
     // Header with blue accent bar
     box(
       width: 100%,
-      stroke: (bottom: 3pt + primary-color),
+      stroke: (bottom: 3pt + accent-color),
       inset: (bottom: 12pt),
       [
         #if has-visible-picture(data.basics) {
-          render-picture(data.basics, primary-color)
+          render-picture(data.basics, accent-color)
           v(8pt)
         }
 
-        #text(size: 28pt, weight: "bold", fill: primary-color)[#data.basics.name]
+        #text(size: 28pt, weight: "bold", fill: accent-color)[#data.basics.name]
 
         #if data.basics.headline != "" {
           v(4pt)

--- a/crates/render/src/typst_engine/templates/onyx.typ
+++ b/crates/render/src/typst_engine/templates/onyx.typ
@@ -11,7 +11,12 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#6b7280")
+  let muted-color = text-color.lighten(35%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(20%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
@@ -19,9 +24,9 @@
     v(14pt)
     box(
       width: 100%,
-      stroke: (bottom: 1.5pt + primary-color),
+      stroke: (bottom: 1.5pt + accent-color),
       inset: (bottom: 4pt),
-      text(weight: "bold", size: 10pt, fill: primary-color, tracking: 0.06em)[#upper(title)]
+      text(weight: "bold", size: 10pt, fill: accent-color, tracking: 0.06em)[#upper(title)]
     )
     v(10pt)
   }
@@ -40,9 +45,9 @@
   let rating-squares(level) = {
     let level = clamp-level(level)
     if level-display == "template-default" {
-      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 0pt, 2pt)
+      rating-indicators(level, 8pt, 8pt, accent-color, bg-color.darken(10%), 0pt, 2pt)
     } else {
-      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+      render-level(level, level-display, accent-color, bg-color.darken(10%), width: 8pt, height: 8pt)
     }
   }
 
@@ -53,7 +58,7 @@
       [
         #text(weight: "bold", size: 11pt, fill: text-color)[#item.position]
         #v(2pt)
-        #text(size: 10pt, fill: primary-color)[#item.company]
+        #text(size: 10pt, fill: accent-color)[#item.company]
         #if item.location != "" {
           text(size: 9pt, fill: muted-color)[ · #item.location]
         }
@@ -117,10 +122,10 @@
       v(2pt)
       for keyword in item.keywords {
         box(
-          fill: primary-color.lighten(92%),
+          fill: accent-color.lighten(92%),
           radius: 3pt,
           inset: (x: 6pt, y: 2pt),
-          text(size: 8pt, fill: primary-color)[#keyword]
+          text(size: 8pt, fill: accent-color)[#keyword]
         )
         h(4pt)
       }
@@ -156,7 +161,7 @@
       item,
       size: 10pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: if has-url(item) { "network" } else { "network-username" },
     )
     h(14pt)
@@ -184,10 +189,10 @@
       v(4pt)
       for keyword in item.keywords {
         box(
-          fill: primary-color.lighten(92%),
+          fill: accent-color.lighten(92%),
           radius: 3pt,
           inset: (x: 6pt, y: 2pt),
-          text(size: 8pt, fill: primary-color)[#keyword]
+          text(size: 8pt, fill: accent-color)[#keyword]
         )
         h(4pt)
       }
@@ -344,16 +349,16 @@
       v(2pt)
       for keyword in item.keywords {
         box(
-          fill: primary-color.lighten(92%),
+          fill: accent-color.lighten(92%),
           radius: 3pt,
           inset: (x: 6pt, y: 2pt),
-          text(size: 8pt, fill: primary-color)[#keyword]
+          text(size: 8pt, fill: accent-color)[#keyword]
         )
         h(4pt)
       }
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(8pt)
   }
 
@@ -402,14 +407,14 @@
             columns: (auto, 1fr),
             column-gutter: 12pt,
             align(horizon)[
-              #render-picture(data.basics, primary-color)
+              #render-picture(data.basics, accent-color)
             ],
             [
               #text(size: 26pt, weight: "bold", fill: text-color)[#data.basics.name]
 
               #if data.basics.headline != "" {
                 v(4pt)
-                text(size: 12pt, fill: primary-color)[#data.basics.headline]
+                text(size: 12pt, fill: accent-color)[#data.basics.headline]
               }
             ]
           )
@@ -418,13 +423,13 @@
 
           if data.basics.headline != "" {
             v(4pt)
-            text(size: 12pt, fill: primary-color)[#data.basics.headline]
+            text(size: 12pt, fill: accent-color)[#data.basics.headline]
           }
         }
       ],
       align(right)[
         #let contact-items = build-contact-items(data.basics)
-        #if has-url(data.basics) { contact-items = contact-items + (link(data.basics.url.href)[#text(fill: primary-color)[#url-display-label(data.basics.url)]],) }
+        #if has-url(data.basics) { contact-items = contact-items + (link(data.basics.url.href)[#text(fill: accent-color)[#url-display-label(data.basics.url)]],) }
 
         #for item in contact-items {
           text(size: 9pt, fill: muted-color)[#item]
@@ -434,7 +439,7 @@
     )
 
     v(8pt)
-    line(length: 100%, stroke: 1.5pt + primary-color)
+    line(length: 100%, stroke: 1.5pt + accent-color)
     v(8pt)
 
     render-resume(data, (

--- a/crates/render/src/typst_engine/templates/pikachu.typ
+++ b/crates/render/src/typst_engine/templates/pikachu.typ
@@ -11,7 +11,12 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#78716c")
+  let muted-color = text-color.lighten(30%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(40%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
@@ -21,14 +26,14 @@
 
   let sidebar-section(title) = {
     v(12pt)
-    text(weight: "bold", size: 9pt, fill: primary-color, tracking: 0.08em)[#upper(title)]
+    text(weight: "bold", size: 9pt, fill: accent-color, tracking: 0.08em)[#upper(title)]
     v(6pt)
   }
 
   let main-section(title) = {
     v(14pt)
     box(
-      fill: primary-color,
+      fill: accent-color,
       inset: (x: 8pt, y: 4pt),
       radius: 2pt,
       text(weight: "bold", size: 10pt, fill: white, tracking: 0.05em)[#upper(title)]
@@ -39,9 +44,9 @@
   let skill-dots(level) = {
     let level = clamp-level(level)
     if level-display == "template-default" {
-      rating-indicators(level, 6pt, 6pt, primary-color, sidebar-bg.darken(15%), 50%, 3pt)
+      rating-indicators(level, 6pt, 6pt, accent-color, sidebar-bg.darken(15%), 50%, 3pt)
     } else {
-      render-level(level, level-display, primary-color, sidebar-bg.darken(15%), spacing: 3pt)
+      render-level(level, level-display, accent-color, sidebar-bg.darken(15%), spacing: 3pt)
     }
   }
 
@@ -50,7 +55,7 @@
 
     text(weight: "bold", size: 11pt)[#item.position]
     v(2pt)
-    text(size: 10pt, fill: primary-color)[#item.company]
+    text(size: 10pt, fill: accent-color)[#item.company]
     h(8pt)
     text(size: 9pt, fill: muted-color)[#item.date]
 
@@ -202,7 +207,7 @@
 
     text(weight: "bold", size: 11pt)[#item.position]
     v(2pt)
-    text(size: 10pt, fill: primary-color)[#item.organization]
+    text(size: 10pt, fill: accent-color)[#item.organization]
     h(8pt)
     text(size: 9pt, fill: muted-color)[#item.date]
 
@@ -232,7 +237,7 @@
     if item.summary != "" {
       v(6pt)
       box(
-        stroke: (left: 2pt + primary-color),
+        stroke: (left: 2pt + accent-color),
         inset: (left: 10pt, y: 2pt),
         render-rich-text(item.summary, size: 9pt, style: "italic", fill: muted-color)
       )
@@ -274,7 +279,7 @@
       text(size: 9pt, fill: muted-color)[#item.keywords.join(" · ")]
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(12pt)
   }
 
@@ -323,12 +328,12 @@
       // Photo when set; otherwise initials avatar.
       #align(center)[
         #if has-visible-picture(data.basics) {
-          render-picture(data.basics, primary-color, default-size: 80pt)
+          render-picture(data.basics, accent-color, default-size: 80pt)
         } else {
           box(
             width: 80pt,
             height: 80pt,
-            fill: primary-color,
+            fill: accent-color,
             radius: 50%,
             [
               #align(center + horizon)[
@@ -375,7 +380,7 @@
 
       #if data.basics.headline != "" {
         v(4pt)
-        text(size: 12pt, fill: primary-color)[#data.basics.headline]
+        text(size: 12pt, fill: accent-color)[#data.basics.headline]
       }
     ]
 

--- a/crates/render/src/typst_engine/templates/rhyhorn.typ
+++ b/crates/render/src/typst_engine/templates/rhyhorn.typ
@@ -12,15 +12,20 @@
   let bg-color = rgb(data.metadata.theme.at("background", default: "#ffffff"))
   let level-display = data.metadata.at("levelDisplay", default: "template-default")
   // Derived colors (not in schema — computed from theme values)
-  let muted-color = rgb("#6b7280")
+  let muted-color = text-color.lighten(40%)
+  // Accent ink: `primary-color` darkened until it clears WCAG AA (4.5:1)
+  // as text on every backdrop this template paints it on — page, tinted
+  // panels, chips and its own profile badge. `primary-color` itself stays
+  // the untouched brand seed the decorative tints below are derived from.
+  let accent-color = primary-color.darken(35%)
 
   // ── Helper functions (capture theme colors from enclosing scope) ──
 
   let section-heading(title) = {
     v(12pt)
-    text(weight: "bold", size: 11pt, fill: primary-color)[#upper(title)]
+    text(weight: "bold", size: 11pt, fill: accent-color)[#upper(title)]
     v(2pt)
-    line(length: 100%, stroke: 0.5pt + primary-color)
+    line(length: 100%, stroke: 0.5pt + accent-color)
     v(6pt)
   }
 
@@ -39,10 +44,10 @@
     let level = clamp-level(level)
     if level-display == "template-default" {
       h(4pt)
-      rating-indicators(level, 8pt, 8pt, primary-color, bg-color.darken(10%), 2pt, 2pt)
+      rating-indicators(level, 8pt, 8pt, accent-color, bg-color.darken(10%), 2pt, 2pt)
     } else if should-render-level(level, level-display) {
       h(4pt)
-      render-level(level, level-display, primary-color, bg-color.darken(10%), width: 8pt, height: 8pt)
+      render-level(level, level-display, accent-color, bg-color.darken(10%), width: 8pt, height: 8pt)
     }
   }
 
@@ -140,7 +145,7 @@
       item,
       size: 10pt,
       fill: text-color,
-      link-fill: primary-color,
+      link-fill: accent-color,
       label-mode: if has-url(item) { "username" } else { "network-username" },
     )
     v(4pt)
@@ -318,7 +323,7 @@
       text(size: 9pt, fill: muted-color)[#item.keywords.join(", ")]
     }
 
-    render-url(item, primary-color)
+    render-url(item, accent-color)
     v(8pt)
   }
 
@@ -367,7 +372,7 @@
             columns: (auto, 1fr),
             column-gutter: 12pt,
             align(horizon)[
-              #render-picture(data.basics, primary-color)
+              #render-picture(data.basics, accent-color)
             ],
             [
               #text(size: 24pt, weight: "bold")[#data.basics.name]
@@ -402,7 +407,7 @@
     )
 
     v(8pt)
-    line(length: 100%, stroke: 0.5pt + primary-color)
+    line(length: 100%, stroke: 0.5pt + accent-color)
     v(8pt)
 
     render-resume(data, (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title:

  ```text
  fix(templates): contrast-audit the 12 resume templates for screen and print
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The 12 resume templates render the actual product artefact — the thing a user
sends to an employer — and had never been contrast-audited. **All 12 failed.**
The audit found 102 failing ink/backdrop pairs. This PR fixes every one and
adds a template x surface matrix to the e2e suite so they cannot regress.

### Correction to the issue's premise — please read before reviewing

#619 asks for axe to be run with the colour-contrast rule against the rendered
preview, per template. **That is not possible in this architecture, and doing
it would have produced a falsely clean audit.**

A template is a Typst document. `crates/render` compiles it once and hands it
to two backends — `typst-render` rasterises a PNG for the on-screen preview,
`typst-pdf` writes the export. The preview the user sees in the editor is an
`<img>`, and every glyph inside it is opaque to axe. Scanning that surface with
the colour-contrast rule reports a clean page while the resume inside it fails.
The e2e fixtures make this concrete: `PREVIEW_ROUTE` is stubbed with a 1x1
transparent PNG.

So the matrix gates the **colour source of both renders** instead: every
ink-on-backdrop pair the templates can paint, resolved from the `.typ` sources
themselves. Two properties fall out of that which a rendered-page scan does not
have:

- It is **content-independent**. It holds for every resume a template can
  render, not just whichever fixture a scan happened to load. (The issue warns
  that empty templates hide failures — this sidesteps that failure mode rather
  than mitigating it.)
- It **reaches the PDF**, which no browser-side check can. `renderPdf` in
  `apps/web/src/api/render.ts` POSTs to the server; the bytes never exist
  client-side.

axe still runs, per template, over the editor chrome that frames the preview —
that surface *is* DOM, and it is where a template switch could regress the app.

### The fix

Each template now derives an `accent-color`: the brand seed darkened until it
clears 4.5:1 as text on every backdrop that template paints it on — page,
tinted panels, keyword chips, and the self-tinted profile badge in
`_common.typ` (a pair no template declares, so it was easy to miss).
`primary-color` is untouched and still seeds the decorative tints, so the
palettes keep their hue.

`muted-color` becomes a per-template `text-color` tint rather than a hardcoded
grey, so it stays readable on sidebars and panels *and* responds to a themed
text colour instead of ignoring it.

Rating indicators gain a `filled-color` outline. SC 1.4.11 wants 3:1 twice
over — between the filled and empty states, **and** between an empty step and
the page, so a reader can tell how many steps the scale has. No pair of solid
fills satisfies both: a tint pale enough to read as "empty" against a filled
accent is nearly invisible on white. The outline breaks the tie the way a radio
button does — the ring carries visibility, the fill carries state. Nosepass's
hand-rolled skill bullets are hollowed for the same reason, and its and
Kakuna's neutral borders move from `#d9d9d9` (1.41:1) to 3.36:1.

### Per-template results

Worst measured cell per template, after the fix. Both surfaces, all 12 clear.

| template | accent (before → after) | screen worst | print worst |
| --- | --- | --- | --- |
| azurill | `#d97706` → `#8d4d04` | 5.00 | 5.44 |
| bronzor | `#0891b2` → `#06667d` | 4.96 | 5.57 |
| chikorita | `#16a34a` → `#0e6a30` | 5.09 | 6.27 |
| ditto | `#0891b2` → `#06667d` | 4.80 | 5.25 |
| gengar | `#67b8c8` → `#39656e` | 4.95 | 5.16 |
| glalie | `#14b8a6` → `#0b655b` | 5.09 | 5.02 |
| kakuna | `#78716c` → `#66605c` | 4.79 | 4.78 |
| leafish | `#9f1239` (unchanged) | **3.67** ¹ | **4.87** ¹ |
| nosepass | `#3b82f6` → `#295bac` | **3.36** ¹ | **3.36** ¹ |
| onyx | `#dc2626` → `#b01e1e` | 5.06 | 5.49 |
| pikachu | `#ca8a04` → `#795302` | 5.24 | 5.59 |
| rhyhorn | `#65a30d` → `#426a08` | 4.89 | 5.74 |

¹ **These two sub-4.5 figures are not text failures.** Leafish's worst cell is
its contact-bar separator and nosepass's is its section rule / skill-box
border — both non-text content gated at the SC 1.4.11 floor of 3:1, which they
clear. Every **text** cell in the matrix clears 4.5:1 on both surfaces; the
tightest is ditto's header headline on its accent bar at 4.80.

Leafish's crimson already cleared 4.79:1 at its worst, so its seed is used
as-is; the `accent-color` alias is still introduced there so ink and decorative
tint stay distinguishable.

### The two surfaces

Both renders come from one Typst document, so the colour *values* are
identical — the surfaces differ only in how a reader's device resolves them.
The print surface projects both colours onto a monochrome print driver's single
ink (BT.601 luma), which is the one place they genuinely diverge. Note this is
deliberately **not** WCAG relative luminance: the WCAG ratio is already
luminance-only, so a greyscale surface computed that way would be an exact copy
of the screen surface and gate nothing. BT.601 weights hue differently, so it
catches colours that separate on screen and converge on paper. It is not
uniformly stricter — it is a different projection, and both are asserted.

### Gradients

axe flattens a gradient to one colour and misses one-end failures, and so would
a flat pair matrix. **No template paints ink on a Typst gradient today**, so
rather than ship an untested ramp sampler, there is a guard test that fails if
one appears and points at the sampler `apps/site/scripts/check-craft-contrast.mjs`
already has from #617.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #619
- Relates to #352
- Relates to #650
- Relates to #653

## Details

### Review notes

**This branch got no local AI pre-push review. Both tools failed, for
different reasons, and reviewers should weigh the diff accordingly.**

- **Greptile:** unavailable. `greptile review` returned
  `free_reviews_limit_reached` at the account level on both `--agent` and
  `--json`, reproduced from an unrelated worktree, so it is not specific to this
  branch. The owner accepted this gap explicitly.
- **CodeRabbit:** dispatched locally against this diff, ran for ~45 minutes
  without returning, and was then terminated. **It produced zero findings — not
  a clean result, no result.** Nothing was triaged because nothing came back.

- **CodeRabbit (GitHub side):** posted only a *Review limit reached* warning on
  this PR. No walkthrough, no inline findings.

**What was done instead.** Because no AI reviewer was available from any source,
the branch was reviewed by hand against the lintro AI-review checklist corpus
(py-lintro's `tier1.yaml` plus the tier2 items matching rust / ts / e2e / test /
ci). That is a checklist-driven human pass, **not** a CodeRabbit or Greptile
run, and it is recorded here as such. Outcome:

- The Typst colour maths was verified against upstream source rather than
  assumed: `Color::Rgb` is `palette::rgb::Rgba<Srgb, f32>` (gamma-encoded) in
  `typst-library` 0.15.x, and palette 0.7.x `Lighten`/`Darken` move each stored
  component toward its bound, giving `c + (1-c)*f` and `c*(1-f)` — exactly what
  `apps/web/e2e/support/contrast.ts` implements. Spot-checked end to end
  (`darken(35%)` of `#d97706` → `#8d4d04`, matching the template's real accent).
- One substantive finding, **P2, not blocking and deliberately not fixed here**:
  the matrix has no guard that every colour-bearing binding is covered by a
  pair, so a future tint painted with text could go unaudited. Filed as #653.
- Two P3 nits left as-is: a hardcoded toast literal in
  `template-contrast.spec.ts`, and `FULL_TEMPLATE_CATALOG`'s hardcoded
  `primary: "#65a30d"` duplicating rhyhorn's production seed.

Given all of the above, the human review remains load-bearing — particularly on the
Typst `lighten`/`darken` reimplementation in `apps/web/e2e/support/contrast.ts`,
where a wrong colour-space assumption would make the whole matrix agree with
itself while measuring colours the renderer never paints. The reasoning and the
upstream sources it was checked against are documented below and in the file.

**Anti-drift.** No hex value is copied into the matrix. It declares only
*relationships* — which ink lands on which backdrop — and resolves the colours
from the `.typ` sources by evaluating the small Typst colour grammar the
templates use (`rgb(...)`, theme lookups with defaults, `.lighten(n%)`,
`.darken(n%)`, bindings). Rename a binding or retune a tint and the audit fails
loudly instead of quietly measuring a colour the template no longer paints.

`lighten`/`darken` are reimplemented to match Typst exactly: `rgb("#…")` is
`palette::rgb::Rgba<Srgb, f32>`, and palette's `Lighten`/`Darken` move each
**gamma-encoded** channel toward its bound (`c + (1-c)*f` / `c*(1-f)`). Doing
this in linear light would yield visibly different colours and a bogus audit.
Verified against the palette 0.7.6 and typst-library 0.15.1 sources.

### Scope

Confined to the 12 template sources, `_common.typ`, and four new files under
`apps/web/e2e/`. `apps/web/e2e/accessibility.spec.ts` is **not** touched (that
is #622's file) — the per-template axe scan lives in the new spec, which is why
`scanForViolations` is small and local rather than shared.

`TEMPLATE_FIXTURES` in `e2e/support/fixtures.ts` is **not** widened either. It
serves a deliberately small three-template catalog that `visual.spec.ts`
screenshots; extending it would have moved a committed baseline belonging to
another lane. The new spec route-overrides the catalog to the full 12 for itself
only.

### Testing

- `bun run test:e2e` in `apps/web` — **run three times**, 64 passed each time,
  no flake. (5 visual tests skip locally by design; baselines are CI-generated.)
- `cargo test -p rustume-render` — 135 + 15 passed. The existing integration
  tests render all 12 templates, including the `level > 0` and non-default
  `LevelDisplay` branches, so the changed indicator and bullet paths are
  exercised.
- `bun run test` (vitest) — 585 passed.
- `bun run typecheck`, `bun run lint` (oxlint) — clean.
- `uv run lintro fmt` + `uv run lintro chk` — 0 issues, health score 100/100.

### Deliberately out of scope

- **Themed palettes.** The derivations are per-template literal factors chosen
  for the shipped defaults. A user-supplied `theme.primary` is not auto-corrected
  — gating colour choice belongs in the ThemeEditor, not the templates.
- **Template thumbnails** under `apps/site/` are now slightly stale against the
  retuned accents. `apps/site/**` belongs to another lane, so they are left
  alone rather than regenerated here.
- **#650** — glalie is the only template that never applies the themed page
  background, found during this audit and filed separately rather than folded in.
- The unscanned `text-stone` alpha modifiers noted as follow-up debt in #618 were
  not reached by these scans, and remain #622/#623's.

