### PR TITLE
fix(deps): disable base64 default simd-unsafe feature

### DIFF
--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -27,7 +27,7 @@ typst-assets.workspace = true
 chrono.workspace = true
 
 # Decode data-URL profile pictures into Typst binary assets
-base64 = "0.23"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 
 # Embedded template directory
 include_dir.workspace = true

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -44,7 +44,7 @@ tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Base64 for binary data in JSON
-base64 = "0.23"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 
 # Caching
 lru.workspace = true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(deps): disable base64 default simd-unsafe feature
  ```

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Explicitly selects `base64` features for the two direct dependents instead of
relying on defaults, dropping the `simd-unsafe` feature while keeping `std`
(and therefore `alloc`) so existing call sites keep working unchanged:

- `crates/render/Cargo.toml`
- `crates/server/Cargo.toml`

```toml
base64 = { version = "0.23", default-features = false, features = ["std"] }
```

No call-site changes were needed: `base64::engine::general_purpose::STANDARD`
and the `Engine` trait (used in `crates/render/src/typst_engine/engine.rs` and
`crates/server/src/routes/parse.rs`) are both available under `std`.

### Proof `simd-unsafe` is off

`env -u CARGO_HTTP_CAINFO cargo tree -e features -i base64@0.23.0`

Before:

```
base64 v0.23.0
├── base64 feature "alloc"
│   └── base64 feature "std"
│       └── base64 feature "default"
│           ├── rustume-render v0.56.0 ...
│           └── rustume-server v0.56.0 ...
├── base64 feature "default" (*)
├── base64 feature "simd-unsafe"
│   └── base64 feature "default" (*)
└── base64 feature "std" (*)
```

After:

```
base64 v0.23.0
├── base64 feature "alloc"
│   └── base64 feature "std"
│       ├── rustume-render v0.56.0 ...
│       └── rustume-server v0.56.0 ...
└── base64 feature "std" (*)
```

`simd-unsafe` no longer appears for the direct dependency.

### Transitive base64 0.22.1 (out of scope, per issue)

`Cargo.lock` also carries `base64 v0.22.1` transitively via `sqlx-core`
(alloc feature only, no `simd-unsafe`, no explicit `std` request). Disabling
default features on the two direct deps does not govern this duplicate
version. The duplicate-version cleanup is left to #575 as specified in the
issue.

`Cargo.lock` has no diff — feature selections are not recorded in the lock
file format used here; only the two `Cargo.toml` manifests changed.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (none needed; no behavior change, existing suite covers call sites)
- [ ] Docs updated if user-facing (N/A)
- [x] Local CI passed (`cargo build --workspace`, `cargo test --workspace`, `uv run lintro fmt`, `uv run lintro chk`)

## Closes

- Closes #574

## Details

- `default-features = false, features = ["std"]` was applied identically to
  both `crates/render/Cargo.toml:30` and `crates/server/Cargo.toml:47`, per
  the issue's authoritative spec. `std = ["alloc"]` in base64 0.23, so nothing
  in current usage lost access.
- Verified with `cargo build --workspace` (succeeds) and
  `cargo test --workspace` (all suites pass, 0 failed).
- `uv run lintro fmt` and `uv run lintro chk` are clean for everything this
  diff could affect. Two pre-existing environment issues unrelated to this
  change were observed and are not being worked around:
  - `pip-audit` reports `ERROR` — its ensurepip venv dies with SIGABRT on this
    machine (documented, pre-existing).
  - `gitleaks` timed out once at the default 60s limit under heavy concurrent
    load from sibling worktrees; re-run with a longer timeout
    (`--tool-options gitleaks:timeout=180`) passed cleanly with 0 issues.
