### PR TITLE
fix(typst): apply the themed page background in glalie

### DIFF
--- a/crates/render/src/typst_engine/templates/glalie.typ
+++ b/crates/render/src/typst_engine/templates/glalie.typ
@@ -384,6 +384,9 @@
   )
 
   set page(
+    fill: bg-color,
+    // Zero margin is load-bearing: the sidebar is full-bleed and must meet the
+    // page edge, so the themed fill sits behind it rather than framing it.
     margin: 0pt,
   )
 

--- a/crates/render/tests/integration_tests.rs
+++ b/crates/render/tests/integration_tests.rs
@@ -1031,6 +1031,84 @@ fn test_templates_use_shared_render_contract() {
     }
 }
 
+/// Extract the argument list of the first `set page(...)` call in a template,
+/// balancing nested parentheses so multi-line and nested calls survive.
+fn set_page_arguments(contents: &str) -> Option<&str> {
+    let start = contents.find("set page(")? + "set page(".len();
+    let rest = &contents[start..];
+    let mut depth = 1_usize;
+    for (idx, ch) in rest.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&rest[..idx]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Every template must paint `data.metadata.theme.background` onto the page.
+///
+/// Regression guard for #650: `glalie` bound `bg-color` but never passed it to
+/// `set page`, so a themed background was silently discarded in one of the
+/// twelve templates. Asserting the invariant across all templates is what
+/// would have caught the drift.
+#[test]
+fn test_templates_apply_themed_page_background() {
+    let template_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("typst_engine")
+        .join("templates");
+
+    for template in TEMPLATES {
+        let path = template_dir.join(format!("{template}.typ"));
+        let contents = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()));
+
+        assert!(
+            contents.contains(r#"let bg-color = rgb(data.metadata.theme.at("background""#),
+            "{template} must bind bg-color from data.metadata.theme.background"
+        );
+
+        let page_arguments = set_page_arguments(&contents)
+            .unwrap_or_else(|| panic!("{template} must configure the page with `set page(...)`"));
+        assert!(
+            page_arguments.contains("fill: bg-color"),
+            "{template} must apply the themed page background via \
+             `set page(fill: bg-color, ...)`; without it a themed \
+             data.metadata.theme.background is silently ignored"
+        );
+    }
+}
+
+/// The themed background must also survive the Rust → Typst hand-off: the
+/// generated source embeds the resume JSON, so the configured colour has to
+/// reach the template that paints it.
+#[test]
+fn test_generate_source_carries_themed_background() {
+    let renderer = TypstRenderer::new();
+
+    for template in TEMPLATES {
+        let mut resume = sample_resume();
+        resume.metadata.template = (*template).to_string();
+        resume.metadata.theme.background = "#e7e5e4".to_string();
+
+        let source = renderer
+            .generate_source(&resume)
+            .unwrap_or_else(|e| panic!("source generation failed for '{template}': {e:?}"));
+
+        assert!(
+            source.contains("#e7e5e4"),
+            "generated source for '{template}' must carry the themed background colour"
+        );
+    }
+}
+
 #[test]
 fn test_common_defines_profile_icon_helpers() {
     let common = PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(typst): apply the themed page background in glalie
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`glalie` was the only one of the twelve Typst templates that never passed the
themed background to the page. It bound `bg-color` from
`data.metadata.theme.background` at `glalie.typ:14` and used it in derived
colours, but its `set page(...)` only set `margin: 0pt` — so a user who themed
their background saw it work in eleven templates and silently do nothing in the
twelfth.

This adds `fill: bg-color` to that `set page(...)`, keeping `margin: 0pt`
(glalie's full-bleed sidebar depends on the zero margin), and guards the
invariant across every template so no template can drift out of the contract
again.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #650

## Details

### Reproduced first

Rendered `glalie` at `theme.background: "#e7e5e4"` via
`rustume preview` before the change and sampled the PNG: the sidebar band was
tinted as expected, but the whole main column and every page corner outside the
sidebar came back `(255, 255, 255)` — the themed colour was simply not painted.

### Verification of the full-bleed sidebar

After the change, on the same 1224x1584 preview:

- Themed render (`#e7e5e4`): main column and all page corners outside the
  sidebar are now `(231, 229, 228)` — exactly `#e7e5e4`.
- Sidebar edge: scanned every row of the left page edge (`x = 0`) and every
  column of the top and bottom edges within the sidebar band — 0 anomalies, the
  sidebar still reaches all three page edges with no gap.
- Seam check: scanned the sidebar/content boundary for all 1584 rows; the
  transition at `x = 339 → 340` is a hard sidebar-colour → background-colour
  step on every row, with no blended hairline pixel between them.
- Default render (`#ffffff`): byte-identical to the pre-change render, so
  nothing shifts for resumes that do not theme the background.

### Regression guard

Per the issue, the guard asserts on source rather than rendered pixels, and
extends coverage to every template rather than special-casing glalie — the bug
is that one template drifted from a contract nothing enforced:

- `test_templates_apply_themed_page_background` iterates `TEMPLATES` and asserts
  each template both binds `bg-color` from `data.metadata.theme.background` and
  passes `fill: bg-color` inside its `set page(...)` argument list (parsed with a
  paren-balancing helper so multi-line and nested calls are handled).
- `test_generate_source_carries_themed_background` iterates `TEMPLATES` and
  asserts `TypstRenderer::generate_source` carries a themed colour through the
  Rust → Typst hand-off.

Confirmed red before the fix: reverting only `glalie.typ` fails
`test_templates_apply_themed_page_background`.

### Test runs

- `make test` — full Rust workspace plus web vitest (66 files, 599 tests) green.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `apps/web`: `bun run typecheck` clean, `bun run test:e2e` — 66 passed,
  5 visual specs skipped by the default project selection. All e2e fixtures use
  `background: "#ffffff"`, and the default render is byte-identical, so the
  contrast matrix and visual baselines are unaffected. The matrix in
  `templateContrastMatrix.ts` measures glalie's ink against `bg-color`, which
  this makes more accurate rather than less: the page now actually paints that
  colour.
- `uv run lintro chk` — health score 100/100. `pip-audit` reports a tool
  execution error, which reproduces identically on a pristine `origin/main`
  checkout of this worktree (a local `ensurepip` SIGABRT), so it is pre-existing
  and environmental, not from this change.

### Review

CodeRabbit reviewed the committed diff: no findings. Greptile was rate-limited
(`free_reviews_limit_reached`), and the `lintro review` fallback could not run
here because a spawned `claude` subprocess has no inherited auth and neither
`CLAUDE_CODE_OAUTH_TOKEN` nor `ANTHROPIC_API_KEY` is set in this environment.
