### PR TITLE
test(templates): guard contrast matrix coverage of every colour binding

### DIFF
--- a/apps/web/e2e/support/templateContrastMatrix.ts
+++ b/apps/web/e2e/support/templateContrastMatrix.ts
@@ -11,8 +11,13 @@
  * templates and `_common.typ`, recording which enclosing `box`/`rect`/`grid`
  * fill each piece of ink actually lands on. Text that inherits the page-level
  * `set text(fill: text-color)` is covered by the `text-color` rows.
+ *
+ * That walk was a one-time audit; `uncoveredBindings` below is what keeps it
+ * honest. It fails the suite when a template declares a colour no pair
+ * measures, so a template that gains a tint cannot stay silently unaudited.
  */
 import { ContrastRole } from "./contrast";
+import type { Palette } from "./typstPalette";
 
 /** One ink-on-backdrop relationship a template paints. */
 export interface ContrastPair {
@@ -235,4 +240,54 @@ export function pairsFor(templateId: string): readonly ContrastPair[] {
     throw new Error(`no contrast matrix entry for template ${templateId}`);
   }
   return [...UNIVERSAL_PAIRS, ...specific];
+}
+
+/**
+ * Colour bindings that are declared but never painted, so no pair measures them.
+ *
+ * Listed by binding NAME rather than by template on purpose: a per-template
+ * escape hatch would excuse that template's whole palette, including the tint
+ * it gains next year. Naming the binding keeps the exemption as narrow as the
+ * claim behind it, and makes adding one a deliberate act a reviewer can see.
+ *
+ * Every entry carries a comment saying why it is never painted. If a binding IS
+ * painted somewhere, it belongs in the matrix above, not here.
+ */
+export const UNPAINTED_BINDINGS: ReadonlySet<string> = new Set([
+  // The user-facing brand seed. Every template derives its inks from it
+  // (`accent-color = primary-color.darken(35%)`) and its decorative tints too
+  // (`light-bg = primary-color.lighten(90%)`), but deliberately never paints
+  // the raw seed: it is whatever hue the user picked, so it carries no
+  // contrast guarantee of its own. See the comment at `azurill.typ:15-17`.
+  "primary-color",
+]);
+
+/**
+ * Binding names the matrix measures for one template, as ink or as backdrop.
+ *
+ * Only a pair whose expression IS a bare binding name counts. A pair naming
+ * `bg-color.darken(10%)` measures that derived tint; it says nothing about the
+ * contrast of `bg-color` itself, so it must not be credited with covering it.
+ */
+function measuredBindings(templateId: string): ReadonlySet<string> {
+  return new Set(pairsFor(templateId).flatMap((pair) => [pair.ink, pair.backdrop]));
+}
+
+/**
+ * Report every colour binding of a template that no pair measures.
+ *
+ * `parsePalette` returns exactly the bindings that resolved to a colour, so
+ * anything in it either lands in the matrix or is named in
+ * `UNPAINTED_BINDINGS`. Returns one human-readable line per gap, naming the
+ * template and the binding, so the next person can act on the failure without
+ * re-deriving the audit.
+ */
+export function uncoveredBindings(templateId: string, palette: Palette): string[] {
+  const measured = measuredBindings(templateId);
+  return Object.keys(palette)
+    .filter((binding) => !measured.has(binding) && !UNPAINTED_BINDINGS.has(binding))
+    .map(
+      (binding) =>
+        `${templateId}: binding "${binding}" resolves to a colour but no matrix pair measures it`,
+    );
 }

--- a/apps/web/e2e/template-contrast.spec.ts
+++ b/apps/web/e2e/template-contrast.spec.ts
@@ -27,7 +27,7 @@ import { join } from "node:path";
 import type { Page } from "@playwright/test";
 import { test, expect, DEFAULT_TEMPLATE_ID, TEMPLATES_ROUTE } from "./support/fixtures";
 import { ContrastRole, SURFACES, floorFor, surfaceRatio, type Surface } from "./support/contrast";
-import { pairsFor } from "./support/templateContrastMatrix";
+import { pairsFor, uncoveredBindings } from "./support/templateContrastMatrix";
 import {
   TEMPLATE_DIR,
   TEMPLATE_IDS,
@@ -112,6 +112,23 @@ test.describe("template contrast matrix", () => {
     // which is the failure this whole audit started from.
     const missing = TEMPLATE_IDS.filter((templateId) => !readPalette(templateId)["accent-color"]);
     expect(missing).toEqual([]);
+  });
+
+  test("every colour a template declares is measured by the matrix", () => {
+    // The matrix is hand-written, so its coverage was only ever as good as the
+    // one-time walk that produced it. Both drift mechanisms are silent in this
+    // direction: `parsePalette` skips a binding it cannot resolve without
+    // comment, and `resolveColor` throws only for expressions a pair already
+    // REFERENCES — a binding no pair mentions is never looked up. So a template
+    // that gains a tint and paints text on it would stay unaudited while every
+    // test above stayed green, which is the same false-negative class as
+    // scanning the preview `<img>` with axe, one level up. Anything genuinely
+    // never painted is named in `UNPAINTED_BINDINGS`, per binding, with a
+    // reason.
+    const uncovered = TEMPLATE_IDS.flatMap((templateId) =>
+      uncoveredBindings(templateId, readPalette(templateId)),
+    );
+    expect(uncovered).toEqual([]);
   });
 
   test("no template paints ink over an unaudited gradient", () => {


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(templates): guard contrast matrix coverage of every colour binding
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The contrast matrix added in #651 declares ink/backdrop pairs by hand, derived from a
one-time walk of every `fill:`, `stroke:` and `line()` across the 12 templates and
`_common.typ`. Nothing kept that walk accurate, and both drift mechanisms are silent in
this direction:

- `parsePalette` skips a binding whose expression `evaluateExpression` cannot resolve,
  without comment.
- `resolveColor` throws loudly, but only for expressions a pair already *references*. A
  binding no pair mentions is never looked up, so it cannot throw.

So a template that gained a tint and painted text on it stayed unaudited while the suite
stayed green — the same false-negative class #619 exists to eliminate, one level up from
scanning the preview `<img>` with axe.

This adds a guard asserting that every colour-bearing binding `parsePalette` returns for a
template is measured, as ink or as backdrop, by at least one of that template's pairs.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #653
- Relates to #651
- Relates to #619

## Details

### The assertion

`uncoveredBindings(templateId, palette)` in `templateContrastMatrix.ts` diffs the palette
against the binding names the template's pairs measure, and returns one message per gap.
The spec collects them across all 12 templates and asserts the list is empty, so a failure
prints every gap at once rather than the first.

Only a pair whose expression *is* a bare binding name counts as measuring it. A pair naming
`bg-color.darken(10%)` measures that derived tint and says nothing about the contrast of
`bg-color` itself, so it is deliberately not credited with covering it.

### The allowlist

`UNPAINTED_BINDINGS` is keyed by binding **name**, not by template. A per-template escape
hatch would excuse that template's whole palette, including the tint it gains next year;
naming the binding keeps the exemption as narrow as the claim behind it, and makes adding
one a deliberate act visible in review. Every entry carries a comment saying why it is
never painted.

### Uncovered bindings found

Running the assertion against the current 12 templates surfaced exactly one uncovered
binding, and it is the known legitimate case:

- **`primary-color`** (all 12 templates) — allowlisted. It is the user-facing brand seed.
  Every template derives its inks from it (`accent-color = primary-color.darken(35%)`) and
  its decorative tints too (`light-bg = primary-color.lighten(90%)`), but none paints the
  raw seed: it is whatever hue the user picked, so it carries no contrast guarantee of its
  own, and gating it would fail on any dark brand colour while measuring something the
  reader never sees. The comment at `azurill.typ:15-17` states this intent in the source.

No other binding is uncovered — every tint, sidebar fill, chip background, border and
sidebar ink across the 12 templates is already measured by a pair. The allowlist was not
widened to make the suite green.

### Failure message

Named per template and per binding, so the next person can act on it without re-deriving
the audit:

```text
glalie: binding "sidebar-tint" resolves to a colour but no matrix pair measures it
```

### Proving the guard goes red

Both failure directions were verified, in one run, then reverted:

1. **A pair was removed** — deleted the three `glalie` sidebar pairs from `TEMPLATE_PAIRS`,
   leaving `sidebar-bg` declared but unmeasured.
2. **A binding was added** — appended `let throwaway-tint = accent-color.lighten(88%)` to
   `glalie.typ`, simulating a template that gains a tint.

```text
  ✘  1 [chromium] › e2e/template-contrast.spec.ts:117:3 › template contrast matrix › every colour a template declares is measured by the matrix (16ms)

    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 4

    - Array []
    + Array [
    +   "glalie: binding \"sidebar-bg\" resolves to a colour but no matrix pair measures it",
    +   "glalie: binding \"throwaway-tint\" resolves to a colour but no matrix pair measures it",
    + ]

      129 |       uncoveredBindings(templateId, readPalette(templateId)),
      130 |     );
    > 131 |     expect(uncovered).toEqual([]);
          |                       ^
```

Both edits were reverted; `git status` is clean of them and the full spec passes.

### Out of scope

- Re-deriving the matrix from the Typst sources automatically. That needs a real Typst
  parser and is a much larger change than the risk warrants.
- The reverse assertion (every pair references a still-existing binding). `resolveColor`
  already throws for that at runtime, and it did not fall out of this change for free.

### Testing

- `apps/web` Playwright: all 39 tests in `template-contrast.spec.ts` pass (chromium),
  including the 24 matrix cells, the two existing structural guards and the new one.
- `make test`: `cargo test --workspace` plus 599 vitest tests across 66 files, all green.
- `make lint`: `cargo clippy --workspace -- -D warnings` and `oxlint --max-warnings=0`
  clean. `bun run typecheck` (both `tsconfig` and `tsconfig.e2e.json`) clean.
- `uv run lintro chk`: 0 issues, health score 100/100. (`pip-audit` errors out on this
  machine while bootstrapping its own venv — `ensurepip` dies with SIGABRT — which is
  environmental and unrelated to this diff.)

### AI review

- **CodeRabbit**: ran against the committed diff — **no findings**.
- **Greptile**: unavailable (`free_reviews_limit_reached`).
- **lintro-review fallback**: could not run — a spawned `claude` subprocess has no usable
  auth here (no `CLAUDE_CODE_OAUTH_TOKEN`, no `ANTHROPIC_API_KEY`), and its skill's
  preflight says to stop rather than run blind into an unattributable failure.