### PR TITLE
feat(render): add a markdown-to-typst adapter via comrak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +749,23 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "comrak"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5910408554659ed848ff469e67ec83b30f179e72cec286cfdae64d1616f466"
+dependencies = [
+ "caseless",
+ "entities",
+ "finl_unicode",
+ "jetscii",
+ "phf",
+ "phf_codegen",
+ "rustc-hash",
+ "smallvec",
+ "typed-arena",
+]
 
 [[package]]
 name = "const-oid"
@@ -1162,6 +1188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1312,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "flate2"
@@ -2324,6 +2362,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jetscii"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "jni"
@@ -4276,12 +4320,14 @@ version = "0.53.0"
 dependencies = [
  "ammonia",
  "chrono",
+ "comrak",
  "cuid2",
  "ego-tree",
  "once_cell",
  "regex",
  "rstest",
  "scraper",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ ammonia = "4"
 scraper = "0.27"
 ego-tree = "0.11"
 
+# Markdown (library only: no CLI, no syntax highlighting, no emoji shortcodes)
+comrak = { version = "0.54", default-features = false }
+
 # CSV (for LinkedIn import)
 csv = "1.3"
 

--- a/apps/web/src/wasm/types.ts
+++ b/apps/web/src/wasm/types.ts
@@ -272,6 +272,9 @@ export type LevelDisplay =
   | "progress-bar"
   | "text";
 
+/** Authoring format of a resume's rich-text fields. */
+export type ContentFormat = "html" | "markdown";
+
 export interface Metadata {
   template: string;
   layout: string[][][];
@@ -291,6 +294,12 @@ export interface Metadata {
    * Mutually exclusive, unlike `tags`; absent means unfiled.
    */
   folder?: string;
+  /**
+   * Format of this resume's rich-text fields. Absent means `"html"`: every
+   * resume written before this field existed came from the HTML form builder,
+   * and the renderer never guesses the format from the content.
+   */
+  contentFormat?: ContentFormat;
 }
 
 export interface ResumeData {

--- a/crates/parser/src/reactive_resume_v3.rs
+++ b/crates/parser/src/reactive_resume_v3.rs
@@ -12,10 +12,10 @@
 
 use crate::traits::{ParseError, Parser};
 use rustume_schema::{
-    validate_hex_color_with_optional_alpha, Award, Basics, Certification, CustomCss, CustomField,
-    CustomItem, Education, Experience, FontConfig, Interest, Language, LevelDisplay, Metadata,
-    PageConfig, PageFormat, PageOptions, Profile, Project, Publication, Reference, ResumeData,
-    Section, Skill, SummarySection, Theme, Typography, Url, Volunteer,
+    validate_hex_color_with_optional_alpha, Award, Basics, Certification, ContentFormat, CustomCss,
+    CustomField, CustomItem, Education, Experience, FontConfig, Interest, Language, LevelDisplay,
+    Metadata, PageConfig, PageFormat, PageOptions, Profile, Project, Publication, Reference,
+    ResumeData, Section, Skill, SummarySection, Theme, Typography, Url, Volunteer,
 };
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -412,6 +412,9 @@ pub struct V3Metadata {
     pub css: Option<V3Css>,
     pub locale: Option<String>,
     pub date: Option<V3DateConfig>,
+    /// Rustume extension: declares the rich-text format. Absent in genuine
+    /// Reactive Resume exports, whose rich text is always TipTap HTML.
+    pub content_format: Option<ContentFormat>,
 }
 
 /// V3 Theme
@@ -1116,6 +1119,9 @@ fn convert_metadata(v3: &V3Metadata) -> Metadata {
         locked: false,
         tags: Vec::new(),
         folder: None,
+        // Absent in Reactive Resume exports, which are always HTML; carried
+        // through when a Rustume-authored document declares it.
+        content_format: v3.content_format,
     }
 }
 

--- a/crates/render/src/typst_engine/engine.rs
+++ b/crates/render/src/typst_engine/engine.rs
@@ -2,7 +2,7 @@
 
 use crate::traits::{RenderError, Renderer};
 use crate::typst_engine::world::RustumeWorld;
-use rustume_schema::{PageFormat, ResumeData};
+use rustume_schema::{ContentFormat, PageFormat, ResumeData};
 use rustume_utils::{html_to_typst, markdown_to_typst, sanitize_html};
 use tracing::{debug, instrument, warn};
 
@@ -52,21 +52,23 @@ fn extract_picture_asset(resume: &mut ResumeData) -> Option<(String, Vec<u8>)> {
     Some((path, data))
 }
 
-/// Convert one rich-text field to Typst markup.
+/// Convert one rich-text field to Typst markup, in the format the resume
+/// declares.
 ///
-/// Rich text reaches the renderer in two formats during the document-editor
-/// rollout: the form builder stores TipTap HTML, the document editor stores
-/// markdown. Content containing `<` is treated as HTML and takes the original
-/// sanitize → convert path unchanged; everything else is parsed as markdown.
-fn convert_field(content: &str) -> String {
-    let trimmed = content.trim();
-    if trimmed.is_empty() {
+/// Rich text reaches the renderer in two formats: the form builder stores
+/// TipTap HTML, the document editor stores markdown. The format is taken from
+/// the resume's `contentFormat` marker and never inferred from the content —
+/// the two are not distinguishable by inspection, since plain prose like
+/// `1988. A good year` is a valid markdown ordered list. An absent marker means
+/// HTML, so every pre-existing resume takes the original sanitize → convert
+/// path byte for byte.
+fn convert_field(content: &str, format: ContentFormat) -> String {
+    if content.is_empty() {
         return String::new();
     }
-    if trimmed.contains('<') {
-        html_to_typst(&sanitize_html(content))
-    } else {
-        markdown_to_typst(content)
+    match format {
+        ContentFormat::Html => html_to_typst(&sanitize_html(content)),
+        ContentFormat::Markdown => markdown_to_typst(content),
     }
 }
 
@@ -74,70 +76,72 @@ fn convert_field(content: &str) -> String {
 /// from HTML or markdown to Typst markup so templates can `eval()` them.
 fn preprocess_rich_text(resume: &ResumeData) -> ResumeData {
     let mut r = resume.clone();
+    let format = r.metadata.content_format();
+    let convert = |content: &str| convert_field(content, format);
 
     // Summary section content
-    r.sections.summary.content = convert_field(&r.sections.summary.content);
+    r.sections.summary.content = convert(&r.sections.summary.content);
 
     // Cover letter body
-    r.sections.cover_letter.content = convert_field(&r.sections.cover_letter.content);
+    r.sections.cover_letter.content = convert(&r.sections.cover_letter.content);
 
     // Experience: summary
     for item in &mut r.sections.experience.items {
-        item.summary = convert_field(&item.summary);
+        item.summary = convert(&item.summary);
     }
 
     // Education: summary
     for item in &mut r.sections.education.items {
-        item.summary = convert_field(&item.summary);
+        item.summary = convert(&item.summary);
     }
 
     // Skills: description
     for item in &mut r.sections.skills.items {
-        item.description = convert_field(&item.description);
+        item.description = convert(&item.description);
     }
 
     // Projects: summary, description
     for item in &mut r.sections.projects.items {
-        item.summary = convert_field(&item.summary);
-        item.description = convert_field(&item.description);
+        item.summary = convert(&item.summary);
+        item.description = convert(&item.description);
     }
 
     // Awards: summary
     for item in &mut r.sections.awards.items {
-        item.summary = convert_field(&item.summary);
+        item.summary = convert(&item.summary);
     }
 
     // Certifications: summary
     for item in &mut r.sections.certifications.items {
-        item.summary = convert_field(&item.summary);
+        item.summary = convert(&item.summary);
     }
 
     // Publications: summary
     for item in &mut r.sections.publications.items {
-        item.summary = convert_field(&item.summary);
+        item.summary = convert(&item.summary);
     }
 
     // Languages: description
     for item in &mut r.sections.languages.items {
-        item.description = convert_field(&item.description);
+        item.description = convert(&item.description);
     }
 
     // Volunteer: summary
     for item in &mut r.sections.volunteer.items {
-        item.summary = convert_field(&item.summary);
+        item.summary = convert(&item.summary);
     }
 
     // References: summary, description
     for item in &mut r.sections.references.items {
-        item.summary = convert_field(&item.summary);
-        item.description = convert_field(&item.description);
+        item.summary = convert(&item.summary);
+        item.description = convert(&item.description);
     }
 
     // Custom sections: summary, description
     for section in r.sections.custom.values_mut() {
         for item in &mut section.items {
-            item.summary = convert_field(&item.summary);
-            item.description = convert_field(&item.description);
+            item.summary = convert(&item.summary);
+            item.description = convert(&item.description);
         }
     }
 
@@ -600,6 +604,7 @@ mod tests {
     #[test]
     fn test_preprocess_rich_text_converts_markdown() {
         let mut resume = ResumeData::default();
+        resume.metadata.content_format = Some(ContentFormat::Markdown);
         resume.sections.summary.content = "Built **great** things\n\n- Shipped *fast*".to_string();
         resume.sections.experience = Section::new("experience", "Experience");
         resume.sections.experience.add_item(
@@ -619,14 +624,55 @@ mod tests {
     }
 
     #[test]
-    fn test_preprocess_rich_text_html_takes_html_path() {
-        // Asterisks inside HTML content are literal text, not markdown.
+    fn test_preprocess_rich_text_markdown_marker_does_not_change_html_resumes() {
+        // Asterisks inside HTML content are literal text, not markdown. The
+        // default (absent) marker keeps them on the HTML path.
         let mut resume = ResumeData::default();
         resume.sections.summary.content = "<p>Rated 4*5 stars</p>".to_string();
 
         let processed = preprocess_rich_text(&resume);
 
         assert_eq!(processed.sections.summary.content, "Rated 4\\*5 stars");
+    }
+
+    #[test]
+    fn test_preprocess_without_marker_never_parses_markdown() {
+        // Regression guard for the format-sniffing design this replaced.
+        // Legacy resumes hold plain text alongside HTML, and several plain
+        // strings are also valid markdown. Sniffing parsed them as markdown
+        // and silently rewrote the author's words — most destructively
+        // "1988. A good year", where the ordered-list marker swallowed the
+        // year entirely. With no marker, the content is HTML and stays literal.
+        let cases = [
+            // Ordered-list marker: the number must survive.
+            ("1988. A good year", "1988. A good year"),
+            // Emphasis markers inside identifiers and arithmetic.
+            (
+                "Maintainer of __init__ and 4*5*6",
+                "Maintainer of \\_\\_init\\_\\_ and 4\\*5\\*6",
+            ),
+            // A leading hyphen is a bullet in markdown, plain prose here.
+            ("- not a list", "- not a list"),
+            // A leading hash is a heading in markdown; Typst escapes it either
+            // way, but the text must not lose the marker character.
+            ("#1 pick", "\\#1 pick"),
+        ];
+
+        for (content, expected) in cases {
+            let mut resume = ResumeData::default();
+            resume.sections.summary.content = content.to_string();
+            assert_eq!(
+                resume.metadata.content_format, None,
+                "marker must be absent"
+            );
+
+            let processed = preprocess_rich_text(&resume);
+
+            assert_eq!(
+                processed.sections.summary.content, expected,
+                "unmarked content must render literally: {content}"
+            );
+        }
     }
 
     #[test]

--- a/crates/render/src/typst_engine/engine.rs
+++ b/crates/render/src/typst_engine/engine.rs
@@ -3,7 +3,7 @@
 use crate::traits::{RenderError, Renderer};
 use crate::typst_engine::world::RustumeWorld;
 use rustume_schema::{PageFormat, ResumeData};
-use rustume_utils::{html_to_typst, sanitize_html};
+use rustume_utils::{html_to_typst, markdown_to_typst, sanitize_html};
 use tracing::{debug, instrument, warn};
 
 /// Available templates.
@@ -52,16 +52,26 @@ fn extract_picture_asset(resume: &mut ResumeData) -> Option<(String, Vec<u8>)> {
     Some((path, data))
 }
 
-/// Convert an HTML string to Typst markup via sanitize → convert.
-fn convert_field(html: &str) -> String {
-    if html.is_empty() {
+/// Convert one rich-text field to Typst markup.
+///
+/// Rich text reaches the renderer in two formats during the document-editor
+/// rollout: the form builder stores TipTap HTML, the document editor stores
+/// markdown. Content containing `<` is treated as HTML and takes the original
+/// sanitize → convert path unchanged; everything else is parsed as markdown.
+fn convert_field(content: &str) -> String {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
         return String::new();
     }
-    html_to_typst(&sanitize_html(html))
+    if trimmed.contains('<') {
+        html_to_typst(&sanitize_html(content))
+    } else {
+        markdown_to_typst(content)
+    }
 }
 
 /// Clone resume data and preprocess all rich-text fields (summary, description)
-/// from HTML to Typst markup so templates can `eval()` them.
+/// from HTML or markdown to Typst markup so templates can `eval()` them.
 fn preprocess_rich_text(resume: &ResumeData) -> ResumeData {
     let mut r = resume.clone();
 
@@ -585,6 +595,38 @@ mod tests {
         let processed = preprocess_rich_text(&resume);
 
         assert_eq!(processed.sections.summary.content, "Plain text summary");
+    }
+
+    #[test]
+    fn test_preprocess_rich_text_converts_markdown() {
+        let mut resume = ResumeData::default();
+        resume.sections.summary.content = "Built **great** things\n\n- Shipped *fast*".to_string();
+        resume.sections.experience = Section::new("experience", "Experience");
+        resume.sections.experience.add_item(
+            Experience::new("Acme", "Dev").with_summary("Led [core](https://acme.test) work"),
+        );
+
+        let processed = preprocess_rich_text(&resume);
+
+        assert_eq!(
+            processed.sections.summary.content,
+            "Built #text(weight: \"bold\")[great] things\n\n- Shipped #emph[fast]"
+        );
+        assert_eq!(
+            processed.sections.experience.items[0].summary,
+            "Led #link(\"https://acme.test\")[core] work"
+        );
+    }
+
+    #[test]
+    fn test_preprocess_rich_text_html_takes_html_path() {
+        // Asterisks inside HTML content are literal text, not markdown.
+        let mut resume = ResumeData::default();
+        resume.sections.summary.content = "<p>Rated 4*5 stars</p>".to_string();
+
+        let processed = preprocess_rich_text(&resume);
+
+        assert_eq!(processed.sections.summary.content, "Rated 4\\*5 stars");
     }
 
     #[test]

--- a/crates/render/tests/integration_tests.rs
+++ b/crates/render/tests/integration_tests.rs
@@ -7,8 +7,8 @@ use rstest::rstest;
 use rustume_parser::{JsonResumeParser, Parser, ReactiveResumeV3Parser};
 use rustume_render::{get_page_size, get_template_theme, Renderer, TypstRenderer, TEMPLATES};
 use rustume_schema::{
-    Basics, CustomItem, Education, Experience, LevelDisplay, PageFormat, Picture, PictureEffects,
-    Profile, ResumeData, Section, Skill,
+    Basics, ContentFormat, CustomItem, Education, Experience, LevelDisplay, PageFormat, Picture,
+    PictureEffects, Profile, ResumeData, Section, Skill,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -331,6 +331,11 @@ fn test_render_pdf_from_v3_doc_editor_resume() {
     assert_eq!(
         resume.metadata.template, "ditto",
         "fixture should exercise a sidebar template"
+    );
+    assert_eq!(
+        resume.metadata.content_format(),
+        ContentFormat::Markdown,
+        "fixture should declare markdown so the render takes the markdown path"
     );
 
     let renderer = TypstRenderer::new();

--- a/crates/schema/src/metadata.rs
+++ b/crates/schema/src/metadata.rs
@@ -17,6 +17,24 @@ pub enum LevelDisplay {
     Text,
 }
 
+/// Format the resume's rich-text fields are authored in.
+///
+/// Rich text (summaries, descriptions, cover letter) is stored as a string and
+/// converted to Typst markup at render time. The two authoring surfaces store
+/// different formats: the form builder writes TipTap HTML, the document editor
+/// writes markdown. The renderer cannot tell them apart by inspection — plain
+/// prose such as `1988. A good year` is a valid ordered list in markdown — so
+/// the format is declared, never guessed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, ToSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ContentFormat {
+    /// TipTap HTML, sanitized before conversion. The historical format.
+    #[default]
+    Html,
+    /// CommonMark, as written by the document editor.
+    Markdown,
+}
+
 /// Resume metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -65,6 +83,25 @@ pub struct Metadata {
     /// have to special-case — no migration is needed for existing resumes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub folder: Option<String>,
+
+    /// Format of this resume's rich-text fields.
+    ///
+    /// Omitted when unset, and an absent marker means [`ContentFormat::Html`] —
+    /// every resume written before this field existed came from the HTML form
+    /// builder, so the default keeps them rendering exactly as before and no
+    /// migration is needed. Only a resume that explicitly declares `markdown`
+    /// takes the markdown path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_format: Option<ContentFormat>,
+}
+
+impl Metadata {
+    /// Format the rich-text fields are authored in, resolving an absent marker
+    /// to the historical [`ContentFormat::Html`].
+    #[must_use]
+    pub fn content_format(&self) -> ContentFormat {
+        self.content_format.unwrap_or_default()
+    }
 }
 
 impl Default for Metadata {
@@ -81,6 +118,7 @@ impl Default for Metadata {
             locked: false,
             tags: Vec::new(),
             folder: None,
+            content_format: None,
         }
     }
 }
@@ -390,6 +428,47 @@ mod tests {
     fn metadata_omits_unset_folder_when_serialized() {
         let json = serde_json::to_value(Metadata::default()).unwrap();
         assert!(json.get("folder").is_none());
+    }
+
+    #[test]
+    fn metadata_treats_absent_content_format_as_html() {
+        // Every resume written before this field existed holds TipTap HTML.
+        // Defaulting to markdown would silently reinterpret it — a field
+        // starting "1988. A good year" would render as a list with the year
+        // dropped — so an absent marker must resolve to HTML.
+        let metadata: Metadata = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(metadata.content_format, None);
+        assert_eq!(metadata.content_format(), ContentFormat::Html);
+    }
+
+    #[test]
+    fn metadata_omits_unset_content_format_when_serialized() {
+        let json = serde_json::to_value(Metadata::default()).unwrap();
+        assert!(json.get("contentFormat").is_none());
+    }
+
+    #[test]
+    fn metadata_round_trips_content_format() {
+        let cases = [
+            ("html", ContentFormat::Html),
+            ("markdown", ContentFormat::Markdown),
+        ];
+
+        for (wire, expected) in cases {
+            let metadata: Metadata =
+                serde_json::from_value(json!({ "contentFormat": wire })).unwrap();
+            assert_eq!(metadata.content_format, Some(expected));
+            assert_eq!(metadata.content_format(), expected);
+
+            let json = serde_json::to_value(&metadata).unwrap();
+            assert_eq!(json["contentFormat"], json!(wire));
+        }
+    }
+
+    #[test]
+    fn metadata_rejects_unknown_content_format() {
+        let parsed = serde_json::from_value::<Metadata>(json!({ "contentFormat": "typst" }));
+        assert!(parsed.is_err());
     }
 
     #[test]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,7 +15,9 @@ once_cell.workspace = true
 ammonia.workspace = true
 scraper.workspace = true
 ego-tree.workspace = true
+comrak.workspace = true
 chrono.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+serde_json.workspace = true

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -7,12 +7,14 @@
 //! - Color conversion
 //! - Layout utilities
 //! - HTML sanitization
+//! - Markdown and HTML to Typst conversion
 
 mod color;
 mod date;
 mod html_to_typst;
 mod id;
 mod layout;
+mod markdown_to_typst;
 mod sanitize;
 mod string;
 
@@ -21,5 +23,6 @@ pub use date::*;
 pub use html_to_typst::*;
 pub use id::*;
 pub use layout::*;
+pub use markdown_to_typst::*;
 pub use sanitize::*;
 pub use string::*;

--- a/crates/utils/src/markdown_to_typst.rs
+++ b/crates/utils/src/markdown_to_typst.rs
@@ -1,0 +1,243 @@
+//! Convert markdown to Typst markup.
+//!
+//! The document editor stores rich text as markdown. Rendering reuses the
+//! existing HTML pipeline: markdown is parsed to HTML with raw HTML escaped
+//! (never passed through), sanitized, and then converted to Typst markup by
+//! [`html_to_typst`].
+//!
+//! The extension surface is deliberately minimal — plain CommonMark, matching
+//! what the editor toolbar can produce (bold, italic, links, lists,
+//! paragraphs, hard breaks). Smart punctuation is off so the rendered text is
+//! byte-faithful to what the author typed.
+
+use comrak::{markdown_to_html, Options};
+use once_cell::sync::Lazy;
+
+use crate::html_to_typst::html_to_typst;
+use crate::sanitize::sanitize_html;
+
+/// Comrak options: CommonMark only, raw HTML escaped rather than emitted.
+static MARKDOWN_OPTIONS: Lazy<Options<'static>> = Lazy::new(|| {
+    let mut options = Options::default();
+    // Render raw HTML as visible, escaped text. `unsafe` stays false so no
+    // author-supplied markup can ever reach the sanitizer or Typst `eval()`.
+    options.render.escape = true;
+    options.render.r#unsafe = false;
+    // Keep typed punctuation as typed.
+    options.parse.smart = false;
+    options
+});
+
+/// Convert a markdown string to Typst markup.
+///
+/// Supported constructs (CommonMark subset shared with the editor toolbar):
+/// - `**bold**` — `#text(weight: "bold")[…]`
+/// - `*italic*` — `#emph[…]`
+/// - `[text](url)` — `#link("url")[…]`
+/// - `- item` / `1. item` — `- item` / `+ item`
+/// - blank-line separated paragraphs, and two-space hard breaks
+///
+/// Raw HTML is never interpreted: it is escaped by the markdown renderer and
+/// ends up as literal, Typst-escaped text.
+///
+/// # Examples
+///
+/// ```
+/// use rustume_utils::markdown_to_typst;
+///
+/// assert_eq!(markdown_to_typst("**bold**"), "#text(weight: \"bold\")[bold]");
+/// assert_eq!(markdown_to_typst(""), "");
+/// ```
+#[must_use]
+pub fn markdown_to_typst(md: &str) -> String {
+    let trimmed = md.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let html = markdown_to_html(trimmed, &MARKDOWN_OPTIONS);
+    // Comrak writes a source newline after a hard break (`<br />\n`). Left in
+    // place it survives conversion as a blank line, which Typst reads as a
+    // paragraph break on top of the `#linebreak()`.
+    let html = html.replace("<br />\n", "<br />");
+    // Wrap before converting: escaped raw HTML can leave the sanitizer with no
+    // element at all (`&lt;script&gt;…`), and `html_to_typst`'s tag-free fast
+    // path would then emit those entities literally instead of as text.
+    html_to_typst(&format!("<div>{}</div>", sanitize_html(&html)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(markdown_to_typst(""), "");
+        assert_eq!(markdown_to_typst("   \n  "), "");
+    }
+
+    #[test]
+    fn plain_text_passthrough() {
+        assert_eq!(markdown_to_typst("Hello world"), "Hello world");
+    }
+
+    #[test]
+    fn bold() {
+        assert_eq!(
+            markdown_to_typst("**bold**"),
+            "#text(weight: \"bold\")[bold]"
+        );
+    }
+
+    #[test]
+    fn bold_underscores() {
+        assert_eq!(
+            markdown_to_typst("__bold__"),
+            "#text(weight: \"bold\")[bold]"
+        );
+    }
+
+    #[test]
+    fn italic() {
+        assert_eq!(markdown_to_typst("*italic*"), "#emph[italic]");
+        assert_eq!(markdown_to_typst("_italic_"), "#emph[italic]");
+    }
+
+    #[test]
+    fn bold_inside_italic() {
+        assert_eq!(
+            markdown_to_typst("*italic **and bold***"),
+            "#emph[italic #text(weight: \"bold\")[and bold]]"
+        );
+    }
+
+    #[test]
+    fn link() {
+        assert_eq!(
+            markdown_to_typst("[Example](https://example.com)"),
+            "#link(\"https://example.com\")[Example]"
+        );
+    }
+
+    #[test]
+    fn link_with_unsafe_scheme_renders_as_text() {
+        assert_eq!(markdown_to_typst("[Click](javascript:alert(1))"), "Click");
+    }
+
+    #[test]
+    fn paragraphs() {
+        assert_eq!(markdown_to_typst("First\n\nSecond"), "First\n\nSecond");
+    }
+
+    #[test]
+    fn hard_break() {
+        assert_eq!(
+            markdown_to_typst("Line 1  \nLine 2"),
+            "Line 1#linebreak()\nLine 2"
+        );
+    }
+
+    #[test]
+    fn soft_break_stays_one_paragraph() {
+        assert_eq!(markdown_to_typst("Line 1\nLine 2"), "Line 1\nLine 2");
+    }
+
+    #[test]
+    fn bullet_list() {
+        let result = markdown_to_typst("- Item 1\n- Item 2");
+        assert_eq!(result, "- Item 1\n- Item 2");
+    }
+
+    #[test]
+    fn bullet_list_asterisk_marker() {
+        assert_eq!(
+            markdown_to_typst("* Item 1\n* Item 2"),
+            "- Item 1\n- Item 2"
+        );
+    }
+
+    #[test]
+    fn ordered_list() {
+        assert_eq!(
+            markdown_to_typst("1. First\n2. Second"),
+            "+ First\n+ Second"
+        );
+    }
+
+    #[test]
+    fn list_item_with_formatting() {
+        let result = markdown_to_typst("- **Bold** item\n- Normal item");
+        assert_eq!(
+            result,
+            "- #text(weight: \"bold\")[Bold] item\n- Normal item"
+        );
+    }
+
+    #[test]
+    fn paragraph_then_list() {
+        let result = markdown_to_typst("Responsibilities:\n\n- Item A\n- Item B");
+        assert_eq!(result, "Responsibilities:\n\n- Item A\n- Item B");
+    }
+
+    #[test]
+    fn typst_special_chars_escaped() {
+        assert_eq!(markdown_to_typst("#hashtag"), "\\#hashtag");
+        assert_eq!(markdown_to_typst("Use @mention"), "Use \\@mention");
+        assert_eq!(markdown_to_typst("100$ and 40%"), "100\\$ and 40\\%");
+        assert_eq!(markdown_to_typst("a[b]c"), "a\\[b\\]c");
+    }
+
+    #[test]
+    fn escaped_markdown_emphasis_stays_literal() {
+        assert_eq!(markdown_to_typst(r"\*not italic\*"), "\\*not italic\\*");
+    }
+
+    #[test]
+    fn raw_html_script_is_neutralized() {
+        let result = markdown_to_typst("<script>alert('xss')</script>");
+        assert!(
+            !result.contains("#eval") && !result.contains("<script>"),
+            "script tag must not survive: {result}"
+        );
+        assert!(
+            result.contains("\\<script\\>"),
+            "expected escaped text: {result}"
+        );
+    }
+
+    #[test]
+    fn raw_html_underline_is_neutralized() {
+        let result = markdown_to_typst("<u>underlined</u>");
+        assert!(
+            !result.contains("#underline"),
+            "raw HTML must not become Typst markup: {result}"
+        );
+        assert_eq!(result, "\\<u\\>underlined\\</u\\>");
+    }
+
+    #[test]
+    fn raw_html_inside_paragraph_is_neutralized() {
+        let result = markdown_to_typst("Before <b>bold?</b> after");
+        assert_eq!(result, "Before \\<b\\>bold?\\</b\\> after");
+    }
+
+    #[test]
+    fn typst_code_injection_is_escaped() {
+        let result = markdown_to_typst("#eval(\"1+1\") and #import \"x\"");
+        assert_eq!(result, "\\#eval(\"1+1\") and \\#import \"x\"");
+    }
+
+    #[test]
+    fn strikethrough_extension_is_off() {
+        // No GFM extensions: `~~` is literal text, not `<del>`.
+        assert_eq!(markdown_to_typst("~~struck~~"), "\\~\\~struck\\~\\~");
+    }
+
+    #[test]
+    fn smart_punctuation_is_off() {
+        assert_eq!(
+            markdown_to_typst(r#""quoted" -- dash"#),
+            r#""quoted" -- dash"#
+        );
+    }
+}

--- a/crates/utils/tests/golden/doc-editor.typ.txt
+++ b/crates/utils/tests/golden/doc-editor.typ.txt
@@ -1,0 +1,149 @@
+=== /basics/summary/body ===
+Design systems engineer with #text(weight: "bold")[eleven years] of shipping component libraries that survive contact with real product teams. I work at the seam between design and engineering: tokens, accessibility, and the tooling that keeps both honest.
+
+Currently leading #emph[Halo], the design system behind every Lumen Health surface. I write about the craft at #link("https://okafor.design/notes")[okafor.design/notes].
+
+=== /sections/awards/items[0]/summary ===
+Awarded for the Halo token pipeline, cited by the panel as #emph["the clearest worked example of tokens as versioned infrastructure"].
+
+=== /sections/awards/items[1]/summary ===
+Community-nominated award recognising the #text(weight: "bold")[WCAG 2.2 audit write-up] and the open office hours that followed it.
+
+=== /sections/certifications/items[0]/summary ===
+The #text(weight: "bold")[CPACC] covers disability models, standards, and organisational policy. Verification is available through the #link("https://www.accessibilityassociation.org/certification")[IAAP directory].
+
+=== /sections/certifications/items[1]/summary ===
+Taken during the Northbeam rewrite, mostly to #emph[argue more precisely] about scope with the delivery team.
+
+=== /sections/custom/advisory/items[0]/summary ===
+Quarterly review of the collective's shared patterns for clinical interfaces, with a standing focus on #emph[colour-blind safe] status indicators.
+
+=== /sections/custom/advisory/items[1]/summary ===
+Reviewed #text(weight: "bold")[sixty-odd] talk proposals across two years and mentored three first-time speakers through their outlines.
+
+=== /sections/custom/speaking/items[0]/summary ===
+Forty minutes on what happens when a token set has to describe motion, elevation, and density rather than just colour.
+
+- Why #emph[semantic] naming breaks down at the third platform
+- The versioning policy we adopted after two painful renames
+
+Slides and a transcript are at #link("https://okafor.design/talks/beyond-colour")[okafor.design/talks/beyond-colour].
+
+=== /sections/custom/speaking/items[1]/summary ===
+A meetup talk on making the accessible path the #text(weight: "bold")[easy] path: sensible defaults, a focus-visible policy, and CI checks that fail loudly.
+
+=== /sections/custom/speaking/items[2]/summary ===
+A half-day workshop, run twice, on the operational side of a small systems team.
+
++ Triage: what earns a place in the library and what stays in the product
++ Contribution: review turnaround as the #emph[only] metric that matters
++ Deprecation: how to remove a component without breaking six teams
+
+=== /sections/education/items[0]/summary ===
+Dissertation on #text(weight: "bold")[perceptual colour spaces for data visualisation], supervised by Dr. Helen Marsh.
+
+- Course representative for the 2014-15 cohort
+- Ran the department's weekly accessibility reading group
+
+=== /sections/education/items[1]/summary ===
+Taken part-time alongside full-time work. Coursework in #emph[interaction design], usability evaluation, and assistive technology.
+
+The final project measured screen-reader task completion across three component library APIs and became the basis for a later conference talk.
+
+=== /sections/experience/items[0]/summary ===
+Own #text(weight: "bold")[Halo], the design system behind every Lumen Health surface: the web console, the clinician tablet app, and the patient mobile app.
+
+- Rebuilt the token pipeline so design and code read from a single source, cutting drift reports from roughly fourteen per quarter to two
+- Shipped a #emph[codemod] that migrated 1,100 hard-coded colour values in one review
+- Added contrast assertions to CI, which now block any token pair below 4.5:1
+- Wrote the #link("https://halo.lumenhealth.io/contributing")[Halo contribution guide]; outside contributions rose from three to thirty-one in a year
+- Led the remediation that took the clinician tablet app to #text(weight: "bold")[WCAG 2.2 AA], verified by an external audit in January 2025
+
+Team: four engineers.#linebreak()
+Review load: around sixty component pull requests per quarter.
+
+=== /sections/experience/items[1]/summary ===
+Led the rewrite of Northbeam's reporting console from a jQuery monolith to a typed React application, delivered in three phases without a feature freeze.
+
++ Split the monolith into nine route-level bundles, taking first contentful paint from 4.8s to 1.3s on a throttled 3G profile
++ Introduced #emph[contract tests] against the reporting API, which caught twenty-three breaking changes before release
++ Handed the resulting patterns to the platform team as Northbeam's first shared component library
+
+Also mentored two engineers through their first year; both are still shipping.
+
+=== /sections/experience/items[2]/summary ===
+Built marketing sites and small product front-ends for agency clients: #emph[fast turnarounds, unforgiving briefs].
+
+- Delivered more than twenty client projects, several on two-week timelines
+- Set up the studio's first shared #text(weight: "bold")[Sass toolkit], which ended the habit of copying the previous project's stylesheet
+
+=== /sections/languages/items[0]/description ===
+#text(weight: "bold")[Native.] Schooling and all professional work to date.
+
+=== /sections/languages/items[1]/description ===
+Fluent; day-to-day language #emph[outside] work since 2018.
+
+=== /sections/languages/items[2]/description ===
+Conversational, spoken at home.
+
+=== /sections/languages/items[3]/description ===
+Working proficiency, retained from three years in Berlin.
+
+=== /sections/projects/items[0]/description ===
+Browser extension for auditing colour contrast in #text(weight: "bold")[live] interfaces
+
+=== /sections/projects/items[0]/summary ===
+Started as a debugging aid for the Halo remediation and grew into a small public tool.
+
++ Samples computed styles rather than design files, so it catches the blends that palettes miss
++ Reports failures against #emph[both] WCAG 2.1 and 2.2 thresholds
++ Exports a CSV that plugs straight into an audit spreadsheet
+
+Around 4,000 weekly active users.
+
+=== /sections/projects/items[1]/description ===
+#emph[Zero-config] CLI that compiles design tokens to CSS, Swift, and Kotlin
+
+=== /sections/projects/items[1]/summary ===
+Written in Rust after the Node build step became the slowest part of Halo's release.
+
+- Full compile of 2,300 tokens went from 11s to under 400ms
+- Emits a diff report so reviewers can see what a token change actually costs
+- Ships as a single binary; see the #link("https://github.com/mireilleokafor/tokenwright#install")[installation notes]
+
+=== /sections/publications/items[0]/summary ===
+Argues that a token set is an #text(weight: "bold")[API] with the same compatibility obligations as any other, and proposes a deprecation policy for teams that rename things too freely.
+
+=== /sections/publications/items[1]/summary ===
+A write-up of the Halo audit, including the failures that automated tooling missed.
+
+- Target size was the most common new 2.2 failure
+- Focus appearance failures clustered in #emph[composed] components rather than primitives
+
+=== /sections/references/items[0]/description ===
+#text(weight: "bold")[Dissertation supervisor], University of Manchester
+
+=== /sections/references/items[0]/summary ===
+Contact details supplied on request, alongside a reference from my current engineering director.
+
+=== /sections/skills/items[0]/description ===
+The day-to-day language for #text(weight: "bold")[library code]. Comfortable with generic component APIs and the type-level work that keeps them ergonomic.
+
+=== /sections/skills/items[1]/description ===
+Pipelines from design-tool variables to platform artefacts. Documented in the #link("https://halo.lumenhealth.io/tokens")[Halo token spec].
+
+=== /sections/skills/items[2]/description ===
+WCAG 2.2 AA in practice rather than in theory:
+
+- Keyboard and focus-order review
+- Screen reader passes with NVDA and VoiceOver
+- Automated axe checks wired into CI
+
+=== /sections/skills/items[3]/description ===
+Reached for build tooling: a token compiler and a #emph[considerably] faster SVG icon pipeline.
+
+=== /sections/volunteer/items[0]/summary ===
+Coach at fortnightly workshops for people underrepresented in tech.
+
+Usually paired with a student for a full term, working through HTML and CSS before moving on to their first JavaScript project.
+

--- a/crates/utils/tests/markdown_corpus.rs
+++ b/crates/utils/tests/markdown_corpus.rs
@@ -17,6 +17,25 @@ use serde_json::Value;
 /// JSON keys that hold rich text in the v3 schema.
 const RICH_TEXT_KEYS: [&str; 4] = ["body", "content", "description", "summary"];
 
+/// Assert the fixture declares markdown, then hand back its parsed JSON.
+///
+/// The renderer dispatches on `metadata.contentFormat`, never on the shape of
+/// the content, so this corpus is only meaningful while the fixture carries the
+/// marker that puts it on the markdown path.
+fn markdown_fixture() -> Value {
+    let raw = fs::read_to_string(fixture_path()).expect("failed to read doc-editor.json fixture");
+    let json: Value = serde_json::from_str(&raw).expect("doc-editor.json must be valid JSON");
+
+    assert_eq!(
+        json["metadata"]["contentFormat"],
+        Value::String("markdown".to_string()),
+        "the doc-editor fixture must declare contentFormat: markdown, or the renderer \
+         treats it as HTML and this corpus tests a path it never takes",
+    );
+
+    json
+}
+
 /// Path to the document-editor fixture in the workspace test corpus.
 fn fixture_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -82,8 +101,7 @@ fn render_corpus(fields: &[(String, String)]) -> String {
 
 #[test]
 fn doc_editor_fixture_matches_golden() {
-    let raw = fs::read_to_string(fixture_path()).expect("failed to read doc-editor.json fixture");
-    let json: Value = serde_json::from_str(&raw).expect("doc-editor.json must be valid JSON");
+    let json = markdown_fixture();
 
     let mut fields = Vec::new();
     collect_rich_text(&json, "", &mut fields);
@@ -117,8 +135,7 @@ fn doc_editor_fixture_matches_golden() {
 
 #[test]
 fn doc_editor_fixture_never_emits_typst_code() {
-    let raw = fs::read_to_string(fixture_path()).expect("failed to read doc-editor.json fixture");
-    let json: Value = serde_json::from_str(&raw).expect("doc-editor.json must be valid JSON");
+    let json = markdown_fixture();
 
     let mut fields = Vec::new();
     collect_rich_text(&json, "", &mut fields);

--- a/crates/utils/tests/markdown_corpus.rs
+++ b/crates/utils/tests/markdown_corpus.rs
@@ -1,0 +1,157 @@
+//! Corpus test: every rich-text field of the document-editor fixture through
+//! [`markdown_to_typst`], pinned against a committed golden file.
+//!
+//! The fixture (`tests/fixtures/v3/doc-editor.json`) is the shared corpus for
+//! the document editor. This test is the tripwire for unintended conversion
+//! changes: any diff in the rendered Typst shows up as a golden mismatch.
+//!
+//! Regenerate after a deliberate change:
+//! `UPDATE_GOLDEN=1 cargo test -p rustume-utils --test markdown_corpus`
+
+use std::fs;
+use std::path::PathBuf;
+
+use rustume_utils::markdown_to_typst;
+use serde_json::Value;
+
+/// JSON keys that hold rich text in the v3 schema.
+const RICH_TEXT_KEYS: [&str; 4] = ["body", "content", "description", "summary"];
+
+/// Path to the document-editor fixture in the workspace test corpus.
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("utils crate must live under crates/")
+        .parent()
+        .expect("crates/ must live under the workspace root")
+        .join("tests")
+        .join("fixtures")
+        .join("v3")
+        .join("doc-editor.json")
+}
+
+/// Path to the committed golden file.
+fn golden_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("golden")
+        .join("doc-editor.typ.txt")
+}
+
+/// Collect `(json path, rich text)` for every non-empty rich-text field,
+/// depth-first with object keys visited in sorted order for determinism.
+fn collect_rich_text(value: &Value, path: &str, out: &mut Vec<(String, String)>) {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            for key in keys {
+                let child = &map[key];
+                let child_path = format!("{path}/{key}");
+                if RICH_TEXT_KEYS.contains(&key.as_str()) {
+                    if let Value::String(text) = child {
+                        if !text.trim().is_empty() {
+                            out.push((child_path.clone(), text.clone()));
+                        }
+                    }
+                }
+                collect_rich_text(child, &child_path, out);
+            }
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                collect_rich_text(item, &format!("{path}[{index}]"), out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Render the corpus into the golden file's text format.
+fn render_corpus(fields: &[(String, String)]) -> String {
+    let mut out = String::new();
+    for (path, source) in fields {
+        out.push_str("=== ");
+        out.push_str(path);
+        out.push_str(" ===\n");
+        out.push_str(&markdown_to_typst(source));
+        out.push_str("\n\n");
+    }
+    out
+}
+
+#[test]
+fn doc_editor_fixture_matches_golden() {
+    let raw = fs::read_to_string(fixture_path()).expect("failed to read doc-editor.json fixture");
+    let json: Value = serde_json::from_str(&raw).expect("doc-editor.json must be valid JSON");
+
+    let mut fields = Vec::new();
+    collect_rich_text(&json, "", &mut fields);
+    assert!(
+        fields.len() >= 30,
+        "expected the fixture to carry a substantial rich-text corpus, found {}",
+        fields.len()
+    );
+
+    let actual = render_corpus(&fields);
+
+    if std::env::var_os("UPDATE_GOLDEN").is_some() {
+        let path = golden_path();
+        fs::create_dir_all(path.parent().expect("golden path must have a parent"))
+            .expect("failed to create golden directory");
+        fs::write(&path, &actual).expect("failed to write golden file");
+        return;
+    }
+
+    let expected = fs::read_to_string(golden_path()).expect(
+        "missing golden file; regenerate with \
+         UPDATE_GOLDEN=1 cargo test -p rustume-utils --test markdown_corpus",
+    );
+
+    assert_eq!(
+        actual, expected,
+        "markdown conversion of the doc-editor corpus changed; review the diff, then \
+         regenerate with UPDATE_GOLDEN=1 cargo test -p rustume-utils --test markdown_corpus"
+    );
+}
+
+#[test]
+fn doc_editor_fixture_never_emits_typst_code() {
+    let raw = fs::read_to_string(fixture_path()).expect("failed to read doc-editor.json fixture");
+    let json: Value = serde_json::from_str(&raw).expect("doc-editor.json must be valid JSON");
+
+    let mut fields = Vec::new();
+    collect_rich_text(&json, "", &mut fields);
+
+    // Only the markup this converter emits may start a Typst code expression;
+    // anything else authored by the user must arrive escaped.
+    const ALLOWED_HASH_PREFIXES: [&str; 3] = ["#text(weight: \"bold\")[", "#emph[", "#linebreak()"];
+    const LINK_PREFIX: &str = "#link(\"";
+
+    for (path, source) in &fields {
+        let typst = markdown_to_typst(source);
+        let mut rest = typst.as_str();
+        while let Some(index) = rest.find('#') {
+            let escaped = index > 0 && rest.as_bytes()[index - 1] == b'\\';
+            let tail = &rest[index..];
+            if escaped {
+                rest = &tail[1..];
+                continue;
+            }
+            // A link's URL is a Typst string literal, so any `#` inside it is
+            // inert — skip past the whole `#link("…")` head.
+            if let Some(url_and_rest) = tail.strip_prefix(LINK_PREFIX) {
+                let end = url_and_rest
+                    .find("\")[")
+                    .unwrap_or_else(|| panic!("unterminated link in {path}: {tail}"));
+                rest = &url_and_rest[end + 3..];
+                continue;
+            }
+            assert!(
+                ALLOWED_HASH_PREFIXES.iter().any(|p| tail.starts_with(p)),
+                "unescaped Typst code in {path}: {tail}"
+            );
+            rest = &tail[1..];
+        }
+    }
+}

--- a/tests/fixtures/v3/doc-editor.json
+++ b/tests/fixtures/v3/doc-editor.json
@@ -499,6 +499,7 @@
     "css": {
       "value": "",
       "visible": false
-    }
+    },
+    "contentFormat": "markdown"
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(render): add a markdown-to-typst adapter via comrak
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The document editor stores rich text as markdown; the render path assumed
TipTap HTML, so markdown fields would render as escaped literal text.

`markdown_to_typst()` parses markdown to HTML with raw HTML **escaped**
(never passed through), then runs the result through the existing
`sanitize_html` + `html_to_typst` pipeline. Render preprocessing dispatches on
a new optional `metadata.contentFormat` marker (`html` | `markdown`) — never on
the content. An **absent marker means HTML**, so every existing resume renders
byte-identically and no migration is needed; the markdown path is entered only
on an explicit declaration. Both editors coexist unambiguously.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #723

## Details

### Changes

- `Cargo.toml` — pin `comrak = { version = "0.54", default-features = false }`
  (no CLI, no syntect, no emoji shortcodes; adds 4 transitive crates).
- `crates/utils/src/markdown_to_typst.rs` — the adapter. Plain CommonMark:
  no GFM extensions (no tables/strikethrough), smart punctuation off,
  `render.escape = true` and `render.unsafe = false`.
- `crates/schema/src/metadata.rs` — `ContentFormat` (`html` | `markdown`) and
  an optional `content_format` field on `Metadata`, serialized as
  `contentFormat` and omitted when unset. `Metadata::content_format()` resolves
  an absent marker to `Html`.
- `crates/render/src/typst_engine/engine.rs` — `convert_field()` dispatches on
  the marker. The HTML branch is byte-identical to before; all existing render
  tests pass unmodified.
- `crates/parser/src/reactive_resume_v3.rs` — carries a declared marker
  through. Genuine Reactive Resume exports never set it and stay on HTML.
- `tests/fixtures/v3/doc-editor.json` — declares `contentFormat: "markdown"`,
  which is what puts the corpus golden on the markdown path.
- `apps/web/src/wasm/types.ts` — the matching optional TS field.
- Tests: 24 unit tests (per construct, Typst-special escaping, raw-HTML and
  Typst-code neutralization), plus a corpus test over
  `tests/fixtures/v3/doc-editor.json` pinned to a committed golden
  (`crates/utils/tests/golden/doc-editor.typ.txt`, regenerate with
  `UPDATE_GOLDEN=1 cargo test -p rustume-utils --test markdown_corpus`) and a
  second corpus assertion that no unescaped Typst code expression can reach
  `eval()`.

Two conversion details that needed handling and are covered by tests:

- Comrak emits `<br />\n` for a hard break; left alone the trailing newline
  becomes a blank line, which Typst reads as a paragraph break *on top of*
  the `#linebreak()`.
- Escaped raw HTML can leave the sanitizer with no element at all
  (`&lt;script&gt;…`), which `html_to_typst`'s tag-free fast path would emit
  as literal entities. The adapter wraps the sanitized HTML in a `<div>` so
  the entities are decoded to text and Typst-escaped.

### Verification

`cargo test --workspace` (487 tests), `cargo clippy --workspace --all-targets
-- -D warnings`, `uv run lintro chk` (0 issues), and in `apps/web`
`bun run lint` / `bun run typecheck` / `bun run test` (599 tests) — all pass.

**Byte-identical to main without a marker.** Generated Typst source was dumped
for all four v3 fixtures on `main` and on this branch and compared byte for
byte: `complete.json`, `minimal.json` and `string_formats.json` are identical.
`doc-editor.json` differs only because this PR adds the marker to it — with the
marker removed, it is identical to main too.

### Decisions

**1. Format is declared, not sniffed (owner decision).**

The earlier revision of this PR dispatched on the content: a trimmed field
containing `<` took the HTML path, everything else was parsed as markdown.
That is unsafe and has been replaced. Rich text is a bare string with no format
information, and legacy fields hold plain prose next to HTML — and plain prose
is very often also valid markdown, so the guess silently rewrote content the
author never marked up:

| input | sniffed output |
| --- | --- |
| `1988. A good year` | `+ A good year` — **the number is dropped** |
| `Ran __init__ daily` | `Ran #text(weight: "bold")[init] daily` |
| `Scaled 4*5*6 racks` | `Scaled 4#emph[5]6 racks` |
| `    four-space indent` | indentation dropped (parsed as a code block) |

The first row is data loss, not restyling, and it is plausible in imported text
("2019. Promoted to …"). No refinement of the heuristic fixes it: the strings
that break it genuinely *are* markdown constructs, so any sniffing rule routes
exactly those cases to markdown.

The marker keeps the property the issue actually wanted — migration-free
rollout — because absent means HTML, which is what every resume written so far
contains. `test_preprocess_without_marker_never_parses_markdown` pins the
regression, and the fixture comparison above shows no existing resume changes.

**Follow-up owned by #721:** whichever issue builds the document editor must
set `contentFormat: "markdown"` when it creates or saves a doc-editor resume,
or its content renders as HTML. Noted on the epic.

**2. Underline dropped from the doc-editor toolbar.**

No-op in this PR: the doc-editor toolbar does not exist yet (later wave of
#721). Nothing here removes underline from the existing form-builder
`RichTextEditor`, and the HTML path still emits `#underline[…]` for TipTap
`<u>`. The decision only becomes actionable in the toolbar issue.

**3. Pre-existing: nested lists flatten.**

`html_to_typst` does not recurse into a nested `<ul>` inside an `<li>`, so a
nested markdown bullet becomes a sibling top-level bullet (visible in the
golden file, `experience/items[0]`). This is pre-existing — TipTap nested
lists flatten the same way today — so I did not change `html_to_typst` here
(the HTML path has to stay byte-identical). Worth a follow-up issue if the
document editor will offer list nesting.
