### PR TITLE
feat(web): honour prefers-reduced-motion across app and site

### DIFF
--- a/apps/site/src/components/SearchDropdown.astro
+++ b/apps/site/src/components/SearchDropdown.astro
@@ -216,7 +216,12 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
     border: 1px solid var(--turbo-border-default);
     border-radius: var(--radius-full);
     cursor: pointer;
-    transition: all var(--transition-fast);
+    /* Named properties rather than `all`: the bar holds its placeholder text,
+       and `all` would crossfade that text's colour through a theme swap. */
+    transition:
+      background var(--transition-fast),
+      border-color var(--transition-fast),
+      box-shadow var(--transition-fast);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   }
 
@@ -275,7 +280,11 @@ const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
     color: var(--turbo-text-inverse, #fff);
     cursor: pointer;
     flex-shrink: 0;
-    transition: all var(--transition-fast);
+    /* Only what :hover changes. `all` also animated the icon colour and the
+       button fill, which a theme swap rewrites simultaneously. */
+    transition:
+      transform var(--transition-fast),
+      box-shadow var(--transition-fast);
   }
 
   .search-bar-btn:hover {

--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -73,6 +73,39 @@ html {
   -webkit-font-smoothing: antialiased;
 }
 
+/*
+ * Reduced motion.
+ *
+ * The site's motion is all transition-based — dropdown panels, hover lifts,
+ * the theme picker — so zeroing durations sitewide is what honours the
+ * preference, and it holds for any animation a component adds later. Note
+ * that `scroll-behavior: smooth` above is set on `html` and so needs its own
+ * override; it is the one piece of motion the shorthand block cannot reach.
+ *
+ * `animation-iteration-count` is pinned to 1 because a zero-duration
+ * animation that is still `infinite` repaints forever.
+ *
+ * A near-zero duration rather than `none` keeps `transitionend` and
+ * `animationend` listeners firing, so any script that waits on one still
+ * advances.
+ */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-delay: -0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 body {
   font-family: var(--font-body, var(--turbo-font-sans));
   color: var(--turbo-body-primary, var(--turbo-text-primary));
@@ -1144,7 +1177,11 @@ th {
   z-index: 2;
   margin-bottom: -40px;
   box-shadow: 0 4px 20px color-mix(in srgb, var(--site-accent, var(--turbo-brand-primary)) 40%, transparent);
-  transition: all 0.3s ease;
+  /* Named properties rather than `all`: `all` also covers `color` and
+     `background`, which a theme swap rewrites under the pointer. */
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
 }
 
 .feature-tile:hover .feature-tile-bubble {
@@ -1172,7 +1209,11 @@ th {
   text-align: center;
   width: 100%;
   flex: 1;
-  transition: all 0.3s ease;
+  /* The tile body carries the feature's heading and copy, so it must not
+     transition `color` on a theme swap — only the box the hover changes. */
+  transition:
+    border-color 0.3s ease,
+    box-shadow 0.3s ease;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -1558,11 +1599,19 @@ th {
   font-weight: 500;
   line-height: 1.2;
   cursor: pointer;
+  /*
+   * `color` is deliberately absent. Picking a theme rewrites every
+   * `--turbo-*` custom property at once, and a transition on `color` makes
+   * the label crossfade from the old theme's ink to the new one while its
+   * background has already switched — the two are momentarily near-identical
+   * and the control fails AA mid-swap. turbo-themes#774 removed exactly this
+   * transition for exactly this reason. Hover and focus still animate,
+   * because those change the box, not the text colour.
+   */
   transition:
     border-color var(--transition-fast),
     background var(--transition-fast),
-    box-shadow var(--transition-fast),
-    color var(--transition-fast);
+    box-shadow var(--transition-fast);
   box-shadow: 0 1px 3px color-mix(in srgb, var(--turbo-bg-base) 25%, transparent);
 }
 
@@ -1668,10 +1717,11 @@ th {
   font-size: 0.84rem;
   text-align: left;
   cursor: pointer;
+  /* `color` omitted for the same reason as `.theme-picker-trigger`: this
+     option list is on screen while the theme swap it triggers repaints. */
   transition:
     background var(--transition-fast),
-    border-color var(--transition-fast),
-    color var(--transition-fast);
+    border-color var(--transition-fast);
 }
 
 .theme-picker-option:hover,

--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -78,9 +78,9 @@ html {
  *
  * The site's motion is all transition-based — dropdown panels, hover lifts,
  * the theme picker — so zeroing durations sitewide is what honours the
- * preference, and it holds for any animation a component adds later. Note
- * that `scroll-behavior: smooth` above is set on `html` and so needs its own
- * override; it is the one piece of motion the shorthand block cannot reach.
+ * preference, and it holds for any animation a component adds later. The
+ * universal selector also matches `html`, which is what unsets the
+ * `scroll-behavior: smooth` declared above it.
  *
  * `animation-iteration-count` is pinned to 1 because a zero-duration
  * animation that is still `infinite` repaints forever.
@@ -90,10 +90,6 @@ html {
  * advances.
  */
 @media (prefers-reduced-motion: reduce) {
-  html {
-    scroll-behavior: auto;
-  }
-
   *,
   *::before,
   *::after {

--- a/apps/site/src/styles/motion.test.ts
+++ b/apps/site/src/styles/motion.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const globalCss = readFileSync(resolve(here, "./global.css"), "utf8");
+const searchDropdown = readFileSync(resolve(here, "../components/SearchDropdown.astro"), "utf8");
+
+/** Body of the sitewide `prefers-reduced-motion` block. */
+function reducedMotionBlock(css: string): string {
+  const start = css.indexOf("@media (prefers-reduced-motion: reduce)");
+  expect(start).toBeGreaterThan(-1);
+
+  let depth = 0;
+  let index = css.indexOf("{", start);
+  const open = index;
+
+  while (index < css.length) {
+    if (css[index] === "{") depth += 1;
+    if (css[index] === "}") {
+      depth -= 1;
+      if (depth === 0) break;
+    }
+    index += 1;
+  }
+
+  return css.slice(open, index);
+}
+
+describe("site motion", () => {
+  it("zeroes durations and caps iterations under prefers-reduced-motion", () => {
+    const block = reducedMotionBlock(globalCss);
+
+    expect(block).toContain("animation-duration: 0.01ms !important");
+    expect(block).toContain("transition-duration: 0.01ms !important");
+    expect(block).toContain("animation-iteration-count: 1 !important");
+  });
+
+  it("unsets smooth scrolling, which the shorthand block must reach", () => {
+    // `html` declares `scroll-behavior: smooth`; the universal selector in the
+    // reduced-motion block is what overrides it.
+    expect(globalCss).toContain("scroll-behavior: smooth");
+    expect(reducedMotionBlock(globalCss)).toContain("scroll-behavior: auto !important");
+  });
+
+  it("never transitions colour on the theme picker", () => {
+    // A theme swap rewrites every `--turbo-*` property at once. Transitioning
+    // `color` crossfades the label's ink against a background that has already
+    // changed, so the control fails AA mid-swap (turbo-themes#774).
+    for (const selector of [".theme-picker-trigger {", ".theme-picker-option {"]) {
+      const start = globalCss.indexOf(selector);
+      expect(start, `${selector} not found`).toBeGreaterThan(-1);
+
+      const rule = globalCss.slice(start, globalCss.indexOf("}", start));
+      expect(rule).toContain("transition:");
+      expect(rule).not.toMatch(/^\s*color\s/m);
+    }
+  });
+
+  it("names transitioned properties instead of using the `all` shorthand", () => {
+    // `transition: all` sweeps up `color` and `background`, which every theme
+    // swap rewrites — the same mid-blend hazard, reintroduced by accident.
+    expect(globalCss).not.toMatch(/transition:\s*all\b/);
+    expect(searchDropdown).not.toMatch(/transition:\s*all\b/);
+  });
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -13,6 +13,25 @@ const allBrowsers = !process.env.CI && process.env.PLAYWRIGHT_ALL_BROWSERS === "
 // baseline on the first attempt, so a retry would silently pass against it).
 const VISUAL_SPEC = /visual\.spec\.ts/;
 
+/**
+ * `reducedMotion` states the intent of these runs — they assert the steady
+ * state of a surface, not a frame of its entrance animation. It is not what
+ * makes them deterministic: Rustume#618 measured that `matchMedia` still
+ * reports `no-preference` under Playwright 1.61 with `devices["Desktop
+ * Chrome"]`, so the `prefers-reduced-motion` rule in `src/index.css` does not
+ * actually engage. What keeps the scans stable is that no entrance animation
+ * interpolates `opacity` any more, so there is no frame in which text is
+ * composited toward its backdrop.
+ *
+ * In Playwright 1.61 the option only type-checks under `contextOptions`; the
+ * top-level `use.reducedMotion` key no longer exists.
+ *
+ * The `visual` project is deliberately excluded: its baselines are committed,
+ * and a flag that is inert today but honoured by a future Playwright would
+ * silently invalidate them.
+ */
+const REDUCED_MOTION = { contextOptions: { reducedMotion: "reduce" } } as const;
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -38,7 +57,11 @@ export default defineConfig({
     serviceWorkers: "block",
   },
   projects: [
-    { name: "chromium", use: { ...devices["Desktop Chrome"] }, testIgnore: VISUAL_SPEC },
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], ...REDUCED_MOTION },
+      testIgnore: VISUAL_SPEC,
+    },
     {
       name: "visual",
       use: { ...devices["Desktop Chrome"] },
@@ -49,12 +72,12 @@ export default defineConfig({
       ? [
           {
             name: "firefox",
-            use: { ...devices["Desktop Firefox"] },
+            use: { ...devices["Desktop Firefox"], ...REDUCED_MOTION },
             testIgnore: VISUAL_SPEC,
           },
           {
             name: "webkit",
-            use: { ...devices["Desktop Safari"] },
+            use: { ...devices["Desktop Safari"], ...REDUCED_MOTION },
             testIgnore: VISUAL_SPEC,
           },
         ]

--- a/apps/web/src/__tests__/motionStyles.test.ts
+++ b/apps/web/src/__tests__/motionStyles.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Keyframes allowed to interpolate `opacity`.
+ *
+ * Every other keyframe runs on a surface that carries text. A partially
+ * transparent element is composited toward whatever sits behind it, so its
+ * text and its own background blend together and the pair falls below the AA
+ * contrast ratio for the length of the animation — which is how an axe scan
+ * lands on a failure that does not exist at rest (Rustume#618, turbo-themes#774).
+ *
+ * The three below animate text-free decoration: `fade-in` is applied only to
+ * scrims and overlays, `ink-drop` is a ripple, and `pulse-subtle` is a status
+ * dot.
+ */
+const OPACITY_ALLOWED = new Set(["fade-in", "ink-drop", "pulse-subtle"]);
+
+/** Splits the stylesheet into `@keyframes` blocks keyed by animation name. */
+function keyframeBlocks(css: string): Map<string, string> {
+  const blocks = new Map<string, string>();
+  const pattern = /@keyframes\s+([\w-]+)\s*\{/g;
+
+  for (let match = pattern.exec(css); match !== null; match = pattern.exec(css)) {
+    const name = match[1] as string;
+    let depth = 1;
+    let index = match.index + match[0].length;
+    const start = index;
+
+    while (index < css.length && depth > 0) {
+      const char = css[index];
+      if (char === "{") depth += 1;
+      if (char === "}") depth -= 1;
+      index += 1;
+    }
+
+    blocks.set(name, css.slice(start, index - 1));
+  }
+
+  return blocks;
+}
+
+describe("motion styles", () => {
+  const css = readFileSync(resolve(__dirname, "../index.css"), "utf8");
+
+  it("zeroes durations and caps iterations under prefers-reduced-motion", () => {
+    const block = css.slice(css.indexOf("@media (prefers-reduced-motion: reduce)"));
+
+    expect(css).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(block).toContain("animation-duration: 0.01ms !important");
+    expect(block).toContain("transition-duration: 0.01ms !important");
+    // `pulse-subtle` runs `infinite`: a zero-duration animation that never
+    // stops still repaints forever.
+    expect(block).toContain("animation-iteration-count: 1 !important");
+    expect(block).toContain("scroll-behavior: auto !important");
+  });
+
+  it("finds the keyframes it means to check", () => {
+    // Guards the parser itself: a silent zero-block match would make every
+    // assertion below vacuously pass.
+    expect([...keyframeBlocks(css).keys()]).toEqual(
+      expect.arrayContaining(["slide-up", "toast-slide-in", "tooltip-in"]),
+    );
+  });
+
+  it("keeps text-bearing keyframes off opacity", () => {
+    const offenders = [...keyframeBlocks(css)]
+      .filter(([name, body]) => !OPACITY_ALLOWED.has(name) && /\bopacity\s*:/.test(body))
+      .map(([name]) => name);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("moves toasts by translation alone so they clear the viewport", () => {
+    const blocks = keyframeBlocks(css);
+
+    for (const name of ["toast-slide-in", "toast-slide-out", "toast-swipe-out"]) {
+      expect(blocks.get(name)).toMatch(/translateX/);
+    }
+    // The exit animations rely on leaving the viewport rather than fading,
+    // so they must end fully off-canvas.
+    expect(blocks.get("toast-slide-out")).toContain("translateX(100%)");
+    expect(blocks.get("toast-swipe-out")).toContain("translateX(100%)");
+  });
+});

--- a/apps/web/src/components/LayoutEditor/DraggableSection.tsx
+++ b/apps/web/src/components/LayoutEditor/DraggableSection.tsx
@@ -31,7 +31,8 @@ export function DraggableSection(props: DraggableSectionProps) {
       aria-selected={props.kbActive ?? false}
       data-section-id={props.id}
       class="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-paper
-        transition-all duration-150 cursor-grab active:cursor-grabbing select-none group
+        transition-[opacity,border-color,box-shadow,transform] duration-150
+        motion-reduce:transition-none cursor-grab active:cursor-grabbing select-none group
         focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
       classList={{
         "opacity-25 border-dashed": sortable.isActiveDraggable,

--- a/apps/web/src/components/LayoutEditor/DroppableColumn.tsx
+++ b/apps/web/src/components/LayoutEditor/DroppableColumn.tsx
@@ -36,7 +36,7 @@ export function DroppableColumn(props: DroppableColumnProps) {
       ref={droppable.ref}
       role="listbox"
       aria-label={label()}
-      class="flex-1 min-w-0 rounded-lg border-2 border-dashed transition-colors duration-150 p-2"
+      class="flex-1 min-w-0 rounded-lg border-2 border-dashed transition-colors duration-150 motion-reduce:transition-none p-2"
       classList={{
         "border-accent/50 bg-accent/5": droppable.isActiveDroppable,
         "border-border bg-surface/30": !droppable.isActiveDroppable,

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -129,7 +129,7 @@ export const AppShell: ParentComponent = (props) => {
             {/* Offline Indicator */}
             <Show when={!isOnline()}>
               <div class="flex items-center gap-2 px-3 py-1.5 bg-offline/10 rounded-full">
-                <div class="w-2 h-2 bg-offline rounded-full animate-pulse-subtle" />
+                <div class="w-2 h-2 bg-offline rounded-full animate-pulse-subtle motion-reduce:animate-none" />
                 <span class="text-xs font-mono text-stone">Offline</span>
               </div>
             </Show>

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -157,7 +157,7 @@ export function Sidebar(props: SidebarProps) {
                       {renderIcon(item.icon)}
                     </Tooltip.Trigger>
                     <Tooltip.Portal>
-                      <Tooltip.Content class="z-50 px-2.5 py-1.5 bg-ink text-paper text-xs font-medium rounded-lg shadow-lg animate-fade-in">
+                      <Tooltip.Content class="z-50 px-2.5 py-1.5 bg-ink text-paper text-xs font-medium rounded-lg shadow-lg">
                         {item.label}
                         <Tooltip.Arrow />
                       </Tooltip.Content>

--- a/apps/web/src/components/ui/Accordion.tsx
+++ b/apps/web/src/components/ui/Accordion.tsx
@@ -85,13 +85,17 @@ if (typeof document !== "undefined") {
     const style = document.createElement("style");
     style.id = styleId;
     style.textContent = `
+      /* Height only. The panel is text-bearing, and an opacity ramp
+         composites that text toward the surface behind it, so the pair sits
+         below AA contrast for the length of the animation. The clipping
+         wrapper already reveals and hides the content on its own. */
       @keyframes accordion-down {
-        from { height: 0; opacity: 0; }
-        to { height: var(--kb-accordion-content-height); opacity: 1; }
+        from { height: 0; }
+        to { height: var(--kb-accordion-content-height); }
       }
       @keyframes accordion-up {
-        from { height: var(--kb-accordion-content-height); opacity: 1; }
-        to { height: 0; opacity: 0; }
+        from { height: var(--kb-accordion-content-height); }
+        to { height: 0; }
       }
       [data-kb-accordion-content][data-expanded] {
         animation: accordion-down 200ms ease-out;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -163,11 +163,17 @@ body {
 /*
  * Reduced motion.
  *
- * Now that `slide-up` and `stagger-in` animate transform alone, movement is
- * the only entrance cue they offer — which is exactly the cue a motion-
- * sensitive reader needs suppressed. Components already opt out of their own
- * transitions via `motion-reduce:transition-none`; this is the global
- * counterpart that also covers the keyframe animations.
+ * Now that `slide-up`, `stagger-in`, `tooltip-in` and the toast keyframes
+ * animate transform alone, movement is the only entrance cue they offer —
+ * which is exactly the cue a motion-sensitive reader needs suppressed.
+ * Components already opt out of their own transitions via
+ * `motion-reduce:transition-none`; this is the global counterpart that also
+ * covers the keyframe animations, including ones declared at runtime (the
+ * accordion's injected stylesheet) and any a component adds later.
+ *
+ * `animation-iteration-count` matters on its own: `pulse-subtle` runs
+ * `infinite`, and a zero-duration animation that never stops still repaints
+ * forever.
  */
 @media (prefers-reduced-motion: reduce) {
   *,
@@ -378,13 +384,13 @@ body {
   animation: tooltip-in 0.15s ease-out;
 }
 
+/* Scale only: the tooltip carries its label text, so an opacity ramp would
+   composite that text toward the page behind it for the duration. */
 @keyframes tooltip-in {
   from {
-    opacity: 0;
     transform: scale(0.96);
   }
   to {
-    opacity: 1;
     transform: scale(1);
   }
 }
@@ -416,35 +422,39 @@ body {
   animation: toast-swipe-out 0.15s ease-out forwards;
 }
 
+/*
+ * Toast motion is translation only.
+ *
+ * A toast is a text-bearing surface that arrives unannounced and overlaps
+ * whatever is beneath it, so fading it in or out composites its message and
+ * its own background toward the page behind — the pair drops below AA for the
+ * length of the ramp, and an axe scan that lands mid-flight reports a contrast
+ * failure that does not exist at rest. Sliding fully off-canvas ends the exit
+ * animations just as decisively as `opacity: 0` did.
+ */
 @keyframes toast-slide-in {
   from {
-    opacity: 0;
     transform: translateX(100%);
   }
   to {
-    opacity: 1;
     transform: translateX(0);
   }
 }
 
 @keyframes toast-slide-out {
   from {
-    opacity: 1;
     transform: translateX(0);
   }
   to {
-    opacity: 0;
     transform: translateX(100%);
   }
 }
 
 @keyframes toast-swipe-out {
   from {
-    opacity: 1;
     transform: translateX(var(--kb-toast-swipe-end-x));
   }
   to {
-    opacity: 0;
     transform: translateX(100%);
   }
 }

--- a/apps/web/src/pages/home/HomeSidebar.tsx
+++ b/apps/web/src/pages/home/HomeSidebar.tsx
@@ -303,7 +303,7 @@ export function HomeSidebar(props: { home: HomePageModel; isDrawer: () => boolea
       tabindex={-1}
       data-testid="home-scope-rail"
       class="z-40 flex flex-col border-r border-border bg-surface
-        motion-safe:animate-fade-in
+        motion-safe:animate-slide-up
         max-[899px]:fixed max-[899px]:inset-y-0 max-[899px]:left-0 max-[899px]:w-[17rem]
         max-[899px]:shadow-card
         min-[900px]:sticky min-[900px]:top-14 min-[900px]:self-start


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): honour prefers-reduced-motion across app and site
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Two things, and they are the same thing seen from two angles.

**For readers.** `apps/site` had no reduced-motion opt-out at all — every
dropdown panel, hover lift and theme-picker transition ran regardless of the OS
preference. It now has the sitewide block, and `apps/web`'s existing block (from
#618) is no longer defeated by component-level animations that outran it.

**For the scanner.** A partially transparent element is composited toward
whatever sits behind it, so its text and its own background blend together and
the pair falls below AA for the length of the animation. That is how axe lands
on a contrast failure that does not exist at rest. #618 removed the opacity ramp
from `slide-up` and `stagger-in`; this PR finds the ones it did not reach, and
does the same for the site's theme swap, where transitioning `color` crossfades
old ink against a background that has already changed.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #624
- Relates to #352

## Details

### Animations changed, and why

**Opacity-based — the class that breaks contrast scans:**

| Animation | Where | Now |
| --- | --- | --- |
| `toast-slide-in` / `toast-slide-out` / `toast-swipe-out` | `apps/web/src/index.css` | Translation only. A toast is a text-bearing surface that arrives unannounced over other content; sliding fully off-canvas ends the exit animations as decisively as `opacity: 0` did. |
| `tooltip-in` | `apps/web/src/index.css` | Scale only. The tooltip *is* its label text. |
| `accordion-down` / `accordion-up` | `Accordion.tsx` (runtime-injected stylesheet) | Height only. The clipping wrapper already reveals and hides the panel. |
| `animate-fade-in` on the sidebar tooltip | `Sidebar.tsx` | Removed — it stacked a second opacity ramp on top of the Kobalte tooltip keyframes. |
| `motion-safe:animate-fade-in` on the library rail | `HomeSidebar.tsx` | `motion-safe:animate-slide-up`; same final state, transform-only entrance. |

`fade-in`, `ink-drop` and `pulse-subtle` keep their opacity ramps: they animate
text-free decoration (scrims, a ripple, a status dot). The new test allowlists
exactly those three.

**Colour-on-theme-swap — the turbo-themes#774 pattern:**

Note that the issue's prompt pointed at `apps/web/src/index.css` here; #618
already verified it has no `color` transitions. The offenders are on the site:

- `.theme-picker-trigger` and `.theme-picker-option` dropped `color` from their
  transition lists. These are literally on screen while the swap they trigger
  repaints.
- `transition: all` narrowed to named properties on `.feature-tile-bubble`,
  `.feature-tile-body`, `.search-bar-inner` and `.search-bar-btn` — `all`
  silently included `color` and `background`.

**Other motion:** both `@thisbeyond/solid-dnd` surfaces opt out under reduced
motion, and `DraggableSection`'s `transition-all` narrowed to the properties its
drag states actually change. The offline indicator's `infinite` pulse takes an
explicit `motion-reduce:animate-none`, matching `StatusStrip`.

### What `reducedMotion` actually does here

**Nothing observable.** Set for intent in both configs, in the `contextOptions`
placement Playwright 1.61 requires (the top-level `use.reducedMotion` key no
longer type-checks). #618 measured that `matchMedia` still reports
`no-preference` under `devices["Desktop Chrome"]`, so neither
`prefers-reduced-motion` block engages during a scan. **These runs are not
deterministic because the flag is present** — they are deterministic because no
entrance animation interpolates opacity any more, so there is no frame in which
text is composited toward its backdrop. `apps/site` already had the flag from
#620; `apps/web` gains it on `chromium`, `firefox` and `webkit`, and
deliberately *not* on `visual` — those baselines are committed, and a flag that
is inert today but honoured by a future Playwright would silently invalidate
them.

### Testing

- `apps/web`: 64 e2e passed, run twice (5 visual skipped locally by design — CI-generated baselines). 589 unit tests.
- `apps/site`: 27 e2e passed, run twice. 174 unit tests.
- Local ports were overridden via `E2E_PORT` to avoid clashing with parallel work; no port change is committed.
- New guard tests read the stylesheets the way the existing `printStyles.test.ts` does: the web one parses `@keyframes` blocks and asserts none outside the allowlist touches opacity; the site one asserts the reduced-motion block, the absence of `color` on the theme picker, and the absence of `transition: all`. Both were confirmed to **fail** against a deliberately reintroduced offender, and the web suite asserts its parser found the blocks it means to check so a regex matching nothing cannot pass vacuously.
- `uv run lintro fmt` + `uv run lintro chk`: zero issues. `pip-audit` errors on this machine (`ensurepip` aborts in its temp venv) and does so identically on a clean tree — pre-existing environment, unrelated to this diff.

### AI review

**Neither CodeRabbit nor Greptile ran.** Greptile is account-blocked
(`free_reviews_limit_reached`) and CodeRabbit is unreliable. The `lintro-review`
skill was attempted and its CLI transport failed —
`Claude CLI exited with code 1` with empty stderr, on both a default and a
`--depth 1` pass, while a bare `claude -p` in the same shell succeeds (live
signal for py-lintro#1614). The documented fallback was used instead: a
self-review of the branch diff against py-lintro's checklist corpus
(`tier1.yaml`, plus `tier2.yaml` filtered to ts/tsx/css/e2e/test domains).

Two findings from that pass, both fixed before push:

1. *contract-drift* — the site block carried a redundant
   `html { scroll-behavior: auto }` and a comment claiming the universal
   selector could not reach `html`. It can. Rule and claim both removed.
2. *test-gap (#133/#134)* — changed production code with no test in the same
   diff. Hence the two guard suites above.

### Scope

Stays clear of #622 (target-size): no `accessibility.spec.ts` in either app, no
WCAG 2.2 tags, and `SectionEditor.tsx` / `CustomSectionEditor.tsx` / the editor
toolbar are untouched. Nothing under `.github/workflows/site-quality.yml` or
`scripts/ci/site/` (#621). The component edits here are single-line animation
fixes, not restructuring.
