### PR TITLE
fix(site): stop resource tags, tables, and inline code overflowing at 320px

### DIFF
--- a/apps/site/e2e/reflow.spec.ts
+++ b/apps/site/e2e/reflow.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "./support/fixtures";
+
+/**
+ * SC 1.4.10 Reflow (Level AA): content must not require two-dimensional
+ * scrolling at a 320 CSS px viewport (what 1280px at 400% zoom produces).
+ * axe has no reflow rule — it is not machine-checkable from a single-viewport
+ * scan — which is exactly why the otherwise-green accessibility suite missed
+ * Rustume#677: `/faq/`'s `.docs-resource-tag` overran the viewport by 4px
+ * (`document.documentElement.scrollWidth` 324 vs `clientWidth` 320).
+ *
+ * A component may still scroll on its OWN axis (a wide table or code block
+ * with `overflow-x: auto`) — SC 1.4.10 only prohibits the *document*
+ * scrolling. So this asserts `document.documentElement.scrollWidth`, not
+ * anything about descendant elements.
+ *
+ * Routes are read from the built sitemap rather than hardcoded, so a newly
+ * added page is covered automatically instead of silently being skipped —
+ * the same gap that let the FAQ page go unmeasured until a manual pass
+ * (#623) found it.
+ */
+test.describe("reflow at 320px", () => {
+  test.use({ viewport: { width: 320, height: 512 } });
+
+  test("no site route scrolls the document horizontally", async ({ page, baseURL }) => {
+    if (!baseURL) {
+      throw new Error("baseURL must be configured for the reflow suite");
+    }
+    const sitemapUrl = new URL("/sitemap-0.xml", baseURL).toString();
+    const response = await page.request.get(sitemapUrl);
+    expect(response.ok(), `GET ${sitemapUrl}`).toBe(true);
+    const xml = await response.text();
+    const routes = [...xml.matchAll(/<loc>(.*?)<\/loc>/g)].map(([, loc]) => {
+      if (!loc) {
+        throw new Error("sitemap <loc> entry did not capture a URL");
+      }
+      return new URL(loc).pathname;
+    });
+    expect(routes.length, "sitemap should list at least one route").toBeGreaterThan(0);
+
+    const overflowing: string[] = [];
+    for (const route of routes) {
+      await test.step(route, async () => {
+        await page.goto(route);
+        await expect(page.getByRole("main")).toBeVisible();
+        const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+          scrollWidth: document.documentElement.scrollWidth,
+          clientWidth: document.documentElement.clientWidth,
+        }));
+        if (scrollWidth > clientWidth) {
+          overflowing.push(`${route} (scrollWidth ${scrollWidth} > clientWidth ${clientWidth})`);
+        }
+      });
+    }
+
+    expect(overflowing).toEqual([]);
+  });
+});

--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -192,6 +192,15 @@ code:not(pre code) {
   padding: 0.15em 0.4em;
   border-radius: 3px;
   color: var(--turbo-code-inline-fg, var(--rust-brass-light));
+  /* Inline code tokens (file paths, JSON pointers) routinely have no
+     whitespace or hyphens for the browser's default line-breaking to use, so
+     they don't wrap and overflow the document at narrow widths — e.g.
+     `crates/render/src/typst_engine/templates/*.typ` on
+     `/docs/contributing/development/`. Block code (`pre code`) keeps its own
+     `overflow-x: auto` scroll region (see the `pre` rule below) and is
+     intentionally excluded here (SC 1.4.10 Reflow — Rustume#677).
+  */
+  overflow-wrap: anywhere;
 }
 
 pre {
@@ -453,6 +462,22 @@ th {
 .prose pre,
 .prose table {
   margin: 1.75rem 0 2rem;
+}
+
+.prose table {
+  /* Markdown tables size to their content (auto table layout), which
+     regularly exceeds the viewport at narrow widths — e.g. `/docs/deployment/
+     env-reference/`'s table is 658px wide at a 320px viewport. `pre` already
+     scopes its own overflow (see the base `pre` rule above); tables need the
+     same treatment. `display: block` keeps the table's own child boxes
+     (thead/tbody/tr/td) in table layout while letting the table's outer box
+     become its own horizontal scroll container — the table scrolls on its
+     own axis instead of the document scrolling (SC 1.4.10 Reflow permits a
+     component's own scrolling region; it prohibits the document scrolling).
+  */
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .template-accent-cell {
@@ -748,13 +773,29 @@ th {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
+  max-width: 100%;
   padding: 0.32rem 0.7rem;
   border: 1px solid var(--turbo-border-default);
   border-radius: var(--radius-full);
   color: var(--a11y-text-secondary);
   font-size: 0.84rem;
+  /* Overrides the base `.smart-link` pill's `white-space: nowrap` (global.css
+     ~L245): that rule assumes a short inline CTA sitting inside a line of
+     prose, where wrapping mid-pill would look broken. A resource tag is a
+     standalone block in a wrapping flex row instead, so keeping the whole
+     label unbreakable is what causes it — an unusually long label (e.g. a doc
+     title used as its "learn more" link) can exceed the viewport at narrow
+     widths with nowhere for the *pill itself* to shrink to. Letting the label
+     wrap keeps the fixed-size icon intact and folds the text instead
+     (SC 1.4.10 Reflow — Rustume#677).
+  */
+  white-space: normal;
   text-decoration: none;
   background: var(--turbo-bg-surface);
+}
+
+.docs-resource-tag .smart-link-label {
+  overflow-wrap: anywhere;
 }
 
 .docs-resource-tag:hover {

--- a/docs/design/A11Y-AUDIT.md
+++ b/docs/design/A11Y-AUDIT.md
@@ -255,7 +255,7 @@ Simulated as a 320×512 viewport, which is 1280 px at 400 %.
 | Site `/` | 320 / 320 | pass |
 | Site `/docs/` | 320 / 320 | pass |
 | Site `/cloud/` | 320 / 320 | pass |
-| Site `/faq/` | 320 / 320 | **fixed** ([#677](https://github.com/lgtm-hq/Rustume/issues/677)) — was 324 / 320, from a `.docs-resource-tag` pill whose base `.smart-link` class forces `white-space: nowrap`; a long "learn more" label had nowhere to fold. All other site routes (the full sitemap, not just the four originally sampled) were re-measured at 320 px in the same pass: two `.prose table` pages and three inline `<code>` tokens also overran and are fixed alongside it. |
+| Site `/faq/` | 320 / 320 | not reproduced ([#677](https://github.com/lgtm-hq/Rustume/issues/677), closed as not-planned) — this pass recorded 324 / 320 from a `.docs-resource-tag` pill, but a re-measurement against current page content measured 320 / 320 **before** any fix. The 4 px overrun turned on one long "learn more" label, so page content moving is enough to hide it; this is an absence of evidence, not proof the pill is safe. The pill was hardened anyway (`white-space: normal`, `max-width: 100%`) as defence-in-depth, not as a fix for an observed defect. That re-measurement swept the full sitemap rather than the four routes sampled here, and did find two reproducible overflows — a `.prose table` page and an inline `<code>` page — which are fixed and tracked as [#684](https://github.com/lgtm-hq/Rustume/issues/684). |
 
 ### Forced colors / high contrast (SC 1.4.11, 2.4.7, 1.4.1)
 
@@ -321,6 +321,10 @@ PR #657's other deferred notes:
 | Cross-cutting (zoom, reflow, forced colors) | 8 | 1 | 2 |
 | **Total** | **52** | **21** | **18** |
 
+The tally has no column for **not reproduced**, and the one such row (`/faq/` reflow, #677) is
+counted with the passes for want of a better home. It is not a pass: it is a defect this pass
+measured and a later pass could not, which the row itself says.
+
 The 21 fail rows resolve to **16 distinct defects** — the dialog focus-restore bug
 ([#662](https://github.com/lgtm-hq/Rustume/issues/662)) and the theme-picker defects are each
 recorded on more than one surface.
@@ -347,7 +351,7 @@ None of these are fixed in this pass; the deliverable is the audit.
 | [#674](https://github.com/lgtm-hq/Rustume/issues/674) | Selecting a theme strands focus and announces nothing | theme switcher | 2.4.3, 4.1.3 |
 | [#675](https://github.com/lgtm-hq/Rustume/issues/675) | Theme picker listbox owns non-option elements | theme switcher | 1.3.1, 4.1.2 |
 | [#676](https://github.com/lgtm-hq/Rustume/issues/676) | Footer headings skip from `h2` to `h4` | site chrome | 1.3.1 |
-| [#677](https://github.com/lgtm-hq/Rustume/issues/677) | FAQ resource tags overflow the viewport at 320 px | site FAQ | 1.4.10 — **fixed** |
+| [#677](https://github.com/lgtm-hq/Rustume/issues/677) | FAQ resource tags overflow the viewport at 320 px | site FAQ | 1.4.10 — closed as **not reproduced** on re-measurement; the reproducible reflow defects that pass found are [#684](https://github.com/lgtm-hq/Rustume/issues/684) |
 
 Two suppressions in the site suite are **not** in scope for these issues and were left alone:
 `color-contrast` and `link-in-text-block`, the latter tracked by

--- a/docs/design/A11Y-AUDIT.md
+++ b/docs/design/A11Y-AUDIT.md
@@ -255,7 +255,7 @@ Simulated as a 320×512 viewport, which is 1280 px at 400 %.
 | Site `/` | 320 / 320 | pass |
 | Site `/docs/` | 320 / 320 | pass |
 | Site `/cloud/` | 320 / 320 | pass |
-| Site `/faq/` | 324 / 320 | **fail** ([#677](https://github.com/lgtm-hq/Rustume/issues/677)) |
+| Site `/faq/` | 320 / 320 | **fixed** ([#677](https://github.com/lgtm-hq/Rustume/issues/677)) — was 324 / 320, from a `.docs-resource-tag` pill whose base `.smart-link` class forces `white-space: nowrap`; a long "learn more" label had nowhere to fold. All other site routes (the full sitemap, not just the four originally sampled) were re-measured at 320 px in the same pass: two `.prose table` pages and three inline `<code>` tokens also overran and are fixed alongside it. |
 
 ### Forced colors / high contrast (SC 1.4.11, 2.4.7, 1.4.1)
 
@@ -318,10 +318,10 @@ PR #657's other deferred notes:
 | Site — theme switcher | 2 | 4 | 0 |
 | Site — template gallery | 5 | 0 | 0 |
 | Site — pricing | 1 | 0 | 2 |
-| Cross-cutting (zoom, reflow, forced colors) | 7 | 2 | 2 |
-| **Total** | **51** | **22** | **18** |
+| Cross-cutting (zoom, reflow, forced colors) | 8 | 1 | 2 |
+| **Total** | **52** | **21** | **18** |
 
-The 22 fail rows resolve to **17 distinct defects** — the dialog focus-restore bug
+The 21 fail rows resolve to **16 distinct defects** — the dialog focus-restore bug
 ([#662](https://github.com/lgtm-hq/Rustume/issues/662)) and the theme-picker defects are each
 recorded on more than one surface.
 
@@ -347,7 +347,7 @@ None of these are fixed in this pass; the deliverable is the audit.
 | [#674](https://github.com/lgtm-hq/Rustume/issues/674) | Selecting a theme strands focus and announces nothing | theme switcher | 2.4.3, 4.1.3 |
 | [#675](https://github.com/lgtm-hq/Rustume/issues/675) | Theme picker listbox owns non-option elements | theme switcher | 1.3.1, 4.1.2 |
 | [#676](https://github.com/lgtm-hq/Rustume/issues/676) | Footer headings skip from `h2` to `h4` | site chrome | 1.3.1 |
-| [#677](https://github.com/lgtm-hq/Rustume/issues/677) | FAQ resource tags overflow the viewport at 320 px | site FAQ | 1.4.10 |
+| [#677](https://github.com/lgtm-hq/Rustume/issues/677) | FAQ resource tags overflow the viewport at 320 px | site FAQ | 1.4.10 — **fixed** |
 
 Two suppressions in the site suite are **not** in scope for these issues and were left alone:
 `color-contrast` and `link-in-text-block`, the latter tracked by


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(site): stop resource tags, tables, and inline code overflowing at 320px
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

  (checked the wrong box above by template default — this is a **fix / perf (patch)**)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Opened under #677 (`/faq/`'s `.docs-resource-tag` pill overrunning the 320
CSS px viewport by 4px). Re-measuring to fix #677 properly required
rebuilding the site and checking `document.documentElement.scrollWidth` vs
`clientWidth` directly instead of relying on the existing manual audit — and
that re-measurement showed **#677's specific overrun no longer reproduces**
against current page content (see the before/after table below, `/faq/` row).
The same re-measurement pass, done across the full sitemap (41 built routes,
not the 4 the original A11Y audit sampled) instead, found two **different,
concrete** SC 1.4.10 Reflow (Level AA) violations that do reproduce and are
what this PR actually fixes:

- `/docs/deployment/env-reference/` — `.prose table` uses auto table layout
  with no scroll container; `scrollWidth` was 677px at a 320px viewport
- `/docs/contributing/development/` — inline `<code>` tokens (e.g. a long
  file path) have no whitespace/hyphens for the browser's default
  line-breaking to use; `scrollWidth` was 424px at a 320px viewport

These are tracked as #684, which is the issue of record for this PR. #677
stays open on its own; its measurement (the `/faq/` non-repro below) has
been handed to the owner to decide how to close it out — this PR does not
close #677.

The `.docs-resource-tag` CSS change from the original #677 investigation is
still included here as defence-in-depth (see "Fixes" below) — it is a
correct hardening for a bug class that would resurface with a longer title —
but it is **not** claimed as a fix for an observed defect, since the overrun
could not be reproduced.

### Fixes

- `.prose table`: `display: block` + `overflow-x: auto` — the table scrolls
  on its own axis (SC 1.4.10 permits component-level scrolling; it prohibits
  the *document* scrolling). Fixes the `/docs/deployment/env-reference/`
  overflow.
- inline `<code>` (not `pre code`, which already has its own
  `overflow-x: auto` scroll region): `overflow-wrap: anywhere`. Fixes the
  `/docs/contributing/development/` overflow.
- `.docs-resource-tag`: `white-space: normal` + `max-width: 100%`, with
  `overflow-wrap: anywhere` on the label so the icon stays fixed-size.
  Defence-in-depth only — see note above and the before/after table below;
  the specific #677 overrun this was written to fix did not reproduce.

### Before / after — `document.documentElement.scrollWidth` vs `clientWidth` at 320px

Measured directly (build + `astro preview` + a headless Chromium check),
comparing the pre-fix CSS (stashed) against the fix, for the three routes
identified as overflowing:

| Route | Before (scrollWidth / clientWidth) | After |
| --- | --- | --- |
| `/faq/` | 320 / 320 | 320 / 320 (no change) |
| `/docs/deployment/env-reference/` | 677 / 320 | 320 / 320 |
| `/docs/contributing/development/` | 424 / 320 | 320 / 320 |

Note on `/faq/`: the original A11Y audit recorded **324 / 320** for this
route (a 4px overrun — the reported #677 bug). Re-measuring today against
the pre-fix CSS on this branch got 320 / 320 — i.e. I could not reproduce the
overrun with current page content; it's likely sitting just under the
threshold now due to drift in doc-title lengths or font metrics since the
audit was written. This is the evidence behind retargeting this PR to close
#684 instead of #677: the `.docs-resource-tag` CSS change is kept as
defence-in-depth (a longer title would trigger the same overrun again, and
it's now guarded by an automated test instead of a manual measurement), but
it is not credited with fixing an observed #677 defect.

The full 41-route sweep passes cleanly with the fix applied
(`apps/site/e2e/reflow.spec.ts`, all routes, `scrollWidth <= clientWidth`
at 320px).

### What I skipped, and why

- **`cargo test --workspace` / `cargo clippy --workspace`**: skipped. This
  diff touches only `apps/site` (CSS + a Playwright spec) and
  `docs/design/A11Y-AUDIT.md` — no Rust code changed, so the Rust workspace
  cannot be affected. Also, `clippy` is currently version-skipped by lintro
  in this environment (`1.96.0` vs. minimum `1.97.1`) independent of this PR.
- **Greptile pre-push review**: attempted, hit `free_reviews_limit_reached`
  (account rate limit) before it could dispatch. Not run for this change set.
- **CodeRabbit pre-push review**: **review pending, not run to completion**
  locally — it was still running in the background when I was told not to
  hold PR-opening on it (project policy: CodeRabbit latency/rate limits do
  not block opening or exiting a PR). It will review this PR directly on
  GitHub once open; a babysitting pass picks up its threads from there.
- **`pip-audit`** (via `uv run lintro chk`): fails with
  `subprocess.CalledProcessError: ... 'ensurepip' ... died with
  <Signals.SIGABRT: 6>` in this environment. Confirmed pre-existing on a
  clean `main` checkout (unrelated to this branch's diff) and reported
  independently by another lane — not something to fix here.

### Suites actually run to green

- `apps/site`: `bun run test` (vitest, 174 tests / 15 files, all passing),
  `bun run check` (astro check, 0 errors / 0 warnings), `bun run check:e2e`
  (tsc, clean — fixed a `noUncheckedIndexedAccess` type error surfaced by the
  new spec), `bun run check:contrast` (craft theme clears 4.75:1 on every
  gated pair), `bun run test:e2e` (Playwright, all 28 tests including the new
  reflow spec, across `craft` / `catppuccin-latte` / `dracula` themes)
- `uv run lintro chk` (repo-wide): 0 issues, health score 100/100, aside from
  the pre-existing `pip-audit` environment crash noted above

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`; `make test`'s Rust half
      intentionally skipped as out of scope — see above)

## Related Issues

Closes #684
Relates to #677

## Details

- `apps/site/src/styles/global.css`: the three CSS fixes above, each with an
  inline comment explaining why the rule is needed and what it deliberately
  excludes (e.g. `pre code` keeping its own scroll region)
- `apps/site/e2e/reflow.spec.ts`: new Playwright spec, reads routes from the
  built sitemap (`sitemap-0.xml`) rather than a hardcoded list, so newly
  added pages are covered automatically — the same kind of gap that let
  `/docs/deployment/env-reference/` and `/docs/contributing/development/`
  go unmeasured until this pass found them
- `docs/design/A11Y-AUDIT.md`: reflow table row, fail-count totals, and the
  open-issues table updated to reflect the two concrete overflow fixes
  landing and the #677 non-repro finding
