### PR TITLE
feat(web): raise axe coverage to WCAG 2.2 AA and enable target-size

### DIFF
--- a/apps/site/e2e/accessibility.spec.ts
+++ b/apps/site/e2e/accessibility.spec.ts
@@ -10,8 +10,8 @@ import {
 } from "./support/fixtures";
 import { SCANNED_THEMES } from "./support/themes";
 
-/** WCAG 2.1 AA scan scope (also includes the 2.0 A/AA baseline). */
-const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+/** WCAG 2.2 AA scan scope (also includes the 2.0 and 2.1 A/AA baselines). */
+const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22a", "wcag22aa"];
 
 /**
  * Rules deferred to follow-up work, both from the "distinguished by color"
@@ -28,9 +28,22 @@ const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
  *
  * Neither is suppressed to hide a flake — both fail deterministically today,
  * and shipping them red would make the suite unusable as a gate. Every other
- * WCAG 2.1 A/AA rule runs.
+ * WCAG 2.2 A/AA rule runs.
  */
 const DEFERRED_RULES = ["color-contrast", "link-in-text-block"];
+
+/**
+ * Rule overrides layered on top of the tag selection.
+ *
+ * `target-size` (SC 2.5.8, 24x24 CSS px minimum) ships `enabled: false` in
+ * axe-core, so selecting the `wcag22aa` tag is not enough to run it — it has
+ * to be switched on explicitly. The deferred rules are turned off in the same
+ * map because `disableRules()` would replace it wholesale.
+ */
+const RULE_OVERRIDES: Record<string, { enabled: boolean }> = {
+  "target-size": { enabled: true },
+  ...Object.fromEntries(DEFERRED_RULES.map((rule) => [rule, { enabled: false }])),
+};
 
 /** Human-readable summary so failures state the rule, impact, and targets. */
 interface ViolationSummary {
@@ -40,12 +53,38 @@ interface ViolationSummary {
   targets: string[];
 }
 
+/** Every bucket axe reports a rule under once it has actually been evaluated. */
+const RESULT_GROUPS = ["passes", "violations", "incomplete", "inapplicable"] as const;
+
+type AxeResults = Awaited<ReturnType<AxeBuilder["analyze"]>>;
+
+/**
+ * Guard against a silently skipped rule. `target-size` is off by default and
+ * only runs because of `RULE_OVERRIDES`; if a refactor drops that override (or
+ * reorders `options()` after `withTags()`), the suite would keep passing while
+ * scanning strictly less. A rule that ran always lands in one of the four
+ * result buckets, so absence from all of them means it never ran.
+ */
+function assertRuleEvaluated(results: AxeResults, ruleId: string): void {
+  const evaluated = RESULT_GROUPS.some((group) =>
+    results[group].some((result) => result.id === ruleId),
+  );
+  if (!evaluated) {
+    throw new Error(
+      `axe never evaluated the "${ruleId}" rule — check RULE_OVERRIDES and the tag scope.`,
+    );
+  }
+}
+
 async function scanForViolations(page: Page, include?: string): Promise<ViolationSummary[]> {
-  let builder = new AxeBuilder({ page }).withTags(WCAG_TAGS).disableRules(DEFERRED_RULES);
+  // `options()` replaces the whole option object, so it must come before
+  // `withTags()` — the reverse order would drop the tag selection.
+  let builder = new AxeBuilder({ page }).options({ rules: RULE_OVERRIDES }).withTags(WCAG_TAGS);
   if (include) {
     builder = builder.include(include);
   }
   const results = await builder.analyze();
+  assertRuleEvaluated(results, "target-size");
   return results.violations.map((violation) => ({
     rule: violation.id,
     impact: violation.impact ?? "unknown",
@@ -56,21 +95,21 @@ async function scanForViolations(page: Page, include?: string): Promise<Violatio
 
 for (const theme of SCANNED_THEMES) {
   test.describe(`accessibility (${theme.id})`, () => {
-    test("home page has no WCAG 2.1 AA violations", async ({ page, homePage }) => {
+    test("home page has no WCAG 2.2 AA violations", async ({ page, homePage }) => {
       await homePage.open();
       await homePage.assertLoaded();
       await homePage.useTheme(theme);
       expect(await scanForViolations(page)).toEqual([]);
     });
 
-    test("docs page has no WCAG 2.1 AA violations", async ({ page, docsPage }) => {
+    test("docs page has no WCAG 2.2 AA violations", async ({ page, docsPage }) => {
       await docsPage.open(SAMPLE_DOC.slug);
       await docsPage.assertLoaded(SAMPLE_DOC.title);
       await docsPage.useTheme(theme);
       expect(await scanForViolations(page)).toEqual([]);
     });
 
-    test("pricing table has no WCAG 2.1 AA violations", async ({ page, pricingPage }) => {
+    test("pricing table has no WCAG 2.2 AA violations", async ({ page, pricingPage }) => {
       await pricingPage.open();
       await pricingPage.assertLoaded(PRICING_TITLE);
       await pricingPage.assertPlansTableVisible();
@@ -78,7 +117,7 @@ for (const theme of SCANNED_THEMES) {
       expect(await scanForViolations(page)).toEqual([]);
     });
 
-    test("template gallery has no WCAG 2.1 AA violations", async ({
+    test("template gallery has no WCAG 2.2 AA violations", async ({
       page,
       templateGalleryPage,
     }) => {
@@ -89,7 +128,7 @@ for (const theme of SCANNED_THEMES) {
       expect(await scanForViolations(page)).toEqual([]);
     });
 
-    test("open template preview dialog has no WCAG 2.1 AA violations", async ({
+    test("open template preview dialog has no WCAG 2.2 AA violations", async ({
       page,
       templateGalleryPage,
     }) => {
@@ -100,14 +139,14 @@ for (const theme of SCANNED_THEMES) {
       expect(await scanForViolations(page)).toEqual([]);
     });
 
-    test("open search dialog has no WCAG 2.1 AA violations", async ({ page, homePage }) => {
+    test("open search dialog has no WCAG 2.2 AA violations", async ({ page, homePage }) => {
       await homePage.open();
       await homePage.useTheme(theme);
       await homePage.openSearch();
       expect(await scanForViolations(page)).toEqual([]);
     });
 
-    test("open theme picker has no WCAG 2.1 AA violations", async ({ page, homePage }) => {
+    test("open theme picker has no WCAG 2.2 AA violations", async ({ page, homePage }) => {
       await homePage.open();
       await homePage.useTheme(theme);
       await homePage.openThemeMenu();

--- a/apps/web/e2e/accessibility.spec.ts
+++ b/apps/web/e2e/accessibility.spec.ts
@@ -138,6 +138,7 @@ test.describe("accessibility", () => {
     await builderPage.fillItemField("Position", "Designer");
     await builderPage.assertSectionItemCount(2);
     await builderPage.assertSaved();
+    await expect(page.getByText("New resume created")).toBeHidden({ timeout: 15_000 });
     expect(await scanForViolations(page)).toEqual([]);
   });
 
@@ -155,6 +156,7 @@ test.describe("accessibility", () => {
     await builderPage.assertSectionOpen("Layout");
     await expect(page.getByRole("group", { name: "Main" })).toBeVisible();
     await expect(page.getByRole("group", { name: "Sidebar" })).toBeVisible();
+    await expect(page.getByText("New resume created")).toBeHidden({ timeout: 15_000 });
     expect(await scanForViolations(page)).toEqual([]);
   });
 

--- a/apps/web/e2e/accessibility.spec.ts
+++ b/apps/web/e2e/accessibility.spec.ts
@@ -2,8 +2,19 @@ import AxeBuilder from "@axe-core/playwright";
 import type { Page } from "@playwright/test";
 import { test, expect, DEFAULT_TEMPLATE_ID } from "./support/fixtures";
 
-/** WCAG 2.1 AA scan scope (also includes the 2.0 A/AA baseline). */
-const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+/** WCAG 2.2 AA scan scope (also includes the 2.0 and 2.1 A/AA baselines). */
+const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22a", "wcag22aa"];
+
+/**
+ * Rule overrides layered on top of the tag selection.
+ *
+ * `target-size` (SC 2.5.8, 24x24 CSS px minimum) ships `enabled: false` in
+ * axe-core, so selecting the `wcag22aa` tag is not enough to run it — it has
+ * to be switched on explicitly.
+ */
+const RULE_OVERRIDES: Record<string, { enabled: boolean }> = {
+  "target-size": { enabled: true },
+};
 
 /** Human-readable summary so failures state the rule, impact, and targets. */
 interface ViolationSummary {
@@ -13,12 +24,38 @@ interface ViolationSummary {
   targets: string[];
 }
 
+/** Every bucket axe reports a rule under once it has actually been evaluated. */
+const RESULT_GROUPS = ["passes", "violations", "incomplete", "inapplicable"] as const;
+
+type AxeResults = Awaited<ReturnType<AxeBuilder["analyze"]>>;
+
+/**
+ * Guard against a silently skipped rule. `target-size` is off by default and
+ * only runs because of `RULE_OVERRIDES`; if a refactor drops that override (or
+ * reorders `options()` after `withTags()`), the suite would keep passing while
+ * scanning strictly less. A rule that ran always lands in one of the four
+ * result buckets, so absence from all of them means it never ran.
+ */
+function assertRuleEvaluated(results: AxeResults, ruleId: string): void {
+  const evaluated = RESULT_GROUPS.some((group) =>
+    results[group].some((result) => result.id === ruleId),
+  );
+  if (!evaluated) {
+    throw new Error(
+      `axe never evaluated the "${ruleId}" rule — check RULE_OVERRIDES and the tag scope.`,
+    );
+  }
+}
+
 async function scanForViolations(page: Page, include?: string): Promise<ViolationSummary[]> {
-  let builder = new AxeBuilder({ page }).withTags(WCAG_TAGS);
+  // `options()` replaces the whole option object, so it must come before
+  // `withTags()` — the reverse order would drop the tag selection.
+  let builder = new AxeBuilder({ page }).options({ rules: RULE_OVERRIDES }).withTags(WCAG_TAGS);
   if (include) {
     builder = builder.include(include);
   }
   const results = await builder.analyze();
+  assertRuleEvaluated(results, "target-size");
   return results.violations.map((violation) => ({
     rule: violation.id,
     impact: violation.impact ?? "unknown",
@@ -28,13 +65,13 @@ async function scanForViolations(page: Page, include?: string): Promise<Violatio
 }
 
 test.describe("accessibility", () => {
-  test("home page has no WCAG 2.1 AA violations", async ({ page, homePage }) => {
+  test("home page has no WCAG 2.2 AA violations", async ({ page, homePage }) => {
     await homePage.open();
     await homePage.assertLoaded();
     expect(await scanForViolations(page)).toEqual([]);
   });
 
-  test("editor has no WCAG 2.1 AA violations", async ({ page, homePage, builderPage }) => {
+  test("editor has no WCAG 2.2 AA violations", async ({ page, homePage, builderPage }) => {
     await homePage.open();
     await homePage.createResume();
     await builderPage.assertEditorOpen();
@@ -46,7 +83,7 @@ test.describe("accessibility", () => {
     expect(await scanForViolations(page)).toEqual([]);
   });
 
-  test("template picker dialog has no WCAG 2.1 AA violations", async ({
+  test("template picker dialog has no WCAG 2.2 AA violations", async ({
     page,
     homePage,
     builderPage,
@@ -62,7 +99,7 @@ test.describe("accessibility", () => {
     expect(await scanForViolations(page, '[role="dialog"]')).toEqual([]);
   });
 
-  test("export dialog has no WCAG 2.1 AA violations", async ({
+  test("export dialog has no WCAG 2.2 AA violations", async ({
     page,
     homePage,
     builderPage,
@@ -77,7 +114,51 @@ test.describe("accessibility", () => {
     expect(await scanForViolations(page, '[role="dialog"]')).toEqual([]);
   });
 
-  test("account page has no WCAG 2.1 AA violations", async ({ page, accountPage }) => {
+  /**
+   * A freshly created resume has no section items, so the editor scan above
+   * never reaches the reorder controls, the visibility toggle, the remove
+   * button or the rich-text toolbar — exactly the dense, icon-only controls
+   * SC 2.5.8 exists for. Populate a section so those targets are in the tree.
+   */
+  test("populated section editor has no WCAG 2.2 AA violations", async ({
+    page,
+    homePage,
+    builderPage,
+  }) => {
+    await homePage.open();
+    await homePage.createResume();
+    await builderPage.assertEditorOpen();
+    await builderPage.openSection("Experience");
+    await builderPage.assertSectionOpen("Experience");
+    await builderPage.addSectionItem();
+    await builderPage.fillItemField("Position", "Engineer");
+    // A second item makes the reorder buttons meaningful: with one item both
+    // are disabled, and axe skips disabled controls.
+    await builderPage.addSectionItem();
+    await builderPage.fillItemField("Position", "Designer");
+    await builderPage.assertSectionItemCount(2);
+    await builderPage.assertSaved();
+    expect(await scanForViolations(page)).toEqual([]);
+  });
+
+  /**
+   * The layout editor is the app's only drag-and-drop surface, so it carries
+   * the SC 2.5.7 move controls and the densest cluster of icon-only buttons in
+   * the product. A new resume defaults to two columns, so the lateral move
+   * controls render without any extra setup.
+   */
+  test("layout editor has no WCAG 2.2 AA violations", async ({ page, homePage, builderPage }) => {
+    await homePage.open();
+    await homePage.createResume();
+    await builderPage.assertEditorOpen();
+    await builderPage.openSection("Layout");
+    await builderPage.assertSectionOpen("Layout");
+    await expect(page.getByRole("group", { name: "Main" })).toBeVisible();
+    await expect(page.getByRole("group", { name: "Sidebar" })).toBeVisible();
+    expect(await scanForViolations(page)).toEqual([]);
+  });
+
+  test("account page has no WCAG 2.2 AA violations", async ({ page, accountPage }) => {
     await accountPage.open();
     await accountPage.assertLocalMode();
     expect(await scanForViolations(page)).toEqual([]);

--- a/apps/web/src/components/Auth/SubscriptionBanner.tsx
+++ b/apps/web/src/components/Auth/SubscriptionBanner.tsx
@@ -59,7 +59,7 @@ export function SubscriptionBanner() {
             </p>
             <a
               href="/account#export"
-              class="inline-flex items-center justify-center rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-ink hover:bg-border/50"
+              class="inline-flex items-center justify-center rounded-md border border-border bg-surface px-3 py-1.5 text-sm font-medium text-ink hover:bg-accent-light"
             >
               Export data
             </a>

--- a/apps/web/src/components/LayoutEditor/ColumnControls.tsx
+++ b/apps/web/src/components/LayoutEditor/ColumnControls.tsx
@@ -28,7 +28,11 @@ export function ColumnControls(props: ColumnControlsProps) {
           class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-mono
             transition-colors border"
           classList={{
-            "bg-accent/10 text-accent border-accent/30": props.columnCount === preset.count,
+            // Ink label, not `text-accent`: accent over `bg-accent/10`
+            // measured below 4.5:1, because the tint pulls the background
+            // toward the very color the label is drawn in. The accent cue
+            // moves to the border, which is not held to the text threshold.
+            "bg-accent/10 text-ink border-accent": props.columnCount === preset.count,
             "text-stone hover:text-ink hover:bg-surface border-transparent":
               props.columnCount !== preset.count,
           }}

--- a/apps/web/src/components/LayoutEditor/DraggableSection.tsx
+++ b/apps/web/src/components/LayoutEditor/DraggableSection.tsx
@@ -1,18 +1,45 @@
-import { Show } from "solid-js";
+import { For, Show } from "solid-js";
 import { createSortable, transformStyle, useDragDropContext } from "@thisbeyond/solid-dnd";
 import { SECTIONS, type SectionInfo } from "../builder/constants";
+
+/** Arrow key each move control stands in for, reusing the keyboard drag vocabulary. */
+export type MoveDirection = "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight";
 
 interface DraggableSectionProps {
   id: string;
   label: string;
   /** Whether this section is currently being keyboard-dragged. */
   kbActive?: boolean;
+  /** Move this section one step in the given direction. */
+  onMove: (direction: MoveDirection) => void;
+  /** Position within its column, for disabling the vertical controls. */
+  isFirstInColumn: boolean;
+  isLastInColumn: boolean;
+  /** Position of its column, for disabling the lateral controls. */
+  isFirstColumn: boolean;
+  isLastColumn: boolean;
+  /** Lateral controls are pointless in a single-column layout. */
+  showLateralControls: boolean;
 }
 
 /** Look up the human-friendly label and icon for a section ID. */
 function getSectionInfo(id: string): SectionInfo | undefined {
   return SECTIONS.find((s) => s.key === id);
 }
+
+const ARROW_PATHS: Record<MoveDirection, string> = {
+  ArrowUp: "M5 15l7-7 7 7",
+  ArrowDown: "M19 9l-7 7-7-7",
+  ArrowLeft: "M15 19l-7-7 7-7",
+  ArrowRight: "M9 5l7 7-7 7",
+};
+
+const DIRECTION_WORDS: Record<MoveDirection, string> = {
+  ArrowUp: "up",
+  ArrowDown: "down",
+  ArrowLeft: "to the previous column",
+  ArrowRight: "to the next column",
+};
 
 export function DraggableSection(props: DraggableSectionProps) {
   const sortable = createSortable(props.id);
@@ -22,53 +49,109 @@ export function DraggableSection(props: DraggableSectionProps) {
 
   const info = () => getSectionInfo(props.id);
 
+  /**
+   * Single-pointer alternative to dragging (SC 2.5.7). These live outside the
+   * draggable element on purpose: the drag activators are bound to the card,
+   * and a press held past solid-dnd's 250 ms activation delay starts a drag
+   * and swallows the click — so a control nested inside the card could not be
+   * relied on to fire.
+   */
+  const controls = (): { direction: MoveDirection; disabled: boolean }[] => [
+    { direction: "ArrowUp", disabled: props.isFirstInColumn },
+    { direction: "ArrowDown", disabled: props.isLastInColumn },
+    ...(props.showLateralControls
+      ? ([
+          { direction: "ArrowLeft", disabled: props.isFirstColumn },
+          { direction: "ArrowRight", disabled: props.isLastColumn },
+        ] as const)
+      : []),
+  ];
+
   return (
-    <div
-      ref={sortable.ref}
-      tabindex="0"
-      role="option"
-      aria-roledescription="draggable section"
-      aria-selected={props.kbActive ?? false}
-      data-section-id={props.id}
-      class="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-paper
-        transition-all duration-150 cursor-grab active:cursor-grabbing select-none group
-        focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
-      classList={{
-        "opacity-25 border-dashed": sortable.isActiveDraggable,
-        "shadow-md ring-2 ring-accent/30 scale-[1.02]": isActive() && !sortable.isActiveDraggable,
-        "ring-2 ring-accent bg-accent/5": props.kbActive === true,
-      }}
-      style={transformStyle(sortable.transform)}
-      {...sortable.dragActivators}
-    >
-      {/* Drag Handle */}
-      <svg
-        class="w-4 h-4 text-stone/50 group-hover:text-stone flex-shrink-0 transition-colors"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
+    <div ref={sortable.ref} class="flex flex-col gap-1" style={transformStyle(sortable.transform)}>
+      <div
+        tabindex="0"
+        // Deliberately not `role="option"`. The move controls below are
+        // interactive, and an `option` may own no focusable descendants (and a
+        // `listbox` may own nothing but options/groups) — so keeping the
+        // listbox model would have made SC 2.5.7's controls invalid ARIA. The
+        // pick-up state that `aria-selected` used to carry is announced by the
+        // editor's live region on every pick up, move, drop and cancel.
+        aria-roledescription="draggable section"
+        data-section-id={props.id}
+        class="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-paper
+          transition-all duration-150 cursor-grab active:cursor-grabbing select-none group
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+        classList={{
+          "opacity-25 border-dashed": sortable.isActiveDraggable,
+          "shadow-md ring-2 ring-accent/30 scale-[1.02]": isActive() && !sortable.isActiveDraggable,
+          "ring-2 ring-accent bg-accent/5": props.kbActive === true,
+        }}
+        {...sortable.dragActivators}
       >
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
-      </svg>
+        {/* Drag Handle */}
+        <svg
+          class="w-4 h-4 text-stone group-hover:text-ink flex-shrink-0 transition-colors"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 8h16M4 16h16"
+          />
+        </svg>
 
-      {/* Section Icon */}
-      <Show when={info()} keyed>
-        {(i) => (
-          <svg
-            class="w-4 h-4 text-stone flex-shrink-0"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d={i.icon} />
-          </svg>
-        )}
-      </Show>
+        {/* Section Icon */}
+        <Show when={info()} keyed>
+          {(i) => (
+            <svg
+              class="w-4 h-4 text-stone flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d={i.icon} />
+            </svg>
+          )}
+        </Show>
 
-      {/* Section Label */}
-      <span class="text-sm font-body text-ink truncate">{props.label}</span>
+        {/* Section Label */}
+        <span class="text-sm font-body text-ink truncate">{props.label}</span>
+      </div>
+
+      <div class="flex items-center justify-end gap-0.5">
+        <For each={controls()}>
+          {(control) => (
+            <button
+              type="button"
+              // 28px square keeps every control clear of the 24px SC 2.5.8 floor.
+              class="focus-ring p-1.5 text-stone hover:text-ink hover:bg-surface rounded
+                disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              data-layout-move={`${props.id}-${control.direction}`}
+              disabled={control.disabled}
+              // Named per section: a column holds a dozen identical arrows, so
+              // "Move up" alone would not tell them apart out of context.
+              aria-label={`Move ${props.label} ${DIRECTION_WORDS[control.direction]}`}
+              title={`Move ${props.label} ${DIRECTION_WORDS[control.direction]}`}
+              onClick={() => props.onMove(control.direction)}
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d={ARROW_PATHS[control.direction]}
+                />
+              </svg>
+            </button>
+          )}
+        </For>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/LayoutEditor/DraggableSection.tsx
+++ b/apps/web/src/components/LayoutEditor/DraggableSection.tsx
@@ -77,7 +77,12 @@ export function DraggableSection(props: DraggableSectionProps) {
         // listbox model would have made SC 2.5.7's controls invalid ARIA. The
         // pick-up state that `aria-selected` used to carry is announced by the
         // editor's live region on every pick up, move, drop and cancel.
+        //
+        // `group` is stated explicitly: a bare `div` maps to the `generic`
+        // role, which prohibits both `aria-roledescription` and `aria-label`.
+        role="group"
         aria-roledescription="draggable section"
+        aria-label={props.label}
         data-section-id={props.id}
         class="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-paper
           transition-[opacity,border-color,box-shadow,transform] duration-150

--- a/apps/web/src/components/LayoutEditor/DroppableColumn.tsx
+++ b/apps/web/src/components/LayoutEditor/DroppableColumn.tsx
@@ -1,6 +1,6 @@
 import { For, Show } from "solid-js";
 import { createDroppable } from "@thisbeyond/solid-dnd";
-import { DraggableSection } from "./DraggableSection";
+import { DraggableSection, type MoveDirection } from "./DraggableSection";
 
 interface DroppableColumnProps {
   /** Unique identifier for this column droppable (e.g. "col-0", "col-1"). */
@@ -15,6 +15,8 @@ interface DroppableColumnProps {
   kbActiveId?: string | null;
   /** Resolve a section ID to its human-friendly label. */
   getSectionLabel: (id: string) => string;
+  /** Move a section one step in the given direction (single-pointer path). */
+  onMoveSection: (sectionId: string, direction: MoveDirection) => void;
 }
 
 const COLUMN_LABELS: Record<number, string[]> = {
@@ -34,7 +36,9 @@ export function DroppableColumn(props: DroppableColumnProps) {
   return (
     <div
       ref={droppable.ref}
-      role="listbox"
+      // A group, not a listbox: nothing here is selected, and each section now
+      // carries its own move controls (SC 2.5.7), which a listbox may not own.
+      role="group"
       aria-label={label()}
       class="flex-1 min-w-0 rounded-lg border-2 border-dashed transition-colors duration-150 p-2"
       classList={{
@@ -47,7 +51,7 @@ export function DroppableColumn(props: DroppableColumnProps) {
         <span class="text-xs font-mono font-semibold text-stone uppercase tracking-wider">
           {label()}
         </span>
-        <span class="text-xs font-mono text-stone/60">
+        <span class="text-xs font-mono text-stone">
           {props.sectionIds.length} {props.sectionIds.length === 1 ? "section" : "sections"}
         </span>
       </div>
@@ -55,18 +59,24 @@ export function DroppableColumn(props: DroppableColumnProps) {
       {/* Sortable Section List */}
       <div class="space-y-1.5 min-h-[48px]">
         <For each={props.sectionIds}>
-          {(sectionId) => (
+          {(sectionId, index) => (
             <DraggableSection
               id={sectionId}
               label={props.getSectionLabel(sectionId)}
               kbActive={props.kbActiveId === sectionId}
+              onMove={(direction) => props.onMoveSection(sectionId, direction)}
+              isFirstInColumn={index() === 0}
+              isLastInColumn={index() === props.sectionIds.length - 1}
+              isFirstColumn={props.index === 0}
+              isLastColumn={props.index === props.totalColumns - 1}
+              showLateralControls={props.totalColumns > 1}
             />
           )}
         </For>
 
         {/* Empty state */}
         <Show when={props.sectionIds.length === 0}>
-          <div class="flex items-center justify-center h-12 text-xs text-stone/50 italic">
+          <div class="flex items-center justify-center h-12 text-xs text-stone italic">
             Drop sections here
           </div>
         </Show>

--- a/apps/web/src/components/LayoutEditor/LayoutEditor.tsx
+++ b/apps/web/src/components/LayoutEditor/LayoutEditor.tsx
@@ -169,11 +169,17 @@ export function LayoutEditor() {
     announceLive(setAnnouncement, message);
   }
 
-  /** Move a section in the given direction during keyboard drag. */
-  function moveSection(sectionId: string, key: string) {
+  /**
+   * Apply a one-step move of `sectionId` in `key`'s direction to the local
+   * column state, announcing the result. Returns whether anything moved.
+   * Shared by the keyboard drag and the pointer move controls; neither focus
+   * handling nor persistence belongs here, because the two callers differ on
+   * both.
+   */
+  function applyMove(sectionId: string, key: string): boolean {
     const cols = columns();
     const colIdx = findColumnOfSection(sectionId);
-    if (colIdx < 0) return;
+    if (colIdx < 0) return false;
 
     const col = cols[colIdx];
     const sectionIdx = col.indexOf(sectionId);
@@ -203,12 +209,46 @@ export function LayoutEditor() {
       newCols[colIdx + 1].push(sectionId);
       setColumns(newCols);
       announce(`${sectionLabel(sectionId)} moved to column ${colIdx + 2}`);
+    } else {
+      return false;
     }
+
+    return true;
+  }
+
+  /** Move a section in the given direction during keyboard drag. */
+  function moveSection(sectionId: string, key: string) {
+    applyMove(sectionId, key);
 
     // Re-focus the section after DOM updates
     requestAnimationFrame(() => {
       const el = document.querySelector(`[data-section-id="${sectionId}"]`) as HTMLElement | null;
       el?.focus();
+    });
+  }
+
+  /**
+   * Pointer-driven equivalent of a drag, for SC 2.5.7 (Dragging Movements):
+   * every rearrangement possible by dragging is also reachable with a single
+   * click on a move control. Unlike the keyboard drag — which batches into a
+   * pick-up/drop transaction — each click is a complete action, so it persists
+   * immediately.
+   */
+  function handleMoveControl(sectionId: string, key: string) {
+    if (!applyMove(sectionId, key)) return;
+    persistLayout(columns());
+
+    // Keep the pointer/keyboard user on the control they just used. It may
+    // have become disabled at a boundary, in which case fall back to the card.
+    requestAnimationFrame(() => {
+      const control = document.querySelector<HTMLButtonElement>(
+        `[data-layout-move="${sectionId}-${key}"]`,
+      );
+      if (control && !control.disabled) {
+        control.focus();
+        return;
+      }
+      document.querySelector<HTMLElement>(`[data-section-id="${sectionId}"]`)?.focus();
     });
   }
 
@@ -387,7 +427,9 @@ export function LayoutEditor() {
         </div>
         <div>
           <h2 class="font-display text-lg font-semibold text-ink">Layout</h2>
-          <p class="text-sm text-stone">Drag sections between columns to rearrange</p>
+          <p class="text-sm text-stone">
+            Drag sections, or use the move buttons, to rearrange them
+          </p>
         </div>
       </div>
 
@@ -425,6 +467,7 @@ export function LayoutEditor() {
                     totalColumns={columns().length}
                     kbActiveId={kbDragId()}
                     getSectionLabel={sectionLabel}
+                    onMoveSection={handleMoveControl}
                   />
                 )}
               </For>
@@ -445,10 +488,10 @@ export function LayoutEditor() {
       </Show>
 
       {/* Help Text */}
-      <p class="text-xs text-stone/60 leading-relaxed">
-        Drag sections or use the keyboard (Space to pick up, arrow keys to move, Space to drop,
-        Escape to cancel) to reorder them within a column or move them between columns. The layout
-        determines how sections appear in your resume PDF.
+      <p class="text-xs text-stone leading-relaxed">
+        Reorder sections by dragging them, by clicking the move buttons beneath each one, or with
+        the keyboard (Space to pick up, arrow keys to move, Space to drop, Escape to cancel). The
+        layout determines how sections appear in your resume PDF.
       </p>
 
       {/* Screen reader live region for DnD announcements */}

--- a/apps/web/src/components/LayoutEditor/__tests__/LayoutEditor.pointer.test.tsx
+++ b/apps/web/src/components/LayoutEditor/__tests__/LayoutEditor.pointer.test.tsx
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, waitFor } from "@solidjs/testing-library";
+import { createDefaultResume } from "../../../wasm/defaults";
+import { resumeStore } from "../../../stores/resume";
+import { LayoutEditor } from "../LayoutEditor";
+
+vi.mock("../../../wasm", () => ({
+  createEmptyResume: () => createDefaultResume(),
+  saveResume: vi.fn().mockResolvedValue(undefined),
+  getResume: vi.fn(),
+  isWasmReady: () => false,
+}));
+
+/** Section IDs in the order they currently appear in the DOM. */
+function sectionOrder(): string[] {
+  return [...document.querySelectorAll("[data-section-id]")].map(
+    (el) => el.getAttribute("data-section-id") ?? "",
+  );
+}
+
+function moveControl(sectionId: string, direction: string): HTMLButtonElement {
+  const control = document.querySelector<HTMLButtonElement>(
+    `[data-layout-move="${sectionId}-${direction}"]`,
+  );
+  if (!control) throw new Error(`No ${direction} control for ${sectionId}`);
+  return control;
+}
+
+/**
+ * SC 2.5.7 (Dragging Movements): every rearrangement reachable by dragging
+ * must also be reachable with a single pointer. These controls are that path.
+ */
+describe("LayoutEditor pointer move controls", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resumeStore.createNewResume("layout-pointer-test");
+  });
+
+  it("reorders a section within its column on a single click", async () => {
+    render(() => <LayoutEditor />);
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-section-id="experience"]')).toBeTruthy();
+    });
+
+    const before = sectionOrder();
+    const index = before.indexOf("experience");
+    const successor = before[index + 1];
+
+    fireEvent.click(moveControl("experience", "ArrowDown"));
+
+    await waitFor(() => {
+      const after = sectionOrder();
+      expect(after[index]).toBe(successor);
+      expect(after[index + 1]).toBe("experience");
+    });
+  });
+
+  it("announces the move so it is not a silent, sighted-only action", async () => {
+    render(() => <LayoutEditor />);
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-section-id="experience"]')).toBeTruthy();
+    });
+
+    fireEvent.click(moveControl("experience", "ArrowDown"));
+
+    await waitFor(() => {
+      const liveRegion = document.querySelector('[aria-live="polite"]');
+      expect(liveRegion?.textContent).toMatch(/experience moved to position \d+ of \d+/i);
+    });
+  });
+
+  it("persists the new order to the store, unlike an in-progress keyboard drag", async () => {
+    render(() => <LayoutEditor />);
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-section-id="experience"]')).toBeTruthy();
+    });
+
+    const before = sectionOrder();
+    const successor = before[before.indexOf("experience") + 1];
+
+    fireEvent.click(moveControl("experience", "ArrowDown"));
+
+    await waitFor(() => {
+      const column = resumeStore.store.resume?.metadata.layout?.[0]?.[0] ?? [];
+      expect(column.indexOf(successor)).toBeLessThan(column.indexOf("experience"));
+    });
+  });
+
+  it("disables the controls that would move a section past a boundary", async () => {
+    render(() => <LayoutEditor />);
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-section-id="experience"]')).toBeTruthy();
+    });
+
+    const columns = resumeStore.store.resume?.metadata.layout?.[0] ?? [];
+    expect(columns.length).toBeGreaterThan(1);
+
+    const firstColumn = columns[0];
+    const lastColumn = columns[columns.length - 1];
+
+    expect(moveControl(firstColumn[0], "ArrowUp").disabled).toBe(true);
+    expect(moveControl(firstColumn[firstColumn.length - 1], "ArrowDown").disabled).toBe(true);
+    // Nothing sits left of the first column or right of the last one.
+    expect(moveControl(firstColumn[0], "ArrowLeft").disabled).toBe(true);
+    expect(moveControl(lastColumn[0], "ArrowRight").disabled).toBe(true);
+    // ...but the inward direction stays available from both ends.
+    expect(moveControl(firstColumn[0], "ArrowRight").disabled).toBe(false);
+    expect(moveControl(lastColumn[0], "ArrowLeft").disabled).toBe(false);
+  });
+});

--- a/apps/web/src/components/builder/CoverLetterEditor.tsx
+++ b/apps/web/src/components/builder/CoverLetterEditor.tsx
@@ -90,7 +90,9 @@ export function CoverLetterEditor() {
             <div class="space-y-4 pt-4 border-t border-border">
               <h3 class="font-mono text-xs uppercase tracking-wider text-stone">Letter Body</h3>
               <RichTextEditor
-                ariaLabel="Cover letter"
+                // Matches the visible "Letter Body" heading that introduces it,
+                // so a name-based voice command reaches the right control.
+                ariaLabel="Cover letter body"
                 placeholder="Write your cover letter. Introduce yourself, explain why you're a strong fit, and close with a clear call to action..."
                 value={resume().sections.coverLetter.content}
                 onInput={updateCoverLetter}

--- a/apps/web/src/components/builder/CoverLetterEditor.tsx
+++ b/apps/web/src/components/builder/CoverLetterEditor.tsx
@@ -90,6 +90,7 @@ export function CoverLetterEditor() {
             <div class="space-y-4 pt-4 border-t border-border">
               <h3 class="font-mono text-xs uppercase tracking-wider text-stone">Letter Body</h3>
               <RichTextEditor
+                ariaLabel="Cover letter"
                 placeholder="Write your cover letter. Introduce yourself, explain why you're a strong fit, and close with a clear call to action..."
                 value={resume().sections.coverLetter.content}
                 onInput={updateCoverLetter}

--- a/apps/web/src/components/builder/ImageUpload.tsx
+++ b/apps/web/src/components/builder/ImageUpload.tsx
@@ -335,7 +335,7 @@ export function ImageUpload(props: ImageUploadProps) {
                     />
                   </svg>
                   <span class="text-sm text-stone">Click to upload or drag and drop</span>
-                  <span class="text-xs text-stone/70">JPG, PNG, or WebP (max 5 MB)</span>
+                  <span class="text-xs text-stone">JPG, PNG, or WebP (max 5 MB)</span>
                 </div>
               </Show>
             </button>

--- a/apps/web/src/components/builder/SummaryEditor.tsx
+++ b/apps/web/src/components/builder/SummaryEditor.tsx
@@ -34,6 +34,7 @@ export function SummaryEditor() {
       <Show when={store.resume}>
         {(resume) => (
           <RichTextEditor
+            ariaLabel="Summary"
             placeholder="Write a compelling summary that highlights your key strengths, experience, and what you're looking for in your next role..."
             value={resume().sections.summary.content}
             onInput={updateSummary}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -131,7 +131,7 @@ export function Sidebar(props: SidebarProps) {
                     </Show>
                   }
                 >
-                  <div class="mb-1 px-2 text-[10px] font-mono uppercase tracking-wider text-stone/70">
+                  <div class="mb-1 px-2 text-[10px] font-mono uppercase tracking-wider text-stone">
                     {item.group}
                   </div>
                 </Show>
@@ -173,7 +173,12 @@ export function Sidebar(props: SidebarProps) {
                     class={`w-full px-2.5 py-2 flex items-center gap-3 rounded-lg transition-colors
                       ${
                         isItemActive(item)
-                          ? "text-accent bg-accent/10"
+                          ? // Ink label over the accent tint: `text-accent` here
+                            // measured 4.12:1, since the tint drags the
+                            // background toward the label's own color. The
+                            // accent cue moves to an inset bar, matching the
+                            // selected-item treatment in HomeSidebar.
+                            "text-ink bg-accent/10 shadow-[inset_2px_0_0_var(--color-accent)]"
                           : "text-stone hover:text-ink hover:bg-paper"
                       }`}
                     onClick={() => props.onSelect(item.id)}
@@ -192,7 +197,7 @@ export function Sidebar(props: SidebarProps) {
                             class={`w-full px-2 py-1.5 flex items-center gap-2 rounded-lg transition-colors
                               ${
                                 props.activeId === child.id
-                                  ? "text-accent bg-accent/10"
+                                  ? "text-ink bg-accent/10 shadow-[inset_2px_0_0_var(--color-accent)]"
                                   : "text-stone hover:text-ink hover:bg-paper"
                               }`}
                             onClick={() => props.onSelect(child.id)}

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -28,10 +28,18 @@ export const Button: ParentComponent<ButtonProps> = (props) => {
   const baseClasses =
     "inline-flex items-center justify-center font-body font-medium transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed";
 
+  // Hover and active fills come from background tokens (`surface`,
+  // `accent-light` = `--turbo-bg-overlay`), never from `border`. `--color-border`
+  // is deliberately blended toward `--color-ink` (see `--a11y-border` in
+  // index.css) so borders stay visible — which makes it far too close to the
+  // text color to sit behind `text-ink`. `hover:bg-border/50` measured 3.96:1
+  // against ink, below the 4.5:1 AA threshold.
   const variantClasses = {
     primary: "bg-ink text-paper hover:bg-ink/90 active:bg-ink/80 shadow-soft",
-    secondary: "bg-surface text-ink border border-border hover:bg-border/50 active:bg-border",
-    ghost: "text-ink hover:bg-surface active:bg-border",
+    secondary:
+      "bg-surface text-ink border border-border hover:bg-accent-light active:bg-accent-light active:shadow-[inset_0_1px_3px_var(--color-shadow)]",
+    ghost:
+      "text-ink hover:bg-surface active:bg-accent-light active:shadow-[inset_0_1px_3px_var(--color-shadow)]",
     danger: "bg-red-600 text-white hover:bg-red-700 active:bg-red-800 shadow-soft",
   };
 

--- a/apps/web/src/components/ui/CommandPalette.tsx
+++ b/apps/web/src/components/ui/CommandPalette.tsx
@@ -230,7 +230,7 @@ export function CommandPalette(props: CommandPaletteProps) {
                     <>
                       <Show when={headingFor(index())}>
                         {(heading) => (
-                          <div class="px-3 pb-1 pt-3 text-[10px] font-mono uppercase tracking-[0.2em] text-stone/70 first:pt-1">
+                          <div class="px-3 pb-1 pt-3 text-[10px] font-mono uppercase tracking-[0.2em] text-stone first:pt-1">
                             {heading()}
                           </div>
                         )}

--- a/apps/web/src/components/ui/RichTextEditor.tsx
+++ b/apps/web/src/components/ui/RichTextEditor.tsx
@@ -17,6 +17,12 @@ export interface RichTextEditorProps {
   class?: string;
   /** Hide the expand-to-fullscreen control (used inside the fullscreen modal itself). */
   hideExpand?: boolean;
+  /**
+   * Accessible name for the editing surface when no visible `label` is
+   * rendered. The ProseMirror surface exposes `role="textbox"`, so it needs a
+   * name of its own — a nearby heading does not supply one.
+   */
+  ariaLabel?: string;
 }
 
 let editorIdCounter = 0;
@@ -37,11 +43,29 @@ export function RichTextEditor(props: RichTextEditorProps) {
   const [txVersion, setTxVersion] = createSignal(0);
   const [expanded, setExpanded] = createSignal(false);
 
+  /**
+   * Name the editing surface. `editorProps.attributes` replaces Tiptap's own
+   * defaults rather than merging with them, so `role="textbox"` is restated
+   * here — without it the contenteditable loses its role and the naming
+   * attribute becomes prohibited. Prefer the visible label so the accessible
+   * name matches what a sighted user reads.
+   */
+  const editorAriaAttributes = (): Record<string, string> => {
+    const attributes: Record<string, string> = { role: "textbox", "aria-multiline": "true" };
+    if (props.label) {
+      attributes["aria-labelledby"] = labelId;
+    } else if (props.ariaLabel) {
+      attributes["aria-label"] = props.ariaLabel;
+    }
+    return attributes;
+  };
+
   onMount(() => {
     const el = editorEl();
     if (!el) return;
     const ed = new Editor({
       element: el,
+      editorProps: { attributes: editorAriaAttributes() },
       extensions: [
         StarterKit.configure({
           heading: false,
@@ -336,6 +360,9 @@ export function RichTextEditor(props: RichTextEditorProps) {
           <RichTextEditor
             hideExpand
             label={undefined}
+            // The modal title carries the visible name; the nested surface is
+            // rendered without a label of its own, so name it explicitly.
+            ariaLabel={props.label || props.ariaLabel || "Edit content"}
             placeholder={props.placeholder}
             value={props.value}
             onInput={props.onInput}

--- a/apps/web/src/components/ui/RichTextEditor.tsx
+++ b/apps/web/src/components/ui/RichTextEditor.tsx
@@ -132,6 +132,27 @@ export function RichTextEditor(props: RichTextEditorProps) {
     }
   });
 
+  /**
+   * `editorProps.attributes` is snapshotted when the editor is constructed, so
+   * a later change to `label`/`ariaLabel` would leave the ProseMirror node
+   * naming the editor after text that is no longer on screen. Re-apply the
+   * naming attributes reactively, dropping the inactive alternative so the two
+   * never coexist.
+   */
+  createEffect(() => {
+    const attributes = editorAriaAttributes();
+    const dom = editor()?.view.dom;
+    if (!dom) return;
+    for (const name of ["aria-labelledby", "aria-label"] as const) {
+      const value = attributes[name];
+      if (value === undefined) {
+        dom.removeAttribute(name);
+      } else {
+        dom.setAttribute(name, value);
+      }
+    }
+  });
+
   onCleanup(() => {
     editor()?.destroy();
   });

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -137,7 +137,17 @@ const ToastContent: Component<ToastContentProps> = (props) => {
 export const ToastRegion: Component = () => {
   return (
     <ToastPrimitive.Region swipeDirection="right" limit={5}>
-      <ToastPrimitive.List class="fixed bottom-4 right-4 flex flex-col gap-2 z-50 outline-none" />
+      {/*
+        Kobalte renders the stack as an `<ol>` whose children are
+        `<li role="status">`. A status is not a listitem, so the list
+        semantics are invalid (axe `list`). The ordering is a layout detail,
+        not information a screen reader needs — the labelled region plus the
+        per-toast live status carry the meaning — so drop the list role.
+      */}
+      <ToastPrimitive.List
+        role="none"
+        class="fixed bottom-4 right-4 flex flex-col gap-2 z-50 outline-none"
+      />
     </ToastPrimitive.Region>
   );
 };

--- a/apps/web/src/components/ui/__tests__/RichTextEditor.test.tsx
+++ b/apps/web/src/components/ui/__tests__/RichTextEditor.test.tsx
@@ -1,3 +1,4 @@
+import { createSignal } from "solid-js";
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { RichTextEditor } from "../RichTextEditor";
@@ -52,26 +53,53 @@ describe("RichTextEditor toolbar keyboard navigation", () => {
  * field and must carry a name of its own — a nearby heading does not count.
  */
 describe("RichTextEditor accessible name", () => {
-  const surface = () => document.querySelector('.rich-text-editor [role="textbox"]');
+  // Scoped to the render container: a stale editor left in the document by an
+  // earlier test would otherwise be able to satisfy these assertions.
+  const surface = (container: HTMLElement) =>
+    container.querySelector('.rich-text-editor [role="textbox"]');
 
   it("points the editing surface at the visible label", () => {
-    render(() => <RichTextEditor label="Summary" value="" onInput={vi.fn()} />);
+    const { container } = render(() => (
+      <RichTextEditor label="Summary" value="" onInput={vi.fn()} />
+    ));
 
-    const labelledBy = surface()?.getAttribute("aria-labelledby");
+    const labelledBy = surface(container)?.getAttribute("aria-labelledby");
     expect(labelledBy).toBeTruthy();
-    expect(document.getElementById(labelledBy!)?.textContent).toBe("Summary");
+    expect(container.querySelector(`#${labelledBy}`)?.textContent).toBe("Summary");
   });
 
   it("falls back to ariaLabel where no label is rendered", () => {
-    render(() => <RichTextEditor ariaLabel="Cover letter" value="" onInput={vi.fn()} />);
+    const { container } = render(() => (
+      <RichTextEditor ariaLabel="Cover letter body" value="" onInput={vi.fn()} />
+    ));
 
-    expect(surface()).toHaveAttribute("aria-label", "Cover letter");
-    expect(surface()).not.toHaveAttribute("aria-labelledby");
+    expect(surface(container)).toHaveAttribute("aria-label", "Cover letter body");
+    expect(surface(container)).not.toHaveAttribute("aria-labelledby");
   });
 
   it("keeps the textbox role that editorProps.attributes would otherwise replace", () => {
-    render(() => <RichTextEditor label="Summary" value="" onInput={vi.fn()} />);
+    const { container } = render(() => (
+      <RichTextEditor label="Summary" value="" onInput={vi.fn()} />
+    ));
 
-    expect(surface()).toHaveAttribute("aria-multiline", "true");
+    expect(surface(container)).toHaveAttribute("aria-multiline", "true");
+  });
+
+  it("re-names the surface when the label prop changes", () => {
+    const [label, setLabel] = createSignal<string | undefined>(undefined);
+    const { container } = render(() => (
+      <RichTextEditor label={label()} ariaLabel="Cover letter body" value="" onInput={vi.fn()} />
+    ));
+
+    expect(surface(container)).toHaveAttribute("aria-label", "Cover letter body");
+
+    setLabel("Summary");
+
+    const labelledBy = surface(container)?.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    expect(container.querySelector(`#${labelledBy}`)?.textContent).toBe("Summary");
+    // The two naming attributes must never coexist — `aria-labelledby` wins,
+    // so a leftover `aria-label` would be silently dead markup.
+    expect(surface(container)).not.toHaveAttribute("aria-label");
   });
 });

--- a/apps/web/src/components/ui/__tests__/RichTextEditor.test.tsx
+++ b/apps/web/src/components/ui/__tests__/RichTextEditor.test.tsx
@@ -46,3 +46,32 @@ describe("RichTextEditor toolbar keyboard navigation", () => {
     );
   });
 });
+
+/**
+ * The ProseMirror surface reports `role="textbox"`, so it is an ARIA input
+ * field and must carry a name of its own — a nearby heading does not count.
+ */
+describe("RichTextEditor accessible name", () => {
+  const surface = () => document.querySelector('.rich-text-editor [role="textbox"]');
+
+  it("points the editing surface at the visible label", () => {
+    render(() => <RichTextEditor label="Summary" value="" onInput={vi.fn()} />);
+
+    const labelledBy = surface()?.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)?.textContent).toBe("Summary");
+  });
+
+  it("falls back to ariaLabel where no label is rendered", () => {
+    render(() => <RichTextEditor ariaLabel="Cover letter" value="" onInput={vi.fn()} />);
+
+    expect(surface()).toHaveAttribute("aria-label", "Cover letter");
+    expect(surface()).not.toHaveAttribute("aria-labelledby");
+  });
+
+  it("keeps the textbox role that editorProps.attributes would otherwise replace", () => {
+    render(() => <RichTextEditor label="Summary" value="" onInput={vi.fn()} />);
+
+    expect(surface()).toHaveAttribute("aria-multiline", "true");
+  });
+});

--- a/apps/web/src/components/ui/__tests__/Toast.test.tsx
+++ b/apps/web/src/components/ui/__tests__/Toast.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { render, waitFor } from "@solidjs/testing-library";
+import { ToastRegion } from "../Toast";
+
+/**
+ * Kobalte renders the stack as an `<ol>` whose children are `<li role="status">`.
+ * A status is not a listitem, so leaving the implicit list role in place makes
+ * the markup fail axe's `list` rule for as long as any toast is on screen.
+ */
+describe("ToastRegion list semantics", () => {
+  it("does not expose the toast stack as a list", async () => {
+    render(() => <ToastRegion />);
+
+    await waitFor(() => {
+      expect(document.querySelector("ol")).toBeTruthy();
+    });
+
+    expect(document.querySelector("ol")).toHaveAttribute("role", "none");
+  });
+
+  it("keeps the labelled notification region that carries the announcements", async () => {
+    render(() => <ToastRegion />);
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="region"]')).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/components/ui/__tests__/Toast.test.tsx
+++ b/apps/web/src/components/ui/__tests__/Toast.test.tsx
@@ -9,20 +9,22 @@ import { ToastRegion } from "../Toast";
  */
 describe("ToastRegion list semantics", () => {
   it("does not expose the toast stack as a list", async () => {
-    render(() => <ToastRegion />);
+    // Scoped to this render's container: querying the whole document would let
+    // a region left behind by another test satisfy the assertion.
+    const { container } = render(() => <ToastRegion />);
 
     await waitFor(() => {
-      expect(document.querySelector("ol")).toBeTruthy();
+      expect(container.querySelector("ol")).toBeTruthy();
     });
 
-    expect(document.querySelector("ol")).toHaveAttribute("role", "none");
+    expect(container.querySelector("ol")).toHaveAttribute("role", "none");
   });
 
   it("keeps the labelled notification region that carries the announcements", async () => {
-    render(() => <ToastRegion />);
+    const { container } = render(() => <ToastRegion />);
 
     await waitFor(() => {
-      expect(document.querySelector('[role="region"]')).toBeTruthy();
+      expect(container.querySelector('[role="region"]')).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): raise axe coverage to WCAG 2.2 AA and enable target-size
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Both a11y suites scanned WCAG 2.1 A/AA while epic #352 targets 2.2 AA. This adds
`wcag22a` / `wcag22aa` to `WCAG_TAGS` in the web and site suites, turns on the
`target-size` rule, and fixes everything the wider scan surfaced.

Two things needed more than a tag change:

- **`target-size` ships `enabled: false` in axe-core**, so the tag alone would not
  have run it. It is enabled explicitly, and every scan now asserts the rule
  actually landed in one of axe's four result buckets — a silently skipped rule
  would otherwise look exactly like a clean pass.
- **SC 2.5.7 was not satisfied.** The issue expected it to be, but the buttons it
  pointed at (`SectionEditor` / `CustomSectionEditor` "Move up") sit on surfaces
  that are not draggable at all. The one real drag surface, the layout editor,
  offered dragging plus a keyboard pick-up/drop cycle and no single-pointer path.
  2.5.7 asks for a *pointer* alternative, not a keyboard one, so move controls
  were added.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #622
- Relates to #352

## Details

### What the WCAG 2.2 tags surfaced

`target-size` itself found **zero** violations: 56 nodes pass, and the reorder
buttons the issue suspected are `p-1.5` + `w-4 h-4` = **28x28 px**, already clear
of the 24 px floor. The rich-text toolbar buttons are `h-7 w-7` = **28x28 px**.
Nothing needed resizing.

What the run *did* surface came from widening scan coverage, because the existing
scans could not reach the controls this issue is about — a freshly created resume
has no section items, so the editor scan never saw a reorder button, a visibility
toggle or a rich-text toolbar, and nothing covered the layout editor at all. Two
web scans were added, and they found:

| Rule | Where | Fix |
| --- | --- | --- |
| `aria-input-field-name` | `.tiptap` — the ProseMirror surface reports `role="textbox"` with no name; `RichTextEditor` computed a label id and never associated it | Wire the visible label as `aria-labelledby`; add an `ariaLabel` prop for the summary, cover-letter and full-screen editors that render without one |
| `aria-prohibited-attr` | Follow-on from the above — `editorProps.attributes` **replaces** Tiptap's defaults instead of merging, dropping `role="textbox"` | Restate `role` and `aria-multiline` alongside the name |
| `list` | Toast `<ol>` with `<li role="status">` children (Kobalte markup) | Mark the stack `role="none"`; the labelled region and per-toast status carry the meaning |
| `color-contrast` 3.96:1 | Secondary/ghost buttons filled hover/active with `--color-border`, which `--a11y-border` deliberately blends *toward* `--color-ink` so borders stay visible | Hover/active use background tokens (`surface`, `accent-light`) |
| `color-contrast` 4.12:1 | Selected sidebar items and column presets drew `text-accent` over `bg-accent/10` — the tint pulls the background toward the label's own color | Ink label; accent cue moves to an inset bar (matching `HomeSidebar`) or the border |
| `color-contrast` 2.66:1 | `text-stone/70` group headings — the alpha-dilution debt #618 deferred here | Drop the alpha modifier |

The same-root-cause instances on unscanned surfaces were fixed alongside them
(`SubscriptionBanner`, `CommandPalette`, `ImageUpload`). `hover:bg-border/30` was
measured under hover and **passes**, so it was left alone.

### SC 2.5.7 — what already worked vs. what was added

| Affordance | Before | Now |
| --- | --- | --- |
| `SectionEditor` / `CustomSectionEditor` item reorder | "Move up"/"Move down" buttons, no drag anywhere on the surface | Unchanged — 2.5.7 never applied |
| `LayoutEditor` section reorder + cross-column move | `@thisbeyond/solid-dnd` drag, plus a keyboard pick-up/arrow/drop cycle. **No single-pointer path** | Per-section move controls covering both axes the drag supports |

The keyboard reordering is untouched; the shared mutation was factored into
`applyMove` and both paths call it. Each click is a complete action, so it
persists immediately rather than batching the way the keyboard drag does.

Two constraints shaped the implementation:

- The controls sit **outside** the draggable card. solid-dnd activates a drag
  after a 250 ms press and `preventDefault()`s the pointerup, so a control nested
  inside the card would not reliably fire for a slow tap — precisely the users
  2.5.7 protects.
- That means the card can no longer be `role="option"`: an option may own no
  focusable descendants, and a listbox may own nothing but options/groups, so
  keeping the listbox model would have made the new controls invalid ARIA. The
  column is now a `group`, and the pick-up state previously carried by
  `aria-selected` is left to the live region that already announces every pick
  up, move, drop and cancel. Controls are 28 px square.

### Noted for the manual pass in #623

- **SC 2.4.11 Focus Not Obscured** — not asserted. It is only partly
  machine-checkable and forcing a scanner assertion would not really test it. The
  suspects are the sticky editor toolbar, the bottom-right toast stack (which can
  cover a focused control in the lower right of the editor pane), and the preview
  pane in split view.
- **Hover-state contrast is not scanned systematically.** The `bg-border/50`
  failure was caught only because Playwright's cursor happened to rest on the
  button after a click. Other hover and active fills across the app have never
  been measured.
- **`toast-slide-in` / `toast-slide-out` still interpolate opacity** in
  `index.css`. Both new scans wait the toast out before scanning (matching the
  existing editor scan) rather than measuring mid-ramp. `index.css` belongs to
  the #624 lane, so the keyframes were left alone.
- **Icon-only accent affordances** (collapsed sidebar rail, pin button) keep
  `text-accent` on `bg-accent/10`. axe's `color-contrast` does not evaluate
  icons; these fall under SC 1.4.11 non-text contrast and want a manual look.
- **Pointer dragging itself has no automated coverage.** `createSortable`'s ref
  moved from the card to the new row wrapper (activators stay on the card — the
  standard drag-handle split). The keyboard and pointer-control paths are tested;
  actual drag gestures were already untested before this change.

### Testing

- `apps/web`: 66 e2e passed, run twice. 594 unit tests passed (10 new).
- `apps/site`: 27 e2e passed, run twice.
- `bun run typecheck` and `bun run lint` clean; `uv run lintro chk` 100/100.
- E2E run locally on `E2E_PORT` 4194 / 4342 to avoid sibling lanes; no port
  change is committed.

### Pre-push AI review

Neither default reviewer was usable: Greptile is account-blocked
(`free_reviews_limit_reached`) and CodeRabbit is unreliable. The **`lintro-review`**
skill was invoked, but `lintro review --transport cli` aborted
(`Claude CLI exited with code 1`) with no `ANTHROPIC_API_KEY` available for the
API transport. Per the fallback, the diff was reviewed **manually against
py-lintro's checklist corpus** (`tier1.yaml`, plus `tier2.yaml` filtered to
`ts`/`tsx`/`e2e`/`test` domains). **This is not a CodeRabbit or Greptile pass.**

That review is what caught the toast opacity-ramp flake risk (item 139,
non-deterministic tests) and the missing coverage for the toast and naming fixes
(items 133/134), both fixed in the final commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added accessible move buttons for rearranging layout sections with keyboard or pointer controls.
  - Added an accessible search dialog scenario and expanded layout editing accessibility coverage.
  - Added accessible names for cover letter, summary, and rich-text editing fields.

- **Accessibility**
  - Updated automated checks to WCAG 2.2 AA.
  - Improved toast notifications, draggable sections, and editor semantics for assistive technologies.

- **Style**
  - Improved contrast and active-state styling across buttons, navigation, column controls, upload guidance, and subscription links.

- **Tests**
  - Added coverage for section movement, boundary controls, editor labeling, and toast accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->