### PR TITLE
feat(server): expose template layout metadata in GET /api/templates

### DIFF
--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -29,5 +29,6 @@ mod typst_engine;
 
 pub use traits::{RenderError, Renderer};
 pub use typst_engine::{
-    get_page_size, get_template_theme, TemplateTheme, TypstRenderer, TEMPLATES,
+    get_page_size, get_template_layout, get_template_theme, ContactIn, HeaderStyle, LayoutMode,
+    TemplateLayout, TemplateTheme, TypstRenderer, TEMPLATES,
 };

--- a/crates/render/src/typst_engine/mod.rs
+++ b/crates/render/src/typst_engine/mod.rs
@@ -3,6 +3,10 @@
 //! This module provides PDF generation using the Typst typesetting system.
 
 mod engine;
+mod template_layout;
 mod world;
 
 pub use engine::{get_page_size, get_template_theme, TemplateTheme, TypstRenderer, TEMPLATES};
+pub use template_layout::{
+    get_template_layout, ContactIn, HeaderStyle, LayoutMode, TemplateLayout,
+};

--- a/crates/render/src/typst_engine/template_layout.rs
+++ b/crates/render/src/typst_engine/template_layout.rs
@@ -1,0 +1,435 @@
+//! Structural layout metadata for the bundled Typst templates.
+//!
+//! Every value here is derived from the template's own Typst source in
+//! `crates/render/src/typst_engine/templates/<name>.typ` — specifically from
+//! the `render-resume(data, (...))` configuration and the header markup that
+//! precedes it. The prose comments on [`TEMPLATES`](crate::TEMPLATES) are a
+//! cross-check only; the Typst source wins.
+//!
+//! Column indices follow the layout editor's convention: column `0` is the
+//! main column and column `1` is the sidebar column, regardless of which side
+//! the template paints them on.
+
+/// How a template arranges its page-0 columns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutMode {
+    /// One linear column; every section flows top to bottom.
+    Single,
+    /// Narrow sidebar on the visual left, main column on the right.
+    SidebarLeft,
+    /// Main column on the visual left, narrow sidebar on the right.
+    SidebarRight,
+    /// Full-width header band above two equally weighted columns.
+    HeaderSplit,
+}
+
+impl LayoutMode {
+    /// Wire representation used by the HTTP API.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Single => "single",
+            Self::SidebarLeft => "sidebar-left",
+            Self::SidebarRight => "sidebar-right",
+            Self::HeaderSplit => "header-split",
+        }
+    }
+}
+
+/// How a template presents the name/headline block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeaderStyle {
+    /// Left-aligned name block at the top of the content area.
+    Left,
+    /// Centered name block at the top of the content area.
+    Center,
+    /// Full-bleed filled band spanning the page width.
+    Banner,
+    /// Name block inside a stroked/rounded box.
+    Boxed,
+    /// Name block rendered inside the sidebar column.
+    Sidebar,
+}
+
+impl HeaderStyle {
+    /// Wire representation used by the HTTP API.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Left => "left",
+            Self::Center => "center",
+            Self::Banner => "banner",
+            Self::Boxed => "boxed",
+            Self::Sidebar => "sidebar",
+        }
+    }
+}
+
+/// Where a template prints the contact details (email, phone, location, URL).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContactIn {
+    /// Inside the sidebar column.
+    Sidebar,
+    /// Inside the header block, above the content columns.
+    Header,
+    /// Inside the full-bleed header band.
+    Banner,
+}
+
+impl ContactIn {
+    /// Wire representation used by the HTTP API.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sidebar => "sidebar",
+            Self::Header => "header",
+            Self::Banner => "banner",
+        }
+    }
+}
+
+/// Structural description of a template, enough for a client to draw the
+/// sheet chrome without re-deriving it from the Typst source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateLayout {
+    /// Column arrangement of the page.
+    pub layout_mode: LayoutMode,
+    /// Page-0 section ids per column as `[main, sidebar]`, used when the
+    /// resume carries no explicit `metadata.layout`. Single-column templates
+    /// return every section in the main slot and an empty sidebar slot.
+    pub default_columns: [Vec<String>; 2],
+    /// Presentation of the name/headline block.
+    pub header_style: HeaderStyle,
+    /// Placement of the contact details.
+    pub contact_in: ContactIn,
+    /// Default sidebar width in typographic points, for templates whose
+    /// sidebar is a fixed width. `None` when the split is proportional
+    /// (`fr` units) or when the template has no sidebar at all.
+    pub sidebar_width: Option<u32>,
+}
+
+/// `default-main-sections` in `templates/_common.typ`.
+const MAIN_SECTIONS: &[&str] = &[
+    "summary",
+    "experience",
+    "education",
+    "awards",
+    "certifications",
+    "publications",
+    "volunteer",
+    "projects",
+    "references",
+];
+
+/// `default-sidebar-sections` in `templates/_common.typ`.
+const SIDEBAR_SECTIONS: &[&str] = &[
+    "profiles",
+    "skills",
+    "interests",
+    "certifications",
+    "awards",
+    "publications",
+    "languages",
+];
+
+/// De-duplicate section ids while preserving first-seen order, mirroring
+/// `unique-section-order` in `templates/_common.typ`.
+fn unique_sections(sources: &[&[&str]]) -> Vec<String> {
+    let mut keys: Vec<String> = Vec::new();
+    for source in sources {
+        for key in *source {
+            if !keys.iter().any(|existing| existing == key) {
+                keys.push((*key).to_string());
+            }
+        }
+    }
+    keys
+}
+
+/// `default-main-sections + ("custom",)`.
+fn main_with_custom() -> Vec<String> {
+    unique_sections(&[MAIN_SECTIONS, &["custom"]])
+}
+
+/// `default-sidebar-sections`.
+fn sidebar_default() -> Vec<String> {
+    unique_sections(&[SIDEBAR_SECTIONS])
+}
+
+/// `default-all-sections`, the fallback for single-column templates.
+fn all_sections() -> Vec<String> {
+    unique_sections(&[MAIN_SECTIONS, SIDEBAR_SECTIONS, &["custom"]])
+}
+
+/// Layout for a single-column template: everything in the main slot.
+fn single(header_style: HeaderStyle) -> TemplateLayout {
+    TemplateLayout {
+        layout_mode: LayoutMode::Single,
+        default_columns: [all_sections(), Vec::new()],
+        header_style,
+        contact_in: ContactIn::Header,
+        sidebar_width: None,
+    }
+}
+
+/// Layout for a two-column template using the shared column fallbacks.
+fn two_column(
+    layout_mode: LayoutMode,
+    header_style: HeaderStyle,
+    contact_in: ContactIn,
+    sidebar_width: Option<u32>,
+) -> TemplateLayout {
+    TemplateLayout {
+        layout_mode,
+        default_columns: [main_with_custom(), sidebar_default()],
+        header_style,
+        contact_in,
+        sidebar_width,
+    }
+}
+
+/// Get the structural layout of a template.
+///
+/// Unknown template ids fall back to `rhyhorn`, mirroring
+/// [`get_template_theme`](crate::get_template_theme).
+///
+/// # Examples
+///
+/// ```
+/// use rustume_render::get_template_layout;
+///
+/// let layout = rustume_render::get_template_layout("pikachu");
+/// assert_eq!(layout.sidebar_width, Some(180));
+/// ```
+#[must_use]
+pub fn get_template_layout(template: &str) -> TemplateLayout {
+    match template {
+        // Single-column, name left with contact stacked right, accent rule.
+        "rhyhorn" | "onyx" => single(HeaderStyle::Left),
+        // Single-column, name over a thick accent underline.
+        "nosepass" => single(HeaderStyle::Left),
+        // Single-column, centered name and inline contact row.
+        "bronzor" => single(HeaderStyle::Center),
+        // Single-column, centered name inside a stroked box.
+        "kakuna" => single(HeaderStyle::Boxed),
+        // Centered header above proportional (1fr, 2fr) columns; the sidebar
+        // column is painted on the visual left.
+        "azurill" => two_column(
+            LayoutMode::SidebarLeft,
+            HeaderStyle::Center,
+            ContactIn::Header,
+            None,
+        ),
+        // Left-aligned header above proportional (2fr, 1fr) columns; the
+        // sidebar column is painted on the visual right.
+        "chikorita" => two_column(
+            LayoutMode::SidebarRight,
+            HeaderStyle::Left,
+            ContactIn::Header,
+            None,
+        ),
+        // Full-width accent banner above a fixed 160pt left sidebar.
+        "ditto" => two_column(
+            LayoutMode::SidebarLeft,
+            HeaderStyle::Banner,
+            ContactIn::Banner,
+            Some(160),
+        ),
+        // Name, headline and contact all live inside a fixed 170pt sidebar.
+        "gengar" | "glalie" => two_column(
+            LayoutMode::SidebarLeft,
+            HeaderStyle::Sidebar,
+            ContactIn::Sidebar,
+            Some(170),
+        ),
+        // Name and headline head the main column; contact lives in the fixed
+        // 180pt sidebar.
+        "pikachu" => two_column(
+            LayoutMode::SidebarLeft,
+            HeaderStyle::Left,
+            ContactIn::Sidebar,
+            Some(180),
+        ),
+        // Two-tier full-width header band above equal (1fr, 1fr) columns.
+        // `custom` sits in the right column here, not the left one.
+        "leafish" => TemplateLayout {
+            layout_mode: LayoutMode::HeaderSplit,
+            default_columns: [
+                unique_sections(&[MAIN_SECTIONS]),
+                unique_sections(&[SIDEBAR_SECTIONS, &["custom"]]),
+            ],
+            header_style: HeaderStyle::Banner,
+            contact_in: ContactIn::Banner,
+            sidebar_width: None,
+        },
+        // Unknown templates mirror the rhyhorn fallback.
+        _ => single(HeaderStyle::Left),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TEMPLATES;
+
+    /// Templates whose sidebar is a fixed point width in the Typst source.
+    const FIXED_SIDEBAR_WIDTHS: &[(&str, u32)] = &[
+        ("ditto", 160),
+        ("gengar", 170),
+        ("glalie", 170),
+        ("pikachu", 180),
+    ];
+
+    const SINGLE_COLUMN: &[&str] = &["rhyhorn", "nosepass", "bronzor", "kakuna", "onyx"];
+
+    #[test]
+    fn every_template_has_a_non_empty_main_column() {
+        for template in TEMPLATES {
+            let layout = get_template_layout(template);
+            assert!(
+                !layout.default_columns[0].is_empty(),
+                "{template} has an empty main column"
+            );
+        }
+    }
+
+    #[test]
+    fn single_column_templates_have_an_empty_sidebar_column() {
+        for template in SINGLE_COLUMN {
+            let layout = get_template_layout(template);
+            assert_eq!(
+                layout.layout_mode,
+                LayoutMode::Single,
+                "{template} should be single-column"
+            );
+            assert!(
+                layout.default_columns[1].is_empty(),
+                "{template} should have an empty sidebar column"
+            );
+            assert_eq!(layout.sidebar_width, None, "{template} has no sidebar");
+        }
+    }
+
+    #[test]
+    fn multi_column_templates_have_a_non_empty_sidebar_column() {
+        for template in TEMPLATES {
+            let layout = get_template_layout(template);
+            if layout.layout_mode == LayoutMode::Single {
+                continue;
+            }
+            assert!(
+                !layout.default_columns[1].is_empty(),
+                "{template} should populate its sidebar column"
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_sidebar_templates_declare_their_width() {
+        for (template, width) in FIXED_SIDEBAR_WIDTHS {
+            let layout = get_template_layout(template);
+            assert_eq!(
+                layout.sidebar_width,
+                Some(*width),
+                "{template} sidebar width"
+            );
+        }
+    }
+
+    #[test]
+    fn proportional_sidebar_templates_declare_no_fixed_width() {
+        for template in ["azurill", "chikorita", "leafish"] {
+            let layout = get_template_layout(template);
+            assert_ne!(layout.layout_mode, LayoutMode::Single);
+            assert_eq!(
+                layout.sidebar_width, None,
+                "{template} splits proportionally"
+            );
+        }
+    }
+
+    #[test]
+    fn columns_never_repeat_a_section_within_themselves() {
+        for template in TEMPLATES {
+            let layout = get_template_layout(template);
+            for column in &layout.default_columns {
+                let mut seen = column.clone();
+                seen.sort_unstable();
+                seen.dedup();
+                assert_eq!(seen.len(), column.len(), "{template} repeats a section id");
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_templates_fall_back_to_rhyhorn() {
+        assert_eq!(
+            get_template_layout("not-a-template"),
+            get_template_layout("rhyhorn")
+        );
+    }
+
+    #[test]
+    fn layout_modes_match_the_template_sources() {
+        let expected = [
+            ("rhyhorn", LayoutMode::Single),
+            ("azurill", LayoutMode::SidebarLeft),
+            ("pikachu", LayoutMode::SidebarLeft),
+            ("nosepass", LayoutMode::Single),
+            ("bronzor", LayoutMode::Single),
+            ("chikorita", LayoutMode::SidebarRight),
+            ("ditto", LayoutMode::SidebarLeft),
+            ("gengar", LayoutMode::SidebarLeft),
+            ("glalie", LayoutMode::SidebarLeft),
+            ("kakuna", LayoutMode::Single),
+            ("leafish", LayoutMode::HeaderSplit),
+            ("onyx", LayoutMode::Single),
+        ];
+        assert_eq!(expected.len(), TEMPLATES.len());
+        for (template, mode) in expected {
+            assert_eq!(
+                get_template_layout(template).layout_mode,
+                mode,
+                "{template}"
+            );
+        }
+    }
+
+    #[test]
+    fn header_and_contact_placement_match_the_template_sources() {
+        let expected = [
+            ("rhyhorn", HeaderStyle::Left, ContactIn::Header),
+            ("azurill", HeaderStyle::Center, ContactIn::Header),
+            ("pikachu", HeaderStyle::Left, ContactIn::Sidebar),
+            ("nosepass", HeaderStyle::Left, ContactIn::Header),
+            ("bronzor", HeaderStyle::Center, ContactIn::Header),
+            ("chikorita", HeaderStyle::Left, ContactIn::Header),
+            ("ditto", HeaderStyle::Banner, ContactIn::Banner),
+            ("gengar", HeaderStyle::Sidebar, ContactIn::Sidebar),
+            ("glalie", HeaderStyle::Sidebar, ContactIn::Sidebar),
+            ("kakuna", HeaderStyle::Boxed, ContactIn::Header),
+            ("leafish", HeaderStyle::Banner, ContactIn::Banner),
+            ("onyx", HeaderStyle::Left, ContactIn::Header),
+        ];
+        for (template, header_style, contact_in) in expected {
+            let layout = get_template_layout(template);
+            assert_eq!(layout.header_style, header_style, "{template} header");
+            assert_eq!(layout.contact_in, contact_in, "{template} contact");
+        }
+    }
+
+    #[test]
+    fn leafish_keeps_custom_in_the_sidebar_column() {
+        let layout = get_template_layout("leafish");
+        assert!(!layout.default_columns[0].iter().any(|id| id == "custom"));
+        assert!(layout.default_columns[1].iter().any(|id| id == "custom"));
+    }
+
+    #[test]
+    fn wire_values_are_kebab_case() {
+        assert_eq!(LayoutMode::SidebarLeft.as_str(), "sidebar-left");
+        assert_eq!(LayoutMode::HeaderSplit.as_str(), "header-split");
+        assert_eq!(HeaderStyle::Boxed.as_str(), "boxed");
+        assert_eq!(ContactIn::Banner.as_str(), "banner");
+    }
+}

--- a/crates/server/src/dto.rs
+++ b/crates/server/src/dto.rs
@@ -79,6 +79,32 @@ pub struct TemplateInfo {
     pub name: String,
     /// Theme colors for this template
     pub theme: ThemeInfo,
+    /// Structural layout of this template
+    pub layout: LayoutInfo,
+}
+
+/// Structural layout of a template, as rendered by its Typst source
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LayoutInfo {
+    /// Column arrangement: `single`, `sidebar-left`, `sidebar-right` or `header-split`
+    #[schema(example = "sidebar-left")]
+    pub layout_mode: String,
+    /// Page-0 section ids per column as `[main, sidebar]`, used when the resume
+    /// carries no explicit layout. Single-column templates leave the second
+    /// entry empty.
+    #[schema(example = json!([["summary", "experience"], ["profiles", "skills"]]))]
+    pub default_columns: Vec<Vec<String>>,
+    /// Header presentation: `left`, `center`, `banner`, `boxed` or `sidebar`
+    #[schema(example = "center")]
+    pub header_style: String,
+    /// Where contact details are printed: `sidebar`, `header` or `banner`
+    #[schema(example = "header")]
+    pub contact_in: String,
+    /// Default sidebar width in typographic points, or `null` when the split is
+    /// proportional or the template has no sidebar
+    #[schema(example = 180)]
+    pub sidebar_width: Option<u32>,
 }
 
 /// Theme colors for a template

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -733,6 +733,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_templates_expose_layout_metadata() {
+        let app = create_router();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/templates")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let templates: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(templates.len(), 12);
+        for template in &templates {
+            let id = template["id"].as_str().unwrap();
+            let layout = &template["layout"];
+            assert!(layout.is_object(), "{id} is missing layout");
+            assert!(
+                layout["layoutMode"].as_str().is_some_and(|m| !m.is_empty()),
+                "{id} is missing layoutMode"
+            );
+            assert!(
+                layout["headerStyle"]
+                    .as_str()
+                    .is_some_and(|h| !h.is_empty()),
+                "{id} is missing headerStyle"
+            );
+            assert!(
+                layout["contactIn"].as_str().is_some_and(|c| !c.is_empty()),
+                "{id} is missing contactIn"
+            );
+            assert!(layout.get("sidebarWidth").is_some(), "{id} sidebarWidth");
+
+            let columns = layout["defaultColumns"].as_array().unwrap();
+            assert_eq!(columns.len(), 2, "{id} should expose two columns");
+            assert!(
+                !columns[0].as_array().unwrap().is_empty(),
+                "{id} has an empty main column"
+            );
+        }
+
+        let pikachu = templates.iter().find(|t| t["id"] == "pikachu").unwrap();
+        assert_eq!(pikachu["layout"]["layoutMode"], "sidebar-left");
+        assert_eq!(pikachu["layout"]["contactIn"], "sidebar");
+        assert_eq!(pikachu["layout"]["sidebarWidth"], 180);
+
+        let onyx = templates.iter().find(|t| t["id"] == "onyx").unwrap();
+        assert_eq!(onyx["layout"]["layoutMode"], "single");
+        assert!(onyx["layout"]["defaultColumns"][1]
+            .as_array()
+            .unwrap()
+            .is_empty());
+        assert!(onyx["layout"]["sidebarWidth"].is_null());
+    }
+
+    #[tokio::test]
     async fn test_health_returns_json_compatible() {
         let app = create_router();
 

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -13,8 +13,8 @@ use crate::db::{
     UpdateSharingRequest,
 };
 use crate::dto::{
-    ParseFormat, ParseRequest, RenderPdfRequest, RenderPreviewRequest, TemplateInfo, ThemeInfo,
-    ValidationResponse,
+    LayoutInfo, ParseFormat, ParseRequest, RenderPdfRequest, RenderPreviewRequest, TemplateInfo,
+    ThemeInfo, ValidationResponse,
 };
 use crate::error::ApiError;
 use crate::routes::version::VersionResponse;
@@ -79,6 +79,7 @@ impl Modify for CookieAuthAddon {
             RenderPreviewRequest,
             TemplateInfo,
             ThemeInfo,
+            LayoutInfo,
             ValidationResponse,
             AuthUserResponse,
             AuthMeUnauthorizedResponse,

--- a/crates/server/src/routes/templates.rs
+++ b/crates/server/src/routes/templates.rs
@@ -5,13 +5,13 @@ use axum::{
     Json,
 };
 use lru::LruCache;
-use rustume_render::{get_template_theme, Renderer, TEMPLATES};
+use rustume_render::{get_template_layout, get_template_theme, Renderer, TEMPLATES};
 use rustume_schema::ResumeData;
 use std::num::NonZeroUsize;
 use std::sync::OnceLock;
 use tokio::sync::Mutex as AsyncMutex;
 
-use crate::dto::{TemplateInfo, ThemeInfo};
+use crate::dto::{LayoutInfo, TemplateInfo, ThemeInfo};
 use crate::error::ApiError;
 use crate::state::AppState;
 
@@ -102,7 +102,8 @@ fn create_sample_resume() -> ResumeData {
 
 /// List available templates
 ///
-/// Returns a list of all available resume templates with their theme colors.
+/// Returns a list of all available resume templates with their theme colors
+/// and layout structure.
 #[utoipa::path(
     get,
     path = "/api/templates",
@@ -116,6 +117,7 @@ pub async fn list_templates() -> Json<Vec<TemplateInfo>> {
         .iter()
         .map(|name| {
             let theme = get_template_theme(name);
+            let layout = get_template_layout(name);
             // Capitalize first letter for display name
             let display_name = {
                 let mut chars = name.chars();
@@ -131,6 +133,13 @@ pub async fn list_templates() -> Json<Vec<TemplateInfo>> {
                     background: theme.background,
                     text: theme.text,
                     primary: theme.primary,
+                },
+                layout: LayoutInfo {
+                    layout_mode: layout.layout_mode.as_str().to_string(),
+                    default_columns: layout.default_columns.into(),
+                    header_style: layout.header_style.as_str().to_string(),
+                    contact_in: layout.contact_in.as_str().to_string(),
+                    sidebar_width: layout.sidebar_width,
                 },
             }
         })


### PR DESCRIPTION
## Summary

Adds structural layout metadata to the template registry so the document
editor can draw sheet chrome from server truth (design decision 3 of #721).

- **`rustume-render`**: new `typst_engine/template_layout.rs` with
  `TemplateLayout` (`layout_mode`, `default_columns: [Vec<String>; 2]`,
  `header_style`, `contact_in`, `sidebar_width`) plus `LayoutMode`,
  `HeaderStyle`, `ContactIn` enums and `get_template_layout()` covering all
  12 templates. Unknown ids fall back to `rhyhorn`, mirroring
  `get_template_theme()`. Re-exported from `lib.rs`.
- **`rustume-server`**: new `LayoutInfo` DTO (camelCase serde, utoipa
  `ToSchema`, registered in `openapi.rs`) and an additive `layout` field on
  `TemplateInfo`, populated in `list_templates()`.
- Purely additive. `apps/web` is untouched: `templateInfoSchema` is a
  non-strict Zod object, so the extra key is stripped and `TemplatePicker`
  keeps working unchanged.

## Derivation

Every row was derived from the template's own Typst source — the
`render-resume(data, (...))` config plus the header markup preceding it —
not from the `TEMPLATES` prose comments.

| template | layout_mode | header_style | contact_in | sidebar_width |
| --- | --- | --- | --- | --- |
| rhyhorn | single | left | header | – |
| azurill | sidebar-left | center | header | – (1fr:2fr) |
| pikachu | sidebar-left | left | sidebar | 180pt |
| nosepass | single | left | header | – |
| bronzor | single | center | header | – |
| chikorita | sidebar-right | left | header | – (2fr:1fr) |
| ditto | sidebar-left | banner | banner | 160pt |
| gengar | sidebar-left | sidebar | sidebar | 170pt |
| glalie | sidebar-left | sidebar | sidebar | 170pt |
| kakuna | single | boxed | header | – |
| leafish | header-split | banner | banner | – (1fr:1fr) |
| onyx | single | left | header | – |

`default_columns` mirrors `_common.typ`: single-column templates get
`default-all-sections` in the main slot and an empty sidebar slot;
two-column templates get `default-main-sections + custom` /
`default-sidebar-sections`. `leafish` is the exception — its Typst source
puts `custom` in the **right** column, not the main one.

## Typst source vs. `TEMPLATES` prose comments

No outright contradictions, but two comments are **incomplete** — flagged
rather than silently reconciled (comments left untouched):

- **`ditto`** — comment says "Sidebar left + main right". The source also
  renders a full-width accent banner (name, headline **and** contact) above
  both columns, and uses the `full-header-sidebar` Typst layout rather than
  `sidebar-left`. Encoded as `sidebar-left` + `header_style: banner`.
- **`kakuna`** — comment says "Single-column linear". The source's header is
  centered inside a stroked box, which is why `header_style` is `boxed`
  rather than `center`/`left`.

Also worth noting: the issue body cites "pikachu … 190 px sidebar". The
Typst source's actual default is `sidebar-width-from-ratio(data, 180pt)`,
so this PR reports **180**.

## Judgment call: `sidebar_width` on proportional templates

`azurill`, `chikorita` and `leafish` split with `fr` units, not a fixed
width, so they report `sidebarWidth: null` rather than a fabricated point
value. The issue's test bullet ("sidebar templates declare a width") is
therefore implemented as: the four fixed-width sidebar templates
(`ditto`/`gengar`/`glalie`/`pikachu`) assert exact widths, and the
proportional ones assert `None` explicitly. Deriving a pt number for them
would require guessing a page format and margin, which the server does not
know at list time. `layout_mode` still tells a client which side the
sidebar is on.

## Tests

- 11 new render-crate unit tests: non-empty main column for all 12
  templates, empty sidebar column + `None` width for single-column
  templates, non-empty sidebar column for multi-column templates, exact
  fixed widths, no-fixed-width for proportional splits, no repeated section
  id within a column, rhyhorn fallback, per-template `layout_mode` and
  header/contact tables, kebab-case wire values, and `leafish`'s `custom`
  placement. Plus a doctest on `get_template_layout`.
- New server route test `test_templates_expose_layout_metadata`: every
  `/api/templates` entry carries a well-formed `layout` object with two
  columns, a non-empty main column and all four scalar keys present;
  spot-checks pikachu (sidebar-left / sidebar / 180) and onyx (single /
  empty sidebar column / null width).

## Verification

- `uv run lintro fmt` + `uv run lintro chk` — 0 issues, health score 100/100
- `cargo test --workspace` — all pass
- `cargo clippy --workspace -- -D warnings` — clean
- `apps/web` untouched, so no web suite run needed

Closes #724


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added layout metadata to template listings, including layout mode, default columns, header style, contact placement, and sidebar width.
  * Exposed layout details for all available templates through the API.
  * Added documented API schema support for the new layout information.

* **Bug Fixes**
  * Added fallback layout handling for unrecognized templates.

* **Tests**
  * Added coverage validating layout metadata across all templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->