### PR TITLE
fix(site): underline docs prose links and unsuppress link-in-text-block

### DIFF
--- a/apps/site/e2e/accessibility.spec.ts
+++ b/apps/site/e2e/accessibility.spec.ts
@@ -86,6 +86,12 @@ async function scanForViolations(page: Page, include?: string): Promise<Violatio
   const results = await builder.analyze();
   assertRuleEvaluated(results, "target-size");
   assertRuleEvaluated(results, "heading-order");
+  // This one is tag-selected rather than overridden, so nothing in
+  // RULE_OVERRIDES keeps it alive — but it was suppressed until #648 and the
+  // claim that it runs again is the point of that change. Dropping it back
+  // into DEFERRED_RULES would otherwise turn the suite green by scanning less,
+  // which is the failure mode this guard exists for.
+  assertRuleEvaluated(results, "link-in-text-block");
   return results.violations.map((violation) => ({
     rule: violation.id,
     impact: violation.impact ?? "unknown",

--- a/apps/site/e2e/accessibility.spec.ts
+++ b/apps/site/e2e/accessibility.spec.ts
@@ -14,23 +14,20 @@ import { SCANNED_THEMES } from "./support/themes";
 const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22a", "wcag22aa"];
 
 /**
- * Rules deferred to follow-up work, both from the "distinguished by color"
- * family. This suite asserts structure, semantics and ARIA across themes;
- * color decisions are design-language work with their own lane.
+ * Rules deferred to follow-up work. This suite asserts structure, semantics
+ * and ARIA across themes; color decisions are design-language work with their
+ * own lane.
  *
  * - `color-contrast`: the audited Craft palette already has a dedicated gate
  *   (`bun run check:contrast`), but the 40+ turbo flavors the picker offers
  *   have not been audited against the site's own components.
- * - `link-in-text-block`: prose links in docs content are currently
- *   distinguished from body text by color alone (no underline, and under 3:1
- *   against surrounding text). Fixing it is a visual change to every docs
- *   page, not a test change.
  *
- * Neither is suppressed to hide a flake — both fail deterministically today,
- * and shipping them red would make the suite unusable as a gate. Every other
- * WCAG 2.2 A/AA rule runs.
+ * It is not suppressed to hide a flake — it fails deterministically today, and
+ * shipping it red would make the suite unusable as a gate. Every other WCAG
+ * 2.2 A/AA rule runs, including `link-in-text-block`, whose failure was fixed
+ * by underlining docs prose links (Rustume#648).
  */
-const DEFERRED_RULES = ["color-contrast", "link-in-text-block"];
+const DEFERRED_RULES = ["color-contrast"];
 
 /**
  * Rule overrides layered on top of the tag selection.

--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -34,6 +34,18 @@
   --shadow-glow-sm: 0 0 0 3px color-mix(in srgb, var(--rust-forge) 30%, transparent);
 
   /*
+   * Prose link underline metrics. A hairline rule set clear of the descenders
+   * reads as a document underline rather than as a control; hover and focus
+   * thicken it so the state change is legible without relying on the colour
+   * shift `a:hover` also applies. BRAND.md §3 records a pending Archivo ->
+   * Source Serif 4 migration for this app — these want a retune against the
+   * final face.
+   */
+  --prose-link-underline: 1px;
+  --prose-link-underline-strong: 2px;
+  --prose-link-underline-offset: 0.18em;
+
+  /*
    * Contrast-improved secondary text: some turbo theme palettes ship a
    * secondary color below the 4.5:1 AA contrast ratio on base/surface
    * backgrounds (e.g. solarized-light #657b83 on #eee8d5 is 3.64:1). Mixing
@@ -393,6 +405,34 @@ th {
 .prose {
   --prose-section-gap: 3.75rem;
   --prose-block-gap: 1.5rem;
+}
+
+/*
+ * WCAG 1.4.1 (axe `link-in-text-block`): a link sitting inside a sentence must
+ * be distinguishable from the prose around it by something other than hue.
+ * Docs body copy is the only place that happens — navigation, buttons, cards
+ * and the template gallery are standalone targets, so they stay undecorated
+ * and are deliberately outside this selector. `.smart-link` / `.doc-link` are
+ * pill chips that already carry a border and a background, so they are
+ * excluded even where they appear inline.
+ *
+ * Scoped to text-bearing blocks rather than `.prose a`, so a link wrapping a
+ * figure or a block-level component does not pick up a stray rule.
+ */
+.prose
+  :where(p, li, blockquote, dd, td, th, figcaption)
+  a[href]:not(.smart-link, .doc-link, .btn),
+.docs-description a[href]:not(.smart-link, .doc-link, .btn) {
+  text-decoration: underline;
+  text-decoration-thickness: var(--prose-link-underline);
+  text-underline-offset: var(--prose-link-underline-offset);
+}
+
+.prose
+  :where(p, li, blockquote, dd, td, th, figcaption)
+  a[href]:not(.smart-link, .doc-link, .btn):is(:hover, :focus-visible),
+.docs-description a[href]:not(.smart-link, .doc-link, .btn):is(:hover, :focus-visible) {
+  text-decoration-thickness: var(--prose-link-underline-strong);
 }
 
 .prose h2 {


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(site): underline docs prose links and unsuppress link-in-text-block
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Docs prose links were distinguished from the surrounding body text by hue alone, failing
axe `link-in-text-block` (WCAG 1.4.1 Use of Colour). The rule was suppressed in
`apps/site/e2e/accessibility.spec.ts` so the suite could ship green. This underlines the
links and deletes the suppression.

Per the owner decision recorded on #648, this is option 1 (underline), not the
contrast-only route. That decision is consistent with `docs/design/BRAND.md` §3 — the
design language is paper/ink and serif-set body copy, and an underlined link is the
document idiom; distinguishing a link by colour weight alone is the app idiom. No
conflict with BRAND.md was found.

### Reproduction (before)

With `link-in-text-block` removed from `DEFERRED_RULES` and no CSS change, the suite
failed **12 of 21** tests — the same four surfaces on **all three scanned themes**
(craft, catppuccin-latte, dracula), confirming a typography problem rather than a
palette one:

| Surface | craft | catppuccin-latte | dracula |
| --- | --- | --- | --- |
| docs page | fail | fail | fail |
| pricing table | fail | fail | fail |
| template gallery | fail | fail | fail |
| template preview dialog | fail | fail | fail |

Every failing node was inside `.prose` or `.docs-description` — for example
`.docs-description > a[href$="docker/"]`, `p:nth-child(8) > a[href$="rust-lang.org/"]`,
`li:nth-child(1) > a[href$="rustup.rs/"]`, `td:nth-child(2) > a[href$="openapis.org/"]`.
Home page, search dialog and theme picker passed throughout — they have no prose links.

### The treatment

```css
.prose :where(p, li, blockquote, dd, td, th, figcaption) a[href]:not(.smart-link, .doc-link, .btn),
.docs-description a[href]:not(.smart-link, .doc-link, .btn) {
  text-decoration: underline;
  text-decoration-thickness: 1px;   /* var(--prose-link-underline) */
  text-underline-offset: 0.18em;    /* var(--prose-link-underline-offset) */
}
```

Metrics live as `:root` tokens so the pending Archivo -> Source Serif 4 migration
(BRAND.md §3) has one place to retune. Measured computed values on a docs page:

| State | `text-decoration-thickness` | `text-underline-offset` |
| --- | --- | --- |
| rest | `1px` | `2.88px` (0.18em at 16px body) |
| hover / focus-visible | `2px` | `2.88px` |

The thickness change gives hover and focus a non-colour cue of their own, so the state
change does not depend on the hue shift `a:hover` already applies.

### Scope check

The failure mode #648 warns about is a global `a { text-decoration: underline }` leaking
into chrome. Audited every `<a>` on six surfaces with computed `text-decoration-line`:

| Surface | underlined | not underlined |
| --- | --- | --- |
| landing `/` | 0 | 93 (nav, dropdowns, footer, `.btn`, `.craft-link`, `.doc-link`, `.smart-link`, skip link) |
| FAQ `/faq/` | 0 | 103 (nav, footer, resource tags, FAQ body links) |
| docs index `/docs/` | 0 | 85 (nav, footer, `.link-card`, docs list) |
| docs page (quickstart) | **33** (32 `.prose` + 1 `.docs-description`) | 104 (nav, sidebar, footer, resource tags) |
| pricing `/docs/pricing/plans/` | **6** (`.prose`, incl. the table cell link) | 76 |
| template gallery | **3** (`.prose`) | 71 (nav, TOC, footer; the gallery cards are `<button>`, untouched) |

Zero underlines outside `.prose` / `.docs-description` on every surface. The template
gallery cards are `<button>` elements, so they were never in scope.

Note: the FAQ page has in-sentence links with the same colour-only distinction, but it is
not a `.prose` surface and is not in the a11y scan scope. Left alone deliberately rather
than widening this diff — worth a follow-up issue.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`; see testing note below for `make test`)

## Closes

- Closes #648

## Details

### Files touched

- `apps/site/src/styles/global.css` — three `:root` tokens plus the two prose-link rules
- `apps/site/e2e/accessibility.spec.ts` — `link-in-text-block` removed from
  `DEFERRED_RULES`, and the docblock above it updated so it no longer describes a
  suppression that is gone. Nothing else in that file changed, to keep the rebase against
  #681 trivial.

`color-contrast` stays deferred — it is epic-tracked under its own lane and is not this
PR's business. The `RULE_OVERRIDES` ordering trap from #622 is untouched: `options()`
still precedes `withTags()`, and the remaining deferred rule stays folded into the same
map.

### Testing

Run from `apps/site` unless noted:

- `bun run test:e2e` — **27/27 passed**, run twice, both clean. Covers all three scanned
  themes with `link-in-text-block` live.
- `bun run test` (vitest) — 15 files, 174 tests passed
- `bun run check` (astro check) — 0 errors, 0 warnings
- `bun run check:e2e` (tsc for the e2e project) — clean
- `bun run check:contrast` — craft theme clears 4.75:1 on every gated pair
- `bun run build` — clean, including the Pagefind index
- `uv run lintro chk` (repo root) — 0 issues, health score 100/100

**`cargo test` / `cargo clippy` deliberately skipped.** The diff is one CSS file and one
Playwright spec; it cannot reach the Rust workspace.

### AI review

- **CodeRabbit**: ran on the committed branch diff — **0 findings** across both files.
  (The first attempt returned `rate_limit`; retried after the stated cooldown and it
  completed.)
- **Greptile**: could not run — `error: free_reviews_limit_reached`.
- The `lintro review` fallback is not usable in this environment (py-lintro#1614: the CLI
  transport passes `--bare` to the spawned `claude -p`, which breaks session auth), so no
  substitute review was attempted.

### Rebase note

Two sibling PRs are open against files this touches — #681 (`heading-order` in
`accessibility.spec.ts`) and #686 (`.prose table` and inline `<code>` styling). This
branches from current `main`; the diff is kept localized so a rebase after they land is
mechanical.
