### PR TITLE
fix(ci): stop cancelling in-progress required checks on main pushes

### DIFF
--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: boundary-guard-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   boundary:

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -33,7 +33,12 @@ name: Quality - Lint & Format
 permissions: {}
 
 concurrency:
-  group: lint-${{ github.ref }}
+  # Give every main commit its own group: a shared group holds only one
+  # pending run, and each new push evicts it regardless of
+  # cancel-in-progress, so post-merge required checks were being lost.
+  group: >-
+    lint-${{ github.ref }}${{ github.ref == 'refs/heads/main'
+    && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -34,7 +34,7 @@ permissions: {}
 
 concurrency:
   group: lint-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   quality:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,12 @@ name: Security - CodeQL Code Scanning
 permissions: {}
 
 concurrency:
-  group: codeql-${{ github.ref }}
+  # Give every main commit its own group: a shared group holds only one
+  # pending run, and each new push evicts it regardless of
+  # cancel-in-progress, so post-merge required checks were being lost.
+  group: >-
+    codeql-${{ github.ref }}${{ github.ref == 'refs/heads/main'
+    && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ permissions: {}
 
 concurrency:
   group: codeql-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   codeql:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,12 @@ permissions:
 # Cancel superseded PR runs; never cancel main (post-merge coverage must
 # complete so Pages coverage publishing and required gates stay reliable).
 concurrency:
-  group: coverage-${{ github.ref }}
+  # Give every main commit its own group: a shared group holds only one
+  # pending run, and each new push evicts it regardless of
+  # cancel-in-progress, so post-merge required checks were being lost.
+  group: >-
+    coverage-${{ github.ref }}${{ github.ref == 'refs/heads/main'
+    && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -39,7 +39,12 @@ permissions:
 # (a cancelled publish would leave GHCR tags and signatures in a partial
 # state, and downstream rustume-ops deploys pull these tags).
 concurrency:
-  group: docker-${{ github.ref }}
+  # Give every main commit its own group: a shared group holds only one
+  # pending run, and each new push evicts it regardless of
+  # cancel-in-progress, so post-merge required checks were being lost.
+  group: >-
+    docker-${{ github.ref }}${{ github.ref == 'refs/heads/main'
+    && format('-{0}', github.sha) || '' }}
   cancel-in-progress: >-
     ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/pin-sync-guard.yml
+++ b/.github/workflows/pin-sync-guard.yml
@@ -23,7 +23,7 @@ permissions:
 
 concurrency:
   group: pin-sync-guard-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   pin-sync:

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -16,7 +16,12 @@ name: Security - Dependency Vulnerability Scan
 permissions: {}
 
 concurrency:
-  group: security-audit-${{ github.ref }}
+  # Give every main commit its own group: a shared group holds only one
+  # pending run, and each new push evicts it regardless of
+  # cancel-in-progress, so post-merge required checks were being lost.
+  group: >-
+    security-audit-${{ github.ref }}${{ github.ref == 'refs/heads/main'
+    && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -17,7 +17,7 @@ permissions: {}
 
 concurrency:
   group: security-audit-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   security-audit:

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -26,7 +26,7 @@ permissions: {}
 
 concurrency:
   group: site-quality-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   craft-contrast:

--- a/.github/workflows/test-boundary-shell.yml
+++ b/.github/workflows/test-boundary-shell.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: test-boundary-shell-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   shell-tests:

--- a/.github/workflows/test-docker-shell.yml
+++ b/.github/workflows/test-docker-shell.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: test-docker-shell-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   shell-tests:

--- a/.github/workflows/test-e2e-site.yml
+++ b/.github/workflows/test-e2e-site.yml
@@ -42,7 +42,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: test-e2e-site-${{ github.ref }}
+  # Give every main commit its own group: a shared group holds only one
+  # pending run, and each new push evicts it regardless of
+  # cancel-in-progress, so post-merge required checks were being lost.
+  group: >-
+    test-e2e-site-${{ github.ref }}${{ github.ref == 'refs/heads/main'
+    && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/test-e2e-web.yml
+++ b/.github/workflows/test-e2e-web.yml
@@ -42,7 +42,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: test-e2e-web-${{ github.ref }}
+  # Give every main commit its own group: a shared group holds only one
+  # pending run, and each new push evicts it regardless of
+  # cancel-in-progress, so post-merge required checks were being lost.
+  group: >-
+    test-e2e-web-${{ github.ref }}${{ github.ref == 'refs/heads/main'
+    && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/test-maintenance-shell.yml
+++ b/.github/workflows/test-maintenance-shell.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: test-maintenance-shell-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   shell-tests:

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -21,7 +21,7 @@ permissions: {}
 
 concurrency:
   group: build-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   rust-build:

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -20,7 +20,12 @@ name: Rust Build (workspace)
 permissions: {}
 
 concurrency:
-  group: build-${{ github.ref }}
+  # Give every main commit its own group: a shared group holds only one
+  # pending run, and each new push evicts it regardless of
+  # cancel-in-progress, so post-merge required checks were being lost.
+  group: >-
+    build-${{ github.ref }}${{ github.ref == 'refs/heads/main'
+    && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] chore / ci / style
- Breaking change: no

## What's Changing

Closes #714.

Ten workflows that trigger on `push: branches: [main]` used a concurrency group keyed on `${{ github.ref }}` together with an unconditional `cancel-in-progress: true`. Every push to `main` shares the same `github.ref`, so consecutive merges cancelled the previous commit's still-running required checks. The required-check gate turns `result=cancelled` into a failure:

```
UPSTREAM_RESULT: cancelled
##[error]Upstream job failed (result=cancelled)
```

The result is permanently red commits on `main` when nothing is actually broken — observed on `72d215a`, `c5803b1` and `6ca64cf` during the 2026-07-30 backlog drain.

### The change

One line per workflow, adopting the guard **already used** by `coverage.yml`, `test-e2e-site.yml` and `test-e2e-web.yml`:

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

PR branches still cancel superseded runs (saving CI minutes); `main` never cancels, so every merged commit keeps a complete, trustworthy check result.

### Files (10)

`boundary-guard` · `ci-lintro-analysis` · `codeql` · `pin-sync-guard` · `security-dependency-review` · `site-quality` · `test-boundary-shell` · `test-docker-shell` · `test-maintenance-shell` · `test-rust`

Three of these (`boundary-guard`, `ci-lintro-analysis`, `security-dependency-review`) are the proven reproducers — they are exactly the jobs that showed `cancelled` on each red commit. The other seven carry the identical latent bug and were found by auditing every `push: main` workflow.

### Deliberately excluded

`semantic-release.yml` matches the same pattern but is **intentionally unchanged**. It creates the automated version PR rather than reporting a required check; there, superseding an in-flight run is the desired behaviour, and a non-cancelling config would risk racing or duplicate release PRs. It was not among the cancelled jobs on any red commit.

### Why this matters beyond cosmetics

Red commits on `main` break `git bisect` over CI state and make "was `main` green at commit X?" unanswerable. It also recurs on every rapid-succession merge — i.e. every backlog drain. Notably, merge pacing alone cannot prevent it: of the five commits involved, `renovate[bot]` and `lgtm-release-bot[bot]` self-merged three of them on green, independently of any human sequencing.

## Checklist

- [x] Title follows Conventional Commits
- [x] `uv run lintro chk` — no new issues (28 pre-existing on `main`, all in `deploy-railway-cloud.yml`, unchanged by this PR)
- [x] Signed commit