### PR TITLE
feat(web): add the document-editor layout model

### DIFF
--- a/apps/web/src/components/export/coverLetterExport.ts
+++ b/apps/web/src/components/export/coverLetterExport.ts
@@ -1,5 +1,5 @@
 import type { ResumeData } from "../../wasm/types";
-import { isHtmlEmpty } from "../../stores/resume";
+import { isHtmlEmpty } from "../../lib/resumeSections";
 
 export type PdfExportScope = "resume" | "coverLetter";
 

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -1,0 +1,713 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  CUSTOM_SECTION_SENTINEL,
+  emptyItemFor,
+  FIXED_SECTION_IDS,
+  findSectionPlacement,
+  isCustomId,
+  layoutColumns,
+  layoutForTemplate,
+  layoutPages,
+  nextId,
+  renderPages,
+  SECTION_LABELS,
+  sectionTitle,
+  sectionVisible,
+  type TemplateLayout,
+} from "../docLayout";
+import { createEmptyPicture } from "../../wasm/types";
+import type { CustomItem, ResumeData, Section, Theme, Typography, Url } from "../../wasm/types";
+
+/**
+ * The shared document-editor corpus is stored in the Reactive Resume v3 wire
+ * format, which the Rust parser normalizes into `ResumeData`. Vitest cannot run
+ * that parser, so the adapter below mirrors it: summary moves out of `basics`,
+ * and custom items map `title`/`subtitle` onto `name`/`description`.
+ */
+// jsdom's `URL` is not a Node file URL, so resolve through the path API.
+const FIXTURE_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../../tests/fixtures/v3/doc-editor.json",
+);
+
+interface RawSection {
+  id: string;
+  name: string;
+  visible: boolean;
+  columns: number;
+  items: unknown[];
+}
+
+interface RawCustomItem {
+  id: string;
+  visible: boolean;
+  title: string;
+  subtitle: string;
+  date: string;
+  location: string;
+  summary: string;
+  keywords?: string[];
+  url?: Url;
+}
+
+interface RawCustomSection extends Omit<RawSection, "items"> {
+  items: RawCustomItem[];
+}
+
+interface RawFixture {
+  basics: {
+    name: string;
+    headline: string;
+    email: string;
+    phone: string;
+    location: string;
+    summary: { body: string; visible: boolean };
+    url: Url;
+    customFields: { id: string; icon: string; name: string; value: string }[];
+  };
+  sections: Record<string, RawSection> & { custom: Record<string, RawCustomSection> };
+  metadata: {
+    template: string;
+    layout: string[][][];
+    theme: Theme;
+    typography: Typography;
+  };
+}
+
+function toItemSection<T>(raw: RawSection): Section<T> {
+  return {
+    id: raw.id,
+    name: raw.name,
+    columns: raw.columns,
+    separateLinks: false,
+    visible: raw.visible,
+    // Fixed-section items already match the wasm item shapes field for field.
+    items: raw.items as T[],
+  };
+}
+
+function toCustomSection(raw: RawCustomSection): Section<CustomItem> {
+  return {
+    id: raw.id,
+    name: raw.name,
+    columns: raw.columns,
+    separateLinks: false,
+    visible: raw.visible,
+    items: raw.items.map((item) => ({
+      id: item.id,
+      visible: item.visible,
+      name: item.title,
+      description: item.subtitle,
+      date: item.date,
+      location: item.location,
+      summary: item.summary,
+      keywords: item.keywords ?? [],
+      url: item.url ?? { label: "", href: "" },
+    })),
+  };
+}
+
+/** A fresh `ResumeData` built from the shared document-editor fixture. */
+function loadFixture(): ResumeData {
+  const raw = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as RawFixture;
+  const custom: Record<string, Section<CustomItem>> = {};
+  for (const [key, section] of Object.entries(raw.sections.custom)) {
+    custom[key] = toCustomSection(section);
+  }
+
+  return {
+    basics: {
+      name: raw.basics.name,
+      headline: raw.basics.headline,
+      email: raw.basics.email,
+      phone: raw.basics.phone,
+      location: raw.basics.location,
+      url: raw.basics.url,
+      customFields: raw.basics.customFields,
+      picture: createEmptyPicture(),
+    },
+    sections: {
+      summary: {
+        id: "summary",
+        name: "Summary",
+        columns: 1,
+        separateLinks: false,
+        visible: raw.basics.summary.visible,
+        content: raw.basics.summary.body,
+      },
+      coverLetter: {
+        id: "coverLetter",
+        name: "Cover Letter",
+        visible: false,
+        recipient: { name: "", title: "", company: "", address: "", email: "" },
+        content: "",
+      },
+      experience: toItemSection(raw.sections.experience),
+      education: toItemSection(raw.sections.education),
+      skills: toItemSection(raw.sections.skills),
+      projects: toItemSection(raw.sections.projects),
+      profiles: toItemSection(raw.sections.profiles),
+      awards: toItemSection(raw.sections.awards),
+      certifications: toItemSection(raw.sections.certifications),
+      publications: toItemSection(raw.sections.publications),
+      languages: toItemSection(raw.sections.languages),
+      interests: toItemSection(raw.sections.interests),
+      volunteer: toItemSection(raw.sections.volunteer),
+      references: toItemSection(raw.sections.references),
+      custom,
+    },
+    metadata: {
+      template: raw.metadata.template,
+      layout: raw.metadata.layout,
+      css: { value: "", visible: false },
+      page: { margin: 20, format: "a4", breakLine: true, pageNumbers: true },
+      theme: raw.metadata.theme,
+      typography: raw.metadata.typography,
+      notes: "",
+    },
+  };
+}
+
+/** Mirrors `rhyhorn`: one column holding every section. */
+const SINGLE_TEMPLATE: TemplateLayout = {
+  layoutMode: "single",
+  defaultColumns: [
+    [
+      "summary",
+      "experience",
+      "education",
+      "awards",
+      "certifications",
+      "publications",
+      "volunteer",
+      "projects",
+      "references",
+      "profiles",
+      "skills",
+      "interests",
+      "languages",
+      CUSTOM_SECTION_SENTINEL,
+    ],
+    [],
+  ],
+  headerStyle: "center",
+  contactIn: "header",
+  sidebarWidth: null,
+};
+
+/** Mirrors `pikachu`: fixed 180pt sidebar painted on the left. */
+const SIDEBAR_TEMPLATE: TemplateLayout = {
+  layoutMode: "sidebar-left",
+  defaultColumns: [
+    [
+      "summary",
+      "experience",
+      "education",
+      "awards",
+      "certifications",
+      "publications",
+      "volunteer",
+      "projects",
+      "references",
+      CUSTOM_SECTION_SENTINEL,
+    ],
+    ["profiles", "skills", "interests", "certifications", "awards", "publications", "languages"],
+  ],
+  headerStyle: "sidebar",
+  contactIn: "sidebar",
+  sidebarWidth: 180,
+};
+
+/** Mirrors a proportional two-column template with no fixed sidebar width. */
+const PROPORTIONAL_TEMPLATE: TemplateLayout = {
+  ...SIDEBAR_TEMPLATE,
+  layoutMode: "sidebar-right",
+  sidebarWidth: null,
+};
+
+describe("FIXED_SECTION_IDS / SECTION_LABELS", () => {
+  it("covers every fixed section exactly once", () => {
+    expect(new Set(FIXED_SECTION_IDS).size).toBe(FIXED_SECTION_IDS.length);
+    expect(FIXED_SECTION_IDS).toContain("summary");
+    expect(FIXED_SECTION_IDS).toContain("experience");
+    expect(FIXED_SECTION_IDS).not.toContain(CUSTOM_SECTION_SENTINEL);
+  });
+
+  it("labels every fixed section", () => {
+    for (const id of FIXED_SECTION_IDS) {
+      expect(SECTION_LABELS[id]).toBeTruthy();
+    }
+    expect(SECTION_LABELS.coverLetter).toBe("Cover Letter");
+  });
+});
+
+describe("layoutPages", () => {
+  it("honours the resume's stored layout", () => {
+    const resume = loadFixture();
+
+    expect(layoutPages(resume, SIDEBAR_TEMPLATE)).toEqual([
+      [
+        ["summary", "experience", "education", "projects"],
+        ["profiles", "skills", "speaking"],
+      ],
+      [
+        ["publications", "volunteer", "awards"],
+        ["languages", "interests", "certifications", "advisory"],
+      ],
+    ]);
+  });
+
+  it("falls back to the template's default columns when the layout is empty", () => {
+    const resume = loadFixture();
+    resume.metadata.layout = [];
+
+    const pages = layoutPages(resume, SIDEBAR_TEMPLATE);
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0]).toHaveLength(2);
+    expect(pages[0][0][0]).toBe("summary");
+    expect(pages[0][1][0]).toBe("profiles");
+    // The `custom` sentinel expands to the resume's own custom sections.
+    expect(pages[0][0]).toContain("speaking");
+    expect(pages[0][0]).toContain("advisory");
+    expect(pages[0].flat()).not.toContain(CUSTOM_SECTION_SENTINEL);
+  });
+
+  it("collapses a single-column template to one column", () => {
+    const resume = loadFixture();
+    resume.metadata.layout = [];
+
+    const pages = layoutPages(resume, SINGLE_TEMPLATE);
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0]).toHaveLength(1);
+    expect(pages[0][0]).toContain("languages");
+  });
+
+  it("keeps only the first occurrence of a repeated section id", () => {
+    const resume = loadFixture();
+    resume.metadata.layout = [[["experience", "skills"], ["experience"]]];
+
+    expect(layoutPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience", "skills"], []]]);
+  });
+
+  it("drops ids that address no section", () => {
+    const resume = loadFixture();
+    resume.metadata.layout = [[["experience", "not-a-section"]]];
+
+    expect(layoutPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
+  });
+});
+
+describe("renderPages", () => {
+  it("drops hidden sections", () => {
+    const resume = loadFixture();
+
+    const pages = renderPages(resume, SIDEBAR_TEMPLATE);
+
+    // `advisory` is a custom section with `visible: false`.
+    expect(pages[1][1]).toEqual(["languages", "interests", "certifications"]);
+  });
+
+  it("drops sections with no content", () => {
+    const resume = loadFixture();
+    resume.sections.awards.items = [];
+    resume.metadata.layout = [[["awards", "experience"]]];
+
+    expect(renderPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
+  });
+
+  it("drops a section whose items are all hidden", () => {
+    const resume = loadFixture();
+    resume.sections.publications.items = resume.sections.publications.items.map((item) => ({
+      ...item,
+      visible: false,
+    }));
+    resume.metadata.layout = [[["publications", "experience"]]];
+
+    expect(renderPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
+  });
+
+  it("removes a page left empty by filtering", () => {
+    const resume = loadFixture();
+    resume.metadata.layout = [[["experience"]], [["references", "advisory"]]];
+
+    expect(renderPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
+  });
+
+  it("keeps a page that still has content", () => {
+    const resume = loadFixture();
+
+    const pages = renderPages(resume, SIDEBAR_TEMPLATE);
+
+    expect(pages).toHaveLength(2);
+    expect(pages[0][0]).toEqual(["summary", "experience", "education", "projects"]);
+    expect(pages[0][1]).toEqual(["profiles", "skills", "speaking"]);
+  });
+});
+
+describe("layoutColumns", () => {
+  it("describes a single-column template as one full-width column", () => {
+    expect(layoutColumns([["summary", "experience"]], SINGLE_TEMPLATE)).toEqual([
+      { index: 0, role: "main", width: 1, order: 0 },
+    ]);
+  });
+
+  it("derives sidebar width from the template's fixed sidebar", () => {
+    const columns = layoutColumns([["summary"], ["profiles"]], SIDEBAR_TEMPLATE);
+
+    expect(columns).toHaveLength(2);
+    expect(columns[1].role).toBe("sidebar");
+    // 180pt of a nominal A4 content width (595.28pt - 2 * 18pt).
+    expect(columns[1].width).toBeCloseTo(0.3218, 4);
+    expect(columns[0].width).toBeCloseTo(1 - columns[1].width, 10);
+    // A left sidebar paints before the main column.
+    expect(columns[0].order).toBe(1);
+    expect(columns[1].order).toBe(0);
+  });
+
+  it("uses the proportional default when the template has no fixed sidebar", () => {
+    const columns = layoutColumns([["summary"], ["profiles"]], PROPORTIONAL_TEMPLATE);
+
+    expect(columns[1].width).toBeCloseTo(1 / 3, 10);
+    expect(columns[0].order).toBe(0);
+    expect(columns[1].order).toBe(1);
+  });
+
+  it("gives a sidebar template its second column even on a one-column page", () => {
+    expect(layoutColumns([["summary"]], SIDEBAR_TEMPLATE)).toHaveLength(2);
+  });
+
+  it("shares width evenly when a page carries more columns than the mode implies", () => {
+    const columns = layoutColumns([["a"], ["b"], ["c"]], SIDEBAR_TEMPLATE);
+
+    expect(columns).toHaveLength(3);
+    for (const column of columns) {
+      expect(column.width).toBeCloseTo(1 / 3, 10);
+    }
+  });
+});
+
+describe("findSectionPlacement", () => {
+  it("finds a fixed section", () => {
+    const resume = loadFixture();
+
+    expect(findSectionPlacement(resume.metadata.layout, "experience")).toEqual({
+      page: 0,
+      column: 0,
+      index: 1,
+    });
+  });
+
+  it("finds a custom section on a later page", () => {
+    const resume = loadFixture();
+
+    expect(findSectionPlacement(resume.metadata.layout, "advisory")).toEqual({
+      page: 1,
+      column: 1,
+      index: 3,
+    });
+  });
+
+  it("returns null for a section that is not placed", () => {
+    const resume = loadFixture();
+
+    expect(findSectionPlacement(resume.metadata.layout, "references")).toBeNull();
+  });
+});
+
+describe("sectionVisible", () => {
+  it("reports fixed sections", () => {
+    const resume = loadFixture();
+
+    expect(sectionVisible(resume, "experience")).toBe(true);
+    expect(sectionVisible(resume, "references")).toBe(false);
+  });
+
+  it("reports custom sections", () => {
+    const resume = loadFixture();
+
+    expect(sectionVisible(resume, "speaking")).toBe(true);
+    expect(sectionVisible(resume, "advisory")).toBe(false);
+  });
+
+  it("treats an unknown id as not visible", () => {
+    expect(sectionVisible(loadFixture(), "not-a-section")).toBe(false);
+  });
+});
+
+describe("sectionTitle", () => {
+  it("uses the section's own name", () => {
+    const resume = loadFixture();
+
+    expect(sectionTitle(resume, "volunteer")).toBe("Volunteering");
+    expect(sectionTitle(resume, "speaking")).toBe("Talks & Workshops");
+  });
+
+  it("falls back to the canonical label when a name is blank", () => {
+    const resume = loadFixture();
+    resume.sections.experience.name = "  ";
+
+    expect(sectionTitle(resume, "experience")).toBe("Experience");
+  });
+
+  it("falls back to a placeholder for an unnamed custom section", () => {
+    const resume = loadFixture();
+    resume.sections.custom.speaking.name = "";
+
+    expect(sectionTitle(resume, "speaking")).toBe("Untitled");
+  });
+
+  it("returns an empty string for an unknown id", () => {
+    expect(sectionTitle(loadFixture(), "not-a-section")).toBe("");
+  });
+});
+
+describe("isCustomId", () => {
+  it("recognises custom section ids", () => {
+    expect(isCustomId("speaking")).toBe(true);
+    expect(isCustomId(CUSTOM_SECTION_SENTINEL)).toBe(true);
+  });
+
+  it("rejects fixed section ids and the empty id", () => {
+    expect(isCustomId("experience")).toBe(false);
+    expect(isCustomId("summary")).toBe(false);
+    expect(isCustomId("")).toBe(false);
+  });
+});
+
+describe("nextId", () => {
+  it("starts at one when nothing is taken", () => {
+    expect(nextId("section", [])).toBe("section-1");
+  });
+
+  it("skips taken ids", () => {
+    expect(nextId("section", ["section-1", "section-2"])).toBe("section-3");
+  });
+
+  it("ignores gaps left by unrelated prefixes", () => {
+    expect(nextId("item", ["section-1", "item-1"])).toBe("item-2");
+  });
+});
+
+describe("layoutForTemplate", () => {
+  it("adopts the template's default columns", () => {
+    const resume = loadFixture();
+
+    const layout = layoutForTemplate(resume, SIDEBAR_TEMPLATE);
+
+    expect(layout).toHaveLength(1);
+    expect(layout[0]).toHaveLength(2);
+    expect(layout[0][0][0]).toBe("summary");
+    expect(layout[0][1]).toEqual(["profiles", "skills", "interests", "languages"]);
+  });
+
+  it("preserves every custom section across single -> sidebar -> single", () => {
+    const resume = loadFixture();
+    const customIds = Object.keys(resume.sections.custom);
+
+    const single = layoutForTemplate(resume, SINGLE_TEMPLATE);
+    resume.metadata.layout = single;
+    const sidebar = layoutForTemplate(resume, SIDEBAR_TEMPLATE);
+    resume.metadata.layout = sidebar;
+    const backToSingle = layoutForTemplate(resume, SINGLE_TEMPLATE);
+
+    for (const layout of [single, sidebar, backToSingle]) {
+      for (const id of customIds) {
+        expect(layout.flat(2)).toContain(id);
+      }
+    }
+    expect(single[0]).toHaveLength(1);
+    expect(backToSingle[0]).toHaveLength(1);
+  });
+
+  it("re-places custom sections the template defaults never mention", () => {
+    const resume = loadFixture();
+    const withoutSentinel: TemplateLayout = {
+      ...SIDEBAR_TEMPLATE,
+      defaultColumns: [
+        SIDEBAR_TEMPLATE.defaultColumns[0].filter((id) => id !== CUSTOM_SECTION_SENTINEL),
+        SIDEBAR_TEMPLATE.defaultColumns[1],
+      ],
+    };
+
+    const layout = layoutForTemplate(resume, withoutSentinel);
+
+    expect(layout[0][0]).toContain("speaking");
+    expect(layout[0][0]).toContain("advisory");
+  });
+
+  it("does not mutate the resume", () => {
+    const resume = loadFixture();
+    const before = JSON.stringify(resume.metadata.layout);
+
+    layoutForTemplate(resume, SINGLE_TEMPLATE);
+
+    expect(JSON.stringify(resume.metadata.layout)).toBe(before);
+  });
+});
+
+describe("emptyItemFor", () => {
+  it("shapes an experience item", () => {
+    expect(emptyItemFor("experience")).toEqual({
+      id: "",
+      visible: true,
+      company: "",
+      position: "",
+      location: "",
+      date: "",
+      summary: "",
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("shapes an education item", () => {
+    expect(emptyItemFor("education")).toEqual({
+      id: "",
+      visible: true,
+      institution: "",
+      area: "",
+      studyType: "",
+      date: "",
+      score: "",
+      summary: "",
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("shapes a skill item", () => {
+    expect(emptyItemFor("skills")).toEqual({
+      id: "",
+      visible: true,
+      name: "",
+      description: "",
+      level: 0,
+      keywords: [],
+    });
+  });
+
+  it("shapes a project item", () => {
+    expect(emptyItemFor("projects")).toEqual({
+      id: "",
+      visible: true,
+      name: "",
+      description: "",
+      date: "",
+      summary: "",
+      keywords: [],
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("shapes a profile item", () => {
+    expect(emptyItemFor("profiles")).toEqual({
+      id: "",
+      visible: true,
+      network: "",
+      username: "",
+      icon: "",
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("shapes an award item", () => {
+    expect(emptyItemFor("awards")).toEqual({
+      id: "",
+      visible: true,
+      title: "",
+      awarder: "",
+      date: "",
+      summary: "",
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("shapes a certification item", () => {
+    expect(emptyItemFor("certifications")).toEqual({
+      id: "",
+      visible: true,
+      name: "",
+      issuer: "",
+      date: "",
+      summary: "",
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("shapes a publication item", () => {
+    expect(emptyItemFor("publications")).toEqual({
+      id: "",
+      visible: true,
+      name: "",
+      publisher: "",
+      date: "",
+      summary: "",
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("shapes a language item", () => {
+    expect(emptyItemFor("languages")).toEqual({
+      id: "",
+      visible: true,
+      name: "",
+      description: "",
+      level: 0,
+    });
+  });
+
+  it("shapes an interest item", () => {
+    expect(emptyItemFor("interests")).toEqual({
+      id: "",
+      visible: true,
+      name: "",
+      keywords: [],
+    });
+  });
+
+  it("shapes a volunteer item", () => {
+    expect(emptyItemFor("volunteer")).toEqual({
+      id: "",
+      visible: true,
+      organization: "",
+      position: "",
+      location: "",
+      date: "",
+      summary: "",
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("shapes a reference item", () => {
+    expect(emptyItemFor("references")).toEqual({
+      id: "",
+      visible: true,
+      name: "",
+      description: "",
+      summary: "",
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("shapes a custom item", () => {
+    expect(emptyItemFor("speaking")).toEqual({
+      id: "",
+      visible: true,
+      name: "",
+      description: "",
+      date: "",
+      location: "",
+      summary: "",
+      keywords: [],
+      url: { label: "", href: "" },
+    });
+  });
+
+  it("returns null for sections that hold rich text rather than items", () => {
+    expect(emptyItemFor("summary")).toBeNull();
+    expect(emptyItemFor("coverLetter")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -228,6 +228,15 @@ const PROPORTIONAL_TEMPLATE: TemplateLayout = {
   sidebarWidth: null,
 };
 
+/** Mirrors `leafish`: a full-width header band above equal (1fr, 1fr) columns. */
+const HEADER_SPLIT_TEMPLATE: TemplateLayout = {
+  ...SIDEBAR_TEMPLATE,
+  layoutMode: "header-split",
+  headerStyle: "banner",
+  contactIn: "banner",
+  sidebarWidth: null,
+};
+
 describe("FIXED_SECTION_IDS / SECTION_LABELS", () => {
   it("covers every fixed section exactly once", () => {
     expect(new Set(FIXED_SECTION_IDS).size).toBe(FIXED_SECTION_IDS.length);
@@ -379,6 +388,17 @@ describe("layoutColumns", () => {
 
   it("gives a sidebar template its second column even on a one-column page", () => {
     expect(layoutColumns([["summary"]], SIDEBAR_TEMPLATE)).toHaveLength(2);
+  });
+
+  it("splits a header-split template evenly, ignoring any sidebar width", () => {
+    const columns = layoutColumns([["summary"], ["profiles"]], {
+      ...HEADER_SPLIT_TEMPLATE,
+      sidebarWidth: 180,
+    });
+
+    expect(columns).toHaveLength(2);
+    expect(columns.map((column) => column.width)).toEqual([0.5, 0.5]);
+    expect(columns.map((column) => column.order)).toEqual([0, 1]);
   });
 
   it("shares width evenly when a page carries more columns than the mode implies", () => {
@@ -704,6 +724,10 @@ describe("emptyItemFor", () => {
       keywords: [],
       url: { label: "", href: "" },
     });
+  });
+
+  it("shapes an unknown id as a custom item", () => {
+    expect(emptyItemFor("not-a-section")).toEqual(emptyItemFor("speaking"));
   });
 
   it("returns null for sections that hold rich text rather than items", () => {

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -296,6 +296,31 @@ describe("layoutPages", () => {
     expect(pages[0][0]).toContain("languages");
   });
 
+  it("falls back to the template defaults when the stored layout holds only empty columns", () => {
+    const resume = loadFixture();
+    resume.metadata.layout = [[[], []]];
+
+    const pages = layoutPages(resume, SIDEBAR_TEMPLATE);
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0][0][0]).toBe("summary");
+    expect(pages[0][1][0]).toBe("profiles");
+  });
+
+  it("expands the custom sentinel only once", () => {
+    const resume = loadFixture();
+    resume.metadata.layout = [
+      [
+        ["experience", CUSTOM_SECTION_SENTINEL],
+        [CUSTOM_SECTION_SENTINEL, "skills"],
+      ],
+    ];
+
+    expect(layoutPages(resume, SIDEBAR_TEMPLATE)).toEqual([
+      [["experience", "speaking", "advisory"], ["skills"]],
+    ]);
+  });
+
   it("keeps only the first occurrence of a repeated section id", () => {
     const resume = loadFixture();
     resume.metadata.layout = [[["experience", "skills"], ["experience"]]];
@@ -340,6 +365,13 @@ describe("renderPages", () => {
     expect(renderPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
   });
 
+  it("keeps a column emptied by filtering so column indices stay stable", () => {
+    const resume = loadFixture();
+    resume.metadata.layout = [[["experience"], ["advisory"]]];
+
+    expect(renderPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"], []]]);
+  });
+
   it("removes a page left empty by filtering", () => {
     const resume = loadFixture();
     resume.metadata.layout = [[["experience"]], [["references", "advisory"]]];
@@ -371,11 +403,29 @@ describe("layoutColumns", () => {
     expect(columns).toHaveLength(2);
     expect(columns[1].role).toBe("sidebar");
     // 180pt of a nominal A4 content width (595.28pt - 2 * 18pt).
-    expect(columns[1].width).toBeCloseTo(0.3218, 4);
+    expect(columns[1].width).toBeCloseTo(180 / (595.28 - 2 * 18), 10);
     expect(columns[0].width).toBeCloseTo(1 - columns[1].width, 10);
     // A left sidebar paints before the main column.
     expect(columns[0].order).toBe(1);
     expect(columns[1].order).toBe(0);
+  });
+
+  it("clamps a sidebar wider than half the content width", () => {
+    const columns = layoutColumns([["summary"], ["profiles"]], {
+      ...SIDEBAR_TEMPLATE,
+      sidebarWidth: 500,
+    });
+
+    expect(columns[1].width).toBeCloseTo(0.5, 10);
+  });
+
+  it("clamps a sidebar narrower than a tenth of the content width", () => {
+    const columns = layoutColumns([["summary"], ["profiles"]], {
+      ...SIDEBAR_TEMPLATE,
+      sidebarWidth: 10,
+    });
+
+    expect(columns[1].width).toBeCloseTo(0.1, 10);
   });
 
   it("uses the proportional default when the template has no fixed sidebar", () => {
@@ -560,13 +610,25 @@ describe("layoutForTemplate", () => {
     expect(layout[0][0]).toContain("advisory");
   });
 
-  it("does not mutate the resume", () => {
+  it("preserves a placed fixed section the template defaults omit", () => {
+    const resume = loadFixture();
+    // No template lists `coverLetter` in its default columns.
+    resume.metadata.layout = [[["coverLetter", "experience"], []]];
+
+    const layout = layoutForTemplate(resume, SIDEBAR_TEMPLATE);
+
+    expect(layout.flat(2)).toContain("coverLetter");
+  });
+
+  it("does not mutate the resume or the template layout", () => {
     const resume = loadFixture();
     const before = JSON.stringify(resume.metadata.layout);
+    const templateBefore = JSON.stringify(SINGLE_TEMPLATE.defaultColumns);
 
     layoutForTemplate(resume, SINGLE_TEMPLATE);
 
     expect(JSON.stringify(resume.metadata.layout)).toBe(before);
+    expect(JSON.stringify(SINGLE_TEMPLATE.defaultColumns)).toBe(templateBefore);
   });
 });
 

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -418,9 +418,11 @@ export function nextId(prefix: string, existing: Iterable<string>): string {
 }
 
 /**
- * A blank item shaped for `sectionId`, or `null` for sections that hold rich
- * text rather than items (`summary`, `coverLetter`) and for ids that address no
- * item-bearing section.
+ * A blank item shaped for `sectionId`, or `null` for the fixed sections that
+ * hold rich text rather than items (`summary`, `coverLetter`).
+ *
+ * Any id that is not a fixed section is treated as a custom section id — same
+ * rule as {@link isCustomId} — and yields a blank {@link CustomItem}.
  *
  * The item's `id` is left empty on purpose: id generation is not pure, so the
  * caller assigns one (via {@link nextId} or `generateId`) before storing it.

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -13,7 +13,7 @@
  * breaks.
  */
 
-import { FIXED_LAYOUT_SECTION_KEYS, isHtmlEmpty } from "../stores/resume";
+import { FIXED_LAYOUT_SECTION_KEYS, isHtmlEmpty } from "./resumeSections";
 import { createEmptyUrl } from "../wasm/types";
 import type {
   Award,
@@ -38,7 +38,7 @@ export type FixedSectionId = "summary" | "coverLetter" | (typeof FIXED_LAYOUT_SE
 /**
  * Canonical fixed-section ids, in layout order.
  *
- * Derived from `FIXED_LAYOUT_SECTION_KEYS` in `stores/resume` — the single
+ * Derived from `FIXED_LAYOUT_SECTION_KEYS` in `lib/resumeSections` — the single
  * source of truth for item-bearing sections — plus the two rich-text sections
  * that carry content rather than items.
  */
@@ -379,8 +379,12 @@ export function findSectionPlacement(
 /**
  * A fresh `metadata.layout` for a template switch.
  *
- * Adopts the template's default columns and re-places any custom section the
- * defaults do not mention, so switching templates never silently drops one.
+ * Adopts the template's default columns and re-places anything the defaults do
+ * not mention — custom sections, and fixed sections such as `coverLetter` that
+ * no template lists — so switching templates never silently drops a section.
+ * Existing pagination is deliberately not preserved: the new template's page-0
+ * arrangement wins, and everything carried over lands on it.
+ *
  * Returns the value to hand to `resumeStore.updateLayout`; nothing is mutated.
  */
 export function layoutForTemplate(
@@ -393,7 +397,13 @@ export function layoutForTemplate(
   const columns = materializeColumns([seed], resume)[0];
 
   const placed = new Set(columns.flat());
-  const missing = customSectionIds(resume).filter((id) => !placed.has(id));
+  const customIds = customSectionIds(resume);
+  const known = new Set<string>([...FIXED_SECTION_IDS, ...customIds]);
+  // Everything the previous layout carried, plus every custom section, minus
+  // whatever the new defaults already place. `coverLetter` is the fixed section
+  // this saves: no template lists it in `defaultColumns`.
+  const carried = new Set<string>([...(resume.metadata?.layout ?? []).flat(2), ...customIds]);
+  const missing = [...carried].filter((id) => known.has(id) && !placed.has(id));
   if (missing.length > 0) {
     if (columns.length === 0) {
       columns.push([...missing]);

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -1,0 +1,560 @@
+/**
+ * Document-editor layout model.
+ *
+ * Pure, synchronous helpers that turn a `ResumeData` plus a template's layout
+ * metadata into the concrete page/column structure the document editor draws.
+ * Nothing here reads a store, touches the DOM, or performs I/O: callers read
+ * reactive values and pass them in, and callers own every mutation (this module
+ * only computes what the next `metadata.layout` *should* be — the write goes
+ * through `resumeStore.updateLayout`).
+ *
+ * `metadata.layout` is `string[][][]`: pages -> columns -> section ids. Section
+ * placement is the only pagination mechanism; there are no item-level page
+ * breaks.
+ */
+
+import { FIXED_LAYOUT_SECTION_KEYS, isHtmlEmpty } from "../stores/resume";
+import { createEmptyUrl } from "../wasm/types";
+import type {
+  Award,
+  Certification,
+  CustomItem,
+  Education,
+  Experience,
+  Interest,
+  Language,
+  Profile,
+  Project,
+  Publication,
+  Reference,
+  ResumeData,
+  Skill,
+  Volunteer,
+} from "../wasm/types";
+
+/** A fixed (non-custom) section id that may appear in `metadata.layout`. */
+export type FixedSectionId = "summary" | "coverLetter" | (typeof FIXED_LAYOUT_SECTION_KEYS)[number];
+
+/**
+ * Canonical fixed-section ids, in layout order.
+ *
+ * Derived from `FIXED_LAYOUT_SECTION_KEYS` in `stores/resume` — the single
+ * source of truth for item-bearing sections — plus the two rich-text sections
+ * that carry content rather than items.
+ */
+export const FIXED_SECTION_IDS: readonly FixedSectionId[] = [
+  "summary",
+  "coverLetter",
+  ...FIXED_LAYOUT_SECTION_KEYS,
+];
+
+const FIXED_SECTION_ID_SET: ReadonlySet<string> = new Set<string>(FIXED_SECTION_IDS);
+
+/** Display labels for the fixed sections, used when a section has no name. */
+export const SECTION_LABELS: Readonly<Record<FixedSectionId, string>> = {
+  summary: "Summary",
+  coverLetter: "Cover Letter",
+  experience: "Experience",
+  education: "Education",
+  skills: "Skills",
+  projects: "Projects",
+  profiles: "Profiles",
+  awards: "Awards",
+  certifications: "Certifications",
+  publications: "Publications",
+  languages: "Languages",
+  interests: "Interests",
+  volunteer: "Volunteer",
+  references: "References",
+};
+
+/** Fallback title for a custom section that has no name yet. */
+const UNTITLED_CUSTOM_SECTION = "Untitled";
+
+/**
+ * Placeholder id that stands for "every custom section, in order".
+ *
+ * Templates emit it in their default columns (`main_with_custom()` in
+ * `crates/render/src/typst_engine/template_layout.rs`) because they cannot know
+ * a resume's custom section ids; it is expanded on the way into a page model.
+ */
+export const CUSTOM_SECTION_SENTINEL = "custom";
+
+/** Column arrangement of a template's page. */
+export type TemplateLayoutMode = "single" | "sidebar-left" | "sidebar-right" | "header-split";
+
+/** Presentation of a template's name/headline block. */
+export type TemplateHeaderStyle = "left" | "center" | "banner" | "boxed" | "sidebar";
+
+/** Where a template prints the contact details. */
+export type TemplateContactIn = "sidebar" | "header" | "banner";
+
+/**
+ * Structural layout metadata for a template, as served by `GET /api/templates`
+ * (`LayoutInfo` in `crates/server/src/dto.rs`).
+ *
+ * Always injected by the caller — this module never fetches it.
+ */
+export interface TemplateLayout {
+  /** Column arrangement of the page. */
+  layoutMode: TemplateLayoutMode;
+  /**
+   * Page-0 section ids per column as `[main, sidebar]`, used when the resume
+   * carries no explicit layout. Single-column templates leave the sidebar slot
+   * empty. May contain {@link CUSTOM_SECTION_SENTINEL}.
+   */
+  defaultColumns: string[][];
+  /** Presentation of the name/headline block. */
+  headerStyle: TemplateHeaderStyle;
+  /** Placement of the contact details. */
+  contactIn: TemplateContactIn;
+  /**
+   * Fixed sidebar width in typographic points, or `null` when the split is
+   * proportional or the template has no sidebar.
+   */
+  sidebarWidth: number | null;
+}
+
+/** Where a section sits inside a `metadata.layout` array. */
+export interface SectionPlacement {
+  /** Index of the page. */
+  page: number;
+  /** Index of the column within that page. */
+  column: number;
+  /** Index of the section id within that column. */
+  index: number;
+}
+
+/** Role a column plays on the sheet. Column 0 is always the main column. */
+export type ColumnRole = "main" | "sidebar";
+
+/** Geometry of one column on a rendered page. */
+export interface LayoutColumn {
+  /** Index into the page's column array. */
+  index: number;
+  /** Whether this column is the main content column or the sidebar. */
+  role: ColumnRole;
+  /** Relative width; the widths of a page's columns sum to 1. */
+  width: number;
+  /** Visual left-to-right order, which differs from `index` for left sidebars. */
+  order: number;
+}
+
+/** Any item type a section can hold. */
+export type SectionItem =
+  | Award
+  | Certification
+  | CustomItem
+  | Education
+  | Experience
+  | Interest
+  | Language
+  | Profile
+  | Project
+  | Publication
+  | Reference
+  | Skill
+  | Volunteer;
+
+/**
+ * Nominal sheet geometry used to turn a template's fixed sidebar width into a
+ * relative width. Mirrors `content-width` in `templates/_common.typ` and the
+ * ratio math in `components/templates/ThemeEditor.tsx`; keep the three in step.
+ */
+const A4_PAPER_WIDTH_PT = 595.28;
+const DEFAULT_PAGE_MARGIN_PT = 18;
+const NOMINAL_CONTENT_WIDTH_PT = A4_PAPER_WIDTH_PT - 2 * DEFAULT_PAGE_MARGIN_PT;
+
+/** Sidebar share used when a template's split is proportional rather than fixed. */
+const DEFAULT_SIDEBAR_RATIO = 1 / 3;
+const MIN_SIDEBAR_RATIO = 0.1;
+const MAX_SIDEBAR_RATIO = 0.5;
+
+function clampSidebarRatio(ratio: number): number {
+  return Math.min(MAX_SIDEBAR_RATIO, Math.max(MIN_SIDEBAR_RATIO, ratio));
+}
+
+/**
+ * Whether an id addresses `sections.custom` rather than a fixed section.
+ *
+ * True for {@link CUSTOM_SECTION_SENTINEL} as well, which addresses every
+ * custom section at once.
+ */
+export function isCustomId(id: string): boolean {
+  return id !== "" && !FIXED_SECTION_ID_SET.has(id);
+}
+
+function customSectionIds(resume: ResumeData): string[] {
+  return Object.keys(resume.sections.custom ?? {});
+}
+
+function fixedSection(
+  resume: ResumeData,
+  id: string,
+): { name: string; visible: boolean } | undefined {
+  if (!FIXED_SECTION_ID_SET.has(id)) return undefined;
+  return resume.sections[id as FixedSectionId];
+}
+
+/**
+ * Whether a section is switched on. Unknown ids are not visible.
+ */
+export function sectionVisible(resume: ResumeData, sectionId: string): boolean {
+  if (isCustomId(sectionId)) {
+    return resume.sections.custom?.[sectionId]?.visible === true;
+  }
+  return fixedSection(resume, sectionId)?.visible === true;
+}
+
+/**
+ * Display title for a section: its own name, falling back to the canonical
+ * label. Unknown ids yield an empty string.
+ */
+export function sectionTitle(resume: ResumeData, sectionId: string): string {
+  if (isCustomId(sectionId)) {
+    const section = resume.sections.custom?.[sectionId];
+    if (!section) return "";
+    return section.name.trim() === "" ? UNTITLED_CUSTOM_SECTION : section.name;
+  }
+  const section = fixedSection(resume, sectionId);
+  if (!section) return "";
+  return section.name.trim() === "" ? SECTION_LABELS[sectionId as FixedSectionId] : section.name;
+}
+
+/** Whether a section holds anything worth drawing chrome for. */
+function sectionHasContent(resume: ResumeData, sectionId: string): boolean {
+  if (isCustomId(sectionId)) {
+    const section = resume.sections.custom?.[sectionId];
+    return section !== undefined && section.items.some((item) => item.visible);
+  }
+  if (sectionId === "summary") {
+    return !isHtmlEmpty(resume.sections.summary?.content ?? "");
+  }
+  if (sectionId === "coverLetter") {
+    return !isHtmlEmpty(resume.sections.coverLetter?.content ?? "");
+  }
+  if (!FIXED_SECTION_ID_SET.has(sectionId)) return false;
+  // The item types differ per section; only `visible` matters here, so read the
+  // section through the one shape every item-bearing section shares.
+  const section = resume.sections[sectionId as FixedSectionId] as
+    | { items?: { visible: boolean }[] }
+    | undefined;
+  return section?.items?.some((item) => item.visible) === true;
+}
+
+function dropTrailingEmptyColumns(columns: string[][]): string[][] {
+  const trimmed = [...columns];
+  while (trimmed.length > 1 && trimmed[trimmed.length - 1].length === 0) {
+    trimmed.pop();
+  }
+  return trimmed;
+}
+
+/**
+ * Expand {@link CUSTOM_SECTION_SENTINEL}, drop ids that address no section, and
+ * drop repeats — the first occurrence of an id wins.
+ */
+function materializeColumns(
+  pages: readonly (readonly string[][])[],
+  resume: ResumeData,
+): string[][][] {
+  const customIds = customSectionIds(resume);
+  const knownIds = new Set<string>([...FIXED_SECTION_IDS, ...customIds]);
+  const placed = new Set<string>();
+  let sentinelExpanded = false;
+
+  return pages.map((page) =>
+    page.map((column) => {
+      const materialized: string[] = [];
+      for (const id of column) {
+        let candidates: readonly string[];
+        if (id === CUSTOM_SECTION_SENTINEL) {
+          candidates = sentinelExpanded ? [] : customIds;
+          sentinelExpanded = true;
+        } else {
+          candidates = [id];
+        }
+        for (const candidate of candidates) {
+          if (!knownIds.has(candidate) || placed.has(candidate)) continue;
+          placed.add(candidate);
+          materialized.push(candidate);
+        }
+      }
+      return materialized;
+    }),
+  );
+}
+
+function hasAnySection(layout: readonly (readonly string[][])[]): boolean {
+  return layout.some((page) => page.some((column) => column.length > 0));
+}
+
+/**
+ * The resume's page/column section-id structure.
+ *
+ * Seeded from `metadata.layout`, falling back to the template's default columns
+ * when that layout is absent or empty. The custom-section sentinel is expanded,
+ * ids that address no section are dropped, and a repeated id is kept only at
+ * its first position.
+ */
+export function layoutPages(resume: ResumeData, templateLayout: TemplateLayout): string[][][] {
+  const stored = resume.metadata?.layout;
+  const source =
+    Array.isArray(stored) && hasAnySection(stored)
+      ? stored
+      : [dropTrailingEmptyColumns(templateLayout.defaultColumns)];
+  return materializeColumns(source, resume);
+}
+
+/**
+ * {@link layoutPages} reduced to what actually renders: hidden sections and
+ * sections with no content are dropped, and any page left entirely empty is
+ * removed. Empty columns are kept so column indices stay meaningful.
+ */
+export function renderPages(resume: ResumeData, templateLayout: TemplateLayout): string[][][] {
+  return layoutPages(resume, templateLayout)
+    .map((page) =>
+      page.map((column) =>
+        column.filter((id) => sectionVisible(resume, id) && sectionHasContent(resume, id)),
+      ),
+    )
+    .filter((page) => page.some((column) => column.length > 0));
+}
+
+/**
+ * Column geometry for one page of a layout.
+ *
+ * The template's mode sets the baseline column count (1 for `single`, 2
+ * otherwise); a page that carries more columns than the mode implies keeps all
+ * of them, shared out evenly.
+ */
+export function layoutColumns(
+  page: readonly string[][],
+  templateLayout: TemplateLayout,
+): LayoutColumn[] {
+  const modeColumns = templateLayout.layoutMode === "single" ? 1 : 2;
+  const count = Math.max(modeColumns, page.length);
+
+  if (count === 1) {
+    return [{ index: 0, role: "main", width: 1, order: 0 }];
+  }
+
+  if (count > modeColumns || templateLayout.layoutMode === "header-split") {
+    return Array.from({ length: count }, (_, index) => ({
+      index,
+      role: index === 0 ? ("main" as const) : ("sidebar" as const),
+      width: 1 / count,
+      order: index,
+    }));
+  }
+
+  const sidebarWidth = templateLayout.sidebarWidth;
+  const sidebarRatio =
+    sidebarWidth === null
+      ? DEFAULT_SIDEBAR_RATIO
+      : clampSidebarRatio(sidebarWidth / NOMINAL_CONTENT_WIDTH_PT);
+  const sidebarFirst = templateLayout.layoutMode === "sidebar-left";
+
+  return [
+    { index: 0, role: "main", width: 1 - sidebarRatio, order: sidebarFirst ? 1 : 0 },
+    { index: 1, role: "sidebar", width: sidebarRatio, order: sidebarFirst ? 0 : 1 },
+  ];
+}
+
+/** Where `sectionId` sits in `layout`, or `null` when it is not placed. */
+export function findSectionPlacement(
+  layout: readonly (readonly string[][])[],
+  sectionId: string,
+): SectionPlacement | null {
+  for (let page = 0; page < layout.length; page++) {
+    const columns = layout[page];
+    for (let column = 0; column < columns.length; column++) {
+      const index = columns[column].indexOf(sectionId);
+      if (index !== -1) return { page, column, index };
+    }
+  }
+  return null;
+}
+
+/**
+ * A fresh `metadata.layout` for a template switch.
+ *
+ * Adopts the template's default columns and re-places any custom section the
+ * defaults do not mention, so switching templates never silently drops one.
+ * Returns the value to hand to `resumeStore.updateLayout`; nothing is mutated.
+ */
+export function layoutForTemplate(
+  resume: ResumeData,
+  templateLayout: TemplateLayout,
+): string[][][] {
+  const defaults = templateLayout.defaultColumns;
+  const seed =
+    templateLayout.layoutMode === "single" ? [defaults.flat()] : dropTrailingEmptyColumns(defaults);
+  const columns = materializeColumns([seed], resume)[0];
+
+  const placed = new Set(columns.flat());
+  const missing = customSectionIds(resume).filter((id) => !placed.has(id));
+  if (missing.length > 0) {
+    if (columns.length === 0) {
+      columns.push([...missing]);
+    } else {
+      columns[0] = [...columns[0], ...missing];
+    }
+  }
+
+  return [columns];
+}
+
+/**
+ * A collision-free id of the form `<prefix>-<n>`, given the ids already taken.
+ */
+export function nextId(prefix: string, existing: Iterable<string>): string {
+  const taken = new Set(existing);
+  let counter = 1;
+  while (taken.has(`${prefix}-${counter}`)) {
+    counter += 1;
+  }
+  return `${prefix}-${counter}`;
+}
+
+/**
+ * A blank item shaped for `sectionId`, or `null` for sections that hold rich
+ * text rather than items (`summary`, `coverLetter`) and for ids that address no
+ * item-bearing section.
+ *
+ * The item's `id` is left empty on purpose: id generation is not pure, so the
+ * caller assigns one (via {@link nextId} or `generateId`) before storing it.
+ */
+export function emptyItemFor(sectionId: string): SectionItem | null {
+  if (isCustomId(sectionId)) {
+    return {
+      id: "",
+      visible: true,
+      name: "",
+      description: "",
+      date: "",
+      location: "",
+      summary: "",
+      keywords: [],
+      url: createEmptyUrl(),
+    } satisfies CustomItem;
+  }
+
+  switch (sectionId) {
+    case "experience":
+      return {
+        id: "",
+        visible: true,
+        company: "",
+        position: "",
+        location: "",
+        date: "",
+        summary: "",
+        url: createEmptyUrl(),
+      } satisfies Experience;
+    case "education":
+      return {
+        id: "",
+        visible: true,
+        institution: "",
+        area: "",
+        studyType: "",
+        date: "",
+        score: "",
+        summary: "",
+        url: createEmptyUrl(),
+      } satisfies Education;
+    case "skills":
+      return {
+        id: "",
+        visible: true,
+        name: "",
+        description: "",
+        level: 0,
+        keywords: [],
+      } satisfies Skill;
+    case "projects":
+      return {
+        id: "",
+        visible: true,
+        name: "",
+        description: "",
+        date: "",
+        summary: "",
+        keywords: [],
+        url: createEmptyUrl(),
+      } satisfies Project;
+    case "profiles":
+      return {
+        id: "",
+        visible: true,
+        network: "",
+        username: "",
+        icon: "",
+        url: createEmptyUrl(),
+      } satisfies Profile;
+    case "awards":
+      return {
+        id: "",
+        visible: true,
+        title: "",
+        awarder: "",
+        date: "",
+        summary: "",
+        url: createEmptyUrl(),
+      } satisfies Award;
+    case "certifications":
+      return {
+        id: "",
+        visible: true,
+        name: "",
+        issuer: "",
+        date: "",
+        summary: "",
+        url: createEmptyUrl(),
+      } satisfies Certification;
+    case "publications":
+      return {
+        id: "",
+        visible: true,
+        name: "",
+        publisher: "",
+        date: "",
+        summary: "",
+        url: createEmptyUrl(),
+      } satisfies Publication;
+    case "languages":
+      return {
+        id: "",
+        visible: true,
+        name: "",
+        description: "",
+        level: 0,
+      } satisfies Language;
+    case "interests":
+      return { id: "", visible: true, name: "", keywords: [] } satisfies Interest;
+    case "volunteer":
+      return {
+        id: "",
+        visible: true,
+        organization: "",
+        position: "",
+        location: "",
+        date: "",
+        summary: "",
+        url: createEmptyUrl(),
+      } satisfies Volunteer;
+    case "references":
+      return {
+        id: "",
+        visible: true,
+        name: "",
+        description: "",
+        summary: "",
+        url: createEmptyUrl(),
+      } satisfies Reference;
+    default:
+      // `summary` and `coverLetter` hold rich text rather than items.
+      return null;
+  }
+}

--- a/apps/web/src/lib/resumeSections.ts
+++ b/apps/web/src/lib/resumeSections.ts
@@ -1,0 +1,44 @@
+/**
+ * Resume section primitives shared by the store and the pure layout model.
+ *
+ * These live outside `stores/resume` so that store-agnostic modules can use
+ * them without pulling in the Solid store, the wasm bindings, or the UI
+ * toaster that the store module constructs at import time.
+ */
+
+import type { Sections } from "../wasm/types";
+
+/**
+ * The item-bearing fixed sections, in canonical layout order.
+ *
+ * Excludes `summary` and `coverLetter` (rich text rather than items) and
+ * `custom` (keyed by the resume's own ids).
+ */
+export const FIXED_LAYOUT_SECTION_KEYS: (keyof Omit<
+  Sections,
+  "summary" | "custom" | "coverLetter"
+>)[] = [
+  "experience",
+  "education",
+  "skills",
+  "projects",
+  "profiles",
+  "awards",
+  "certifications",
+  "publications",
+  "languages",
+  "interests",
+  "volunteer",
+  "references",
+];
+
+/** Check if an HTML string is effectively empty (plain empty or TipTap empty editor). */
+export function isHtmlEmpty(html: string): boolean {
+  const trimmed = html.trim();
+  if (trimmed === "") return true;
+  // Normalize common HTML whitespace entities to regular spaces.
+  const normalized = trimmed.replace(/&nbsp;|&#160;|&#xa0;|&ensp;|&#8194;|&emsp;|&#8195;/gi, " ");
+  // Strip all HTML tags and check if any visible text remains.
+  const textContent = normalized.replace(/<[^>]*>/g, "").trim();
+  return textContent === "";
+}

--- a/apps/web/src/stores/__tests__/resume.test.ts
+++ b/apps/web/src/stores/__tests__/resume.test.ts
@@ -1,8 +1,8 @@
 import { createRoot } from "solid-js";
 import { createDefaultResume } from "../../wasm/defaults";
 import type { ResumeData } from "../../wasm/types";
+import { FIXED_LAYOUT_SECTION_KEYS } from "../../lib/resumeSections";
 import {
-  FIXED_LAYOUT_SECTION_KEYS,
   isResumeEmpty,
   useResumeStore,
   ResumeNotFoundError,

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -26,6 +26,7 @@ import {
   saveCloudResume,
   showResumeVersionConflictToast,
 } from "./cloudStorage";
+import { FIXED_LAYOUT_SECTION_KEYS, isHtmlEmpty } from "../lib/resumeSections";
 import { setUndoRecorder, recordUndo } from "./editorUndo";
 import { saveSnapshot } from "./versionHistory";
 import {
@@ -92,23 +93,6 @@ export function isNotFoundError(error: unknown): boolean {
   return false;
 }
 
-export const FIXED_LAYOUT_SECTION_KEYS: (keyof Omit<
-  Sections,
-  "summary" | "custom" | "coverLetter"
->)[] = [
-  "experience",
-  "education",
-  "skills",
-  "projects",
-  "profiles",
-  "awards",
-  "certifications",
-  "publications",
-  "languages",
-  "interests",
-  "volunteer",
-  "references",
-];
 const FIXED_LAYOUT_SECTION_KEY_SET = new Set<string>([
   "summary",
   "coverLetter",
@@ -154,17 +138,6 @@ function materializeCustomLayoutSentinels(layout: string[][][], customIds: strin
   }
 
   return layoutIds;
-}
-
-/** Check if an HTML string is effectively empty (plain empty or TipTap empty editor). */
-export function isHtmlEmpty(html: string): boolean {
-  const trimmed = html.trim();
-  if (trimmed === "") return true;
-  // Normalize common HTML whitespace entities to regular spaces.
-  const normalized = trimmed.replace(/&nbsp;|&#160;|&#xa0;|&ensp;|&#8194;|&emsp;|&#8195;/gi, " ");
-  // Strip all HTML tags and check if any visible text remains.
-  const textContent = normalized.replace(/<[^>]*>/g, "").trim();
-  return textContent === "";
 }
 
 /**


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add the document-editor layout model
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds `apps/web/src/lib/docLayout.ts`, a pure, store-agnostic module that turns a
`ResumeData` plus a template's layout metadata into the concrete page/column
structure the document editor renders — the shared layout truth every later
slice of the document-editor epic builds on.

Every export is pure and synchronous: no store reads, no Solid reactivity, no
DOM, no fetching. The module owns no mutations; it computes what the next
`metadata.layout` *should* be and the caller hands that to
`resumeStore.updateLayout`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #726

## Details

Export contract:

- `FIXED_SECTION_IDS` / `SECTION_LABELS` — canonical fixed-section ids and
  labels, derived from `FIXED_LAYOUT_SECTION_KEYS` in `stores/resume` so there
  is no second, divergent list.
- `layoutPages` — pages → columns → section ids, seeded from `metadata.layout`
  and falling back to the template's `defaultColumns` when it is absent or
  empty. Expands the `custom` sentinel that templates emit, drops ids that
  address no section, and keeps only the first occurrence of a repeated id.
- `renderPages` — `layoutPages` minus hidden sections, minus sections with no
  content, minus pages left entirely empty. Empty columns survive so column
  indices stay meaningful.
- `layoutColumns` — column count, relative widths and paint order from
  `layoutMode` / `sidebarWidth`. A fixed sidebar width is converted against the
  same nominal A4 content width used by `templates/_common.typ` and
  `ThemeEditor.tsx`; proportional templates use the 1/3 default.
- `layoutForTemplate` — a fresh `metadata.layout` for a template switch that
  re-places any custom section the template defaults never mention, so none is
  silently dropped.
- `findSectionPlacement`, `sectionVisible`, `sectionTitle`, `isCustomId`,
  `nextId`, `emptyItemFor` — custom sections included throughout.

`TemplateLayout` mirrors the shape now served by `GET /api/templates`
(`LayoutInfo` in `crates/server/src/dto.rs`, landed in #737) and is always
injected as a parameter. Section-level placement stays the only pagination
mechanism — no item-level page breaks.

### Testing strategy

`apps/web/src/lib/__tests__/docLayout.test.ts` adds 50 Vitest cases, one block
per export, over the shared corpus `tests/fixtures/v3/doc-editor.json`. That
fixture is stored in the Reactive Resume v3 wire format, which Vitest cannot run
the Rust parser over, so the test carries a small adapter that mirrors the
parser (summary moves out of `basics`; custom items map `title`/`subtitle` onto
`name`/`description`).

Verified locally: `uv run lintro chk` clean, `cargo test --workspace` green, and
`bun run test` (67 files, 649 tests), `bun run lint`, `bun run typecheck` all
green in `apps/web`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document layout support for single-column, sidebar, proportional, and header-split templates.
  * Added automatic pagination, column sizing, section ordering, placement, visibility, and titles.
  * Added support for custom sections, generated identifiers, template switching, and blank section items.

* **Bug Fixes**
  * Improved handling of duplicate or unknown sections and removed empty or invalid content from layouts.

* **Tests**
  * Added comprehensive automated coverage for document layout behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->