### PR TITLE
fix(ci): recover cargo from CARGO_HOME when setup-rust leaves it off PATH

### DIFF
--- a/scripts/ci/release/build-binaries.sh
+++ b/scripts/ci/release/build-binaries.sh
@@ -33,6 +33,23 @@ if [[ "${USE_CROSS:-}" == "true" ]]; then
 	BUILD_CMD="cross"
 fi
 
-echo "Building with $BUILD_CMD for target $TARGET"
+# The shared setup-rust action can exit 0 without leaving the toolchain on PATH
+# (seen on macos-15-intel: rustup resolves, cargo does not). Recover the
+# canonical bin dir ourselves rather than failing three steps later with a bare
+# "cargo: command not found", which names the script instead of the cause.
+CARGO_BIN="${CARGO_HOME:-$HOME/.cargo}/bin"
+if ! command -v "$BUILD_CMD" >/dev/null 2>&1 && [[ -x "$CARGO_BIN/$BUILD_CMD" ]]; then
+	echo "$BUILD_CMD not on PATH; adding $CARGO_BIN" >&2
+	export PATH="$CARGO_BIN:$PATH"
+fi
+
+if ! command -v "$BUILD_CMD" >/dev/null 2>&1; then
+	echo "$BUILD_CMD not found on PATH after checking $CARGO_BIN." >&2
+	echo "The Rust toolchain setup did not produce a usable $BUILD_CMD." >&2
+	echo "PATH=$PATH" >&2
+	exit 1
+fi
+
+echo "Building with $BUILD_CMD ($("$BUILD_CMD" --version)) for target $TARGET"
 $BUILD_CMD build --release --target "$TARGET" -p rustume-cli
 $BUILD_CMD build --release --target "$TARGET" -p rustume-server

--- a/tests/bats/unit/release/test_build_binaries.bats
+++ b/tests/bats/unit/release/test_build_binaries.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/release/build-binaries.sh PATH recovery (#702)
+
+bats_require_minimum_version 1.5.0
+
+load "../../helpers/common"
+
+SCRIPT="scripts/ci/release/build-binaries.sh"
+
+setup() {
+	setup_temp_dir
+	# Isolate PATH so the host's real cargo cannot satisfy the lookup and mask
+	# the behaviour under test.
+	STUB_BIN="${BATS_TEST_TMPDIR}/stubbin"
+	FAKE_CARGO_HOME="${BATS_TEST_TMPDIR}/cargohome"
+	mkdir -p "${STUB_BIN}" "${FAKE_CARGO_HOME}/bin"
+	for tool in bash env uname dirname basename; do
+		if command -v "${tool}" >/dev/null 2>&1; then
+			ln -sf "$(command -v "${tool}")" "${STUB_BIN}/${tool}"
+		fi
+	done
+	MINIMAL_PATH="${STUB_BIN}"
+}
+
+# Writes a cargo stub that records its invocations and always succeeds.
+_write_cargo_stub() {
+	local dest="$1"
+	cat >"${dest}" <<-'EOF'
+		#!/usr/bin/env bash
+		if [[ "${1:-}" == "--version" ]]; then
+			echo "cargo 1.0.0-stub"
+			exit 0
+		fi
+		echo "cargo $*" >>"${CARGO_STUB_LOG}"
+	EOF
+	chmod +x "${dest}"
+}
+
+@test "fails clearly when cargo is absent from PATH and CARGO_HOME" {
+	run env PATH="${MINIMAL_PATH}" CARGO_HOME="${FAKE_CARGO_HOME}" \
+		TARGET=x86_64-apple-darwin \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	assert_failure
+	[[ "${output}" == *"cargo not found on PATH"* ]] || {
+		echo "# expected a named cargo-not-found error, got: ${output}" >&2
+		return 1
+	}
+	# The failure must name the toolchain, not just die on a bare
+	# "command not found" from the build line.
+	[[ "${output}" == *"did not produce a usable cargo"* ]] || {
+		echo "# expected the toolchain to be named as the cause, got: ${output}" >&2
+		return 1
+	}
+}
+
+@test "recovers cargo from CARGO_HOME/bin when setup left it off PATH" {
+	_write_cargo_stub "${FAKE_CARGO_HOME}/bin/cargo"
+	local log="${BATS_TEST_TMPDIR}/cargo.log"
+
+	run env PATH="${MINIMAL_PATH}" CARGO_HOME="${FAKE_CARGO_HOME}" \
+		CARGO_STUB_LOG="${log}" TARGET=x86_64-apple-darwin \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	assert_success
+	[[ "${output}" == *"adding ${FAKE_CARGO_HOME}/bin"* ]] || {
+		echo "# expected the PATH recovery to be announced, got: ${output}" >&2
+		return 1
+	}
+	# Both crates must still be built after recovery.
+	grep -q -- "-p rustume-cli" "${log}"
+	grep -q -- "-p rustume-server" "${log}"
+	grep -q -- "--target x86_64-apple-darwin" "${log}"
+}
+
+@test "defaults CARGO_HOME to ~/.cargo when unset" {
+	local home="${BATS_TEST_TMPDIR}/home"
+	mkdir -p "${home}/.cargo/bin"
+	_write_cargo_stub "${home}/.cargo/bin/cargo"
+	local log="${BATS_TEST_TMPDIR}/cargo-default.log"
+
+	run env -u CARGO_HOME PATH="${MINIMAL_PATH}" HOME="${home}" \
+		CARGO_STUB_LOG="${log}" TARGET=aarch64-apple-darwin \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	assert_success
+	grep -q -- "--target aarch64-apple-darwin" "${log}"
+}
+
+@test "uses cross without falling back to the cargo bin dir" {
+	local cross_dir="${BATS_TEST_TMPDIR}/crossbin"
+	mkdir -p "${cross_dir}"
+	_write_cargo_stub "${cross_dir}/cross"
+	local log="${BATS_TEST_TMPDIR}/cross.log"
+
+	run env PATH="${cross_dir}:${MINIMAL_PATH}" CARGO_HOME="${FAKE_CARGO_HOME}" \
+		CARGO_STUB_LOG="${log}" TARGET=aarch64-unknown-linux-gnu USE_CROSS=true \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	assert_success
+	grep -q -- "--target aarch64-unknown-linux-gnu" "${log}"
+}
+
+@test "still requires TARGET" {
+	run env PATH="${MINIMAL_PATH}" CARGO_HOME="${FAKE_CARGO_HOME}" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	assert_failure
+	[[ "${output}" == *"TARGET is required"* ]]
+}


### PR DESCRIPTION
## What's Changing

`scripts/ci/release/build-binaries.sh` now recovers the Rust toolchain when the shared `setup-rust` action exits 0 without leaving `cargo` on `PATH`, and fails with a message that names the real cause when it cannot.

Closes #702 for this repo's release path. The underlying `lgtm-ci` action still warrants the fix described in that issue — this guard makes Rustume's releases independent of it.

## Why

The v0.52.5 release failed **four consecutive times** on `x86_64-apple-darwin`:

```
6  success   Setup Rust
9  failure   Build release binaries
   ./scripts/ci/release/build-binaries.sh: line 37: cargo: command not found
   ##[error]Process completed with exit code 127
```

Steps 10-13 (version read, packaging, artifact upload) then skipped, so `Create GitHub Release` was skipped too and no release was published.

Retrying is **not** a remedy — v0.52.3's equivalent job passed on the same `macos-15-intel` label within the same hour, while v0.52.5 failed on attempts 2, 3 and 4.

I do **not** have a confirmed explanation for why two jobs on the same label diverge — see the correction I posted on #702. Both the passing and failing runners had Homebrew rustup present, so "rustup preinstalled → PATH export skipped" does not separate them. This PR therefore fixes the **symptom deterministically** rather than claiming a root cause: whatever leaves `cargo` unresolvable, the script now recovers or fails loudly at the right step.

## Changes

- Fall back to `${CARGO_HOME:-$HOME/.cargo}/bin` when the build command is not resolvable
- Exit 1 with an explicit message naming the toolchain and dumping `PATH` when it still is not — instead of a bare "command not found" three steps downstream
- Echo the resolved `cargo --version` so logs record which toolchain built the artifacts
- `USE_CROSS=true` is unaffected; the fallback only applies to the command actually in use

## Testing

New `tests/bats/unit/release/test_build_binaries.bats` — 5 tests.

**Verified red without the fix**: tests 1, 2 and 3 fail with exit 127 and the exact `cargo: command not found` seen in CI. Restored, all 5 pass.

- Full bats suite: **65/65 pass**
- `lintro chk`: shellcheck, shfmt, actionlint, yamllint all pass on the changed files. Totals are **identical to clean `main`** (25 issues / health 32) — `gitleaks` (60s timeout), `pip-audit` (`ensurepip` SIGABRT) and `trufflehog` (8 findings) are pre-existing and unrelated
- `cargo test`/`clippy` skipped: the diff is one shell script and one bats file, no Rust touched

## Follow-up

Once merged, cut **v0.52.6** to publish the release v0.52.5 could not. Related: #697, #698 — the other two failure modes that combined to hold up two releases yesterday.