### PR TITLE
feat(web): add click-to-edit and item dialogs to the document sheet

### DIFF
--- a/apps/web/src/components/builder/ImageUpload.tsx
+++ b/apps/web/src/components/builder/ImageUpload.tsx
@@ -5,6 +5,7 @@ import {
   expandShortHex,
   isHexColor,
   normalizeHexColor,
+  picturePreviewStyle,
   processImage,
   validateImageFile,
 } from "../../lib/imageUpload";
@@ -126,36 +127,8 @@ export function ImageUpload(props: ImageUploadProps) {
     });
   }
 
-  // Compute CSS for the preview image
-  const previewStyle = () => {
-    const size = props.picture.size || 64;
-    const br = props.picture.borderRadius;
-    const maxRadius = Math.round(size / 2);
-    const borderRadiusPx = Math.min(br, maxRadius);
-    const effects = props.picture.effects;
-    const borderWidth = effects.borderWidth ?? 2;
-    const borderColor = effects.borderColor || "var(--turbo-brand-primary)";
-    const shadowSize = effects.shadowSize || 0;
-    // Match the Typst PDF output: solid diagonal offset (dx = dy = size / 2), no blur.
-    const shadowOffset = shadowSize / 2;
-    const filters: string[] = [];
-    if (effects.grayscale) {
-      filters.push("grayscale(100%)");
-    }
-    return {
-      width: `${size}px`,
-      height: `${size}px`,
-      "border-radius": `${borderRadiusPx}px`,
-      filter: filters.length > 0 ? filters.join(" ") : undefined,
-      transform: effects.rotation ? `rotate(${effects.rotation}deg)` : undefined,
-      border:
-        effects.border && borderWidth > 0 ? `${borderWidth}px solid ${borderColor}` : undefined,
-      "box-shadow":
-        shadowSize > 0
-          ? `${shadowOffset}px ${shadowOffset}px 0 ${effects.shadowColor || "#00000040"}`
-          : undefined,
-    };
-  };
+  // Shared with the document editor's photo dialog so the previews agree.
+  const previewStyle = () => picturePreviewStyle(props.picture);
 
   return (
     <div class="space-y-4 pt-4 border-t border-border">

--- a/apps/web/src/components/builder/ImageUpload.tsx
+++ b/apps/web/src/components/builder/ImageUpload.tsx
@@ -1,120 +1,18 @@
 import { Show, createSignal } from "solid-js";
 import { Button, Switch, toast } from "../ui";
+import {
+  ACCEPTED_IMAGE_TYPES,
+  expandShortHex,
+  isHexColor,
+  normalizeHexColor,
+  processImage,
+  validateImageFile,
+} from "../../lib/imageUpload";
 import type { Picture } from "../../wasm/types";
 
 export interface ImageUploadProps {
   picture: Picture;
   onPictureChange: (picture: Picture) => void;
-}
-
-/** Resume photos display at ≤200px; keep the encoded asset compact. */
-const MAX_SIZE_PX = 512;
-const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
-const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
-/** Soft cap for the data URL stored in resume JSON (~300 KB payload). */
-const MAX_DATA_URL_CHARS = 400_000;
-
-const HEX_COLOR_REGEX = /^#(?:[0-9A-Fa-f]{3,4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
-const BARE_HEX_REGEX = /^(?:[0-9A-Fa-f]{3,4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
-
-/** Trim and prepend `#` when the value is bare 3/4/6/8-digit hex. */
-function normalizeHexColor(raw: string): string {
-  const trimmed = raw.trim();
-  return BARE_HEX_REGEX.test(trimmed) ? `#${trimmed}` : trimmed;
-}
-
-/** Expand #RGB / #RGBA shorthand to #RRGGBB / #RRGGBBAA (server validation only accepts long form). */
-function expandShortHex(color: string): string {
-  const digits = color.slice(1);
-  if (digits.length === 3 || digits.length === 4) {
-    return `#${digits
-      .split("")
-      .map((c) => c + c)
-      .join("")}`;
-  }
-  return color;
-}
-
-interface ProcessedImage {
-  dataUrl: string;
-  aspectRatio: number;
-}
-
-/**
- * Encode canvas to a data URL, preferring WebP and stepping quality down until
- * the result fits under {@link MAX_DATA_URL_CHARS}.
- */
-function encodeCanvasDataUrl(canvas: HTMLCanvasElement): string {
-  const qualities = [0.82, 0.7, 0.58, 0.45];
-  let best = "";
-  for (const quality of qualities) {
-    let dataUrl = canvas.toDataURL("image/webp", quality);
-    if (!dataUrl.startsWith("data:image/webp")) {
-      dataUrl = canvas.toDataURL("image/jpeg", quality);
-    }
-    best = dataUrl;
-    if (dataUrl.length <= MAX_DATA_URL_CHARS) {
-      return dataUrl;
-    }
-  }
-  return best;
-}
-
-/**
- * Resize an image file to fit within MAX_SIZE_PX x MAX_SIZE_PX,
- * then return a base64 data URL (WebP with JPEG fallback) and aspect ratio.
- */
-async function processImage(file: File): Promise<ProcessedImage> {
-  return new Promise((resolve, reject) => {
-    const url = URL.createObjectURL(file);
-    const img = new Image();
-    img.onload = () => {
-      URL.revokeObjectURL(url);
-      const canvas = document.createElement("canvas");
-
-      let { width, height } = img;
-      if (width > MAX_SIZE_PX || height > MAX_SIZE_PX) {
-        if (width > height) {
-          height = Math.max(1, Math.round((height * MAX_SIZE_PX) / width));
-          width = MAX_SIZE_PX;
-        } else {
-          width = Math.max(1, Math.round((width * MAX_SIZE_PX) / height));
-          height = MAX_SIZE_PX;
-        }
-      }
-
-      canvas.width = width;
-      canvas.height = height;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) {
-        reject(new Error("Could not get canvas context"));
-        return;
-      }
-      ctx.drawImage(img, 0, 0, width, height);
-
-      const dataUrl = encodeCanvasDataUrl(canvas);
-      if (dataUrl.length > MAX_DATA_URL_CHARS) {
-        reject(new Error("Image is still too large after compression. Try a smaller photo."));
-        return;
-      }
-      resolve({ dataUrl, aspectRatio: width / height });
-    };
-    img.onerror = () => {
-      URL.revokeObjectURL(url);
-      reject(new Error("Failed to load image"));
-    };
-    img.src = url;
-  });
-}
-
-function validateFile(file: File): string | null {
-  if (!ACCEPTED_TYPES.includes(file.type)) {
-    return "Please upload a JPG, PNG, or WebP image.";
-  }
-  if (file.size > MAX_FILE_SIZE) {
-    return "Image must be smaller than 5 MB.";
-  }
-  return null;
 }
 
 export function ImageUpload(props: ImageUploadProps) {
@@ -126,7 +24,7 @@ export function ImageUpload(props: ImageUploadProps) {
   const hasPhoto = () => props.picture.url !== "";
 
   async function handleFile(file: File) {
-    const error = validateFile(file);
+    const error = validateImageFile(file);
     if (error) {
       toast.error(error);
       return;
@@ -209,7 +107,7 @@ export function ImageUpload(props: ImageUploadProps) {
 
   function updateColorEffect(key: "borderColor" | "shadowColor", raw: string) {
     const normalized = normalizeHexColor(raw);
-    if (normalized === "" || HEX_COLOR_REGEX.test(normalized)) {
+    if (normalized === "" || isHexColor(normalized)) {
       updateEffect(key, expandShortHex(normalized));
     }
   }
@@ -266,7 +164,7 @@ export function ImageUpload(props: ImageUploadProps) {
       <input
         ref={(el) => (fileInputRef = el)}
         type="file"
-        accept={ACCEPTED_TYPES.join(",")}
+        accept={ACCEPTED_IMAGE_TYPES.join(",")}
         class="hidden"
         aria-label="Choose profile photo"
         onChange={handleInputChange}

--- a/apps/web/src/components/doc-editor/CustomSectionDialog.tsx
+++ b/apps/web/src/components/doc-editor/CustomSectionDialog.tsx
@@ -1,0 +1,66 @@
+/**
+ * Create a custom section, or rename an existing one.
+ *
+ * Creating goes through `addCustomSection`, which also places the new section
+ * in `metadata.layout` — that placement is part of the same store action, so
+ * creating a section stays one undo entry.
+ */
+
+import { createEffect, createSignal, type JSX } from "solid-js";
+import { Button, Input, Modal } from "../ui";
+import { addCustomSection, renameSection } from "./docEdits";
+
+export interface CustomSectionDialogProps {
+  open: boolean;
+  /** Id of the section being renamed. Absent when creating one. */
+  sectionId?: string;
+  /** Current name, when renaming. */
+  name?: string;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CustomSectionDialog(props: CustomSectionDialogProps): JSX.Element {
+  const [draft, setDraft] = createSignal("");
+
+  const isCreating = () => props.sectionId === undefined;
+
+  createEffect(() => {
+    if (!props.open) return;
+    setDraft(props.name ?? "");
+  });
+
+  function save(): void {
+    const name = draft().trim();
+    if (name === "") return;
+    if (isCreating()) {
+      addCustomSection(name);
+    } else {
+      renameSection(props.sectionId as string, name);
+    }
+    props.onOpenChange(false);
+  }
+
+  return (
+    <Modal
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      title={isCreating() ? "Add section" : "Rename section"}
+    >
+      <Input
+        label="Section name"
+        placeholder="Talks & Workshops"
+        value={draft()}
+        onInput={setDraft}
+      />
+
+      <div class="mt-6 flex justify-end gap-3">
+        <Button variant="ghost" onClick={() => props.onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button disabled={draft().trim() === ""} onClick={save}>
+          {isCreating() ? "Add section" : "Rename"}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/doc-editor/DocHeader.tsx
+++ b/apps/web/src/components/doc-editor/DocHeader.tsx
@@ -223,6 +223,7 @@ export function DocHeader(props: DocHeaderProps): JSX.Element {
             value={props.basics.name}
             label="Name"
             placeholder="Your name"
+            triggerId="doc-header-name"
             onCommit={(value) => updateBasicsField("name", value)}
           />
         </h2>
@@ -232,6 +233,7 @@ export function DocHeader(props: DocHeaderProps): JSX.Element {
             value={props.basics.headline}
             label="Headline"
             placeholder="Your headline"
+            triggerId="doc-header-headline"
             onCommit={(value) => updateBasicsField("headline", value)}
           />
         </p>
@@ -251,7 +253,12 @@ export function DocHeader(props: DocHeaderProps): JSX.Element {
                 <Show when={entry.label}>
                   <span class="doc-sheet__contact-label">{entry.label}: </span>
                 </Show>
-                <InlineText value={entry.value} label={entry.fieldLabel} onCommit={entry.commit} />
+                <InlineText
+                  value={entry.value}
+                  label={entry.fieldLabel}
+                  triggerId={`doc-header-${entry.key}`}
+                  onCommit={entry.commit}
+                />
               </li>
             )}
           </For>

--- a/apps/web/src/components/doc-editor/DocHeader.tsx
+++ b/apps/web/src/components/doc-editor/DocHeader.tsx
@@ -6,17 +6,31 @@
  * says where and how the name block is drawn (`banner`, `sidebar`, `boxed`,
  * `left`, `center`) and `contactIn` says which of those regions prints the
  * contact details. Both arrive as layout metadata from `GET /api/templates`.
+ *
+ * Everything the header draws is editable in place. The core contact fields
+ * (email, phone, location) are drawn even when empty, as muted placeholders, so
+ * a blank resume still offers somewhere to type; the personal URL and the
+ * resume's own custom fields appear only once they carry a value, because they
+ * are additions rather than expected parts of a document.
  */
 
-import { For, Show, type JSX } from "solid-js";
+import { For, Show, createSignal, type JSX } from "solid-js";
+import { InlineText } from "./InlineText";
+import { PhotoDialog } from "./PhotoDialog";
+import { updateBasicsField } from "./docEdits";
 import type { TemplateHeaderStyle } from "../../lib/docLayout";
-import type { Basics, Picture, Url } from "../../wasm/types";
+import type { Basics, CustomField, Picture, Url } from "../../wasm/types";
 
-/** One contact line: an optional label plus the value the template prints. */
+/** One contact line: an optional label, the value, and where it writes back. */
 interface ContactEntry {
   key: string;
   label?: string;
   value: string;
+  /** Field name announced by the inline editor. */
+  fieldLabel: string;
+  commit: (value: string) => void;
+  /** Whether the line is drawn even when the value is empty. */
+  alwaysShown?: boolean;
 }
 
 /**
@@ -38,20 +52,61 @@ function urlLabel(url: Url | undefined): string {
  * follow, as the templates that print them do.
  */
 function contactEntries(basics: Basics): ContactEntry[] {
-  const entries: ContactEntry[] = [];
-  if (basics.email.trim() !== "") entries.push({ key: "email", value: basics.email });
-  if (basics.phone.trim() !== "") entries.push({ key: "phone", value: basics.phone });
-  if (basics.location.trim() !== "") entries.push({ key: "location", value: basics.location });
+  const entries: ContactEntry[] = [
+    {
+      key: "email",
+      value: basics.email,
+      fieldLabel: "Email",
+      commit: (value) => updateBasicsField("email", value),
+      alwaysShown: true,
+    },
+    {
+      key: "phone",
+      value: basics.phone,
+      fieldLabel: "Phone",
+      commit: (value) => updateBasicsField("phone", value),
+      alwaysShown: true,
+    },
+    {
+      key: "location",
+      value: basics.location,
+      fieldLabel: "Location",
+      commit: (value) => updateBasicsField("location", value),
+      alwaysShown: true,
+    },
+  ];
 
   const url = urlLabel(basics.url);
-  if (url !== "") entries.push({ key: "url", value: url });
+  if (url !== "") {
+    // The sheet prints the label when there is one, so that is what an inline
+    // edit changes; with no label the href is what is on the page.
+    const hasLabel = (basics.url?.label ?? "").trim() !== "";
+    entries.push({
+      key: "url",
+      value: url,
+      fieldLabel: hasLabel ? "Website label" : "Website URL",
+      commit: (value) =>
+        updateBasicsField("url", { ...basics.url, [hasLabel ? "label" : "href"]: value }),
+    });
+  }
 
   for (const field of basics.customFields) {
     if (field.value.trim() === "") continue;
-    entries.push({ key: `custom:${field.id}`, label: field.name, value: field.value });
+    entries.push({
+      key: `custom:${field.id}`,
+      label: field.name,
+      value: field.value,
+      fieldLabel: field.name === "" ? "Custom field" : field.name,
+      commit: (value) => updateBasicsField("customFields", replaceField(basics, field.id, value)),
+    });
   }
 
   return entries;
+}
+
+/** `customFields` with one field's value replaced — committed as one action. */
+function replaceField(basics: Basics, id: string, value: string): CustomField[] {
+  return basics.customFields.map((field) => (field.id === id ? { ...field, value } : field));
 }
 
 /** Whether a picture is set and not switched off. Mirrors `has-visible-picture`. */
@@ -117,7 +172,12 @@ export interface DocHeaderProps {
 }
 
 export function DocHeader(props: DocHeaderProps): JSX.Element {
-  const entries = () => contactEntries(props.basics);
+  const [isPhotoOpen, setIsPhotoOpen] = createSignal(false);
+
+  const entries = () =>
+    contactEntries(props.basics).filter(
+      (entry) => entry.alwaysShown === true || entry.value.trim() !== "",
+    );
   const links = () => props.profileLinks ?? [];
   const stacked = () => props.headerStyle === "sidebar";
   const showIdentity = () => props.showIdentity ?? true;
@@ -134,16 +194,48 @@ export function DocHeader(props: DocHeaderProps): JSX.Element {
       }}
       data-testid="doc-sheet-header"
     >
-      <Show when={showIdentity() && pictureVisible(props.basics.picture)}>
-        <Avatar picture={props.basics.picture} name={props.basics.name} />
-      </Show>
+      <Show when={showIdentity()}>
+        <Show
+          when={pictureVisible(props.basics.picture)}
+          fallback={
+            <button type="button" class="doc-sheet__action" onClick={() => setIsPhotoOpen(true)}>
+              Add photo
+            </button>
+          }
+        >
+          <button
+            type="button"
+            class="doc-sheet__editable doc-sheet__avatar-button"
+            title="Edit photo"
+            onClick={() => setIsPhotoOpen(true)}
+          >
+            <Avatar picture={props.basics.picture} name={props.basics.name} />
+          </button>
+        </Show>
 
-      <Show when={showIdentity() && props.basics.name.trim() !== ""}>
-        <h2 class="doc-sheet__name">{props.basics.name}</h2>
-      </Show>
+        <h2 class="doc-sheet__name">
+          <InlineText
+            value={props.basics.name}
+            label="Name"
+            placeholder="Your name"
+            onCommit={(value) => updateBasicsField("name", value)}
+          />
+        </h2>
 
-      <Show when={showIdentity() && props.basics.headline.trim() !== ""}>
-        <p class="doc-sheet__headline">{props.basics.headline}</p>
+        <p class="doc-sheet__headline">
+          <InlineText
+            value={props.basics.headline}
+            label="Headline"
+            placeholder="Your headline"
+            onCommit={(value) => updateBasicsField("headline", value)}
+          />
+        </p>
+
+        <PhotoDialog
+          open={isPhotoOpen()}
+          picture={props.basics.picture}
+          onOpenChange={setIsPhotoOpen}
+        />
       </Show>
 
       <Show when={props.showContact && entries().length > 0}>
@@ -154,7 +246,7 @@ export function DocHeader(props: DocHeaderProps): JSX.Element {
                 <Show when={entry.label}>
                   <span class="doc-sheet__contact-label">{entry.label}: </span>
                 </Show>
-                {entry.value}
+                <InlineText value={entry.value} label={entry.fieldLabel} onCommit={entry.commit} />
               </li>
             )}
           </For>
@@ -163,6 +255,8 @@ export function DocHeader(props: DocHeaderProps): JSX.Element {
 
       <Show when={props.showContact && links().length > 0}>
         <ul class="doc-sheet__contact" classList={{ "doc-sheet__contact--stacked": stacked() }}>
+          {/* Profile links mirror the `profiles` section, which is edited where
+              the layout places it rather than twice over. */}
           <For each={links()}>{(link) => <li>{link.label}</li>}</For>
         </ul>
       </Show>

--- a/apps/web/src/components/doc-editor/DocHeader.tsx
+++ b/apps/web/src/components/doc-editor/DocHeader.tsx
@@ -86,7 +86,12 @@ function contactEntries(basics: Basics): ContactEntry[] {
       value: url,
       fieldLabel: hasLabel ? "Website label" : "Website URL",
       commit: (value) =>
-        updateBasicsField("url", { ...basics.url, [hasLabel ? "label" : "href"]: value }),
+        // Spreading a missing `url` alone would drop the other half of the
+        // required `{label, href}` shape.
+        updateBasicsField("url", {
+          ...(basics.url ?? { label: "", href: "" }),
+          [hasLabel ? "label" : "href"]: value,
+        }),
     });
   }
 

--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -1,5 +1,5 @@
 /**
- * Read-only section views for the document sheet.
+ * Section views for the document sheet, with editing in place.
  *
  * Each section type is reduced to one {@link ItemView} descriptor and drawn by
  * a single renderer, so field *order* lives in one obvious place. That order is
@@ -7,15 +7,25 @@
  * `crates/render/src/typst_engine/templates/*.typ`, which are authoritative for
  * what a section shows and in which sequence.
  *
- * Nothing here is interactive. URLs render as text rather than anchors: the
- * sheet is a document surface, not a navigation surface, and click-to-edit
- * (#728) needs the item body free of competing click targets. Faithful
- * rendering — markdown included — is the PDF pane's job (#732).
+ * Every slot the renderer draws carries the item key it came from, which is
+ * what makes click-to-edit possible without a second mapping: committing a slot
+ * writes that one key through `docEdits`. Slots the sheet derives from more than
+ * one field (a degree, say) carry no key and are edited in the item dialog
+ * instead, which is also where the fields the sheet has no room for live.
+ *
+ * URLs still render as text rather than anchors: the sheet is a document
+ * surface, not a navigation surface, and a link inside an item would compete
+ * with the item's own click targets. Faithful markdown rendering is the PDF
+ * pane's job (#732).
  */
 
-import { For, Show, type JSX } from "solid-js";
+import { For, Show, createSignal, type JSX } from "solid-js";
+import { InlineMarkdown } from "./InlineMarkdown";
+import { InlineText } from "./InlineText";
+import { ItemDialog } from "./ItemDialog";
+import { renameSection, updateCoverLetter, updateItem, updateSummary } from "./docEdits";
+import { itemNoun } from "./itemFields";
 import { isCustomId, sectionTitle } from "../../lib/docLayout";
-import { isHtmlEmpty } from "../../lib/resumeSections";
 import type {
   Award,
   Certification,
@@ -38,6 +48,19 @@ import type {
 const MAX_LEVEL = 5;
 
 /**
+ * One drawn slot of an item.
+ *
+ * `field` names the item key the slot writes to; a slot without one is derived
+ * from several fields and is therefore read-only on the sheet.
+ */
+interface ItemField {
+  value: string;
+  /** Human label, announced by the inline editor. */
+  label: string;
+  field?: string;
+}
+
+/**
  * One item of any section, flattened to the slots the sheet draws.
  *
  * The slots render in declaration order: title/subtitle and meta share the
@@ -45,23 +68,38 @@ const MAX_LEVEL = 5;
  */
 interface ItemView {
   /** Primary line — company, institution, name, title. */
-  title: string;
+  title: ItemField;
   /** Secondary line under the title. */
-  subtitle?: string;
+  subtitle?: ItemField;
   /** Right-aligned head-row entries, typically date then location. */
-  meta?: string[];
+  meta?: ItemField[];
   /** Short plain lines between the head row and the body. */
-  details?: string[];
+  details?: ItemField[];
   /** Rich-text (markdown) fields, in template order. */
-  body?: string[];
+  body?: ItemField[];
   keywords?: string[];
   /** 0–5 proficiency, drawn as dots. Absent for sections without a level. */
   level?: number;
   url?: Url;
 }
 
-function nonEmpty(values: (string | undefined)[]): string[] {
-  return values.filter((value): value is string => (value ?? "").trim() !== "");
+/**
+ * A slot bound to one item key.
+ *
+ * The value is read defensively: imported resumes reach the store with fields
+ * the schema declares but the import never filled in.
+ */
+function bind(value: string | undefined, label: string, field: string): ItemField {
+  return { value: value ?? "", label, field };
+}
+
+/** A slot the sheet derives rather than stores, so it cannot be edited inline. */
+function derived(value: string | undefined, label: string): ItemField {
+  return { value: value ?? "", label };
+}
+
+function nonEmpty(fields: ItemField[]): ItemField[] {
+  return fields.filter((entry) => entry.value.trim() !== "");
 }
 
 /** `studyType in area`, matching `format-degree` in `_common.typ`. */
@@ -83,29 +121,30 @@ function urlLabel(url: Url | undefined): string {
 
 function experienceView(item: Experience): ItemView {
   return {
-    title: item.company,
-    subtitle: item.position,
-    meta: nonEmpty([item.date, item.location]),
-    body: nonEmpty([item.summary]),
+    title: bind(item.company, "Company", "company"),
+    subtitle: bind(item.position, "Position", "position"),
+    meta: nonEmpty([bind(item.date, "Date", "date"), bind(item.location, "Location", "location")]),
+    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
     url: item.url,
   };
 }
 
 function educationView(item: Education): ItemView {
   return {
-    title: item.institution,
-    subtitle: formatDegree(item.studyType, item.area),
-    meta: nonEmpty([item.date]),
-    details: nonEmpty([item.score]),
-    body: nonEmpty([item.summary]),
+    title: bind(item.institution, "Institution", "institution"),
+    // `studyType in area` — two fields in one line, so the dialog owns it.
+    subtitle: derived(formatDegree(item.studyType, item.area), "Degree"),
+    meta: nonEmpty([bind(item.date, "Date", "date")]),
+    details: nonEmpty([bind(item.score, "Score", "score")]),
+    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
     url: item.url,
   };
 }
 
 function skillView(item: Skill): ItemView {
   return {
-    title: item.name,
-    body: nonEmpty([item.description]),
+    title: bind(item.name, "Name", "name"),
+    body: nonEmpty([bind(item.description, "Description", "description")]),
     level: item.level,
     keywords: item.keywords,
   };
@@ -113,9 +152,12 @@ function skillView(item: Skill): ItemView {
 
 function projectView(item: Project): ItemView {
   return {
-    title: item.name,
-    meta: nonEmpty([item.date]),
-    body: nonEmpty([item.description, item.summary]),
+    title: bind(item.name, "Name", "name"),
+    meta: nonEmpty([bind(item.date, "Date", "date")]),
+    body: nonEmpty([
+      bind(item.description, "Description", "description"),
+      bind(item.summary, "Summary", "summary"),
+    ]),
     keywords: item.keywords,
     url: item.url,
   };
@@ -123,81 +165,81 @@ function projectView(item: Project): ItemView {
 
 function profileView(item: Profile): ItemView {
   return {
-    title: item.network,
-    subtitle: item.username,
+    title: bind(item.network, "Network", "network"),
+    subtitle: bind(item.username, "Username", "username"),
     url: item.url,
   };
 }
 
 function awardView(item: Award): ItemView {
   return {
-    title: item.title,
-    subtitle: item.awarder,
-    meta: nonEmpty([item.date]),
-    body: nonEmpty([item.summary]),
+    title: bind(item.title, "Title", "title"),
+    subtitle: bind(item.awarder, "Awarder", "awarder"),
+    meta: nonEmpty([bind(item.date, "Date", "date")]),
+    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
     url: item.url,
   };
 }
 
 function certificationView(item: Certification): ItemView {
   return {
-    title: item.name,
-    subtitle: item.issuer,
-    meta: nonEmpty([item.date]),
-    body: nonEmpty([item.summary]),
+    title: bind(item.name, "Name", "name"),
+    subtitle: bind(item.issuer, "Issuer", "issuer"),
+    meta: nonEmpty([bind(item.date, "Date", "date")]),
+    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
     url: item.url,
   };
 }
 
 function publicationView(item: Publication): ItemView {
   return {
-    title: item.name,
-    subtitle: item.publisher,
-    meta: nonEmpty([item.date]),
-    body: nonEmpty([item.summary]),
+    title: bind(item.name, "Name", "name"),
+    subtitle: bind(item.publisher, "Publisher", "publisher"),
+    meta: nonEmpty([bind(item.date, "Date", "date")]),
+    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
     url: item.url,
   };
 }
 
 function languageView(item: Language): ItemView {
   return {
-    title: item.name,
-    subtitle: item.description,
+    title: bind(item.name, "Name", "name"),
+    subtitle: bind(item.description, "Description", "description"),
     level: item.level,
   };
 }
 
 function interestView(item: Interest): ItemView {
-  return { title: item.name, keywords: item.keywords };
+  return { title: bind(item.name, "Name", "name"), keywords: item.keywords };
 }
 
 function volunteerView(item: Volunteer): ItemView {
   return {
-    title: item.organization,
-    subtitle: item.position,
-    meta: nonEmpty([item.date]),
-    details: nonEmpty([item.location]),
-    body: nonEmpty([item.summary]),
+    title: bind(item.organization, "Organization", "organization"),
+    subtitle: bind(item.position, "Position", "position"),
+    meta: nonEmpty([bind(item.date, "Date", "date")]),
+    details: nonEmpty([bind(item.location, "Location", "location")]),
+    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
     url: item.url,
   };
 }
 
 function referenceView(item: Reference): ItemView {
   return {
-    title: item.name,
-    subtitle: item.description,
-    body: nonEmpty([item.summary]),
+    title: bind(item.name, "Name", "name"),
+    subtitle: bind(item.description, "Description", "description"),
+    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
     url: item.url,
   };
 }
 
 function customView(item: CustomItem): ItemView {
   return {
-    title: item.name,
-    subtitle: item.description,
-    meta: nonEmpty([item.date]),
-    details: nonEmpty([item.location]),
-    body: nonEmpty([item.summary]),
+    title: bind(item.name, "Name", "name"),
+    subtitle: bind(item.description, "Description", "description"),
+    meta: nonEmpty([bind(item.date, "Date", "date")]),
+    details: nonEmpty([bind(item.location, "Location", "location")]),
+    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
     keywords: item.keywords,
     url: item.url,
   };
@@ -226,37 +268,43 @@ interface VisibleItem {
   visible: boolean;
 }
 
+/** A drawn item, plus where it sits in the section's own `items` array. */
+interface ItemEntry {
+  id: string;
+  /** Index into the unfiltered `items` array — what the store actions address. */
+  index: number;
+  item: Record<string, unknown>;
+  view: ItemView;
+}
+
 /**
  * The visible items of `sectionId`, already flattened to {@link ItemView}.
  *
  * Item shapes differ per section, and the adapter table above is the only
  * place that knows which is which — so the lookup is done once, here, behind a
- * cast the table's own keys justify.
+ * cast the table's own keys justify. Hidden items are dropped from the drawing
+ * but keep their index, because that is what `updateSectionItem` addresses.
  */
-function itemViews(resume: ResumeData, sectionId: string): { id: string; view: ItemView }[] {
-  if (isCustomId(sectionId)) {
-    const section = resume.sections.custom?.[sectionId];
-    return (section?.items ?? [])
-      .filter((item) => item.visible)
-      .map((item) => ({ id: item.id, view: customView(item) }));
-  }
-
-  const adapter = ITEM_VIEWS[sectionId as ItemSectionId] as
-    | ((item: VisibleItem) => ItemView)
-    | undefined;
+function itemEntries(resume: ResumeData, sectionId: string): ItemEntry[] {
+  const adapter = isCustomId(sectionId)
+    ? (customView as (item: VisibleItem) => ItemView)
+    : (ITEM_VIEWS[sectionId as ItemSectionId] as ((item: VisibleItem) => ItemView) | undefined);
   if (!adapter) return [];
 
-  const section = resume.sections[sectionId as ItemSectionId] as
-    | { items?: VisibleItem[] }
-    | undefined;
-  return (section?.items ?? [])
-    .filter((item) => item.visible)
-    .map((item) => ({ id: item.id, view: adapter(item) }));
-}
+  const section = isCustomId(sectionId)
+    ? resume.sections.custom?.[sectionId]
+    : (resume.sections[sectionId as ItemSectionId] as { items?: VisibleItem[] } | undefined);
 
-/** Rich text shown verbatim — see the module note on markdown. */
-function RichText(props: { value: string }): JSX.Element {
-  return <p class="doc-sheet__rich-text">{props.value}</p>;
+  return (section?.items ?? [])
+    .map((item, index) => ({
+      id: item.id,
+      index,
+      item: item as unknown as Record<string, unknown>,
+      view: adapter(item),
+      visible: item.visible,
+    }))
+    .filter((entry) => entry.visible)
+    .map(({ visible: _visible, ...entry }) => entry);
 }
 
 function Level(props: { value: number }): JSX.Element {
@@ -276,37 +324,94 @@ function Level(props: { value: number }): JSX.Element {
   );
 }
 
-function Item(props: { view: ItemView }): JSX.Element {
-  const meta = () => props.view.meta ?? [];
-  const keywords = () => (props.view.keywords ?? []).filter((keyword) => keyword.trim() !== "");
-  const url = () => urlLabel(props.view.url);
+/** A bound slot as an inline editor; a derived slot as plain text. */
+function Slot(props: {
+  field: ItemField;
+  class?: string;
+  onCommit: (field: string, value: string) => void;
+}): JSX.Element {
+  return (
+    <Show when={props.field.field} fallback={props.field.value}>
+      {(key) => (
+        <InlineText
+          value={props.field.value}
+          label={props.field.label}
+          class={props.class}
+          onCommit={(value) => props.onCommit(key(), value)}
+        />
+      )}
+    </Show>
+  );
+}
+
+function Item(props: {
+  sectionId: string;
+  entry: ItemEntry;
+  /** Singular noun for this section's items, used in the edit button's label. */
+  noun: string;
+  onEdit: (entry: ItemEntry) => void;
+}): JSX.Element {
+  const view = () => props.entry.view;
+  const meta = () => view().meta ?? [];
+  const keywords = () => (view().keywords ?? []).filter((keyword) => keyword.trim() !== "");
+  const url = () => urlLabel(view().url);
+
+  const commit = (field: string, value: string): void => {
+    updateItem(props.sectionId, props.entry.index, { [field]: value });
+  };
 
   return (
     <article class="doc-sheet__item">
       <div class="doc-sheet__item-head">
         <div>
-          <Show when={props.view.title.trim() !== ""}>
-            <h4 class="doc-sheet__item-title">{props.view.title}</h4>
-          </Show>
-          <Show when={(props.view.subtitle ?? "").trim() !== ""}>
-            <p class="doc-sheet__item-subtitle">{props.view.subtitle}</p>
+          <h4 class="doc-sheet__item-title">
+            <Slot field={view().title} onCommit={commit} />
+          </h4>
+          <Show when={view().subtitle}>
+            {(subtitle) => (
+              <p class="doc-sheet__item-subtitle">
+                <Slot field={subtitle()} onCommit={commit} />
+              </p>
+            )}
           </Show>
         </div>
         <Show when={meta().length > 0}>
           <div class="doc-sheet__item-meta">
-            <For each={meta()}>{(entry) => <span>{entry}</span>}</For>
+            <For each={meta()}>
+              {(entry) => (
+                <span>
+                  <Slot field={entry} onCommit={commit} />
+                </span>
+              )}
+            </For>
           </div>
         </Show>
       </div>
 
-      <For each={props.view.details ?? []}>
-        {(detail) => <p class="doc-sheet__item-detail">{detail}</p>}
+      <For each={view().details ?? []}>
+        {(detail) => (
+          <p class="doc-sheet__item-detail">
+            <Slot field={detail} onCommit={commit} />
+          </p>
+        )}
       </For>
 
-      <For each={props.view.body ?? []}>{(text) => <RichText value={text} />}</For>
+      <For each={view().body ?? []}>
+        {(text) => (
+          <Show when={text.field} fallback={<p class="doc-sheet__rich-text">{text.value}</p>}>
+            {(key) => (
+              <InlineMarkdown
+                value={text.value}
+                label={text.label}
+                onCommit={(value) => commit(key(), value)}
+              />
+            )}
+          </Show>
+        )}
+      </For>
 
-      <Show when={props.view.level !== undefined && props.view.level > 0}>
-        <Level value={props.view.level ?? 0} />
+      <Show when={view().level !== undefined && (view().level ?? 0) > 0}>
+        <Level value={view().level ?? 0} />
       </Show>
 
       <Show when={keywords().length > 0}>
@@ -318,6 +423,15 @@ function Item(props: { view: ItemView }): JSX.Element {
       <Show when={url() !== ""}>
         <p class="doc-sheet__url">{url()}</p>
       </Show>
+
+      <button
+        type="button"
+        class="doc-sheet__action doc-sheet__action--item"
+        aria-label={`Edit ${view().title.value.trim() === "" ? props.noun : view().title.value} details`}
+        onClick={() => props.onEdit(props.entry)}
+      >
+        Edit
+      </button>
     </article>
   );
 }
@@ -329,31 +443,81 @@ export interface DocSectionProps {
 }
 
 /**
- * One section of the sheet: its heading plus a read view of its content.
+ * One section of the sheet: its heading plus an editable view of its content.
  *
  * `summary` and `coverLetter` carry rich text; every other section carries
  * items. Hidden items are dropped; hidden and empty *sections* never reach
  * here, because `renderPages()` has already filtered them out.
  */
 export function DocSection(props: DocSectionProps): JSX.Element {
+  const [editing, setEditing] = createSignal<ItemEntry | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = createSignal(false);
+
   const title = () => sectionTitle(props.resume, props.sectionId);
+  const isRichText = () => props.sectionId === "summary" || props.sectionId === "coverLetter";
   const richText = () => {
     if (props.sectionId === "summary") return props.resume.sections.summary?.content ?? "";
     if (props.sectionId === "coverLetter") return props.resume.sections.coverLetter?.content ?? "";
     return "";
   };
-  const items = () => itemViews(props.resume, props.sectionId);
+  const entries = () => itemEntries(props.resume, props.sectionId);
+  const noun = () => itemNoun(title());
+
+  function openAdd(): void {
+    setEditing(null);
+    setIsDialogOpen(true);
+  }
+
+  function openEdit(entry: ItemEntry): void {
+    setEditing(entry);
+    setIsDialogOpen(true);
+  }
 
   return (
     <section class="doc-sheet__section" data-section-id={props.sectionId}>
-      <h3 class="doc-sheet__section-title">{title()}</h3>
-      <Show when={!isHtmlEmpty(richText())}>
-        <RichText value={richText()} />
+      <h3 class="doc-sheet__section-title">
+        <InlineText
+          value={title()}
+          label="Section title"
+          onCommit={(value) => renameSection(props.sectionId, value)}
+        />
+      </h3>
+
+      <Show when={isRichText()}>
+        <InlineMarkdown
+          value={richText()}
+          label={title()}
+          onCommit={(value) =>
+            props.sectionId === "summary" ? updateSummary(value) : updateCoverLetter(value)
+          }
+        />
       </Show>
-      <Show when={items().length > 0}>
+
+      <Show when={entries().length > 0}>
         <div class="doc-sheet__items">
-          <For each={items()}>{(entry) => <Item view={entry.view} />}</For>
+          <For each={entries()}>
+            {(entry) => (
+              <Item sectionId={props.sectionId} entry={entry} noun={noun()} onEdit={openEdit} />
+            )}
+          </For>
         </div>
+      </Show>
+
+      <Show when={!isRichText()}>
+        <div class="doc-sheet__section-actions">
+          <button type="button" class="doc-sheet__action" onClick={openAdd}>
+            Add {noun()}
+          </button>
+        </div>
+
+        <ItemDialog
+          open={isDialogOpen()}
+          sectionId={props.sectionId}
+          sectionTitle={title()}
+          index={editing()?.index}
+          item={editing()?.item}
+          onOpenChange={setIsDialogOpen}
+        />
       </Show>
     </section>
   );

--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -133,7 +133,9 @@ function educationView(item: Education): ItemView {
   return {
     title: bind(item.institution, "Institution", "institution"),
     // `studyType in area` — two fields in one line, so the dialog owns it.
-    subtitle: derived(formatDegree(item.studyType, item.area), "Degree"),
+    // Absent rather than empty when neither is set: a derived slot is truthy
+    // whatever its value, and `<Show>` would draw a blank line for it.
+    subtitle: nonEmpty([derived(formatDegree(item.studyType, item.area), "Degree")])[0],
     meta: nonEmpty([bind(item.date, "Date", "date")]),
     details: nonEmpty([bind(item.score, "Score", "score")]),
     body: nonEmpty([bind(item.summary, "Summary", "summary")]),
@@ -327,6 +329,8 @@ function Level(props: { value: number }): JSX.Element {
 /** A bound slot as an inline editor; a derived slot as plain text. */
 function Slot(props: {
   field: ItemField;
+  /** Stable per-item id prefix; the field key makes it unique per slot. */
+  idPrefix: string;
   class?: string;
   onCommit: (field: string, value: string) => void;
 }): JSX.Element {
@@ -337,6 +341,7 @@ function Slot(props: {
           value={props.field.value}
           label={props.field.label}
           class={props.class}
+          triggerId={`${props.idPrefix}-${key()}`}
           onCommit={(value) => props.onCommit(key(), value)}
         />
       )}
@@ -352,6 +357,9 @@ function Item(props: {
   onEdit: (entry: ItemEntry) => void;
 }): JSX.Element {
   const view = () => props.entry.view;
+  // Stable across redraws: the item's own id, not its position. Inline editors
+  // use it to find their trigger again after a commit redraws the section.
+  const idPrefix = () => `doc-${props.sectionId}-${props.entry.id}`;
   const meta = () => view().meta ?? [];
   const keywords = () => (view().keywords ?? []).filter((keyword) => keyword.trim() !== "");
   const url = () => urlLabel(view().url);
@@ -365,12 +373,12 @@ function Item(props: {
       <div class="doc-sheet__item-head">
         <div>
           <h4 class="doc-sheet__item-title">
-            <Slot field={view().title} onCommit={commit} />
+            <Slot field={view().title} idPrefix={idPrefix()} onCommit={commit} />
           </h4>
           <Show when={view().subtitle}>
             {(subtitle) => (
               <p class="doc-sheet__item-subtitle">
-                <Slot field={subtitle()} onCommit={commit} />
+                <Slot field={subtitle()} idPrefix={idPrefix()} onCommit={commit} />
               </p>
             )}
           </Show>
@@ -380,7 +388,7 @@ function Item(props: {
             <For each={meta()}>
               {(entry) => (
                 <span>
-                  <Slot field={entry} onCommit={commit} />
+                  <Slot field={entry} idPrefix={idPrefix()} onCommit={commit} />
                 </span>
               )}
             </For>
@@ -391,7 +399,7 @@ function Item(props: {
       <For each={view().details ?? []}>
         {(detail) => (
           <p class="doc-sheet__item-detail">
-            <Slot field={detail} onCommit={commit} />
+            <Slot field={detail} idPrefix={idPrefix()} onCommit={commit} />
           </p>
         )}
       </For>
@@ -403,6 +411,7 @@ function Item(props: {
               <InlineMarkdown
                 value={text.value}
                 label={text.label}
+                triggerId={`${idPrefix()}-${key()}`}
                 onCommit={(value) => commit(key(), value)}
               />
             )}
@@ -479,6 +488,7 @@ export function DocSection(props: DocSectionProps): JSX.Element {
         <InlineText
           value={title()}
           label="Section title"
+          triggerId={`doc-${props.sectionId}-section-title`}
           onCommit={(value) => renameSection(props.sectionId, value)}
         />
       </h3>
@@ -487,6 +497,7 @@ export function DocSection(props: DocSectionProps): JSX.Element {
         <InlineMarkdown
           value={richText()}
           label={title()}
+          triggerId={`doc-${props.sectionId}-rich-text`}
           onCommit={(value) =>
             props.sectionId === "summary" ? updateSummary(value) : updateCoverLetter(value)
           }

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -1,10 +1,13 @@
 /**
- * The read-only document sheet: A4 page frames, the template's column grid, the
- * header region, and a read view of every placed section.
+ * The document sheet: A4 page frames, the template's column grid, the header
+ * region, and an editable view of every placed section.
  *
  * The page/column structure comes straight from `renderPages()` and
- * `layoutColumns()` — this component draws that model and nothing else. It has
- * no editing affordances: no inputs, no `contentEditable`, no modals.
+ * `layoutColumns()` — this component draws that model and nothing else. Editing
+ * is click-to-edit in place (`InlineText`, `InlineMarkdown`) plus the item,
+ * section and photo dialogs; every one of them writes through a `resumeStore`
+ * action, never `setStore` (see `docEdits.ts`). Structural editing — moving or
+ * reordering sections — is #729 and is not here.
  *
  * Overflow is *reported*, never absorbed. A column that cannot fit its sections
  * is clipped and flagged; moving a section to another page is a `metadata.layout`
@@ -12,6 +15,7 @@
  */
 
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
+import { CustomSectionDialog } from "./CustomSectionDialog";
 import { DocHeader } from "./DocHeader";
 import { DocSection } from "./DocSection";
 import {
@@ -84,6 +88,7 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
   const theme = () => props.resume.metadata.theme;
 
   const [overflowing, setOverflowing] = createSignal<number[]>([]);
+  const [isSectionDialogOpen, setIsSectionDialogOpen] = createSignal(false);
   let root: HTMLDivElement | undefined;
 
   /**
@@ -222,6 +227,20 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
           );
         }}
       </For>
+
+      {/* Sheet-level chrome: creating a section is not part of any one page. */}
+      <div class="doc-sheet__actions">
+        <button
+          type="button"
+          class="doc-sheet__action"
+          data-testid="doc-sheet-add-section"
+          onClick={() => setIsSectionDialogOpen(true)}
+        >
+          Add section
+        </button>
+      </div>
+
+      <CustomSectionDialog open={isSectionDialogOpen()} onOpenChange={setIsSectionDialogOpen} />
     </div>
   );
 }

--- a/apps/web/src/components/doc-editor/InlineMarkdown.tsx
+++ b/apps/web/src/components/doc-editor/InlineMarkdown.tsx
@@ -1,0 +1,55 @@
+/**
+ * Click-to-edit for the sheet's multi-line markdown fields.
+ *
+ * Read state is the same verbatim markdown the read-only sheet drew, wrapped in
+ * a button so it can be reached by keyboard; edit state is {@link MarkdownEditor}
+ * in place. Rendering markdown faithfully is the PDF pane's job (#732), so the
+ * text still shows its own punctuation here.
+ */
+
+import { Show, createSignal, type JSX } from "solid-js";
+import { MarkdownEditor } from "./MarkdownEditor";
+
+export interface InlineMarkdownProps {
+  /** Current stored markdown. */
+  value: string;
+  /** Field name, e.g. "Summary". Labels the editor and the trigger's tooltip. */
+  label: string;
+  /** Text shown when the value is empty, so the field stays reachable. */
+  placeholder?: string;
+  /** Called with the new markdown when an edit is committed. */
+  onCommit: (value: string) => void;
+}
+
+export function InlineMarkdown(props: InlineMarkdownProps): JSX.Element {
+  const [isEditing, setIsEditing] = createSignal(false);
+
+  const placeholder = () => props.placeholder ?? `Add ${props.label.toLowerCase()}`;
+
+  return (
+    <Show
+      when={isEditing()}
+      fallback={
+        <button
+          type="button"
+          class="doc-sheet__editable doc-sheet__rich-text"
+          classList={{ "doc-sheet__editable--empty": props.value.trim() === "" }}
+          title={`Edit ${props.label.toLowerCase()}`}
+          onClick={() => setIsEditing(true)}
+        >
+          {props.value.trim() === "" ? placeholder() : props.value}
+        </button>
+      }
+    >
+      <MarkdownEditor
+        value={props.value}
+        label={props.label}
+        onCommit={(next) => {
+          setIsEditing(false);
+          props.onCommit(next);
+        }}
+        onCancel={() => setIsEditing(false)}
+      />
+    </Show>
+  );
+}

--- a/apps/web/src/components/doc-editor/InlineMarkdown.tsx
+++ b/apps/web/src/components/doc-editor/InlineMarkdown.tsx
@@ -17,6 +17,11 @@ export interface InlineMarkdownProps {
   label: string;
   /** Text shown when the value is empty, so the field stays reachable. */
   placeholder?: string;
+  /**
+   * Stable DOM id for the trigger button. Supplying it is what lets an edit
+   * hand focus back after the commit redraws the sheet — see `InlineText`.
+   */
+  triggerId?: string;
   /** Called with the new markdown when an edit is committed. */
   onCommit: (value: string) => void;
 }
@@ -26,12 +31,19 @@ export function InlineMarkdown(props: InlineMarkdownProps): JSX.Element {
 
   const placeholder = () => props.placeholder ?? `Add ${props.label.toLowerCase()}`;
 
+  function refocusTrigger(): void {
+    const id = props.triggerId;
+    if (id === undefined) return;
+    queueMicrotask(() => document.getElementById(id)?.focus());
+  }
+
   return (
     <Show
       when={isEditing()}
       fallback={
         <button
           type="button"
+          id={props.triggerId}
           class="doc-sheet__editable doc-sheet__rich-text"
           classList={{ "doc-sheet__editable--empty": props.value.trim() === "" }}
           title={`Edit ${props.label.toLowerCase()}`}
@@ -47,8 +59,12 @@ export function InlineMarkdown(props: InlineMarkdownProps): JSX.Element {
         onCommit={(next) => {
           setIsEditing(false);
           props.onCommit(next);
+          refocusTrigger();
         }}
-        onCancel={() => setIsEditing(false)}
+        onCancel={() => {
+          setIsEditing(false);
+          refocusTrigger();
+        }}
       />
     </Show>
   );

--- a/apps/web/src/components/doc-editor/InlineText.tsx
+++ b/apps/web/src/components/doc-editor/InlineText.tsx
@@ -9,6 +9,12 @@
  * Commit on blur and on Enter; Escape restores the prior value. Every commit
  * calls `onCommit` at most once and only when the text actually changed, which
  * is what keeps one user-visible edit to one store action and one undo entry.
+ *
+ * Ending a keyboard edit puts focus back on the trigger, so Tab carries on from
+ * the field the user was editing rather than restarting at the top of the
+ * document. It refocuses **by id** rather than by ref on purpose: a commit that
+ * changes the store redraws the section, and the button that comes back is a
+ * different DOM node from the one a ref would still be holding.
  */
 
 import { Show, createSignal, type JSX } from "solid-js";
@@ -22,6 +28,11 @@ export interface InlineTextProps {
   placeholder?: string;
   /** Extra class for the trigger and the input, so callers keep their type scale. */
   class?: string;
+  /**
+   * Stable DOM id for the trigger button. Supplying it is what lets a keyboard
+   * edit hand focus back after the commit redraws the sheet.
+   */
+  triggerId?: string;
   /** Called with the new text when an edit is committed. */
   onCommit: (value: string) => void;
 }
@@ -41,6 +52,18 @@ export function InlineText(props: InlineTextProps): JSX.Element {
     setIsEditing(true);
   }
 
+  /**
+   * Put focus back on the trigger once the sheet has settled.
+   *
+   * Only for keyboard exits: a blur means the user has already chosen where
+   * focus should go, and stealing it back would fight them.
+   */
+  function refocusTrigger(): void {
+    const id = props.triggerId;
+    if (id === undefined) return;
+    queueMicrotask(() => document.getElementById(id)?.focus());
+  }
+
   function commit(): void {
     if (isSettled) return;
     isSettled = true;
@@ -58,11 +81,13 @@ export function InlineText(props: InlineTextProps): JSX.Element {
     if (event.key === "Enter") {
       event.preventDefault();
       commit();
+      refocusTrigger();
       return;
     }
     if (event.key === "Escape") {
       event.preventDefault();
       cancel();
+      refocusTrigger();
     }
   }
 
@@ -72,6 +97,7 @@ export function InlineText(props: InlineTextProps): JSX.Element {
       fallback={
         <button
           type="button"
+          id={props.triggerId}
           class={`doc-sheet__editable ${props.class ?? ""}`}
           classList={{ "doc-sheet__editable--empty": props.value.trim() === "" }}
           // No `aria-label`: the accessible name has to stay the value itself,

--- a/apps/web/src/components/doc-editor/InlineText.tsx
+++ b/apps/web/src/components/doc-editor/InlineText.tsx
@@ -1,0 +1,105 @@
+/**
+ * The sheet's single-line click-to-edit primitive.
+ *
+ * A value is drawn as a button carrying the value as its own text, so the
+ * document still reads as a document and assistive technology still announces
+ * the surrounding heading or list item by its content. Activating it — click,
+ * Enter or Space, since it is a real button — swaps in an input in place.
+ *
+ * Commit on blur and on Enter; Escape restores the prior value. Every commit
+ * calls `onCommit` at most once and only when the text actually changed, which
+ * is what keeps one user-visible edit to one store action and one undo entry.
+ */
+
+import { Show, createSignal, type JSX } from "solid-js";
+
+export interface InlineTextProps {
+  /** Current stored value. */
+  value: string;
+  /** Field name, e.g. "Headline". Labels the input and the trigger's tooltip. */
+  label: string;
+  /** Text shown when the value is empty, so the field stays reachable. */
+  placeholder?: string;
+  /** Extra class for the trigger and the input, so callers keep their type scale. */
+  class?: string;
+  /** Called with the new text when an edit is committed. */
+  onCommit: (value: string) => void;
+}
+
+export function InlineText(props: InlineTextProps): JSX.Element {
+  const [isEditing, setIsEditing] = createSignal(false);
+  const [draft, setDraft] = createSignal("");
+  // One edit settles once. Escape unmounts the input and Enter commits it, and
+  // the blur each of those provokes must not reach the store a second time.
+  let isSettled = false;
+
+  const placeholder = () => props.placeholder ?? `Add ${props.label.toLowerCase()}`;
+
+  function start(): void {
+    isSettled = false;
+    setDraft(props.value);
+    setIsEditing(true);
+  }
+
+  function commit(): void {
+    if (isSettled) return;
+    isSettled = true;
+    const next = draft();
+    setIsEditing(false);
+    if (next !== props.value) props.onCommit(next);
+  }
+
+  function cancel(): void {
+    isSettled = true;
+    setIsEditing(false);
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commit();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancel();
+    }
+  }
+
+  return (
+    <Show
+      when={isEditing()}
+      fallback={
+        <button
+          type="button"
+          class={`doc-sheet__editable ${props.class ?? ""}`}
+          classList={{ "doc-sheet__editable--empty": props.value.trim() === "" }}
+          // No `aria-label`: the accessible name has to stay the value itself,
+          // or every heading that wraps one of these would be announced as
+          // "Edit …" instead of as its own text. `title` carries the hint.
+          title={`Edit ${props.label.toLowerCase()}`}
+          onClick={start}
+        >
+          {props.value.trim() === "" ? placeholder() : props.value}
+        </button>
+      }
+    >
+      <input
+        ref={(element) =>
+          queueMicrotask(() => {
+            element.focus();
+            element.select();
+          })
+        }
+        type="text"
+        class={`doc-sheet__inline-input ${props.class ?? ""}`}
+        aria-label={props.label}
+        placeholder={placeholder()}
+        value={draft()}
+        onInput={(event) => setDraft(event.currentTarget.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={commit}
+      />
+    </Show>
+  );
+}

--- a/apps/web/src/components/doc-editor/ItemDialog.tsx
+++ b/apps/web/src/components/doc-editor/ItemDialog.tsx
@@ -65,6 +65,11 @@ function parseKeywords(raw: string): string[] {
 
 export function ItemDialog(props: ItemDialogProps): JSX.Element {
   const [draft, setDraft] = createSignal<ItemUpdates>({});
+  // `Input` is controlled, so rendering the parsed list back would erase the
+  // separator the moment it is typed — "rust," reads back as "rust" and a
+  // second keyword can never be started. Keep the raw text the user typed and
+  // parse alongside it; the draft still holds the array the store wants.
+  const [keywordText, setKeywordText] = createSignal<Record<string, string>>({});
 
   const fields = () => itemFieldsFor(props.sectionId);
   const isAdding = () => props.index === undefined;
@@ -76,6 +81,7 @@ export function ItemDialog(props: ItemDialogProps): JSX.Element {
     if (!props.open) return;
     const seed = props.item ?? (emptyItemFor(props.sectionId) as Record<string, unknown> | null);
     setDraft({ ...(seed ?? {}) });
+    setKeywordText({});
   });
 
   function setField(key: string, value: unknown): void {
@@ -120,8 +126,11 @@ export function ItemDialog(props: ItemDialogProps): JSX.Element {
           <Input
             label={spec().label}
             description="Comma separated"
-            value={asKeywords(value()).join(", ")}
-            onInput={(next) => setField(spec().key, parseKeywords(next))}
+            value={keywordText()[spec().key] ?? asKeywords(value()).join(", ")}
+            onInput={(next) => {
+              setKeywordText((current) => ({ ...current, [spec().key]: next }));
+              setField(spec().key, parseKeywords(next));
+            }}
           />
         </Match>
 

--- a/apps/web/src/components/doc-editor/ItemDialog.tsx
+++ b/apps/web/src/components/doc-editor/ItemDialog.tsx
@@ -10,7 +10,7 @@
  * store action and therefore one undo entry.
  */
 
-import { For, Match, Show, Switch, createEffect, createSignal, type JSX } from "solid-js";
+import { For, Match, Show, Switch, createEffect, createSignal, on, type JSX } from "solid-js";
 import { Button, Input, Modal, TextArea } from "../ui";
 import { emptyItemFor } from "../../lib/docLayout";
 import { addItem, updateItem, type ItemUpdates } from "./docEdits";
@@ -76,13 +76,21 @@ export function ItemDialog(props: ItemDialogProps): JSX.Element {
   const noun = () => itemNoun(props.sectionTitle);
 
   // Reseed every time the dialog opens, so a cancelled edit leaves nothing
-  // behind for the next one.
-  createEffect(() => {
-    if (!props.open) return;
-    const seed = props.item ?? (emptyItemFor(props.sectionId) as Record<string, unknown> | null);
-    setDraft({ ...(seed ?? {}) });
-    setKeywordText({});
-  });
+  // behind for the next one. Tracked on `open` alone: the sheet rebuilds the
+  // item object as it redraws, and reseeding from that would throw away
+  // whatever the user had typed but not yet saved.
+  createEffect(
+    on(
+      () => props.open,
+      (open) => {
+        if (!open) return;
+        const seed =
+          props.item ?? (emptyItemFor(props.sectionId) as Record<string, unknown> | null);
+        setDraft({ ...(seed ?? {}) });
+        setKeywordText({});
+      },
+    ),
+  );
 
   function setField(key: string, value: unknown): void {
     setDraft((current) => ({ ...current, [key]: value }));

--- a/apps/web/src/components/doc-editor/ItemDialog.tsx
+++ b/apps/web/src/components/doc-editor/ItemDialog.tsx
@@ -1,0 +1,193 @@
+/**
+ * Add or edit one item of a section.
+ *
+ * The form is generated from the section's descriptors in `itemFields.ts`, so
+ * every section type — fixed or custom — gets every one of its fields, including
+ * the ones the sheet has no room to draw inline. A blank item comes from
+ * `emptyItemFor()`, the same seed the layout model defines.
+ *
+ * The dialog holds a draft and commits **once**, on save: one item edit is one
+ * store action and therefore one undo entry.
+ */
+
+import { For, Match, Show, Switch, createEffect, createSignal, type JSX } from "solid-js";
+import { Button, Input, Modal, TextArea } from "../ui";
+import { emptyItemFor } from "../../lib/docLayout";
+import { addItem, updateItem, type ItemUpdates } from "./docEdits";
+import { itemFieldsFor, itemNoun, type ItemFieldSpec } from "./itemFields";
+import { generateId } from "../../wasm/types";
+import type { Url } from "../../wasm/types";
+
+/** Highest level a skill or language can carry. Mirrors `clamp-level`. */
+const MAX_LEVEL = 5;
+
+export interface ItemDialogProps {
+  open: boolean;
+  /** A fixed section id, or a custom section's own id. */
+  sectionId: string;
+  /** The section's drawn heading, used in the dialog's title. */
+  sectionTitle: string;
+  /**
+   * Index of the item being edited in the section's own `items` array. Absent
+   * when adding.
+   */
+  index?: number;
+  /** The item being edited. Absent when adding. */
+  item?: Readonly<Record<string, unknown>>;
+  onOpenChange: (open: boolean) => void;
+}
+
+function asText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asLevel(value: unknown): number {
+  return typeof value === "number" ? value : 0;
+}
+
+function asKeywords(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function asUrl(value: unknown): Url {
+  const url = value as Partial<Url> | undefined;
+  return { label: url?.label ?? "", href: url?.href ?? "" };
+}
+
+function parseKeywords(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((keyword) => keyword.trim())
+    .filter((keyword) => keyword !== "");
+}
+
+export function ItemDialog(props: ItemDialogProps): JSX.Element {
+  const [draft, setDraft] = createSignal<ItemUpdates>({});
+
+  const fields = () => itemFieldsFor(props.sectionId);
+  const isAdding = () => props.index === undefined;
+  const noun = () => itemNoun(props.sectionTitle);
+
+  // Reseed every time the dialog opens, so a cancelled edit leaves nothing
+  // behind for the next one.
+  createEffect(() => {
+    if (!props.open) return;
+    const seed = props.item ?? (emptyItemFor(props.sectionId) as Record<string, unknown> | null);
+    setDraft({ ...(seed ?? {}) });
+  });
+
+  function setField(key: string, value: unknown): void {
+    setDraft((current) => ({ ...current, [key]: value }));
+  }
+
+  function save(): void {
+    const next = draft();
+    if (isAdding()) {
+      addItem(props.sectionId, { ...next, id: generateId(), visible: true });
+    } else {
+      updateItem(props.sectionId, props.index as number, next);
+    }
+    props.onOpenChange(false);
+  }
+
+  function Field(fieldProps: { spec: ItemFieldSpec }): JSX.Element {
+    const spec = () => fieldProps.spec;
+    const value = () => draft()[spec().key];
+
+    return (
+      <Switch>
+        <Match when={spec().kind === "text"}>
+          <Input
+            label={spec().label}
+            placeholder={spec().placeholder}
+            value={asText(value())}
+            onInput={(next) => setField(spec().key, next)}
+          />
+        </Match>
+
+        <Match when={spec().kind === "markdown"}>
+          <TextArea
+            label={spec().label}
+            description="Markdown — **bold**, *italic*, [label](href), - item, 1. item"
+            value={asText(value())}
+            onInput={(next) => setField(spec().key, next)}
+          />
+        </Match>
+
+        <Match when={spec().kind === "keywords"}>
+          <Input
+            label={spec().label}
+            description="Comma separated"
+            value={asKeywords(value()).join(", ")}
+            onInput={(next) => setField(spec().key, parseKeywords(next))}
+          />
+        </Match>
+
+        <Match when={spec().kind === "level"}>
+          <div class="flex flex-col gap-1.5">
+            <label
+              class="font-mono text-xs uppercase tracking-wider text-stone"
+              for={`doc-item-level-${spec().key}`}
+            >
+              {spec().label} ({asLevel(value())}/{MAX_LEVEL})
+            </label>
+            <input
+              id={`doc-item-level-${spec().key}`}
+              type="range"
+              min="0"
+              max={MAX_LEVEL}
+              step="1"
+              value={asLevel(value())}
+              onInput={(event) => setField(spec().key, parseInt(event.currentTarget.value, 10))}
+              class="w-full accent-accent"
+            />
+          </div>
+        </Match>
+
+        <Match when={spec().kind === "url"}>
+          <div class="grid grid-cols-2 gap-4">
+            <Input
+              label={`${spec().label} label`}
+              value={asUrl(value()).label}
+              onInput={(next) => setField(spec().key, { ...asUrl(value()), label: next })}
+            />
+            <Input
+              label={`${spec().label} URL`}
+              type="url"
+              placeholder="https://"
+              value={asUrl(value()).href}
+              onInput={(next) => setField(spec().key, { ...asUrl(value()), href: next })}
+            />
+          </div>
+        </Match>
+      </Switch>
+    );
+  }
+
+  return (
+    <Modal
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      title={isAdding() ? `Add ${noun()}` : `Edit ${noun()}`}
+      size="lg"
+    >
+      <Show
+        when={fields().length > 0}
+        fallback={<p class="text-sm text-stone">Nothing to edit.</p>}
+      >
+        <div class="flex flex-col gap-4">
+          <For each={fields()}>{(spec) => <Field spec={spec} />}</For>
+        </div>
+      </Show>
+
+      <div class="mt-6 flex justify-end gap-3">
+        <Button variant="ghost" onClick={() => props.onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button onClick={save}>{isAdding() ? `Add ${noun()}` : "Save"}</Button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/doc-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/doc-editor/MarkdownEditor.tsx
@@ -80,6 +80,11 @@ export function MarkdownEditor(props: MarkdownEditorProps): JSX.Element {
       setIsLinkOpen(true);
       return;
     }
+    // Another command invalidates the snapshot the link row was about to act
+    // on, so close it rather than let a later Apply overwrite newer text.
+    linkRange = null;
+    setLinkHref("");
+    setIsLinkOpen(false);
     applyResult(applyMarkdownCommand(selection(), command));
   }
 

--- a/apps/web/src/components/doc-editor/MarkdownEditor.tsx
+++ b/apps/web/src/components/doc-editor/MarkdownEditor.tsx
@@ -1,0 +1,206 @@
+/**
+ * The sheet's mini rich editor for multi-line fields.
+ *
+ * It edits **markdown** as text: the textarea holds exactly what is stored, and
+ * the toolbar rewrites that text through {@link applyMarkdownCommand}. There is
+ * no hidden document model, so nothing can be typed here that the render path
+ * cannot reproduce.
+ *
+ * The toolbar is bold, italic, link, unordered list and ordered list. It has no
+ * underline button on purpose — markdown has no underline and the conversion in
+ * `crates/utils/src/html_to_typst.rs` has nothing to map one onto.
+ *
+ * Commit is on focus leaving the editor entirely, or on the explicit Done
+ * button; Escape restores the prior value. Toolbar buttons suppress their own
+ * mousedown so pressing one neither steals focus nor drops the selection the
+ * command is about to act on.
+ */
+
+import { For, Show, createSignal, type JSX } from "solid-js";
+import { applyMarkdownCommand, type MarkdownCommand, type MarkdownSelection } from "./markdown";
+
+interface ToolbarAction {
+  command: MarkdownCommand;
+  label: string;
+  /** Short glyph drawn in the button; the accessible name is `label`. */
+  glyph: string;
+}
+
+/** Underline is absent by design — see the module note. */
+const TOOLBAR: readonly ToolbarAction[] = [
+  { command: "bold", label: "Bold", glyph: "B" },
+  { command: "italic", label: "Italic", glyph: "I" },
+  // Typographic glyphs, never emoji — see the brand anti-pattern list.
+  { command: "link", label: "Link", glyph: "Link" },
+  { command: "bulletList", label: "Bulleted list", glyph: "•" },
+  { command: "orderedList", label: "Numbered list", glyph: "1." },
+];
+
+export interface MarkdownEditorProps {
+  /** Markdown to edit. */
+  value: string;
+  /** Field name, e.g. "Summary". Labels the textarea. */
+  label: string;
+  /** Called with the new markdown when the edit is committed. */
+  onCommit: (value: string) => void;
+  /** Called when the edit is abandoned. */
+  onCancel: () => void;
+}
+
+export function MarkdownEditor(props: MarkdownEditorProps): JSX.Element {
+  const [draft, setDraft] = createSignal(props.value);
+  const [linkHref, setLinkHref] = createSignal("");
+  const [isLinkOpen, setIsLinkOpen] = createSignal(false);
+
+  let root: HTMLDivElement | undefined;
+  let textarea: HTMLTextAreaElement | undefined;
+  // The selection the link row will act on, captured before focus moves to it.
+  let linkRange: MarkdownSelection | null = null;
+  // One edit settles once: committing unmounts the editor, and the blur that
+  // follows must not reach the store a second time.
+  let isSettled = false;
+
+  function selection(): MarkdownSelection {
+    const value = draft();
+    if (!textarea) return { value, start: value.length, end: value.length };
+    return { value, start: textarea.selectionStart, end: textarea.selectionEnd };
+  }
+
+  function applyResult(next: MarkdownSelection): void {
+    setDraft(next.value);
+    queueMicrotask(() => {
+      textarea?.focus();
+      textarea?.setSelectionRange(next.start, next.end);
+    });
+  }
+
+  function runCommand(command: MarkdownCommand): void {
+    if (command === "link") {
+      linkRange = selection();
+      setIsLinkOpen(true);
+      return;
+    }
+    applyResult(applyMarkdownCommand(selection(), command));
+  }
+
+  function applyLink(): void {
+    const href = linkHref().trim();
+    if (href === "") return;
+    applyResult(applyMarkdownCommand(linkRange ?? selection(), "link", href));
+    linkRange = null;
+    setLinkHref("");
+    setIsLinkOpen(false);
+  }
+
+  function commit(): void {
+    if (isSettled) return;
+    isSettled = true;
+    const next = draft();
+    if (next === props.value) {
+      props.onCancel();
+      return;
+    }
+    props.onCommit(next);
+  }
+
+  function cancel(): void {
+    if (isSettled) return;
+    isSettled = true;
+    props.onCancel();
+  }
+
+  function handleFocusOut(event: FocusEvent): void {
+    const next = event.relatedTarget;
+    // Moving between the textarea, the toolbar and the link row is still one
+    // editing session; only focus leaving the whole editor commits.
+    if (next instanceof Node && root?.contains(next)) return;
+    commit();
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancel();
+    }
+  }
+
+  return (
+    <div
+      ref={(element) => (root = element)}
+      class="doc-sheet__markdown"
+      onFocusOut={handleFocusOut}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        class="doc-sheet__markdown-toolbar"
+        role="toolbar"
+        aria-label={`${props.label} formatting`}
+      >
+        <For each={TOOLBAR}>
+          {(action) => (
+            <button
+              type="button"
+              class="doc-sheet__markdown-button"
+              aria-label={action.label}
+              // Keep focus (and therefore the selection) in the textarea.
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => runCommand(action.command)}
+            >
+              {action.glyph}
+            </button>
+          )}
+        </For>
+      </div>
+
+      <Show when={isLinkOpen()}>
+        <div class="doc-sheet__markdown-link">
+          <input
+            ref={(element) => queueMicrotask(() => element.focus())}
+            type="url"
+            class="doc-sheet__markdown-href"
+            aria-label="Link URL"
+            placeholder="https://"
+            value={linkHref()}
+            onInput={(event) => setLinkHref(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter") return;
+              event.preventDefault();
+              applyLink();
+            }}
+          />
+          <button
+            type="button"
+            class="doc-sheet__markdown-button"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={applyLink}
+          >
+            Apply link
+          </button>
+        </div>
+      </Show>
+
+      <textarea
+        ref={(element) => {
+          textarea = element;
+          queueMicrotask(() => element.focus());
+        }}
+        class="doc-sheet__markdown-input"
+        aria-label={props.label}
+        rows={5}
+        value={draft()}
+        onInput={(event) => setDraft(event.currentTarget.value)}
+      />
+
+      <div class="doc-sheet__markdown-footer">
+        <button
+          type="button"
+          class="doc-sheet__markdown-button"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={commit}
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/doc-editor/PhotoDialog.tsx
+++ b/apps/web/src/components/doc-editor/PhotoDialog.tsx
@@ -1,0 +1,308 @@
+/**
+ * Edit `basics.picture`: the image itself, its size and shape, and its effects.
+ *
+ * Upload, resize and colour handling come from `lib/imageUpload`, shared with
+ * the form builder's `ImageUpload` so a photo is ingested identically whichever
+ * surface the user reached for.
+ *
+ * The dialog edits a draft and commits **once**, on save, through a single
+ * `updateBasics("picture", …)` — so changing the size, the radius and three
+ * effects together is one undo entry rather than five.
+ */
+
+import { Show, createEffect, createSignal, type JSX } from "solid-js";
+import { Button, Modal, Switch, toast } from "../ui";
+import {
+  ACCEPTED_IMAGE_TYPES,
+  expandShortHex,
+  isHexColor,
+  normalizeHexColor,
+  processImage,
+  validateImageFile,
+} from "../../lib/imageUpload";
+import { updatePicture } from "./docEdits";
+import type { Picture } from "../../wasm/types";
+
+/** Point bounds for the stored photo size, matching the form builder's slider. */
+const MIN_SIZE = 32;
+const MAX_SIZE = 200;
+const MAX_BORDER_WIDTH = 10;
+const MAX_SHADOW_SIZE = 20;
+
+export interface PhotoDialogProps {
+  open: boolean;
+  /** The picture as stored. */
+  picture: Picture;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function PhotoDialog(props: PhotoDialogProps): JSX.Element {
+  const [draft, setDraft] = createSignal<Picture>(props.picture);
+  const [isProcessing, setIsProcessing] = createSignal(false);
+
+  let fileInput: HTMLInputElement | undefined;
+
+  createEffect(() => {
+    if (!props.open) return;
+    setDraft({ ...props.picture, effects: { ...props.picture.effects } });
+  });
+
+  function patch(updates: Partial<Picture>): void {
+    setDraft((current) => ({ ...current, ...updates }));
+  }
+
+  function patchEffect<K extends keyof Picture["effects"]>(
+    key: K,
+    value: Picture["effects"][K],
+  ): void {
+    setDraft((current) => ({ ...current, effects: { ...current.effects, [key]: value } }));
+  }
+
+  function patchColorEffect(key: "borderColor" | "shadowColor", raw: string): void {
+    const normalized = normalizeHexColor(raw);
+    if (normalized === "" || isHexColor(normalized)) {
+      patchEffect(key, expandShortHex(normalized));
+    }
+  }
+
+  async function handleFile(file: File): Promise<void> {
+    const error = validateImageFile(file);
+    if (error) {
+      toast.error(error);
+      return;
+    }
+
+    setIsProcessing(true);
+    try {
+      const { dataUrl, aspectRatio } = await processImage(file);
+      setDraft((current) => ({
+        ...current,
+        url: dataUrl,
+        aspectRatio,
+        effects: { ...current.effects, hidden: false },
+      }));
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Failed to process image");
+    } finally {
+      setIsProcessing(false);
+    }
+  }
+
+  function handleInputChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file) void handleFile(file);
+    // Reset so the same file can be re-selected.
+    input.value = "";
+  }
+
+  function removePhoto(): void {
+    setDraft((current) => ({
+      ...current,
+      url: "",
+      effects: { ...current.effects, hidden: true },
+    }));
+  }
+
+  function save(): void {
+    updatePicture(draft());
+    props.onOpenChange(false);
+  }
+
+  const previewStyle = () => {
+    const picture = draft();
+    const size = picture.size || 64;
+    return {
+      width: `${size}px`,
+      height: `${size}px`,
+      "border-radius": `${Math.min(picture.borderRadius, Math.round(size / 2))}px`,
+      filter: picture.effects.grayscale ? "grayscale(100%)" : undefined,
+      transform: picture.effects.rotation ? `rotate(${picture.effects.rotation}deg)` : undefined,
+    };
+  };
+
+  return (
+    <Modal open={props.open} onOpenChange={props.onOpenChange} title="Photo" size="lg">
+      <input
+        ref={(element) => (fileInput = element)}
+        type="file"
+        accept={ACCEPTED_IMAGE_TYPES.join(",")}
+        class="hidden"
+        aria-label="Choose profile photo"
+        onChange={handleInputChange}
+      />
+
+      <div class="flex flex-col gap-5">
+        <div class="flex items-start gap-4">
+          <Show
+            when={draft().url !== ""}
+            fallback={<div class="text-sm text-stone">No photo yet.</div>}
+          >
+            <img
+              src={draft().url}
+              alt="Profile photo"
+              class="object-cover"
+              style={previewStyle()}
+            />
+          </Show>
+
+          <div class="flex gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              loading={isProcessing()}
+              onClick={() => fileInput?.click()}
+            >
+              {draft().url === "" ? "Upload photo" : "Replace"}
+            </Button>
+            <Show when={draft().url !== ""}>
+              <Button variant="danger" size="sm" onClick={removePhoto}>
+                Remove
+              </Button>
+            </Show>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-1.5">
+          <label class="font-mono text-xs uppercase tracking-wider text-stone" for="doc-photo-size">
+            Size ({draft().size}pt)
+          </label>
+          <input
+            id="doc-photo-size"
+            type="range"
+            min={MIN_SIZE}
+            max={MAX_SIZE}
+            step="4"
+            value={draft().size}
+            onInput={(event) => patch({ size: parseInt(event.currentTarget.value, 10) })}
+            class="w-full accent-accent"
+          />
+        </div>
+
+        <div class="flex flex-col gap-1.5">
+          <label
+            class="font-mono text-xs uppercase tracking-wider text-stone"
+            for="doc-photo-radius"
+          >
+            Corner radius ({draft().borderRadius}pt)
+          </label>
+          <input
+            id="doc-photo-radius"
+            type="range"
+            min="0"
+            max={Math.round(draft().size / 2)}
+            step="1"
+            value={draft().borderRadius}
+            onInput={(event) => patch({ borderRadius: parseInt(event.currentTarget.value, 10) })}
+            class="w-full accent-accent"
+          />
+        </div>
+
+        <p class="text-xs text-stone">
+          Aspect ratio {draft().aspectRatio.toFixed(2)} — recorded from the source image.
+        </p>
+
+        <div class="flex flex-col gap-2">
+          <Switch
+            label="Hidden"
+            description="Hide photo from the document"
+            checked={draft().effects.hidden}
+            onChange={(value) => patchEffect("hidden", value)}
+          />
+          <Switch
+            label="Grayscale"
+            checked={draft().effects.grayscale}
+            onChange={(value) => patchEffect("grayscale", value)}
+          />
+          <Switch
+            label="Border"
+            checked={draft().effects.border}
+            onChange={(value) => patchEffect("border", value)}
+          />
+        </div>
+
+        <div class="flex flex-col gap-1.5">
+          <label
+            class="font-mono text-xs uppercase tracking-wider text-stone"
+            for="doc-photo-rotation"
+          >
+            Rotation ({draft().effects.rotation}deg)
+          </label>
+          <input
+            id="doc-photo-rotation"
+            type="range"
+            min="0"
+            max="360"
+            step="1"
+            value={draft().effects.rotation}
+            onInput={(event) => patchEffect("rotation", parseFloat(event.currentTarget.value))}
+            class="w-full accent-accent"
+          />
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+          <label class="flex flex-col gap-1.5">
+            <span class="font-mono text-xs uppercase tracking-wider text-stone">Border color</span>
+            <input
+              type="text"
+              value={draft().effects.borderColor}
+              onInput={(event) => patchColorEffect("borderColor", event.currentTarget.value)}
+              placeholder="Theme primary"
+              class="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-ink"
+            />
+          </label>
+          <label class="flex flex-col gap-1.5">
+            <span class="font-mono text-xs uppercase tracking-wider text-stone">Border width</span>
+            <input
+              type="number"
+              min="0"
+              max={MAX_BORDER_WIDTH}
+              value={draft().effects.borderWidth}
+              onInput={(event) => {
+                const parsed = parseInt(event.currentTarget.value, 10);
+                if (Number.isNaN(parsed)) return;
+                patchEffect("borderWidth", Math.min(MAX_BORDER_WIDTH, Math.max(0, parsed)));
+              }}
+              class="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-ink"
+            />
+          </label>
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+          <label class="flex flex-col gap-1.5">
+            <span class="font-mono text-xs uppercase tracking-wider text-stone">Shadow color</span>
+            <input
+              type="text"
+              value={draft().effects.shadowColor}
+              onInput={(event) => patchColorEffect("shadowColor", event.currentTarget.value)}
+              placeholder="#00000040"
+              class="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-ink"
+            />
+          </label>
+          <label class="flex flex-col gap-1.5">
+            <span class="font-mono text-xs uppercase tracking-wider text-stone">Shadow size</span>
+            <input
+              type="number"
+              min="0"
+              max={MAX_SHADOW_SIZE}
+              value={draft().effects.shadowSize}
+              onInput={(event) => {
+                const parsed = parseInt(event.currentTarget.value, 10);
+                if (Number.isNaN(parsed)) return;
+                patchEffect("shadowSize", Math.min(MAX_SHADOW_SIZE, Math.max(0, parsed)));
+              }}
+              class="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-ink"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div class="mt-6 flex justify-end gap-3">
+        <Button variant="ghost" onClick={() => props.onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button onClick={save}>Save photo</Button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/doc-editor/PhotoDialog.tsx
+++ b/apps/web/src/components/doc-editor/PhotoDialog.tsx
@@ -40,12 +40,14 @@ export interface PhotoDialogProps {
 export function PhotoDialog(props: PhotoDialogProps): JSX.Element {
   const [draft, setDraft] = createSignal<Picture>(props.picture);
   const [isProcessing, setIsProcessing] = createSignal(false);
+  const [colorText, setColorText] = createSignal<Partial<Record<string, string>>>({});
 
   let fileInput: HTMLInputElement | undefined;
 
   createEffect(() => {
     if (!props.open) return;
     setDraft({ ...props.picture, effects: { ...props.picture.effects } });
+    setColorText({});
   });
 
   function patch(updates: Partial<Picture>): void {
@@ -59,12 +61,23 @@ export function PhotoDialog(props: PhotoDialogProps): JSX.Element {
     setDraft((current) => ({ ...current, effects: { ...current.effects, [key]: value } }));
   }
 
+  /**
+   * Hold the raw text of a colour field while it is being typed.
+   *
+   * The inputs are controlled, so writing the expanded value straight back
+   * would rewrite `#abc` to `#aabbcc` under the cursor mid-entry. The buffer is
+   * what the user sees; the effect only takes a value once it parses.
+   */
   function patchColorEffect(key: "borderColor" | "shadowColor", raw: string): void {
+    setColorText((current) => ({ ...current, [key]: raw }));
     const normalized = normalizeHexColor(raw);
     if (normalized === "" || isHexColor(normalized)) {
       patchEffect(key, expandShortHex(normalized));
     }
   }
+
+  const colorValue = (key: "borderColor" | "shadowColor"): string =>
+    colorText()[key] ?? draft().effects[key];
 
   async function handleFile(file: File): Promise<void> {
     const error = validateImageFile(file);
@@ -246,7 +259,7 @@ export function PhotoDialog(props: PhotoDialogProps): JSX.Element {
             <span class="font-mono text-xs uppercase tracking-wider text-stone">Border color</span>
             <input
               type="text"
-              value={draft().effects.borderColor}
+              value={colorValue("borderColor")}
               onInput={(event) => patchColorEffect("borderColor", event.currentTarget.value)}
               placeholder="Theme primary"
               class="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-ink"
@@ -274,7 +287,7 @@ export function PhotoDialog(props: PhotoDialogProps): JSX.Element {
             <span class="font-mono text-xs uppercase tracking-wider text-stone">Shadow color</span>
             <input
               type="text"
-              value={draft().effects.shadowColor}
+              value={colorValue("shadowColor")}
               onInput={(event) => patchColorEffect("shadowColor", event.currentTarget.value)}
               placeholder="#00000040"
               class="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-ink"

--- a/apps/web/src/components/doc-editor/PhotoDialog.tsx
+++ b/apps/web/src/components/doc-editor/PhotoDialog.tsx
@@ -17,6 +17,7 @@ import {
   expandShortHex,
   isHexColor,
   normalizeHexColor,
+  picturePreviewStyle,
   processImage,
   validateImageFile,
 } from "../../lib/imageUpload";
@@ -79,7 +80,9 @@ export function PhotoDialog(props: PhotoDialogProps): JSX.Element {
         ...current,
         url: dataUrl,
         aspectRatio,
-        effects: { ...current.effects, hidden: false },
+        // A first upload reveals the photo; replacing one leaves the user's own
+        // hidden choice alone. Same rule as the form builder's ImageUpload.
+        effects: { ...current.effects, hidden: current.url ? current.effects.hidden : false },
       }));
     } catch (e: unknown) {
       toast.error(e instanceof Error ? e.message : "Failed to process image");
@@ -109,17 +112,7 @@ export function PhotoDialog(props: PhotoDialogProps): JSX.Element {
     props.onOpenChange(false);
   }
 
-  const previewStyle = () => {
-    const picture = draft();
-    const size = picture.size || 64;
-    return {
-      width: `${size}px`,
-      height: `${size}px`,
-      "border-radius": `${Math.min(picture.borderRadius, Math.round(size / 2))}px`,
-      filter: picture.effects.grayscale ? "grayscale(100%)" : undefined,
-      transform: picture.effects.rotation ? `rotate(${picture.effects.rotation}deg)` : undefined,
-    };
-  };
+  const previewStyle = () => picturePreviewStyle(draft());
 
   return (
     <Modal open={props.open} onOpenChange={props.onOpenChange} title="Photo" size="lg">
@@ -174,7 +167,15 @@ export function PhotoDialog(props: PhotoDialogProps): JSX.Element {
             max={MAX_SIZE}
             step="4"
             value={draft().size}
-            onInput={(event) => patch({ size: parseInt(event.currentTarget.value, 10) })}
+            onInput={(event) => {
+              const size = parseInt(event.currentTarget.value, 10);
+              // The radius slider's max follows the size; keep the stored value
+              // inside it so shrinking the photo cannot save an over-large radius.
+              patch({
+                size,
+                borderRadius: Math.min(draft().borderRadius, Math.round(size / 2)),
+              });
+            }}
             class="w-full accent-accent"
           />
         </div>
@@ -301,7 +302,11 @@ export function PhotoDialog(props: PhotoDialogProps): JSX.Element {
         <Button variant="ghost" onClick={() => props.onOpenChange(false)}>
           Cancel
         </Button>
-        <Button onClick={save}>Save photo</Button>
+        {/* Saving mid-upload would commit a draft without the new image and
+            close the dialog, discarding the photo the user just chose. */}
+        <Button disabled={isProcessing()} onClick={save}>
+          Save photo
+        </Button>
       </div>
     </Modal>
   );

--- a/apps/web/src/components/doc-editor/__tests__/dialogs.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/dialogs.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { emptyItemFor } from "../../../lib/docLayout";
+import { itemFieldsFor } from "../itemFields";
 import { createEmptyPicture } from "../../../wasm/types";
 import { CustomSectionDialog } from "../CustomSectionDialog";
 import { ItemDialog } from "../ItemDialog";
@@ -184,6 +185,24 @@ describe("item dialog", () => {
     expect([sectionId, index]).toEqual([CUSTOM_SECTION_ID, 1]);
     expect(updates.date).toBe("2025");
   });
+
+  it.each([...ITEM_SECTIONS, CUSTOM_SECTION_ID])(
+    "describes every writable key of a %s item",
+    (sectionId) => {
+      // The shape test above seeds *from* `emptyItemFor`, so it would still
+      // pass with an empty descriptor list. This is what actually ties the
+      // dialog's fields to the item the store holds.
+      const stored = Object.keys(emptyItemFor(sectionId) ?? {}).filter(
+        (key) => key !== "id" && key !== "visible",
+      );
+
+      expect(
+        itemFieldsFor(sectionId)
+          .map((field) => field.key)
+          .sort(),
+      ).toEqual(stored.sort());
+    },
+  );
 
   it("keeps the separator while a keyword list is being typed", () => {
     render(() => (

--- a/apps/web/src/components/doc-editor/__tests__/dialogs.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/dialogs.test.tsx
@@ -185,6 +185,36 @@ describe("item dialog", () => {
     expect(updates.date).toBe("2025");
   });
 
+  it("keeps the separator while a keyword list is being typed", () => {
+    render(() => (
+      <ItemDialog
+        open
+        sectionId="skills"
+        sectionTitle="Skills"
+        index={0}
+        item={{ name: "Rust", keywords: [] }}
+        onOpenChange={() => {}}
+      />
+    ));
+
+    // The field is controlled, so rendering the parsed list back would erase
+    // the comma the moment it is typed and no second keyword could be started.
+    const input = screen.getByRole("textbox", { name: "Keywords" }) as HTMLInputElement;
+    fireEvent.input(input, { target: { value: "rust," } });
+    expect(input.value).toBe("rust,");
+    fireEvent.input(input, { target: { value: "rust, wasm" } });
+    expect(input.value).toBe("rust, wasm");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const [, , updates] = store.updateSectionItem.mock.calls[0] as [
+      string,
+      number,
+      Record<string, unknown>,
+    ];
+    expect(updates.keywords).toEqual(["rust", "wasm"]);
+  });
+
   it("is a labelled dialog", () => {
     render(() => (
       <ItemDialog open sectionId="awards" sectionTitle="Awards" onOpenChange={() => {}} />
@@ -253,6 +283,55 @@ describe("photo dialog", () => {
     expect(picture.aspectRatio).toBe(1.5);
     expect(picture.borderRadius).toBe(12);
     expect(picture.effects.hidden).toBe(false);
+  });
+
+  it("leaves a hidden photo hidden when it is replaced", async () => {
+    const picture = createEmptyPicture();
+    render(() => (
+      <PhotoDialog
+        open
+        picture={{
+          ...picture,
+          url: "data:image/webp;base64,OLD",
+          effects: { ...picture.effects, hidden: true },
+        }}
+        onOpenChange={() => {}}
+      />
+    ));
+
+    const file = new File(["binary"], "avatar.png", { type: "image/png" });
+    const input = screen.getByLabelText("Choose profile photo") as HTMLInputElement;
+    Object.defineProperty(input, "files", { value: [file], configurable: true });
+    fireEvent.change(input);
+
+    await waitFor(() =>
+      expect(screen.getByAltText("Profile photo")).toHaveAttribute(
+        "src",
+        "data:image/webp;base64,AAA",
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save photo" }));
+
+    // Only a first upload reveals the photo; "Replace" must not undo the
+    // user's own decision to hide it.
+    const [, saved] = store.updateBasics.mock.calls[0] as [
+      string,
+      { effects: { hidden: boolean } },
+    ];
+    expect(saved.effects.hidden).toBe(true);
+  });
+
+  it("clamps the corner radius when the size shrinks", () => {
+    render(() => (
+      <PhotoDialog open picture={{ ...createEmptyPicture(), size: 200 }} onOpenChange={() => {}} />
+    ));
+
+    fireEvent.input(screen.getByLabelText(/Corner radius/), { target: { value: "100" } });
+    fireEvent.input(screen.getByLabelText(/^Size/), { target: { value: "40" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save photo" }));
+
+    const [, saved] = store.updateBasics.mock.calls[0] as [string, { borderRadius: number }];
+    expect(saved.borderRadius).toBe(20);
   });
 
   it("writes nothing until the dialog is saved", () => {

--- a/apps/web/src/components/doc-editor/__tests__/dialogs.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/dialogs.test.tsx
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { emptyItemFor } from "../../../lib/docLayout";
+import { createEmptyPicture } from "../../../wasm/types";
+import { CustomSectionDialog } from "../CustomSectionDialog";
+import { ItemDialog } from "../ItemDialog";
+import { PhotoDialog } from "../PhotoDialog";
+
+const store = vi.hoisted(() => ({
+  updateBasics: vi.fn(),
+  updateSummary: vi.fn(),
+  updateCoverLetter: vi.fn(),
+  updateSectionName: vi.fn(),
+  updateSectionItem: vi.fn(),
+  addSectionItem: vi.fn(),
+  updateCustomSection: vi.fn(),
+  addCustomSection: vi.fn(() => "custom-1"),
+  updateCustomSectionItem: vi.fn(),
+  addCustomSectionItem: vi.fn(),
+}));
+
+vi.mock("../../../stores/resume", () => ({ resumeStore: store }));
+
+vi.mock("../../../lib/imageUpload", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/imageUpload")>();
+  return {
+    ...actual,
+    processImage: vi.fn(async () => ({ dataUrl: "data:image/webp;base64,AAA", aspectRatio: 1.5 })),
+  };
+});
+
+/** Every fixed section that holds items, plus a custom section id. */
+const ITEM_SECTIONS = [
+  "experience",
+  "education",
+  "skills",
+  "projects",
+  "profiles",
+  "awards",
+  "certifications",
+  "publications",
+  "languages",
+  "interests",
+  "volunteer",
+  "references",
+] as const;
+
+const CUSTOM_SECTION_ID = "speaking";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("item dialog", () => {
+  it.each(ITEM_SECTIONS)("adds a correctly-shaped %s item", (sectionId) => {
+    render(() => (
+      <ItemDialog open sectionId={sectionId} sectionTitle={sectionId} onOpenChange={() => {}} />
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: `Add ${sectionId.replace(/s$/, "")}` }));
+
+    expect(store.addSectionItem).toHaveBeenCalledOnce();
+    const [committedSection, item] = store.addSectionItem.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(committedSection).toBe(sectionId);
+    // The seed is `emptyItemFor()`; the editor supplies the id it deliberately
+    // leaves blank, and the item starts visible.
+    expect(Object.keys(item).sort()).toEqual(
+      Object.keys(emptyItemFor(sectionId) ?? {})
+        .concat()
+        .sort(),
+    );
+    expect(item.id).not.toBe("");
+    expect(item.visible).toBe(true);
+  });
+
+  it("carries typed values into the added item", () => {
+    render(() => (
+      <ItemDialog open sectionId="experience" sectionTitle="Experience" onOpenChange={() => {}} />
+    ));
+
+    fireEvent.input(screen.getByRole("textbox", { name: "Company" }), {
+      target: { value: "Lumen Health" },
+    });
+    fireEvent.input(screen.getByRole("textbox", { name: "Summary" }), {
+      target: { value: "Owned **Halo**." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add experience" }));
+
+    expect(store.addSectionItem).toHaveBeenCalledOnce();
+    const [, item] = store.addSectionItem.mock.calls[0] as [string, Record<string, unknown>];
+    expect(item.company).toBe("Lumen Health");
+    expect(item.summary).toBe("Owned **Halo**.");
+  });
+
+  it("edits an existing item through one updateSectionItem call", () => {
+    const item = {
+      ...(emptyItemFor("skills") as unknown as Record<string, unknown>),
+      id: "s1",
+      name: "Rust",
+    };
+
+    render(() => (
+      <ItemDialog
+        open
+        sectionId="skills"
+        sectionTitle="Skills"
+        index={2}
+        item={item}
+        onOpenChange={() => {}}
+      />
+    ));
+
+    fireEvent.input(screen.getByRole("textbox", { name: "Keywords" }), {
+      target: { value: "wasm, axum" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(store.addSectionItem).not.toHaveBeenCalled();
+    expect(store.updateSectionItem).toHaveBeenCalledOnce();
+    const [sectionId, index, updates] = store.updateSectionItem.mock.calls[0] as [
+      string,
+      number,
+      Record<string, unknown>,
+    ];
+    expect([sectionId, index]).toEqual(["skills", 2]);
+    expect(updates.name).toBe("Rust");
+    expect(updates.keywords).toEqual(["wasm", "axum"]);
+  });
+
+  it("adds a custom-section item through addCustomSectionItem", () => {
+    render(() => (
+      <ItemDialog open sectionId={CUSTOM_SECTION_ID} sectionTitle="Talks" onOpenChange={() => {}} />
+    ));
+
+    fireEvent.input(screen.getByRole("textbox", { name: "Name" }), {
+      target: { value: "Design Tokens" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add talk" }));
+
+    expect(store.addCustomSectionItem).toHaveBeenCalledOnce();
+    const [sectionId, item] = store.addCustomSectionItem.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(sectionId).toBe(CUSTOM_SECTION_ID);
+    expect(item.name).toBe("Design Tokens");
+    expect(Object.keys(item).sort()).toEqual(
+      Object.keys(emptyItemFor(CUSTOM_SECTION_ID) ?? {}).sort(),
+    );
+  });
+
+  it("edits a custom-section item through updateCustomSectionItem", () => {
+    const item = {
+      ...(emptyItemFor(CUSTOM_SECTION_ID) as unknown as Record<string, unknown>),
+      id: "t1",
+      name: "Talk",
+    };
+
+    render(() => (
+      <ItemDialog
+        open
+        sectionId={CUSTOM_SECTION_ID}
+        sectionTitle="Talks"
+        index={1}
+        item={item}
+        onOpenChange={() => {}}
+      />
+    ));
+
+    fireEvent.input(screen.getByRole("textbox", { name: "Date" }), {
+      target: { value: "2025" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(store.updateCustomSectionItem).toHaveBeenCalledOnce();
+    const [sectionId, index, updates] = store.updateCustomSectionItem.mock.calls[0] as [
+      string,
+      number,
+      Record<string, unknown>,
+    ];
+    expect([sectionId, index]).toEqual([CUSTOM_SECTION_ID, 1]);
+    expect(updates.date).toBe("2025");
+  });
+
+  it("is a labelled dialog", () => {
+    render(() => (
+      <ItemDialog open sectionId="awards" sectionTitle="Awards" onOpenChange={() => {}} />
+    ));
+
+    expect(screen.getByRole("dialog", { name: "Add award" })).toBeInTheDocument();
+  });
+});
+
+describe("custom section dialog", () => {
+  it("creates a section through addCustomSection", () => {
+    render(() => <CustomSectionDialog open onOpenChange={() => {}} />);
+
+    fireEvent.input(screen.getByRole("textbox", { name: "Section name" }), {
+      target: { value: "Talks & Workshops" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add section" }));
+
+    expect(store.addCustomSection).toHaveBeenCalledExactlyOnceWith("Talks & Workshops");
+  });
+
+  it("renames a section through updateCustomSection", () => {
+    render(() => (
+      <CustomSectionDialog open sectionId="speaking" name="Talks" onOpenChange={() => {}} />
+    ));
+
+    fireEvent.input(screen.getByRole("textbox", { name: "Section name" }), {
+      target: { value: "Talks & Workshops" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+    expect(store.updateCustomSection).toHaveBeenCalledExactlyOnceWith("speaking", {
+      name: "Talks & Workshops",
+    });
+    expect(store.addCustomSection).not.toHaveBeenCalled();
+  });
+
+  it("refuses an empty name", () => {
+    render(() => <CustomSectionDialog open onOpenChange={() => {}} />);
+
+    expect(screen.getByRole("button", { name: "Add section" })).toBeDisabled();
+  });
+});
+
+describe("photo dialog", () => {
+  it("patches basics.picture once, with the uploaded image", async () => {
+    render(() => <PhotoDialog open picture={createEmptyPicture()} onOpenChange={() => {}} />);
+
+    const file = new File(["binary"], "avatar.png", { type: "image/png" });
+    const input = screen.getByLabelText("Choose profile photo") as HTMLInputElement;
+    Object.defineProperty(input, "files", { value: [file], configurable: true });
+    fireEvent.change(input);
+
+    await waitFor(() => expect(screen.getByAltText("Profile photo")).toBeInTheDocument());
+
+    fireEvent.input(screen.getByLabelText(/Corner radius/), { target: { value: "12" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save photo" }));
+
+    expect(store.updateBasics).toHaveBeenCalledOnce();
+    const [field, picture] = store.updateBasics.mock.calls[0] as [
+      string,
+      { url: string; aspectRatio: number; borderRadius: number; effects: { hidden: boolean } },
+    ];
+    expect(field).toBe("picture");
+    expect(picture.url).toBe("data:image/webp;base64,AAA");
+    expect(picture.aspectRatio).toBe(1.5);
+    expect(picture.borderRadius).toBe(12);
+    expect(picture.effects.hidden).toBe(false);
+  });
+
+  it("writes nothing until the dialog is saved", () => {
+    render(() => <PhotoDialog open picture={createEmptyPicture()} onOpenChange={() => {}} />);
+
+    fireEvent.input(screen.getByLabelText(/^Size/), { target: { value: "96" } });
+
+    expect(store.updateBasics).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/doc-editor/__tests__/inlineEdit.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/inlineEdit.test.tsx
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@solidjs/testing-library";
+import { loadDocEditorFixture, SINGLE_TEMPLATE } from "../../../test/docEditorFixture";
+import { DocSheet } from "../DocSheet";
+import type { ResumeData } from "../../../wasm/types";
+
+const store = vi.hoisted(() => ({
+  updateBasics: vi.fn(),
+  updateSummary: vi.fn(),
+  updateCoverLetter: vi.fn(),
+  updateSectionName: vi.fn(),
+  updateSectionItem: vi.fn(),
+  addSectionItem: vi.fn(),
+  updateCustomSection: vi.fn(),
+  addCustomSection: vi.fn(() => "custom-1"),
+  updateCustomSectionItem: vi.fn(),
+  addCustomSectionItem: vi.fn(),
+}));
+
+vi.mock("../../../stores/resume", () => ({ resumeStore: store }));
+
+/** Total writes recorded across every mocked store action. */
+function writeCount(): number {
+  return Object.values(store).reduce((total, action) => total + action.mock.calls.length, 0);
+}
+
+describe("document sheet inline editing", () => {
+  let resume: ResumeData;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resume = loadDocEditorFixture();
+  });
+
+  function renderSheet() {
+    return render(() => <DocSheet resume={resume} templateLayout={SINGLE_TEMPLATE} />);
+  }
+
+  /**
+   * Open the editor behind the value `name` and return its input.
+   *
+   * `scope` narrows the search when the same text is drawn twice — a headline
+   * and a job title can read identically.
+   */
+  function edit(name: string, fieldLabel: string, scope?: HTMLElement): HTMLInputElement {
+    const region = scope ? within(scope) : screen;
+    fireEvent.click(region.getByRole("button", { name }));
+    return region.getByRole("textbox", { name: fieldLabel }) as HTMLInputElement;
+  }
+
+  /** The header region, where the basics are drawn. */
+  function header(): HTMLElement {
+    return screen.getAllByTestId("doc-sheet-header")[0];
+  }
+
+  it("commits a basics field on blur, through one store action", () => {
+    renderSheet();
+
+    const input = edit("Mireille Okafor", "Name", header());
+    fireEvent.input(input, { target: { value: "Ada Lovelace" } });
+    fireEvent.blur(input);
+
+    expect(store.updateBasics).toHaveBeenCalledExactlyOnceWith("name", "Ada Lovelace");
+    expect(writeCount()).toBe(1);
+  });
+
+  it("commits on Enter", () => {
+    renderSheet();
+
+    const input = edit("Principal Design Systems Engineer", "Headline", header());
+    fireEvent.input(input, { target: { value: "Design Systems Lead" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(store.updateBasics).toHaveBeenCalledExactlyOnceWith("headline", "Design Systems Lead");
+    expect(writeCount()).toBe(1);
+  });
+
+  it("restores the prior value on Escape without writing", () => {
+    renderSheet();
+
+    const input = edit("mireille@okafor.design", "Email", header());
+    fireEvent.input(input, { target: { value: "typo@example.com" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(writeCount()).toBe(0);
+    expect(screen.getByRole("button", { name: "mireille@okafor.design" })).toBeInTheDocument();
+  });
+
+  it("writes nothing when the text is left unchanged", () => {
+    renderSheet();
+
+    const input = edit("Lisbon, Portugal", "Location", header());
+    fireEvent.blur(input);
+
+    expect(writeCount()).toBe(0);
+  });
+
+  it("commits an item field through updateSectionItem at the item's own index", () => {
+    renderSheet();
+
+    const input = edit("Lumen Health", "Company");
+    fireEvent.input(input, { target: { value: "Lumen Health Group" } });
+    fireEvent.blur(input);
+
+    expect(store.updateSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, {
+      company: "Lumen Health Group",
+    });
+    expect(writeCount()).toBe(1);
+  });
+
+  it("commits a custom-section item through updateCustomSectionItem", () => {
+    renderSheet();
+
+    const input = edit("Design Tokens Beyond Colour", "Name");
+    fireEvent.input(input, { target: { value: "Design Tokens, Beyond Colour" } });
+    fireEvent.blur(input);
+
+    expect(store.updateCustomSectionItem).toHaveBeenCalledExactlyOnceWith("speaking", 0, {
+      name: "Design Tokens, Beyond Colour",
+    });
+  });
+
+  it("renames a fixed section through updateSectionName", () => {
+    renderSheet();
+
+    const input = edit("Experience", "Section title");
+    fireEvent.input(input, { target: { value: "Work" } });
+    fireEvent.blur(input);
+
+    expect(store.updateSectionName).toHaveBeenCalledExactlyOnceWith("experience", "Work");
+  });
+
+  it("renames a custom section through updateCustomSection", () => {
+    renderSheet();
+
+    const input = edit("Talks & Workshops", "Section title");
+    fireEvent.input(input, { target: { value: "Talks" } });
+    fireEvent.blur(input);
+
+    expect(store.updateCustomSection).toHaveBeenCalledExactlyOnceWith("speaking", {
+      name: "Talks",
+    });
+  });
+
+  it("offers empty core fields as reachable placeholders", () => {
+    resume.basics.phone = "";
+    renderSheet();
+
+    const input = edit("Add phone", "Phone", header());
+    fireEvent.input(input, { target: { value: "+351 000 000" } });
+    fireEvent.blur(input);
+
+    expect(store.updateBasics).toHaveBeenCalledExactlyOnceWith("phone", "+351 000 000");
+  });
+
+  it("keeps a heading's accessible name the value it draws", () => {
+    renderSheet();
+
+    // The inline trigger must not rename the heading it sits inside — an
+    // `aria-label` here would make every heading announce "Edit …".
+    expect(screen.getByRole("heading", { name: "Mireille Okafor" })).toBeInTheDocument();
+  });
+});
+
+describe("markdown mini editor", () => {
+  let resume: ResumeData;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resume = loadDocEditorFixture();
+  });
+
+  /** Open the summary's markdown editor and return its textarea. */
+  function openSummary(): HTMLTextAreaElement {
+    render(() => <DocSheet resume={resume} templateLayout={SINGLE_TEMPLATE} />);
+    const summary = document.querySelector('[data-section-id="summary"]') as HTMLElement;
+    fireEvent.click(within(summary).getByTitle("Edit summary"));
+    return within(summary).getByRole("textbox", { name: "Summary" }) as HTMLTextAreaElement;
+  }
+
+  function select(textarea: HTMLTextAreaElement, text: string): void {
+    fireEvent.input(textarea, { target: { value: text } });
+    textarea.setSelectionRange(0, text.length);
+  }
+
+  it("has no underline control — markdown has none", () => {
+    openSummary();
+
+    expect(screen.queryByRole("button", { name: /underline/i })).toBeNull();
+    expect(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Italic" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Link" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Bulleted list" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Numbered list" })).toBeInTheDocument();
+  });
+
+  it.each([
+    { action: "Bold", expected: "**text**" },
+    { action: "Italic", expected: "*text*" },
+    { action: "Bulleted list", expected: "- text" },
+    { action: "Numbered list", expected: "1. text" },
+  ])("emits $expected for $action", ({ action, expected }) => {
+    const textarea = openSummary();
+    select(textarea, "text");
+
+    fireEvent.click(screen.getByRole("button", { name: action }));
+
+    expect(textarea.value).toBe(expected);
+  });
+
+  it("emits a markdown link from the link row", () => {
+    const textarea = openSummary();
+    select(textarea, "Halo guide");
+
+    fireEvent.click(screen.getByRole("button", { name: "Link" }));
+    const href = screen.getByRole("textbox", { name: "Link URL" });
+    fireEvent.input(href, { target: { value: "https://halo.example" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply link" }));
+
+    expect(textarea.value).toBe("[Halo guide](https://halo.example)");
+  });
+
+  it("commits the markdown through updateSummary, once", () => {
+    const textarea = openSummary();
+    fireEvent.input(textarea, { target: { value: "Rewritten **summary**." } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(store.updateSummary).toHaveBeenCalledExactlyOnceWith("Rewritten **summary**.");
+    expect(writeCount()).toBe(1);
+  });
+
+  it("commits an item's markdown through updateSectionItem", () => {
+    render(() => <DocSheet resume={resume} templateLayout={SINGLE_TEMPLATE} />);
+    const experience = document.querySelector('[data-section-id="experience"]') as HTMLElement;
+
+    fireEvent.click(within(experience).getAllByTitle("Edit summary")[0]);
+    const textarea = within(experience).getByRole("textbox", { name: "Summary" });
+    fireEvent.input(textarea, { target: { value: "Shorter summary." } });
+    fireEvent.click(within(experience).getByRole("button", { name: "Done" }));
+
+    expect(store.updateSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, {
+      summary: "Shorter summary.",
+    });
+  });
+
+  it("restores the prior markdown on Escape without writing", () => {
+    const textarea = openSummary();
+    fireEvent.input(textarea, { target: { value: "discarded" } });
+
+    fireEvent.keyDown(textarea, { key: "Escape" });
+
+    expect(writeCount()).toBe(0);
+  });
+});

--- a/apps/web/src/components/doc-editor/__tests__/inlineEdit.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/inlineEdit.test.tsx
@@ -220,6 +220,19 @@ describe("markdown mini editor", () => {
     expect(textarea.value).toBe("[Halo guide](https://halo.example)");
   });
 
+  it("closes the link row when another command runs", () => {
+    const textarea = openSummary();
+    select(textarea, "Halo guide");
+
+    fireEvent.click(screen.getByRole("button", { name: "Link" }));
+    fireEvent.click(screen.getByRole("button", { name: "Bold" }));
+
+    // The pending link held a snapshot of the pre-Bold text; applying it later
+    // would have overwritten the bolding with that stale draft.
+    expect(screen.queryByRole("textbox", { name: "Link URL" })).toBeNull();
+    expect(textarea.value).toBe("**Halo guide**");
+  });
+
   it("commits the markdown through updateSummary, once", () => {
     const textarea = openSummary();
     fireEvent.input(textarea, { target: { value: "Rewritten **summary**." } });

--- a/apps/web/src/components/doc-editor/__tests__/inlineEdit.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/inlineEdit.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, within } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { loadDocEditorFixture, SINGLE_TEMPLATE } from "../../../test/docEditorFixture";
 import { DocSheet } from "../DocSheet";
 import type { ResumeData } from "../../../wasm/types";
@@ -52,6 +52,36 @@ describe("document sheet inline editing", () => {
   function header(): HTMLElement {
     return screen.getAllByTestId("doc-sheet-header")[0];
   }
+
+  it.each([
+    { key: "Escape", changed: false },
+    { key: "Enter", changed: false },
+    { key: "Enter", changed: true },
+  ])("hands focus back to the trigger after $key (changed: $changed)", async ({ key, changed }) => {
+    renderSheet();
+
+    const input = edit("Mireille Okafor", "Name", header());
+    if (changed) fireEvent.input(input, { target: { value: "Ada Lovelace" } });
+    fireEvent.keyDown(input, { key });
+
+    // A keyboard edit must not strand focus on <body>: the next Tab has to
+    // carry on from the field, not restart at the top of the document.
+    await waitFor(() =>
+      expect(document.activeElement).toBe(document.getElementById("doc-header-name")),
+    );
+  });
+
+  it("leaves focus alone when the edit ends by blurring", async () => {
+    renderSheet();
+
+    const input = edit("Mireille Okafor", "Name", header());
+    const elsewhere = document.getElementById("doc-header-headline") as HTMLElement;
+    elsewhere.focus();
+    fireEvent.blur(input);
+
+    // The user chose where focus goes; refocusing the trigger would fight them.
+    await waitFor(() => expect(document.activeElement).toBe(elsewhere));
+  });
 
   it("commits a basics field on blur, through one store action", () => {
     renderSheet();

--- a/apps/web/src/components/doc-editor/__tests__/markdown.test.ts
+++ b/apps/web/src/components/doc-editor/__tests__/markdown.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { applyMarkdownCommand } from "../markdown";
+
+/** Run a command over `value` with `[start, end)` selected. */
+function run(
+  value: string,
+  start: number,
+  end: number,
+  command: Parameters<typeof applyMarkdownCommand>[1],
+  href?: string,
+): string {
+  return applyMarkdownCommand({ value, start, end }, command, href).value;
+}
+
+describe("applyMarkdownCommand", () => {
+  it("emits the markdown each toolbar action is named for", () => {
+    expect(run("bold", 0, 4, "bold")).toBe("**bold**");
+    expect(run("italic", 0, 6, "italic")).toBe("*italic*");
+    expect(run("label", 0, 5, "link", "https://example.com")).toBe("[label](https://example.com)");
+    expect(run("item", 0, 4, "bulletList")).toBe("- item");
+    expect(run("item", 0, 4, "orderedList")).toBe("1. item");
+  });
+
+  it("numbers every line of an ordered list", () => {
+    expect(run("one\ntwo\nthree", 0, 13, "orderedList")).toBe("1. one\n2. two\n3. three");
+  });
+
+  it("marks every line of a bulleted list", () => {
+    expect(run("one\ntwo", 0, 7, "bulletList")).toBe("- one\n- two");
+  });
+
+  it("switches a bulleted list to an ordered one", () => {
+    expect(run("- one\n- two", 0, 11, "orderedList")).toBe("1. one\n2. two");
+  });
+
+  it("removes the markers when every touched line already carries them", () => {
+    expect(run("- one\n- two", 0, 11, "bulletList")).toBe("one\ntwo");
+    expect(run("1. one\n2. two", 0, 13, "orderedList")).toBe("one\ntwo");
+  });
+
+  it("unwraps a selection that is already emphasised", () => {
+    expect(run("**bold**", 2, 6, "bold")).toBe("bold");
+    expect(run("*italic*", 1, 7, "italic")).toBe("italic");
+  });
+
+  it("treats the inner asterisks of bold text as bold, not as italic", () => {
+    // Italicising the text inside `**…**` must nest rather than strip the bold.
+    expect(run("**bold**", 2, 6, "italic")).toBe("***bold***");
+  });
+
+  it("inserts a placeholder when nothing is selected", () => {
+    expect(run("", 0, 0, "bold")).toBe("**bold text**");
+    expect(run("", 0, 0, "italic")).toBe("*italic text*");
+    expect(run("", 0, 0, "link", "https://example.com")).toBe("[link](https://example.com)");
+    expect(run("", 0, 0, "bulletList")).toBe("- List item");
+  });
+
+  it("selects the inserted text so it can be typed over", () => {
+    const result = applyMarkdownCommand({ value: "", start: 0, end: 0 }, "bold");
+    expect(result.value.slice(result.start, result.end)).toBe("bold text");
+  });
+
+  it("leaves text outside the selection alone", () => {
+    expect(run("keep bold keep", 5, 9, "bold")).toBe("keep **bold** keep");
+  });
+
+  it("only marks the lines the selection touches", () => {
+    expect(run("one\ntwo\nthree", 4, 7, "bulletList")).toBe("one\n- two\nthree");
+  });
+});

--- a/apps/web/src/components/doc-editor/__tests__/markdown.test.ts
+++ b/apps/web/src/components/doc-editor/__tests__/markdown.test.ts
@@ -67,4 +67,10 @@ describe("applyMarkdownCommand", () => {
   it("only marks the lines the selection touches", () => {
     expect(run("one\ntwo\nthree", 4, 7, "bulletList")).toBe("one\n- two\nthree");
   });
+
+  it("does not reach the next line when the selection ends on the newline", () => {
+    // Shift+Down to the start of line three selects "one\ntwo\n" — the line it
+    // lands on is not part of the selection.
+    expect(run("one\ntwo\nthree", 0, 8, "bulletList")).toBe("- one\n- two\nthree");
+  });
 });

--- a/apps/web/src/components/doc-editor/__tests__/storeContract.test.ts
+++ b/apps/web/src/components/doc-editor/__tests__/storeContract.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The document editor's store contract.
+ *
+ * Decision 4 of the doc-editor epic: every change the sheet makes goes through
+ * a `resumeStore` action. A component that reaches for `setStore` — or builds
+ * its own store — writes without `markDirty()` and without an undo snapshot,
+ * and nothing at runtime would say so. This test is the guard.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const DOC_EDITOR_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Every source file of the document editor, tests excluded. */
+function sourceFiles(): string[] {
+  return readdirSync(DOC_EDITOR_DIR)
+    .filter((name) => name.endsWith(".ts") || name.endsWith(".tsx"))
+    .map((name) => join(DOC_EDITOR_DIR, name));
+}
+
+describe("doc-editor store contract", () => {
+  it("finds the document editor's sources", () => {
+    expect(sourceFiles().length).toBeGreaterThan(5);
+  });
+
+  it.each(sourceFiles())("%s never writes the store directly", (file) => {
+    const source = readFileSync(file, "utf8");
+
+    // A call, not a mention: the modules explain the rule in their own prose.
+    expect(source).not.toMatch(/\bsetStore\s*\(/);
+    expect(source).not.toMatch(/from "solid-js\/store"/);
+  });
+
+  it("routes every store action through docEdits", () => {
+    const offenders = sourceFiles().filter(
+      (file) =>
+        !file.endsWith("docEdits.ts") &&
+        /from "\.\.\/\.\.\/stores\/resume"/.test(readFileSync(file, "utf8")),
+    );
+
+    // One chokepoint keeps the rule above checkable by reading a single file.
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/src/components/doc-editor/__tests__/storeContract.test.ts
+++ b/apps/web/src/components/doc-editor/__tests__/storeContract.test.ts
@@ -31,15 +31,19 @@ describe("doc-editor store contract", () => {
 
     // A call, not a mention: the modules explain the rule in their own prose.
     expect(source).not.toMatch(/\bsetStore\s*\(/);
-    // Quote-agnostic: a formatting variation must not defeat the guard.
+    // Quote-agnostic, and static or dynamic: neither a formatting variation
+    // nor an `import()` may defeat the guard.
     expect(source).not.toMatch(/from\s+['"]solid-js\/store['"]/);
+    expect(source).not.toMatch(/import\s*\(\s*['"]solid-js\/store['"]\s*\)/);
   });
 
   it("routes every store action through docEdits", () => {
     const offenders = sourceFiles().filter(
       (file) =>
         !file.endsWith("docEdits.ts") &&
-        /from\s+['"]\.\.\/\.\.\/stores\/resume['"]/.test(readFileSync(file, "utf8")),
+        /(?:from|import\s*\()\s*['"]\.\.\/\.\.\/stores\/resume['"]/.test(
+          readFileSync(file, "utf8"),
+        ),
     );
 
     // One chokepoint keeps the rule above checkable by reading a single file.

--- a/apps/web/src/components/doc-editor/__tests__/storeContract.test.ts
+++ b/apps/web/src/components/doc-editor/__tests__/storeContract.test.ts
@@ -31,14 +31,15 @@ describe("doc-editor store contract", () => {
 
     // A call, not a mention: the modules explain the rule in their own prose.
     expect(source).not.toMatch(/\bsetStore\s*\(/);
-    expect(source).not.toMatch(/from "solid-js\/store"/);
+    // Quote-agnostic: a formatting variation must not defeat the guard.
+    expect(source).not.toMatch(/from\s+['"]solid-js\/store['"]/);
   });
 
   it("routes every store action through docEdits", () => {
     const offenders = sourceFiles().filter(
       (file) =>
         !file.endsWith("docEdits.ts") &&
-        /from "\.\.\/\.\.\/stores\/resume"/.test(readFileSync(file, "utf8")),
+        /from\s+['"]\.\.\/\.\.\/stores\/resume['"]/.test(readFileSync(file, "utf8")),
     );
 
     // One chokepoint keeps the rule above checkable by reading a single file.

--- a/apps/web/src/components/doc-editor/docEdits.ts
+++ b/apps/web/src/components/doc-editor/docEdits.ts
@@ -13,7 +13,7 @@
  */
 
 import { isCustomId } from "../../lib/docLayout";
-import { resumeStore, type SectionKey } from "../../stores/resume";
+import { resumeStore, type LayoutSectionKey, type SectionKey } from "../../stores/resume";
 import type { Basics, CustomItem, Picture } from "../../wasm/types";
 
 /** A partial item, keyed by the field names in `itemFields.ts`. */
@@ -50,7 +50,7 @@ export function renameSection(sectionId: string, name: string): void {
     resumeStore.updateCustomSection(sectionId, { name });
     return;
   }
-  resumeStore.updateSectionName(sectionId as SectionKey, name);
+  resumeStore.updateSectionName(sectionId as LayoutSectionKey, name);
 }
 
 /** Create a custom section and return its generated id. */

--- a/apps/web/src/components/doc-editor/docEdits.ts
+++ b/apps/web/src/components/doc-editor/docEdits.ts
@@ -1,0 +1,86 @@
+/**
+ * Every write the document sheet makes, in one place.
+ *
+ * **Invariant:** the sheet only ever changes a resume through a `resumeStore`
+ * action. No component under `components/doc-editor/` may reach for `setStore`
+ * — undo (`stores/undoHistory`) and autosave (`markDirty`) both hang off those
+ * actions, so a direct write is silently lost from both. Routing the writes
+ * through this module keeps that rule checkable in one file.
+ *
+ * Each function performs exactly **one** store action, so one user-visible edit
+ * is one undo entry. A dialog that changes several fields therefore commits
+ * once, on save, rather than per keystroke.
+ */
+
+import { isCustomId } from "../../lib/docLayout";
+import { resumeStore, type SectionKey } from "../../stores/resume";
+import type { Basics, CustomItem, Picture } from "../../wasm/types";
+
+/** A partial item, keyed by the field names in `itemFields.ts`. */
+export type ItemUpdates = Record<string, unknown>;
+
+/** Set one field of `basics`. */
+export function updateBasicsField<K extends keyof Basics>(field: K, value: Basics[K]): void {
+  resumeStore.updateBasics(field, value);
+}
+
+/** Replace the profile picture wholesale — size, shape and effects together. */
+export function updatePicture(picture: Picture): void {
+  resumeStore.updateBasics("picture", picture);
+}
+
+/** Replace the summary section's markdown. */
+export function updateSummary(content: string): void {
+  resumeStore.updateSummary(content);
+}
+
+/** Replace the cover letter's markdown. */
+export function updateCoverLetter(content: string): void {
+  resumeStore.updateCoverLetter(content);
+}
+
+/**
+ * Rename a section.
+ *
+ * Custom sections carry their own record; fixed sections carry a `name` that
+ * overrides the canonical label.
+ */
+export function renameSection(sectionId: string, name: string): void {
+  if (isCustomId(sectionId)) {
+    resumeStore.updateCustomSection(sectionId, { name });
+    return;
+  }
+  resumeStore.updateSectionName(sectionId as SectionKey, name);
+}
+
+/** Create a custom section and return its generated id. */
+export function addCustomSection(name: string): string {
+  return resumeStore.addCustomSection(name);
+}
+
+/**
+ * Update one item of a section.
+ *
+ * `index` addresses the section's own `items` array, not the filtered list the
+ * sheet draws — hidden items still occupy a slot.
+ *
+ * The store's item types differ per section and the updates arrive keyed by the
+ * descriptors in `itemFields.ts`, which is the one place that knows a section's
+ * shape; the cast at this boundary is what that indirection costs.
+ */
+export function updateItem(sectionId: string, index: number, updates: ItemUpdates): void {
+  if (isCustomId(sectionId)) {
+    resumeStore.updateCustomSectionItem(sectionId, index, updates as Partial<CustomItem>);
+    return;
+  }
+  resumeStore.updateSectionItem(sectionId as SectionKey, index, updates as never);
+}
+
+/** Append an item to a section. */
+export function addItem(sectionId: string, item: ItemUpdates): void {
+  if (isCustomId(sectionId)) {
+    resumeStore.addCustomSectionItem(sectionId, item as unknown as CustomItem);
+    return;
+  }
+  resumeStore.addSectionItem(sectionId as SectionKey, item as never);
+}

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -272,3 +272,174 @@
   color: var(--doc-sheet-accent);
   overflow-wrap: anywhere;
 }
+
+/* ── Editing affordances ───────────────────────────────────────────────────
+ *
+ * Editable values are real buttons so they are keyboard-reachable, but a
+ * document must not look like a form: they inherit their surroundings entirely
+ * and only declare themselves on hover and on focus. Focus is a visible ring
+ * rather than a colour change, since the sheet paints the resume's own theme
+ * and a colour cue could land on any background.
+ */
+
+.doc-sheet__editable {
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  text-align: inherit;
+  background: none;
+  border: 0;
+  padding: 0.05em 0.15em;
+  margin: -0.05em -0.15em;
+  border-radius: 0.15em;
+  cursor: text;
+  white-space: inherit;
+  max-width: 100%;
+}
+
+.doc-sheet__editable:hover {
+  background: var(--doc-sheet-tint);
+  box-shadow: inset 0 -1px 0 var(--doc-sheet-rule);
+}
+
+.doc-sheet__editable:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+}
+
+/* Empty fields are placeholders: present enough to click, quiet enough to
+   leave the document reading as a document. */
+.doc-sheet__editable--empty {
+  color: var(--doc-sheet-muted);
+  font-style: italic;
+}
+
+.doc-sheet__avatar-button {
+  cursor: pointer;
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+  line-height: 0;
+}
+
+.doc-sheet__inline-input {
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  width: 100%;
+  padding: 0.05em 0.15em;
+  margin: -0.05em -0.15em;
+  background: var(--doc-sheet-bg);
+  border: 1px solid var(--doc-sheet-accent);
+  border-radius: 0.15em;
+}
+
+.doc-sheet__inline-input:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+}
+
+/* ── Markdown mini editor ──────────────────────────────────────────────── */
+
+.doc-sheet__markdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35em;
+  padding: 0.35em;
+  border: 1px solid var(--doc-sheet-rule);
+  border-radius: 0.25em;
+  background: var(--doc-sheet-bg);
+}
+
+.doc-sheet__markdown-toolbar,
+.doc-sheet__markdown-link,
+.doc-sheet__markdown-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25em;
+  align-items: center;
+}
+
+.doc-sheet__markdown-button {
+  font: inherit;
+  font-size: 0.85em;
+  line-height: 1;
+  color: var(--doc-sheet-accent);
+  background: var(--doc-sheet-tint);
+  border: 1px solid var(--doc-sheet-rule);
+  border-radius: 0.2em;
+  padding: 0.3em 0.5em;
+  cursor: pointer;
+  min-width: 2em;
+}
+
+.doc-sheet__markdown-button:hover {
+  background: var(--doc-sheet-rule);
+}
+
+.doc-sheet__markdown-button:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+}
+
+.doc-sheet__markdown-input,
+.doc-sheet__markdown-href {
+  font: inherit;
+  color: inherit;
+  width: 100%;
+  padding: 0.25em 0.35em;
+  background: var(--doc-sheet-bg);
+  border: 1px solid var(--doc-sheet-rule);
+  border-radius: 0.2em;
+  resize: vertical;
+}
+
+.doc-sheet__markdown-href {
+  flex: 1;
+  min-width: 8em;
+}
+
+/* ── Add / edit actions ────────────────────────────────────────────────── */
+
+.doc-sheet__actions,
+.doc-sheet__section-actions {
+  display: flex;
+  gap: 0.4em;
+}
+
+.doc-sheet__action {
+  font: inherit;
+  font-size: 0.8em;
+  color: var(--doc-sheet-accent);
+  background: none;
+  border: 1px dashed var(--doc-sheet-rule);
+  border-radius: 0.2em;
+  padding: 0.15em 0.5em;
+  cursor: pointer;
+}
+
+.doc-sheet__action:hover {
+  background: var(--doc-sheet-tint);
+}
+
+.doc-sheet__action:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+}
+
+/*
+ * Per-item controls stay out of the document's way until the item is hovered
+ * or something inside it takes focus. `opacity` rather than `display`, so the
+ * control is always focusable and always announced.
+ */
+.doc-sheet__action--item {
+  align-self: flex-start;
+  opacity: 0;
+}
+
+.doc-sheet__item:hover .doc-sheet__action--item,
+.doc-sheet__item:focus-within .doc-sheet__action--item {
+  opacity: 1;
+}

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -443,3 +443,14 @@
 .doc-sheet__item:focus-within .doc-sheet__action--item {
   opacity: 1;
 }
+
+/*
+ * Without hover there is nothing to reveal it, and this is the only route to
+ * the fields the sheet has no room to draw — so a touch user would be left
+ * with an invisible control sitting on a tappable rect.
+ */
+@media (hover: none) {
+  .doc-sheet__action--item {
+    opacity: 1;
+  }
+}

--- a/apps/web/src/components/doc-editor/index.ts
+++ b/apps/web/src/components/doc-editor/index.ts
@@ -1,3 +1,9 @@
 export { DocSheet, type DocSheetProps } from "./DocSheet";
 export { DocHeader, type DocHeaderProps } from "./DocHeader";
 export { DocSection, type DocSectionProps } from "./DocSection";
+export { InlineText, type InlineTextProps } from "./InlineText";
+export { InlineMarkdown, type InlineMarkdownProps } from "./InlineMarkdown";
+export { MarkdownEditor, type MarkdownEditorProps } from "./MarkdownEditor";
+export { ItemDialog, type ItemDialogProps } from "./ItemDialog";
+export { CustomSectionDialog, type CustomSectionDialogProps } from "./CustomSectionDialog";
+export { PhotoDialog, type PhotoDialogProps } from "./PhotoDialog";

--- a/apps/web/src/components/doc-editor/itemFields.ts
+++ b/apps/web/src/components/doc-editor/itemFields.ts
@@ -10,6 +10,10 @@
  */
 
 import { isCustomId } from "../../lib/docLayout";
+import { FIXED_LAYOUT_SECTION_KEYS } from "../../lib/resumeSections";
+
+/** The fixed sections that carry items, and therefore need descriptors. */
+type FixedItemSectionKey = (typeof FIXED_LAYOUT_SECTION_KEYS)[number];
 
 /** How a field is edited. */
 export type ItemFieldKind = "text" | "markdown" | "keywords" | "level" | "url";
@@ -51,8 +55,13 @@ export const CUSTOM_ITEM_FIELDS: readonly ItemFieldSpec[] = [
   URL_FIELD,
 ];
 
-/** Editable fields of every fixed, item-bearing section. */
-export const FIXED_ITEM_FIELDS: Readonly<Record<string, readonly ItemFieldSpec[]>> = {
+/**
+ * Editable fields of every fixed, item-bearing section.
+ *
+ * Keyed by the section union rather than `string` so a new fixed section, or a
+ * misspelled key, fails to compile instead of silently drawing an empty dialog.
+ */
+export const FIXED_ITEM_FIELDS: Readonly<Record<FixedItemSectionKey, readonly ItemFieldSpec[]>> = {
   experience: [
     text("company", "Company"),
     text("position", "Position"),
@@ -132,7 +141,7 @@ export const FIXED_ITEM_FIELDS: Readonly<Record<string, readonly ItemFieldSpec[]
  */
 export function itemFieldsFor(sectionId: string): readonly ItemFieldSpec[] {
   if (isCustomId(sectionId)) return CUSTOM_ITEM_FIELDS;
-  return FIXED_ITEM_FIELDS[sectionId] ?? [];
+  return FIXED_ITEM_FIELDS[sectionId as FixedItemSectionKey] ?? [];
 }
 
 /** Singular noun for a section's items, used in dialog titles and buttons. */

--- a/apps/web/src/components/doc-editor/itemFields.ts
+++ b/apps/web/src/components/doc-editor/itemFields.ts
@@ -1,0 +1,145 @@
+/**
+ * The editable shape of a section's items, per section type.
+ *
+ * One descriptor list per section drives both the item dialog's form and the
+ * labels the inline editors announce, so a field is described in exactly one
+ * place. The lists mirror the item interfaces in `wasm/types.ts` and the blanks
+ * `emptyItemFor()` seeds in `lib/docLayout.ts` — every writable key of an item
+ * appears here except `id` and `visible`, which the editor owns rather than the
+ * user.
+ */
+
+import { isCustomId } from "../../lib/docLayout";
+
+/** How a field is edited. */
+export type ItemFieldKind = "text" | "markdown" | "keywords" | "level" | "url";
+
+/** One editable field of an item. */
+export interface ItemFieldSpec {
+  /** Key on the item object. */
+  key: string;
+  /** Human label, used by the dialog and by the inline editors. */
+  label: string;
+  kind: ItemFieldKind;
+  placeholder?: string;
+}
+
+function text(key: string, label: string, placeholder?: string): ItemFieldSpec {
+  return { key, label, kind: "text", placeholder };
+}
+
+function markdown(key: string, label: string): ItemFieldSpec {
+  return { key, label, kind: "markdown" };
+}
+
+const KEYWORDS = {
+  key: "keywords",
+  label: "Keywords",
+  kind: "keywords",
+} as const satisfies ItemFieldSpec;
+const LEVEL = { key: "level", label: "Level", kind: "level" } as const satisfies ItemFieldSpec;
+const URL_FIELD = { key: "url", label: "Link", kind: "url" } as const satisfies ItemFieldSpec;
+
+/** Editable fields of a custom section's items. */
+export const CUSTOM_ITEM_FIELDS: readonly ItemFieldSpec[] = [
+  text("name", "Name"),
+  text("description", "Description"),
+  text("date", "Date"),
+  text("location", "Location"),
+  markdown("summary", "Summary"),
+  KEYWORDS,
+  URL_FIELD,
+];
+
+/** Editable fields of every fixed, item-bearing section. */
+export const FIXED_ITEM_FIELDS: Readonly<Record<string, readonly ItemFieldSpec[]>> = {
+  experience: [
+    text("company", "Company"),
+    text("position", "Position"),
+    text("location", "Location"),
+    text("date", "Date", "March 2022 - Present"),
+    markdown("summary", "Summary"),
+    URL_FIELD,
+  ],
+  education: [
+    text("institution", "Institution"),
+    text("studyType", "Study type", "Bachelor's"),
+    text("area", "Area of study"),
+    text("date", "Date", "2016 - 2020"),
+    text("score", "Score"),
+    markdown("summary", "Summary"),
+    URL_FIELD,
+  ],
+  skills: [text("name", "Name"), text("description", "Description"), LEVEL, KEYWORDS],
+  projects: [
+    text("name", "Name"),
+    text("description", "Description"),
+    text("date", "Date"),
+    markdown("summary", "Summary"),
+    KEYWORDS,
+    URL_FIELD,
+  ],
+  profiles: [
+    text("network", "Network", "GitHub"),
+    text("username", "Username"),
+    text("icon", "Icon"),
+    URL_FIELD,
+  ],
+  awards: [
+    text("title", "Title"),
+    text("awarder", "Awarder"),
+    text("date", "Date"),
+    markdown("summary", "Summary"),
+    URL_FIELD,
+  ],
+  certifications: [
+    text("name", "Name"),
+    text("issuer", "Issuer"),
+    text("date", "Date"),
+    markdown("summary", "Summary"),
+    URL_FIELD,
+  ],
+  publications: [
+    text("name", "Name"),
+    text("publisher", "Publisher"),
+    text("date", "Date"),
+    markdown("summary", "Summary"),
+    URL_FIELD,
+  ],
+  languages: [text("name", "Name"), text("description", "Description"), LEVEL],
+  interests: [text("name", "Name"), KEYWORDS],
+  volunteer: [
+    text("organization", "Organization"),
+    text("position", "Position"),
+    text("location", "Location"),
+    text("date", "Date"),
+    markdown("summary", "Summary"),
+    URL_FIELD,
+  ],
+  references: [
+    text("name", "Name"),
+    text("description", "Description"),
+    markdown("summary", "Summary"),
+    URL_FIELD,
+  ],
+};
+
+/**
+ * Editable fields for `sectionId`.
+ *
+ * Any id that is not a fixed section is a custom section id — the same rule
+ * `isCustomId()` applies — and carries the custom item shape.
+ */
+export function itemFieldsFor(sectionId: string): readonly ItemFieldSpec[] {
+  if (isCustomId(sectionId)) return CUSTOM_ITEM_FIELDS;
+  return FIXED_ITEM_FIELDS[sectionId] ?? [];
+}
+
+/** Singular noun for a section's items, used in dialog titles and buttons. */
+export function itemNoun(sectionTitle: string): string {
+  const lower = sectionTitle.toLowerCase();
+  if (lower.endsWith("ies")) return `${lower.slice(0, -3)}y`;
+  if (lower.endsWith("ses")) return lower.slice(0, -2);
+  if (lower.endsWith("s")) return lower.slice(0, -1);
+  return lower;
+}

--- a/apps/web/src/components/doc-editor/markdown.ts
+++ b/apps/web/src/components/doc-editor/markdown.ts
@@ -1,0 +1,156 @@
+/**
+ * Markdown transforms behind the sheet's mini rich editor.
+ *
+ * Pure text-in / text-out: a command takes the field's value plus the caret
+ * range and returns the next value and the next range. Nothing here touches the
+ * DOM, so the whole toolbar is unit-testable without rendering a textarea.
+ *
+ * The command set is deliberately small — bold, italic, link, unordered list,
+ * ordered list. There is no underline: markdown has none, and the render path
+ * (`crates/utils/src/html_to_typst.rs`) has nothing to turn one into. Anything
+ * emitted here must survive that conversion, which is why the output stays on
+ * `**`, `*`, `[label](href)`, `- ` and `1. `.
+ */
+
+/** A toolbar action. Underline is absent by design — see the module note. */
+export type MarkdownCommand = "bold" | "italic" | "link" | "bulletList" | "orderedList";
+
+/** A field's text with the caret range the user has selected in it. */
+export interface MarkdownSelection {
+  value: string;
+  /** Caret start offset. */
+  start: number;
+  /** Caret end offset; equal to `start` for an empty selection. */
+  end: number;
+}
+
+/** Placeholder inserted when a command runs against an empty selection. */
+const PLACEHOLDERS: Record<MarkdownCommand, string> = {
+  bold: "bold text",
+  italic: "italic text",
+  link: "link",
+  bulletList: "List item",
+  orderedList: "List item",
+};
+
+const BULLET_PREFIX = /^(\s*)-\s+/;
+const ORDERED_PREFIX = /^(\s*)\d+\.\s+/;
+
+function clampRange(selection: MarkdownSelection): MarkdownSelection {
+  const start = Math.max(0, Math.min(selection.start, selection.value.length));
+  const end = Math.max(start, Math.min(selection.end, selection.value.length));
+  return { value: selection.value, start, end };
+}
+
+/**
+ * Whether `marker` already wraps the selection.
+ *
+ * A single `*` sitting inside a `**` pair is bold, not italic, so the italic
+ * check refuses to treat the inner asterisks of `**text**` as its own markers.
+ */
+function isWrapped(value: string, start: number, end: number, marker: string): boolean {
+  if (start < marker.length || end + marker.length > value.length) return false;
+  if (value.slice(start - marker.length, start) !== marker) return false;
+  if (value.slice(end, end + marker.length) !== marker) return false;
+  if (marker === "*") {
+    const before = start - marker.length;
+    if (value.slice(before - 1, before) === "*" || value.slice(end + 1, end + 2) === "*") {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Wrap the selection in `marker`, or unwrap it when it is already wrapped. */
+function toggleWrap(
+  selection: MarkdownSelection,
+  marker: string,
+  placeholder: string,
+): MarkdownSelection {
+  const { value, start, end } = selection;
+
+  if (isWrapped(value, start, end, marker)) {
+    const next =
+      value.slice(0, start - marker.length) +
+      value.slice(start, end) +
+      value.slice(end + marker.length);
+    return { value: next, start: start - marker.length, end: end - marker.length };
+  }
+
+  const selected = start === end ? placeholder : value.slice(start, end);
+  const next = `${value.slice(0, start)}${marker}${selected}${marker}${value.slice(end)}`;
+  const contentStart = start + marker.length;
+  return { value: next, start: contentStart, end: contentStart + selected.length };
+}
+
+/** Bounds of the whole lines the selection touches. */
+function lineRange(value: string, start: number, end: number): { from: number; to: number } {
+  const from = value.lastIndexOf("\n", start - 1) + 1;
+  const lineEnd = value.indexOf("\n", end);
+  return { from, to: lineEnd === -1 ? value.length : lineEnd };
+}
+
+/**
+ * Prefix every touched line with a list marker, or strip the markers when every
+ * touched line already carries one.
+ */
+function toggleList(
+  selection: MarkdownSelection,
+  ordered: boolean,
+  placeholder: string,
+): MarkdownSelection {
+  const { value, start, end } = selection;
+  const { from, to } = lineRange(value, start, end);
+  const block = value.slice(from, to);
+  const lines = block === "" ? [placeholder] : block.split("\n");
+  const pattern = ordered ? ORDERED_PREFIX : BULLET_PREFIX;
+
+  const allMarked = lines.every((line) => pattern.test(line));
+  const next = lines
+    .map((line, index) => {
+      if (allMarked) return line.replace(pattern, "$1");
+      const stripped = line.replace(BULLET_PREFIX, "$1").replace(ORDERED_PREFIX, "$1");
+      const indent = /^\s*/.exec(stripped)?.[0] ?? "";
+      const body = stripped.slice(indent.length);
+      return `${indent}${ordered ? `${index + 1}. ` : "- "}${body}`;
+    })
+    .join("\n");
+
+  const value2 = value.slice(0, from) + next + value.slice(to);
+  return { value: value2, start: from, end: from + next.length };
+}
+
+/** Wrap the selection as a markdown link pointing at `href`. */
+function applyLink(selection: MarkdownSelection, href: string): MarkdownSelection {
+  const { value, start, end } = selection;
+  const label = start === end ? PLACEHOLDERS.link : value.slice(start, end);
+  const link = `[${label}](${href})`;
+  const next = value.slice(0, start) + link + value.slice(end);
+  return { value: next, start: start + 1, end: start + 1 + label.length };
+}
+
+/**
+ * Run `command` over `selection` and return the next value and caret range.
+ *
+ * `href` is only read by the link command; every other command ignores it.
+ */
+export function applyMarkdownCommand(
+  selection: MarkdownSelection,
+  command: MarkdownCommand,
+  href = "",
+): MarkdownSelection {
+  const range = clampRange(selection);
+
+  switch (command) {
+    case "bold":
+      return toggleWrap(range, "**", PLACEHOLDERS.bold);
+    case "italic":
+      return toggleWrap(range, "*", PLACEHOLDERS.italic);
+    case "link":
+      return applyLink(range, href);
+    case "bulletList":
+      return toggleList(range, false, PLACEHOLDERS.bulletList);
+    case "orderedList":
+      return toggleList(range, true, PLACEHOLDERS.orderedList);
+  }
+}

--- a/apps/web/src/components/doc-editor/markdown.ts
+++ b/apps/web/src/components/doc-editor/markdown.ts
@@ -86,7 +86,10 @@ function toggleWrap(
 /** Bounds of the whole lines the selection touches. */
 function lineRange(value: string, start: number, end: number): { from: number; to: number } {
   const from = value.lastIndexOf("\n", start - 1) + 1;
-  const lineEnd = value.indexOf("\n", end);
+  // A selection that stops just past a newline (Shift+Down to the start of the
+  // next line) touches the lines *before* it, not the one it lands on.
+  const searchFrom = end > start && value[end - 1] === "\n" ? end - 1 : end;
+  const lineEnd = value.indexOf("\n", searchFrom);
   return { from, to: lineEnd === -1 ? value.length : lineEnd };
 }
 

--- a/apps/web/src/lib/imageUpload.ts
+++ b/apps/web/src/lib/imageUpload.ts
@@ -12,6 +12,9 @@
  * being stored at source resolution.
  */
 
+import type { JSX } from "solid-js";
+import type { Picture } from "../wasm/types";
+
 /** Resume photos display at <=200px; keep the encoded asset compact. */
 const MAX_SIZE_PX = 512;
 
@@ -96,6 +99,8 @@ export async function processImage(file: File): Promise<ProcessedImage> {
       const canvas = document.createElement("canvas");
 
       let { width, height } = img;
+      // Captured before resizing: rounding the scaled side would shift the ratio.
+      const sourceAspectRatio = width / height;
       if (width > MAX_SIZE_PX || height > MAX_SIZE_PX) {
         if (width > height) {
           height = Math.max(1, Math.round((height * MAX_SIZE_PX) / width));
@@ -120,7 +125,7 @@ export async function processImage(file: File): Promise<ProcessedImage> {
         reject(new Error("Image is still too large after compression. Try a smaller photo."));
         return;
       }
-      resolve({ dataUrl, aspectRatio: width / height });
+      resolve({ dataUrl, aspectRatio: sourceAspectRatio });
     };
     img.onerror = () => {
       URL.revokeObjectURL(url);
@@ -128,6 +133,37 @@ export async function processImage(file: File): Promise<ProcessedImage> {
     };
     img.src = url;
   });
+}
+
+/**
+ * CSS for a photo preview, shared by both photo surfaces so the two previews
+ * cannot drift from each other or from what the Typst render produces.
+ *
+ * The shadow is a solid diagonal offset with no blur (`dx = dy = size / 2`),
+ * matching the PDF output rather than a browser-idiomatic soft shadow.
+ */
+export function picturePreviewStyle(picture: Picture): JSX.CSSProperties {
+  const size = picture.size || 64;
+  const { effects } = picture;
+  const borderWidth = effects.borderWidth ?? 2;
+  const shadowSize = effects.shadowSize || 0;
+  const shadowOffset = shadowSize / 2;
+
+  return {
+    width: `${size}px`,
+    height: `${size}px`,
+    "border-radius": `${Math.min(picture.borderRadius, Math.round(size / 2))}px`,
+    filter: effects.grayscale ? "grayscale(100%)" : undefined,
+    transform: effects.rotation ? `rotate(${effects.rotation}deg)` : undefined,
+    border:
+      effects.border && borderWidth > 0
+        ? `${borderWidth}px solid ${effects.borderColor || "var(--turbo-brand-primary)"}`
+        : undefined,
+    "box-shadow":
+      shadowSize > 0
+        ? `${shadowOffset}px ${shadowOffset}px 0 ${effects.shadowColor || "#00000040"}`
+        : undefined,
+  };
 }
 
 /** The reason `file` cannot be used as a photo, or `null` when it can. */

--- a/apps/web/src/lib/imageUpload.ts
+++ b/apps/web/src/lib/imageUpload.ts
@@ -1,0 +1,142 @@
+/**
+ * Profile-photo ingestion: validation, resizing and colour normalisation.
+ *
+ * Both photo surfaces share this module — the form builder's `ImageUpload` and
+ * the document editor's photo dialog — so a photo lands in `basics.picture` the
+ * same way whichever one the user reached for. It owns no state and touches no
+ * store: callers decide what to do with the encoded result.
+ *
+ * The encoder deliberately trades quality for size. A resume's JSON travels
+ * through `localStorage`, IndexedDB and the cloud sync payload, so the data URL
+ * is stepped down until it fits {@link MAX_IMAGE_DATA_URL_CHARS} rather than
+ * being stored at source resolution.
+ */
+
+/** Resume photos display at <=200px; keep the encoded asset compact. */
+const MAX_SIZE_PX = 512;
+
+/** Image MIME types the file picker and the drop target accept. */
+export const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+/** Largest source file accepted, before resizing. */
+export const MAX_IMAGE_FILE_SIZE = 5 * 1024 * 1024;
+
+/** Soft cap for the data URL stored in resume JSON (~300 KB payload). */
+export const MAX_IMAGE_DATA_URL_CHARS = 400_000;
+
+const HEX_COLOR_REGEX = /^#(?:[0-9A-Fa-f]{3,4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+const BARE_HEX_REGEX = /^(?:[0-9A-Fa-f]{3,4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+
+/** Whether a value is a `#`-prefixed 3/4/6/8-digit hex colour. */
+export function isHexColor(value: string): boolean {
+  return HEX_COLOR_REGEX.test(value);
+}
+
+/** Trim and prepend `#` when the value is bare 3/4/6/8-digit hex. */
+export function normalizeHexColor(raw: string): string {
+  const trimmed = raw.trim();
+  return BARE_HEX_REGEX.test(trimmed) ? `#${trimmed}` : trimmed;
+}
+
+/**
+ * Expand `#RGB` / `#RGBA` shorthand to `#RRGGBB` / `#RRGGBBAA`.
+ *
+ * Server-side validation only accepts the long form.
+ */
+export function expandShortHex(color: string): string {
+  const digits = color.slice(1);
+  if (digits.length === 3 || digits.length === 4) {
+    return `#${digits
+      .split("")
+      .map((c) => c + c)
+      .join("")}`;
+  }
+  return color;
+}
+
+/** An image encoded for storage, plus the proportions of the source file. */
+export interface ProcessedImage {
+  dataUrl: string;
+  aspectRatio: number;
+}
+
+/**
+ * Encode canvas to a data URL, preferring WebP and stepping quality down until
+ * the result fits under {@link MAX_IMAGE_DATA_URL_CHARS}.
+ */
+function encodeCanvasDataUrl(canvas: HTMLCanvasElement): string {
+  const qualities = [0.82, 0.7, 0.58, 0.45];
+  let best = "";
+  for (const quality of qualities) {
+    let dataUrl = canvas.toDataURL("image/webp", quality);
+    if (!dataUrl.startsWith("data:image/webp")) {
+      dataUrl = canvas.toDataURL("image/jpeg", quality);
+    }
+    best = dataUrl;
+    if (dataUrl.length <= MAX_IMAGE_DATA_URL_CHARS) {
+      return dataUrl;
+    }
+  }
+  return best;
+}
+
+/**
+ * Resize an image file to fit within `MAX_SIZE_PX` square, then return a base64
+ * data URL (WebP with a JPEG fallback) and the source aspect ratio.
+ *
+ * Rejects when the image cannot be decoded, when the canvas is unavailable, or
+ * when the smallest encoding still exceeds {@link MAX_IMAGE_DATA_URL_CHARS}.
+ */
+export async function processImage(file: File): Promise<ProcessedImage> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      const canvas = document.createElement("canvas");
+
+      let { width, height } = img;
+      if (width > MAX_SIZE_PX || height > MAX_SIZE_PX) {
+        if (width > height) {
+          height = Math.max(1, Math.round((height * MAX_SIZE_PX) / width));
+          width = MAX_SIZE_PX;
+        } else {
+          width = Math.max(1, Math.round((width * MAX_SIZE_PX) / height));
+          height = MAX_SIZE_PX;
+        }
+      }
+
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Could not get canvas context"));
+        return;
+      }
+      ctx.drawImage(img, 0, 0, width, height);
+
+      const dataUrl = encodeCanvasDataUrl(canvas);
+      if (dataUrl.length > MAX_IMAGE_DATA_URL_CHARS) {
+        reject(new Error("Image is still too large after compression. Try a smaller photo."));
+        return;
+      }
+      resolve({ dataUrl, aspectRatio: width / height });
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("Failed to load image"));
+    };
+    img.src = url;
+  });
+}
+
+/** The reason `file` cannot be used as a photo, or `null` when it can. */
+export function validateImageFile(file: File): string | null {
+  if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+    return "Please upload a JPG, PNG, or WebP image.";
+  }
+  if (file.size > MAX_IMAGE_FILE_SIZE) {
+    return "Image must be smaller than 5 MB.";
+  }
+  return null;
+}

--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
-import { render, screen, waitFor, within } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { MemoryRouter, Route, createMemoryHistory } from "@solidjs/router";
 import { Suspense, type Component } from "solid-js";
 import { axeConfig } from "../../test/a11y";
@@ -163,13 +163,39 @@ describe("DocEditor sheet", () => {
     expect(screen.queryByRole("heading", { name: "Advisory & Standards Work" })).toBeNull();
   });
 
-  it("offers no editing affordances", async () => {
+  it("offers every drawn value as a keyboard-reachable editing affordance", async () => {
     const { container } = await renderSheet();
     const sheet = screen.getByTestId("doc-sheet");
 
-    expect(sheet.querySelectorAll("input, textarea, select, button")).toHaveLength(0);
+    // #728 replaced the read-only sheet: values are buttons that swap for an
+    // input in place. What must stay true is that nothing is click-only and
+    // that no dialog is open until the user asks for one.
+    const experience = sheet.querySelector<HTMLElement>('[data-section-id="experience"]');
+    expect(
+      within(experience as HTMLElement).getByRole("button", { name: "Lumen Health" }),
+    ).toBeInTheDocument();
     expect(sheet.querySelectorAll("[contenteditable]")).toHaveLength(0);
     expect(within(container).queryByRole("dialog")).toBeNull();
+  });
+
+  it("edits a value in place and writes it through the store", async () => {
+    await renderSheet();
+    const sheet = screen.getByTestId("doc-sheet");
+    const experience = sheet.querySelector<HTMLElement>('[data-section-id="experience"]');
+
+    fireEvent.click(
+      within(experience as HTMLElement).getByRole("button", { name: "Lumen Health" }),
+    );
+    const input = within(experience as HTMLElement).getByRole("textbox", { name: "Company" });
+    fireEvent.input(input, { target: { value: "Lumen Health Group" } });
+    fireEvent.blur(input);
+
+    // The store is the real one here, so the sheet redraws from what it holds.
+    await waitFor(() =>
+      expect(
+        within(experience as HTMLElement).getByRole("button", { name: "Lumen Health Group" }),
+      ).toBeInTheDocument(),
+    );
   });
 
   it("reports no overflow when nothing is clipped", async () => {

--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -7,10 +7,14 @@ import { axeConfig } from "../../test/a11y";
 import { loadDocEditorFixture, SIDEBAR_TEMPLATE } from "../../test/docEditorFixture";
 import DocEditor from "../DocEditor";
 
-const { docEditorEnabled, fixture, RESUME_ID } = vi.hoisted(() => ({
+const { docEditorEnabled, fixture, resumeId } = vi.hoisted(() => ({
   docEditorEnabled: { value: false },
   fixture: { value: null as unknown },
-  RESUME_ID: "doc-editor-fixture",
+  // `resumeStore` is a module singleton and `useResumeRouteLoad` skips the load
+  // when the route id already matches what it holds. A fresh id per test forces
+  // the reload, so a test that writes through the store cannot leak into the
+  // next one's fixture.
+  resumeId: { value: "doc-editor-fixture-0" },
 }));
 
 vi.mock("../../lib/flags", () => ({
@@ -52,7 +56,7 @@ vi.mock("../../stores/auth", () => ({
 
 function renderAt(component: Component) {
   const history = createMemoryHistory();
-  history.set({ value: `/edit/${RESUME_ID}`, scroll: false, replace: true });
+  history.set({ value: `/edit/${resumeId.value}`, scroll: false, replace: true });
 
   return render(() => (
     <Suspense fallback={<p>Loading route</p>}>
@@ -74,9 +78,12 @@ function pageColumns(page: HTMLElement): [string, string[]][] {
 }
 
 describe("DocEditor sheet", () => {
+  let renderCount = 0;
+
   beforeEach(() => {
     fixture.value = loadDocEditorFixture();
     docEditorEnabled.value = true;
+    resumeId.value = `doc-editor-fixture-${++renderCount}`;
   });
 
   async function renderSheet() {

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -536,6 +536,24 @@ export function useResumeStore() {
       markDirty();
     },
 
+    /**
+     * Rename a fixed section.
+     *
+     * The custom-section equivalent is `updateCustomSection`; this is the fixed
+     * sections' counterpart, which the document editor needs because it edits
+     * section headings in place on the sheet.
+     */
+    updateSectionName(sectionKey: LayoutSectionKey, name: string) {
+      setStore(
+        produce((s) => {
+          if (!s.resume || sectionKey === "custom") return;
+          if (sectionKey === "coverLetter") ensureCoverLetterSection(s.resume);
+          s.resume.sections[sectionKey].name = name;
+        }),
+      );
+      markDirty();
+    },
+
     // Generic section item operations
     addSectionItem<K extends SectionKey>(sectionKey: K, item: Sections[K]["items"][number]) {
       setStore(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add click-to-edit and item dialogs to the document sheet
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The flag-gated document sheet (#727) drew a faithful document that nothing could
change. This makes it editable, on the sheet itself, without a sidebar form.

- **Inline click-to-edit.** Every value the sheet draws is a button carrying that
  value as its own text; activating it (click, Enter or Space) swaps in an input
  in place. Commit on blur and on Enter, Escape restores. Applies to the name,
  headline, contact fields, section titles and the item fields the sheet draws.
- **Markdown mini editor** for multi-line fields, emitting markdown as text.
  Toolbar: bold, italic, link, unordered list, ordered list. **No underline** —
  markdown has no notation for it and `html_to_typst` would drop it, so the
  output stays inside what the render path reproduces.
- **Dialogs** for what the sheet has no room for: item add/edit per section type
  (seeded by `emptyItemFor()`, covering tag-style and per-type extra fields),
  custom-section create/rename, and the photo. Built on the app's `Modal`, so
  focus trap, Escape and a labelled heading come for free.
- **Photo upload is shared, not duplicated:** the validation, resize and hex
  helpers moved out of `components/builder/ImageUpload.tsx` into
  `src/lib/imageUpload.ts` — that directory is deleted by #735.

Structural editing (moving, reordering, deleting) is #729; the preview pane is
#732; neither is here.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #728

## Details

**The store contract (decision 4).** Every write goes through a `resumeStore`
action — `updateBasics`, `updateSummary`, `updateSectionItem`,
`updateCustomSectionItem`, `addSectionItem`, `addCustomSectionItem`,
`addCustomSection`, `updateCustomSection` — routed through one new module,
`doc-editor/docEdits.ts`. No component under `components/doc-editor/` calls
`setStore` or imports `solid-js/store`; a test asserts both across every file in
the directory, and asserts that `docEdits.ts` is the only one importing the
store at all. One user-visible edit is one action and therefore one undo entry:
inline editors commit once, and each dialog commits once on save rather than per
keystroke.

**One new store action.** Renaming a *fixed* section had no counterpart to
`updateCustomSection`, so `updateSectionName(sectionKey, name)` was added to
`stores/resume.ts` alongside the others (same `produce` + `markDirty` shape).

**Accessibility.** Inline triggers are real buttons, so they are keyboard
reachable and announced as interactive; they deliberately carry no `aria-label`,
because that would rename every heading they sit inside — the hint lives in
`title`. Editing inputs are labelled with their field name. The core contact
fields are drawn even when empty, as muted placeholders, so a blank resume still
offers somewhere to type. Per-item controls fade in on hover but stay focusable
and announced (`opacity`, not `display`).

**Testing.** 68 new tests: the markdown transforms as pure functions
(`**bold**`, `*italic*`, `[label](href)`, `- item`, `1. item`, plus toggling and
multi-line lists); inline commit-on-blur, commit-on-Enter and Escape-reverts-
without-a-write, for basics, fixed items, custom items and section titles;
add/edit through the dialog for every section type and for custom sections; the
photo dialog with the upload mocked; and the `setStore` audit. The DocEditor
page test that asserted the sheet had *no* editing affordances — true of #727,
untrue by design now — was rewritten to assert the affordances exist, are
keyboard reachable, and that a real edit round-trips through the store. The axe
check on the page still passes.

`docSheet.css` gains focus/hover styles under the existing `.doc-sheet` root;
the `container-type` / `font-size` lines that #749 is about were left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline editing for document details, section titles, item fields, and Markdown content.
  * Added dialogs for creating and renaming sections, editing items, and managing profile photos.
  * Added Markdown formatting tools, including bold, italics, links, and lists.
  * Added support for renaming document sections and editing previously empty fields.

* **Bug Fixes**
  * Improved image validation, resizing, formatting, and error handling.

* **Tests**
  * Added comprehensive coverage for editing, dialogs, Markdown formatting, image handling, and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->