### PR TITLE
ci(site): run the site accessibility suite in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -128,7 +128,7 @@ Renovate config lives in `renovate.json`; the shared preset is
 | `.github/workflows/*.yml` | `tooling-ref: '<sha>' # vX.Y.Z` (one per lgtm-ci caller job) | lgtm-ci tooling checkout, mirroring the `uses:` pin in the same file | Renovate custom manager (`lgtm-hq/lgtm-ci`, `github-tags`), enforced by `pin-sync-guard.yml` |
 | `.github/workflows/ci-lintro-analysis.yml`, `.github/workflows/security-dependency-review.yml` | `lintro-image: ghcr.io/lgtm-hq/py-lintro:<version>@sha256:<digest>` | lintro CI image (version and digest together) | Renovate custom manager (`ghcr.io/lgtm-hq/py-lintro`, `docker`) |
 | `.github/workflows/boundary-guard.yml` | `pip install uv==<version>` | uv in the boundary job (`setup-uv` is blocked by the egress policy) | **Manual — no manager** |
-| `.github/workflows/coverage.yml`, `deploy-pages.yml`, `site-quality.yml` | `node-version:`, `python-version:` | CI runtime majors | **Manual — no manager** |
+| `.github/workflows/coverage.yml`, `deploy-pages.yml`, `site-quality.yml`, `test-e2e-web.yml`, `test-e2e-site.yml` | `node-version:`, `python-version:` | CI runtime majors | **Manual — no manager** |
 | `.github/workflows/README.md` | `## Pin format` example | Illustrative lgtm-ci pin | **Manual — no manager**; `pin-sync-guard.yml` does not read Markdown |
 | `docker/Dockerfile` | `FROM <image>@sha256:<digest>` | `rust`, `gcr.io/distroless/static` | Renovate `dockerfile` (digest updates automerged) |
 | `docker/Dockerfile` | `ARG BUN_VERSION=` | bun release tarball | Renovate custom manager (`oven-sh/bun`, `github-releases`) |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,6 +25,12 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
   regression, accessibility) via `reusable-test-e2e-playwright` (`test-command:
   scripts/ci/testing/web/e2e.sh` supplies the Rust/wasm-pack stage the reusable
   has no input for); one call runs every suite because they share that build
+- **test-e2e-site.yml** — Documentation site Playwright accessibility suites (axe
+  scans across surfaces and themes, keyboard/ARIA chrome) via
+  `reusable-test-e2e-playwright` (`test-command: scripts/ci/site/e2e.sh` builds
+  the production `dist/`, serves it with `astro preview`, and refuses to run
+  unless the served build is the one it just built — see
+  `scripts/ci/site/assert-served-build.sh`)
 - **ci-lintro-analysis.yml** — Lintro quality in Docker via `reusable-quality-lint` and
   `reusable-publish-quality-summary`
 - **site-quality.yml** — Docs site build, link check, Astro check, Vitest + pytest via

--- a/.github/workflows/test-e2e-site.yml
+++ b/.github/workflows/test-e2e-site.yml
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Test - Site E2E
+# Playwright accessibility suites for the documentation site (apps/site/e2e) —
+# axe scans across 7 surfaces x 3 themes plus the keyboard/ARIA chrome suite —
+# via lgtm-ci's reusable-test-e2e-playwright.
+#
+# Sibling workflow rather than a job inside site-quality.yml: that workflow
+# delegates wholesale to reusable-site-quality, which offers no hook to run a
+# Playwright suite, so consuming its `site-dist` artifact would mean
+# hand-rolling bun install, the Chromium download and cache, the report
+# artifact and the PR summary comment in this repo — all of which
+# reusable-test-e2e-playwright already owns and test-e2e-web.yml already
+# demonstrates. deploy-pages.yml also rebuilds the site from
+# scripts/ci/site/build.sh rather than deploying site-dist, so "test what
+# deploys" means running that same build script, which scripts/ci/site/e2e.sh
+# does.
+#
+# The suite runs against `astro preview` over the production dist/, never a dev
+# server, and scripts/ci/site/e2e.sh proves the served build is the one it just
+# built (see the staleness guard notes there and in assert-served-build.sh).
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - 'apps/site/**'
+      - 'docs/**'
+      - 'scripts/ci/site/**'
+      - '.github/workflows/test-e2e-site.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/site/**'
+      - 'docs/**'
+      - 'scripts/ci/site/**'
+      - '.github/workflows/test-e2e-site.yml'
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-e2e-site-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  site-e2e:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    permissions:
+      contents: read
+      pull-requests: write # publish-test-summary on PRs
+    with:
+      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      job-name: "♿ Site E2E"
+      node-version: "22"
+      working-directory: apps/site
+      package-manager: bun
+      browsers: chromium
+      # playwright.config.ts already resolves to chromium-only under CI, so no
+      # --project filter is passed.
+      test-command: bash ../../scripts/ci/site/e2e.sh
+      upload-report: true
+      publish-test-summary: true
+      comment-marker: site-e2e-report
+      draft-pr-skip: true
+      egress-policy: block
+      # The reusable's harden-runner step consumes `allowed-endpoints`
+      # verbatim, so `egress-preset: playwright` cannot be extended via
+      # `allowed-endpoints-mode: append` here — the full list is spelled out
+      # instead. It is the lgtm-ci `playwright` preset plus what the Astro +
+      # Pagefind site build needs (npm registry, bun toolchain). Google Fonts
+      # is deliberately absent: e2e/support/fixtures.ts aborts those routes so
+      # the suite renders with fallback fonts and stays hermetic.
+      allowed-endpoints: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        results-receiver.actions.githubusercontent.com:443
+        *.blob.core.windows.net:443
+        registry.npmjs.org:443
+        nodejs.org:443
+        bun.sh:443
+        cdn.playwright.dev:443
+        playwright.azureedge.net:443
+        playwright-akamai.azureedge.net:443
+        playwright-verizon.azureedge.net:443
+        playwright.download.prss.microsoft.com:443
+        storage.googleapis.com:443
+        archive.ubuntu.com:80
+        security.ubuntu.com:80
+        azure.archive.ubuntu.com:80
+        esm.ubuntu.com:443
+        packages.microsoft.com:443
+      runner-image: ubuntu-24.04
+      timeout-minutes: 30

--- a/scripts/ci/site/README.md
+++ b/scripts/ci/site/README.md
@@ -8,6 +8,8 @@
 | `test.sh` | Vitest with coverage |
 | `test-python.sh` | Pytest for `tests/scripts/ci/` |
 | `test-all.sh` | `test.sh` + `test-python.sh` |
+| `e2e.sh` | Build `dist/`, serve it, verify the served build, run the Playwright a11y suites |
+| `assert-served-build.sh` | Staleness guard: the served site must be the build under test |
 | `preview-serve.sh` | `astro preview` with `ASTRO_BASE` from `defaults.env` |
 | `preview-pages-local.sh` | Build dist + optional local coverage bundles for manual Pages preview |
 
@@ -23,6 +25,32 @@ that value — do not duplicate the path elsewhere.
 | Local `make site-dev` / `site-build` | `ASTRO_BASE_DEFAULT` from `defaults.env` |
 | `site-quality.yml` link check build | `/` (root-relative hrefs under `dist/`; lychee via `reusable-site-quality`) |
 | `deploy-pages.yml` production deploy | `ASTRO_BASE_DEFAULT` via `build.sh` |
+| `test-e2e-site.yml` accessibility suites | `ASTRO_BASE_DEFAULT` via `build.sh` (`e2e.sh`) |
+
+## Site accessibility E2E (`e2e.sh`)
+
+[`.github/workflows/test-e2e-site.yml`](../../../.github/workflows/test-e2e-site.yml)
+runs the `apps/site/e2e` Playwright suites through lgtm-ci's
+`reusable-test-e2e-playwright` with `e2e.sh` as its `test-command`. The suites scan the
+production build served by `astro preview` — never a dev server — so CI exercises what
+deploys.
+
+`e2e.sh` starts that server itself (rather than leaving it to Playwright's `webServer`,
+which `playwright.config.ts` lets it reuse via `PLAYWRIGHT_REUSE_SERVER=1`) so the
+**staleness guard** can run before the suite:
+
+1. `dist/index.html` and `dist/pagefind/pagefind.js` must be newer than the build step —
+   a restored cache or skipped build cannot pass as a build.
+2. `dist/e2e-build-stamp.txt` records a sha256 fingerprint of every other file in
+   `dist/`, the commit, and the run id/attempt plus build timestamp.
+3. [`assert-served-build.sh`](assert-served-build.sh) fetches that stamp over HTTP before
+   and after the suite and fails loudly on a mismatch, a non-200, or no response.
+
+This complements `apps/site/scripts/e2e-build.mjs`, which refuses to start when the port
+is busy (`astro preview` silently hops to the next free port). That keeps a foreign
+server from displacing ours; the guard proves the server that actually answered is
+serving this build. Motivation: turbo-themes#824, where a suite ran green against a
+silently stale site.
 
 ## GitHub Pages (Model B: site + bundled reports)
 

--- a/scripts/ci/site/assert-served-build.sh
+++ b/scripts/ci/site/assert-served-build.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Staleness guard: assert the server answering <stamp-url> is serving the build
+# under test, and not some older or unrelated site.
+#
+# turbo-themes#824 is the failure this exists for: a suite generated snapshots
+# against a **stale** server and passed, so the green check meant nothing. A
+# passing accessibility run over yesterday's build is worse than no run, so the
+# contract here is fail-loud, never warn.
+#
+# The stamp is written into dist/ by e2e.sh immediately after the build (see
+# that script for the field-by-field meaning). This script only compares what
+# the server returns against the local copy, byte for byte:
+#
+#   * connection refused / no response  -> retried until the timeout, then fatal
+#   * any non-200 (typically 404)       -> fatal immediately; something is
+#                                          listening on that port but it is not
+#                                          serving this build's dist/
+#   * 200 with different content        -> fatal; a different build is being
+#                                          served
+#
+# Complementary to apps/site/scripts/e2e-build.mjs, which refuses to start when
+# the port is already busy (`astro preview` silently hops to the next free port
+# otherwise). That check prevents *our* server from being displaced; this one
+# proves the server that actually answers is serving *this* build.
+#
+# Usage: assert-served-build.sh <stamp-url> <expected-stamp-file>
+#
+# Optional environment:
+#   SERVED_BUILD_TIMEOUT_SECONDS  - total wait for a first response (default 120)
+#   SERVED_BUILD_POLL_SECONDS     - delay between attempts (default 2)
+set -euo pipefail
+
+STAMP_URL="${1:-}"
+EXPECTED_FILE="${2:-}"
+
+if [[ -z "${STAMP_URL}" || -z "${EXPECTED_FILE}" ]]; then
+	echo "usage: assert-served-build.sh <stamp-url> <expected-stamp-file>" >&2
+	exit 2
+fi
+
+TIMEOUT_SECONDS="${SERVED_BUILD_TIMEOUT_SECONDS:-120}"
+POLL_SECONDS="${SERVED_BUILD_POLL_SECONDS:-2}"
+
+fail() {
+	echo "::error::$1"
+	echo "assert-served-build: $1" >&2
+	exit 1
+}
+
+if [[ ! -f "${EXPECTED_FILE}" ]]; then
+	fail "expected stamp file not found: ${EXPECTED_FILE} (the build did not write one)"
+fi
+
+body_file="$(mktemp)"
+trap 'rm -f "${body_file}"' EXIT
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+status=""
+while :; do
+	status="$(
+		curl --silent --show-error --max-time 10 --output "${body_file}" \
+			--write-out '%{http_code}' "${STAMP_URL}" 2>/dev/null || true
+	)"
+
+	# 000 means the request never completed (nothing listening yet, or the
+	# server is still coming up) — that is the only retryable outcome.
+	if [[ "${status}" != "000" ]]; then
+		break
+	fi
+	if ((SECONDS >= deadline)); then
+		fail "no response from ${STAMP_URL} after ${TIMEOUT_SECONDS}s — the site server never came up"
+	fi
+	sleep "${POLL_SECONDS}"
+done
+
+if [[ "${status}" != "200" ]]; then
+	fail "STALE OR FOREIGN SERVER: ${STAMP_URL} returned HTTP ${status}; the process on that port is not serving this build's dist/"
+fi
+
+if ! diff -q "${EXPECTED_FILE}" "${body_file}" >/dev/null 2>&1; then
+	echo "::error::STALE BUILD: the served site is not the build under test"
+	{
+		echo "assert-served-build: served build stamp does not match the build under test"
+		echo "  url:      ${STAMP_URL}"
+		echo "  expected: (${EXPECTED_FILE})"
+		sed 's/^/    /' "${EXPECTED_FILE}"
+		echo "  served:"
+		head -c 2048 "${body_file}" | sed 's/^/    /'
+		echo ""
+	} >&2
+	exit 1
+fi
+
+echo "assert-served-build: served build matches the build under test (${STAMP_URL})"

--- a/scripts/ci/site/assert-served-build.sh
+++ b/scripts/ci/site/assert-served-build.sh
@@ -64,7 +64,10 @@ while :; do
 	)"
 
 	# 000 means the request never completed (nothing listening yet, or the
-	# server is still coming up) — that is the only retryable outcome.
+	# server is still coming up) — that is the only retryable outcome. An
+	# empty status (curl itself failed to run) is treated the same, so it
+	# ends in the explicit timeout error rather than an "HTTP " message.
+	status="${status:-000}"
 	if [[ "${status}" != "000" ]]; then
 		break
 	fi

--- a/scripts/ci/site/e2e.sh
+++ b/scripts/ci/site/e2e.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Build the documentation site, prove the preview server is serving that exact
+# build, then run the apps/site Playwright accessibility suites against it.
+#
+# Used as the `test-command` of lgtm-ci's reusable-test-e2e-playwright
+# (.github/workflows/test-e2e-site.yml). The reusable owns bun install, the
+# Chromium download/cache, the report artifact and the PR summary; it has no
+# build stage and no notion of "is the server serving the right thing", so both
+# happen here. Extra arguments (the reusable appends `--reporter` flags) are
+# forwarded to `playwright test`.
+#
+# Why the server is started here instead of by Playwright's `webServer`: the
+# staleness guard has to talk to the running server *before* the suite starts,
+# which is only possible from outside Playwright. playwright.config.ts opts into
+# reuse only when PLAYWRIGHT_REUSE_SERVER=1, which this script sets after the
+# guard has passed.
+#
+# The build stamp (dist/e2e-build-stamp.txt, served at /e2e-build-stamp.txt):
+#   fingerprint - sha256 over every file in dist/ except the stamp itself; ties
+#                 the stamp to this build's bytes
+#   commit      - the commit under test
+#   run         - run id/attempt (or "local"), plus the build timestamp, so two
+#                 byte-identical builds still produce distinct stamps and a
+#                 server left over from an earlier run cannot match by accident
+#
+# Two independent checks, because they catch different failures:
+#   1. freshness - dist/ must have been written by *this* invocation, so a
+#      restored cache or a skipped build cannot masquerade as a build
+#   2. served identity - assert-served-build.sh, before and after the suite, so
+#      a green run is always attributable to the build that was stamped
+set -euo pipefail
+
+# The reusable appends `--reporter=html --reporter=json`, but Playwright's CLI
+# keeps only the last `--reporter`, which would drop the HTML report the
+# workflow uploads on failure. Collapse repeated flags into one value.
+playwright_args=()
+reporters=()
+for arg in "$@"; do
+	case "${arg}" in
+	--reporter=*) reporters+=("${arg#--reporter=}") ;;
+	*) playwright_args+=("${arg}") ;;
+	esac
+done
+if [[ ${#reporters[@]} -gt 0 ]]; then
+	joined="$(
+		IFS=,
+		echo "${reporters[*]}"
+	)"
+	playwright_args=("--reporter=${joined}" ${playwright_args[@]+"${playwright_args[@]}"})
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SITE_DIR="${ROOT}/apps/site"
+
+set -a
+# shellcheck disable=SC1091 # defaults.env is resolved via SCRIPT_DIR; not a static shellcheck input
+source "${SCRIPT_DIR}/defaults.env"
+set +a
+
+ASTRO_BASE="${ASTRO_BASE:-${ASTRO_BASE_DEFAULT}}"
+export ASTRO_BASE
+
+# Must match playwright.config.ts, which defaults to 4321 and forwards E2E_PORT.
+E2E_PORT="${E2E_PORT:-4321}"
+export E2E_PORT
+
+STAMP_NAME="e2e-build-stamp.txt"
+STAMP_FILE="${SITE_DIR}/dist/${STAMP_NAME}"
+# ASTRO_BASE is "/" today but may become a subpath; build the URL from it
+# rather than assuming the site is served at the root.
+STAMP_URL="http://127.0.0.1:${E2E_PORT}${ASTRO_BASE%/}/${STAMP_NAME}"
+
+SERVER_LOG="$(mktemp)"
+SERVER_PID=""
+SERVER_IS_GROUP_LEADER=0
+
+# shellcheck disable=SC2329 # invoked indirectly by the EXIT trap below
+cleanup() {
+	if [[ -n "${SERVER_PID}" ]]; then
+		# Under setsid the server leads its own process group, so signalling
+		# the group takes the whole `bun -> astro preview` tree down. Without
+		# it, only the pid can be signalled safely — the script's own group
+		# must never be the target.
+		if ((SERVER_IS_GROUP_LEADER)); then
+			kill -- "-${SERVER_PID}" 2>/dev/null || true
+		fi
+		kill "${SERVER_PID}" 2>/dev/null || true
+		wait "${SERVER_PID}" 2>/dev/null || true
+	fi
+	rm -f "${SERVER_LOG}"
+}
+trap cleanup EXIT
+
+dump_server_log() {
+	echo "----- site preview server log -----" >&2
+	cat "${SERVER_LOG}" >&2 || true
+	echo "-----------------------------------" >&2
+}
+
+# GNU coreutils on the runners, BSD shasum for local macOS runs.
+sha256_cmd=(sha256sum)
+if ! command -v sha256sum >/dev/null 2>&1; then
+	sha256_cmd=(shasum -a 256)
+fi
+
+file_mtime() {
+	# GNU coreutils first (CI runners), BSD stat second (local macOS runs).
+	stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+
+cd "${SITE_DIR}"
+
+build_started="$(date +%s)"
+
+echo "::group::Build site"
+"${SCRIPT_DIR}/build.sh"
+echo "::endgroup::"
+
+# 1. Freshness: the build must have produced these files just now. A restored
+#    cache, a no-op build or a hand-copied dist/ is exactly the "silently stale"
+#    input turbo-themes#824 shipped a green suite against.
+for required in dist/index.html dist/pagefind/pagefind.js; do
+	if [[ ! -f "${required}" ]]; then
+		echo "::error::${required} is missing after the site build" >&2
+		exit 1
+	fi
+	if (($(file_mtime "${required}") < build_started)); then
+		echo "::error::STALE BUILD: ${required} predates this job's build step — dist/ was not rebuilt" >&2
+		exit 1
+	fi
+done
+
+# 2. Stamp the build so the server can be asked what it is serving.
+fingerprint="$(
+	find dist -type f ! -name "${STAMP_NAME}" -print0 |
+		LC_ALL=C sort -z |
+		xargs -0 "${sha256_cmd[@]}" |
+		"${sha256_cmd[@]}" |
+		cut -d' ' -f1
+)"
+{
+	echo "fingerprint=${fingerprint}"
+	echo "commit=${GITHUB_SHA:-$(git -C "${ROOT}" rev-parse HEAD)}"
+	echo "run=${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}-${build_started}"
+} >"${STAMP_FILE}"
+echo "Build stamp: ${fingerprint}"
+
+# 3. Serve the prebuilt dist/. E2E_SITE_PREBUILT=1 tells e2e-build.mjs to skip
+#    the rebuild (it still asserts the artifacts exist and that the port is
+#    free, so no foreign server can displace this one).
+if command -v setsid >/dev/null 2>&1; then
+	E2E_SITE_PREBUILT=1 setsid bun run e2e:server >"${SERVER_LOG}" 2>&1 &
+	SERVER_PID=$!
+	SERVER_IS_GROUP_LEADER=1
+else
+	E2E_SITE_PREBUILT=1 bun run e2e:server >"${SERVER_LOG}" 2>&1 &
+	SERVER_PID=$!
+fi
+
+echo "::group::Verify served build"
+if ! "${SCRIPT_DIR}/assert-served-build.sh" "${STAMP_URL}" "${STAMP_FILE}"; then
+	dump_server_log
+	exit 1
+fi
+echo "::endgroup::"
+
+status=0
+PLAYWRIGHT_REUSE_SERVER=1 bunx playwright test \
+	${playwright_args[@]+"${playwright_args[@]}"} || status=$?
+
+# 4. Re-verify after the suite. If the server died, or something else took over
+#    the port mid-run, the result cannot be attributed to the stamped build —
+#    and an unattributable green is the exact outcome this job exists to
+#    prevent, so it fails even when Playwright itself was happy.
+echo "::group::Re-verify served build"
+if ! SERVED_BUILD_TIMEOUT_SECONDS=10 \
+	"${SCRIPT_DIR}/assert-served-build.sh" "${STAMP_URL}" "${STAMP_FILE}"; then
+	echo "::error::The site server no longer serves the build under test — the suite result cannot be attributed to it" >&2
+	dump_server_log
+	exit 1
+fi
+echo "::endgroup::"
+
+exit "${status}"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci(site): run the site accessibility suite in CI
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`apps/site` gained Playwright + axe coverage in #647, but nothing ran it. This wires
those suites (27 tests: axe scans over 7 surfaces x 3 themes, plus the keyboard/ARIA
chrome suite) into CI so site a11y regressions block merges the way `test-e2e-web.yml`
already does for `apps/web`.

The suite runs against the production build served by `astro preview` — never a dev
server — and refuses to report a result it cannot attribute to that build.

### Why a sibling workflow, not a job in `site-quality.yml`

Both options in the issue were read before choosing. `site-quality.yml` delegates
wholesale to `reusable-site-quality`, which exposes no hook for a Playwright run, so
consuming its `site-dist` artifact would mean hand-rolling bun install, the Chromium
download and cache, the report artifact and the PR summary comment in this repo — all
of which `reusable-test-e2e-playwright` already owns and `test-e2e-web.yml` already
demonstrates. `deploy-pages.yml` also rebuilds the site from `scripts/ci/site/build.sh`
rather than deploying `site-dist`, so "test what deploys" means running that same build
script, which `scripts/ci/site/e2e.sh` does. The a11y run therefore lives in
`test-e2e-site.yml`, modelled on `test-e2e-web.yml`, and follows the harden-runner /
secure-checkout / SHA-pinning shape established by the `Craft theme contrast (WCAG AA)`
job from #617.

### Staleness guard

turbo-themes#824 shipped a green suite over a silently stale site. Two independent
checks make that outcome fail loudly here:

1. **Freshness** — `dist/index.html` and `dist/pagefind/pagefind.js` must be newer than
   this job's build step, so a restored cache or a skipped build cannot pass as a build.
2. **Served identity** — the build is stamped into `dist/e2e-build-stamp.txt`
   (sha256 fingerprint of every other file in `dist/`, the commit, and run
   id/attempt + build timestamp). `scripts/ci/site/assert-served-build.sh` fetches that
   stamp over HTTP **before and after** the suite and fails on a mismatch, a non-200, or
   no response. The post-run check means a server that dies or is replaced mid-run fails
   the job even when Playwright itself was green — an unattributable green is exactly
   what this job exists to prevent.

`e2e.sh` starts the preview server itself (rather than leaving it to Playwright's
`webServer`, which `playwright.config.ts` lets it reuse via `PLAYWRIGHT_REUSE_SERVER=1`)
because the guard has to talk to the running server before the suite starts.

This is **complementary to**, not a duplicate of, `apps/site/scripts/e2e-build.mjs` from
#647: that refuses to start when the port is busy, because `astro preview` silently hops
to the next free port. That keeps a foreign server from displacing ours; this guard
proves the server that actually answered is serving *this* build. If either mechanism
were removed, the other still degrades to a loud failure rather than a silent stale pass.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (CI wiring for the existing suites; guard behaviour verified
      manually — see Details)
- [x] Docs updated if user-facing (`.github/workflows/README.md`,
      `scripts/ci/site/README.md`)
- [x] Local CI passed (`uv run lintro fmt` + `uv run lintro chk`: 0 issues)

## Related Issues

Closes #621

## Details

### Files

- `.github/workflows/test-e2e-site.yml` — new caller of
  `reusable-test-e2e-playwright` (SHA-pinned to `240daf3` / v0.59.16, `tooling-ref`
  mirrored for `pin-sync-guard.yml`). No inline shell. The reusable uploads the
  Playwright report artifact on failure (`upload-report: true`) and posts the PR test
  summary (`comment-marker: site-e2e-report`).
- `scripts/ci/site/e2e.sh` — `test-command`: build, freshness check, stamp, start
  server, guard, run Playwright, re-verify, tear the server down.
- `scripts/ci/site/assert-served-build.sh` — the guard itself, usable standalone:
  `assert-served-build.sh <stamp-url> <expected-stamp-file>`.
- READMEs — workflow inventory, site-script table, staleness-guard rationale, and the
  manual `node-version` pin row (which was already missing `test-e2e-web.yml`).

No spec, `playwright.config.ts` or application source was touched — those belong to the
parallel #622 / #624 lanes.

### Verification

- Full local run of `scripts/ci/site/e2e.sh` under `CI=true`: build → guard → **27/27
  passed** → re-verify → exit 0.
- Guard proven to fail, not warn, on each failure mode (exit 1 every time):
  - served stamp differs from the build under test → `STALE BUILD`, both stamps printed;
  - verified against a **real `astro preview`** serving this build while the expected
    stamp was a different build, not just a synthetic server;
  - server up but no stamp (404) → `STALE OR FOREIGN SERVER`;
  - nothing listening → explicit timeout error.
  - Matching build → exit 0 (guard is not vacuously red).
- `uv run lintro fmt` + `uv run lintro chk` from the repo root: **0 issues** (actionlint,
  shellcheck, yamllint, markdownlint all clean). `pip-audit` errors in this local
  environment on an unrelated `ensurepip` crash, and `pytest` is skipped for a version
  floor — neither is touched by this change.

### Pre-push AI review

**Not** CodeRabbit and **not** Greptile. Greptile is account-blocked
(`free_reviews_limit_reached`) and CodeRabbit is rate-limited. The `lintro-review`
skill was attempted first: `uvx --from 'lintro[ai]>=0.91.10' lintro review --base
origin/main --with-lint --transport cli` aborted with `Claude CLI exited with code 1`
on chunk 1/1 (CLI transport fails from inside an active Claude session — live signal
for py-lintro #1614). The documented fallback was used instead: a manual review of the
diff against py-lintro's checklist corpus (`tier1.yaml`, and `tier2.yaml` filtered to
the `ci` / `shell` / `test` / `e2e` domains). Findings acted on:

- *"Are CI scripts referenced from workflows missing a shebang or executable bit?"* —
  both scripts have `#!/usr/bin/env bash` and mode `755`.
- *"Is substantial shell logic inlined in workflow YAML?"* — the workflow has no `run:`
  block at all.
- *"Are GitHub Actions referenced by mutable version tags?"* — only the SHA-pinned
  reusable is referenced.
- *"Does any error path exit or return success when callers expect failure?"* — fixed:
  an empty `curl` status now retries to the explicit timeout error instead of reporting
  a nonsense `HTTP ` status (2nd commit).
- *"Must two or more files be updated in lockstep?"* — fixed: the manual `node-version`
  pin inventory row now lists both E2E workflows.

Known gap, flagged rather than hidden: the guard has no automated (bats) test. Adding
one means a new shell-test workflow, which is outside this issue's scope; the manual
proof above covers all four failure modes.

### Notes for the reviewer

- **Infra flake watch list.** Jobs across this repo died repeatedly today with
  `The runner has received a shutdown signal`. `Test - Site E2E` is a ~15-20 minute job
  (site build + Chromium + 27 serial tests) and is therefore about as exposed to runner
  reclamation as the jobs already covered by `auto-rerun-on-infra-failure.yml`. I have
  **not** added it to that watch list — flagging it here for a decision instead, since
  `Test - Web E2E` is not on the list either and adding one without the other would be
  inconsistent.
- **Coupling to `playwright.config.ts`** (owned by the #624 lane): the guard relies on
  `reuseExistingServer: PLAYWRIGHT_REUSE_SERVER === "1"` and on the port default staying
  4321. If either changes, Playwright starts its own server, `e2e-build.mjs` hits the
  busy port and the job fails loudly — no silent stale pass.
