### PR TITLE
feat(web): add section cards, add-blocks, and whole-surface drag and drop

### DIFF
--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -13,6 +13,13 @@
  * one field (a degree, say) carry no key and are edited in the item dialog
  * instead, which is also where the fields the sheet has no room for live.
  *
+ * Structural chrome lives here too: each section is a card with hover/focus
+ * controls (move, hide, rename, delete) and each entry carries its own action
+ * row. Drags start from the handles only — never from the surface — so text
+ * selection and inline editing keep working; the sheet (`DocSheet`) owns the
+ * drag-drop context, drop resolution and announcements, and every mutation
+ * still goes through `docEdits`.
+ *
  * URLs still render as text rather than anchors: the sheet is a document
  * surface, not a navigation surface, and a link inside an item would compete
  * with the item's own click targets. Faithful markdown rendering is the PDF
@@ -20,11 +27,24 @@
  */
 
 import { For, Show, createSignal, type JSX } from "solid-js";
+import { createDraggable, createDroppable } from "@thisbeyond/solid-dnd";
+import { CustomSectionDialog } from "./CustomSectionDialog";
 import { InlineMarkdown } from "./InlineMarkdown";
 import { InlineText } from "./InlineText";
 import { ItemDialog } from "./ItemDialog";
-import { renameSection, updateCoverLetter, updateItem, updateSummary } from "./docEdits";
+import {
+  removeItem,
+  removeSection,
+  renameSection,
+  setItemVisibility,
+  toggleSection,
+  duplicateItem,
+  updateCoverLetter,
+  updateItem,
+  updateSummary,
+} from "./docEdits";
 import { itemNoun } from "./itemFields";
+import type { MoveStep } from "../../lib/docDnd";
 import { isCustomId, sectionTitle } from "../../lib/docLayout";
 import type {
   Award,
@@ -275,17 +295,20 @@ interface ItemEntry {
   id: string;
   /** Index into the unfiltered `items` array — what the store actions address. */
   index: number;
+  /** Switched off — drawn as chrome, but absent from the PDF. */
+  hidden: boolean;
   item: Record<string, unknown>;
   view: ItemView;
 }
 
 /**
- * The visible items of `sectionId`, already flattened to {@link ItemView}.
+ * The items of `sectionId`, already flattened to {@link ItemView}.
  *
  * Item shapes differ per section, and the adapter table above is the only
  * place that knows which is which — so the lookup is done once, here, behind a
- * cast the table's own keys justify. Hidden items are dropped from the drawing
- * but keep their index, because that is what `updateSectionItem` addresses.
+ * cast the table's own keys justify. Hidden items stay in the drawing as
+ * flagged chrome — hidden means "not rendered to PDF", not "gone from the
+ * editing surface" — which also keeps drawn order identical to stored order.
  */
 function itemEntries(resume: ResumeData, sectionId: string): ItemEntry[] {
   const adapter = isCustomId(sectionId)
@@ -297,16 +320,13 @@ function itemEntries(resume: ResumeData, sectionId: string): ItemEntry[] {
     ? resume.sections.custom?.[sectionId]
     : (resume.sections[sectionId as ItemSectionId] as { items?: VisibleItem[] } | undefined);
 
-  return (section?.items ?? [])
-    .map((item, index) => ({
-      id: item.id,
-      index,
-      item: item as unknown as Record<string, unknown>,
-      view: adapter(item),
-      visible: item.visible,
-    }))
-    .filter((entry) => entry.visible)
-    .map(({ visible: _visible, ...entry }) => entry);
+  return (section?.items ?? []).map((item, index) => ({
+    id: item.id,
+    index,
+    hidden: !item.visible,
+    item: item as unknown as Record<string, unknown>,
+    view: adapter(item),
+  }));
 }
 
 function Level(props: { value: number }): JSX.Element {
@@ -349,12 +369,38 @@ function Slot(props: {
   );
 }
 
+/** Icon paths for the chrome controls, drawn on a 24x24 grid. */
+const CHROME_ICONS = {
+  handle: "M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01",
+  up: "M5 15l7-7 7 7",
+  down: "M19 9l-7 7-7-7",
+  previous: "M15 19l-7-7 7-7",
+  next: "M9 5l7 7-7 7",
+} as const;
+
+function ChromeIcon(props: { path: string }): JSX.Element {
+  return (
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={props.path} />
+    </svg>
+  );
+}
+
+/** The one-step move controls: label suffix per step, in render order. */
+const STEP_WORDS: Record<MoveStep, string> = {
+  up: "up",
+  down: "down",
+  previous: "to the previous section",
+  next: "to the next section",
+};
+
 function Item(props: {
   sectionId: string;
   entry: ItemEntry;
-  /** Singular noun for this section's items, used in the edit button's label. */
+  /** Singular noun for this section's items, used in the controls' labels. */
   noun: string;
   onEdit: (entry: ItemEntry) => void;
+  onMove: (itemId: string, step: MoveStep) => void;
 }): JSX.Element {
   const view = () => props.entry.view;
   // Stable across redraws: the item's own id, not its position. Inline editors
@@ -363,13 +409,42 @@ function Item(props: {
   const meta = () => view().meta ?? [];
   const keywords = () => (view().keywords ?? []).filter((keyword) => keyword.trim() !== "");
   const url = () => urlLabel(view().url);
+  const label = () => (view().title.value.trim() === "" ? props.noun : view().title.value);
+
+  const draggable = createDraggable(`drag:entry:${props.sectionId}:${props.entry.id}`, {
+    type: "entry",
+    sectionId: props.sectionId,
+    itemId: props.entry.id,
+  });
+  const droppable = createDroppable(`drop:entry:${props.sectionId}:${props.entry.id}`, {
+    type: "entry",
+    sectionId: props.sectionId,
+    itemId: props.entry.id,
+  });
+
+  // Lateral steps mirror the cross-section drag, which only custom sections
+  // support — the only pair with a shared item shape.
+  const steps = (): MoveStep[] =>
+    isCustomId(props.sectionId) ? ["up", "down", "previous", "next"] : ["up", "down"];
 
   const commit = (field: string, value: string): void => {
     updateItem(props.sectionId, props.entry.index, { [field]: value });
   };
 
   return (
-    <article class="doc-sheet__item">
+    <article
+      ref={(element) => {
+        draggable.ref(element);
+        droppable.ref(element);
+      }}
+      class="doc-sheet__item"
+      classList={{
+        "doc-sheet__item--hidden": props.entry.hidden,
+        "doc-sheet__item--drop": droppable.isActiveDroppable,
+        "doc-sheet__item--dragging": draggable.isActiveDraggable,
+      }}
+      data-entry-id={props.entry.id}
+    >
       <div class="doc-sheet__item-head">
         <div>
           <h4 class="doc-sheet__item-title">
@@ -433,14 +508,66 @@ function Item(props: {
         <p class="doc-sheet__url">{url()}</p>
       </Show>
 
-      <button
-        type="button"
-        class="doc-sheet__action doc-sheet__action--item"
-        aria-label={`Edit ${view().title.value.trim() === "" ? props.noun : view().title.value} details`}
-        onClick={() => props.onEdit(props.entry)}
-      >
-        Edit
-      </button>
+      <div class="doc-sheet__item-actions" role="group" aria-label={`${label()} actions`}>
+        <button
+          type="button"
+          class="doc-sheet__action doc-sheet__action--icon doc-sheet__drag-handle"
+          aria-label={`Drag ${label()} to move it`}
+          title={`Drag ${label()} to move it`}
+          {...draggable.dragActivators}
+        >
+          <ChromeIcon path={CHROME_ICONS.handle} />
+        </button>
+        <For each={steps()}>
+          {(step) => (
+            <button
+              type="button"
+              class="doc-sheet__action doc-sheet__action--icon"
+              data-doc-move-entry={`${props.entry.id}:${step}`}
+              aria-label={`Move ${label()} ${STEP_WORDS[step]}`}
+              title={`Move ${label()} ${STEP_WORDS[step]}`}
+              onClick={() => props.onMove(props.entry.id, step)}
+            >
+              <ChromeIcon path={CHROME_ICONS[step]} />
+            </button>
+          )}
+        </For>
+        <button
+          type="button"
+          class="doc-sheet__action"
+          aria-label={`Edit ${label()} details`}
+          onClick={() => props.onEdit(props.entry)}
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          class="doc-sheet__action"
+          aria-label={`Duplicate ${label()}`}
+          onClick={() => duplicateItem(props.sectionId, props.entry.index)}
+        >
+          Duplicate
+        </button>
+        <button
+          type="button"
+          class="doc-sheet__action"
+          aria-label={`${props.entry.hidden ? "Show" : "Hide"} ${label()}`}
+          onClick={() => setItemVisibility(props.sectionId, props.entry.index, props.entry.hidden)}
+        >
+          {props.entry.hidden ? "Show" : "Hide"}
+        </button>
+        <button
+          type="button"
+          class="doc-sheet__action doc-sheet__action--danger"
+          aria-label={`Delete ${label()}`}
+          onClick={() => removeItem(props.sectionId, props.entry.index)}
+        >
+          Delete
+        </button>
+        <Show when={props.entry.hidden}>
+          <span class="doc-sheet__hidden-badge">Hidden</span>
+        </Show>
+      </div>
     </article>
   );
 }
@@ -449,18 +576,34 @@ export interface DocSectionProps {
   resume: ResumeData;
   /** A fixed section id, or a custom section's own id. */
   sectionId: string;
+  /** Switched off — drawn as chrome, but absent from the PDF. */
+  hidden: boolean;
+  /** Perform (and announce) a one-step section move. */
+  onMoveSection: (sectionId: string, step: MoveStep) => void;
+  /** Perform (and announce) a one-step entry move. */
+  onMoveEntry: (sectionId: string, itemId: string, step: MoveStep) => void;
 }
 
+/** The section move controls' label suffixes. */
+const SECTION_STEP_WORDS: Record<MoveStep, string> = {
+  up: "up",
+  down: "down",
+  previous: "to the previous column",
+  next: "to the next column",
+};
+
 /**
- * One section of the sheet: its heading plus an editable view of its content.
+ * One section of the sheet: a card with structural chrome around an editable
+ * view of its content.
  *
  * `summary` and `coverLetter` carry rich text; every other section carries
- * items. Hidden items are dropped; hidden and empty *sections* never reach
- * here, because `renderPages()` has already filtered them out.
+ * items. Hidden sections and items are drawn dimmed, as chrome — the editor
+ * keeps them reachable, the PDF drops them.
  */
 export function DocSection(props: DocSectionProps): JSX.Element {
   const [editing, setEditing] = createSignal<ItemEntry | null>(null);
   const [isDialogOpen, setIsDialogOpen] = createSignal(false);
+  const [isRenameOpen, setIsRenameOpen] = createSignal(false);
 
   const title = () => sectionTitle(props.resume, props.sectionId);
   const isRichText = () => props.sectionId === "summary" || props.sectionId === "coverLetter";
@@ -471,6 +614,16 @@ export function DocSection(props: DocSectionProps): JSX.Element {
   };
   const entries = () => itemEntries(props.resume, props.sectionId);
   const noun = () => itemNoun(title());
+  const isCustom = () => isCustomId(props.sectionId);
+
+  const draggable = createDraggable(`drag:section:${props.sectionId}`, {
+    type: "section",
+    sectionId: props.sectionId,
+  });
+  const droppable = createDroppable(`drop:section:${props.sectionId}`, {
+    type: "section",
+    sectionId: props.sectionId,
+  });
 
   function openAdd(): void {
     setEditing(null);
@@ -483,7 +636,78 @@ export function DocSection(props: DocSectionProps): JSX.Element {
   }
 
   return (
-    <section class="doc-sheet__section" data-section-id={props.sectionId}>
+    <section
+      ref={(element) => {
+        draggable.ref(element);
+        droppable.ref(element);
+      }}
+      class="doc-sheet__section"
+      classList={{
+        "doc-sheet__section--hidden": props.hidden,
+        "doc-sheet__section--drop": droppable.isActiveDroppable,
+        "doc-sheet__section--dragging": draggable.isActiveDraggable,
+      }}
+      data-section-id={props.sectionId}
+    >
+      <div
+        class="doc-sheet__section-chrome"
+        role="group"
+        aria-label={`${title()} section controls`}
+      >
+        <button
+          type="button"
+          class="doc-sheet__action doc-sheet__action--icon doc-sheet__drag-handle"
+          aria-label={`Drag ${title()} section to move it`}
+          title={`Drag ${title()} section to move it`}
+          {...draggable.dragActivators}
+        >
+          <ChromeIcon path={CHROME_ICONS.handle} />
+        </button>
+        <For each={["up", "down", "previous", "next"] as MoveStep[]}>
+          {(step) => (
+            <button
+              type="button"
+              class="doc-sheet__action doc-sheet__action--icon"
+              data-doc-move-section={`${props.sectionId}:${step}`}
+              aria-label={`Move ${title()} section ${SECTION_STEP_WORDS[step]}`}
+              title={`Move ${title()} section ${SECTION_STEP_WORDS[step]}`}
+              onClick={() => props.onMoveSection(props.sectionId, step)}
+            >
+              <ChromeIcon path={CHROME_ICONS[step]} />
+            </button>
+          )}
+        </For>
+        <button
+          type="button"
+          class="doc-sheet__action"
+          aria-label={`${props.hidden ? "Show" : "Hide"} ${title()} section`}
+          onClick={() => toggleSection(props.sectionId)}
+        >
+          {props.hidden ? "Show" : "Hide"}
+        </button>
+        <Show when={isCustom()}>
+          <button
+            type="button"
+            class="doc-sheet__action"
+            aria-label={`Rename ${title()} section`}
+            onClick={() => setIsRenameOpen(true)}
+          >
+            Rename
+          </button>
+          <button
+            type="button"
+            class="doc-sheet__action doc-sheet__action--danger"
+            aria-label={`Delete ${title()} section`}
+            onClick={() => removeSection(props.sectionId)}
+          >
+            Delete
+          </button>
+        </Show>
+        <Show when={props.hidden}>
+          <span class="doc-sheet__hidden-badge">Hidden</span>
+        </Show>
+      </div>
+
       <h3 class="doc-sheet__section-title">
         <InlineText
           value={title()}
@@ -508,7 +732,13 @@ export function DocSection(props: DocSectionProps): JSX.Element {
         <div class="doc-sheet__items">
           <For each={entries()}>
             {(entry) => (
-              <Item sectionId={props.sectionId} entry={entry} noun={noun()} onEdit={openEdit} />
+              <Item
+                sectionId={props.sectionId}
+                entry={entry}
+                noun={noun()}
+                onEdit={openEdit}
+                onMove={(itemId, step) => props.onMoveEntry(props.sectionId, itemId, step)}
+              />
             )}
           </For>
         </div>
@@ -528,6 +758,15 @@ export function DocSection(props: DocSectionProps): JSX.Element {
           index={editing()?.index}
           item={editing()?.item}
           onOpenChange={setIsDialogOpen}
+        />
+      </Show>
+
+      <Show when={isCustom()}>
+        <CustomSectionDialog
+          open={isRenameOpen()}
+          sectionId={props.sectionId}
+          name={title()}
+          onOpenChange={setIsRenameOpen}
         />
       </Show>
     </section>

--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -514,7 +514,8 @@ function Item(props: {
         <button
           type="button"
           class="doc-sheet__action doc-sheet__action--icon doc-sheet__drag-handle"
-          aria-label={`Drag ${label()} to move it`}
+          aria-hidden="true"
+          tabindex="-1"
           title={`Drag ${label()} to move it`}
           {...draggable.dragActivators}
         >
@@ -670,7 +671,8 @@ export function DocSection(props: DocSectionProps): JSX.Element {
         <button
           type="button"
           class="doc-sheet__action doc-sheet__action--icon doc-sheet__drag-handle"
-          aria-label={`Drag ${title()} section to move it`}
+          aria-hidden="true"
+          tabindex="-1"
           title={`Drag ${title()} section to move it`}
           {...draggable.dragActivators}
         >

--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -401,6 +401,8 @@ function Item(props: {
   noun: string;
   onEdit: (entry: ItemEntry) => void;
   onMove: (itemId: string, step: MoveStep) => void;
+  /** Announce a completed action to the sheet's live region. */
+  onAnnounce: (message: string) => void;
 }): JSX.Element {
   const view = () => props.entry.view;
   // Stable across redraws: the item's own id, not its position. Inline editors
@@ -544,7 +546,10 @@ function Item(props: {
           type="button"
           class="doc-sheet__action"
           aria-label={`Duplicate ${label()}`}
-          onClick={() => duplicateItem(props.sectionId, props.entry.index)}
+          onClick={() => {
+            duplicateItem(props.sectionId, props.entry.index);
+            props.onAnnounce(`${label()} duplicated`);
+          }}
         >
           Duplicate
         </button>
@@ -552,7 +557,10 @@ function Item(props: {
           type="button"
           class="doc-sheet__action"
           aria-label={`${props.entry.hidden ? "Show" : "Hide"} ${label()}`}
-          onClick={() => setItemVisibility(props.sectionId, props.entry.index, props.entry.hidden)}
+          onClick={() => {
+            setItemVisibility(props.sectionId, props.entry.index, props.entry.hidden);
+            props.onAnnounce(`${label()} ${props.entry.hidden ? "shown" : "hidden"}`);
+          }}
         >
           {props.entry.hidden ? "Show" : "Hide"}
         </button>
@@ -560,7 +568,10 @@ function Item(props: {
           type="button"
           class="doc-sheet__action doc-sheet__action--danger"
           aria-label={`Delete ${label()}`}
-          onClick={() => removeItem(props.sectionId, props.entry.index)}
+          onClick={() => {
+            removeItem(props.sectionId, props.entry.index);
+            props.onAnnounce(`${label()} deleted`);
+          }}
         >
           Delete
         </button>
@@ -582,6 +593,8 @@ export interface DocSectionProps {
   onMoveSection: (sectionId: string, step: MoveStep) => void;
   /** Perform (and announce) a one-step entry move. */
   onMoveEntry: (sectionId: string, itemId: string, step: MoveStep) => void;
+  /** Announce a completed action to the sheet's live region. */
+  onAnnounce: (message: string) => void;
 }
 
 /** The section move controls' label suffixes. */
@@ -681,7 +694,10 @@ export function DocSection(props: DocSectionProps): JSX.Element {
           type="button"
           class="doc-sheet__action"
           aria-label={`${props.hidden ? "Show" : "Hide"} ${title()} section`}
-          onClick={() => toggleSection(props.sectionId)}
+          onClick={() => {
+            toggleSection(props.sectionId);
+            props.onAnnounce(`${title()} section ${props.hidden ? "shown" : "hidden"}`);
+          }}
         >
           {props.hidden ? "Show" : "Hide"}
         </button>
@@ -698,7 +714,11 @@ export function DocSection(props: DocSectionProps): JSX.Element {
             type="button"
             class="doc-sheet__action doc-sheet__action--danger"
             aria-label={`Delete ${title()} section`}
-            onClick={() => removeSection(props.sectionId)}
+            onClick={() => {
+              const name = title();
+              removeSection(props.sectionId);
+              props.onAnnounce(`${name} section deleted`);
+            }}
           >
             Delete
           </button>
@@ -738,6 +758,7 @@ export function DocSection(props: DocSectionProps): JSX.Element {
                 noun={noun()}
                 onEdit={openEdit}
                 onMove={(itemId, step) => props.onMoveEntry(props.sectionId, itemId, step)}
+                onAnnounce={props.onAnnounce}
               />
             )}
           </For>

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -2,30 +2,87 @@
  * The document sheet: A4 page frames, the template's column grid, the header
  * region, and an editable view of every placed section.
  *
- * The page/column structure comes straight from `renderPages()` and
- * `layoutColumns()` — this component draws that model and nothing else. Editing
- * is click-to-edit in place (`InlineText`, `InlineMarkdown`) plus the item,
- * section and photo dialogs; every one of them writes through a `resumeStore`
- * action, never `setStore` (see `docEdits.ts`). Structural editing — moving or
- * reordering sections — is #729 and is not here.
+ * The page/column structure comes straight from `editorPages()` and
+ * `layoutColumns()` — this component draws that model and nothing else, and the
+ * same model's indices address `metadata.layout` directly, so drag and drop
+ * needs no second layout representation. Editing is click-to-edit in place
+ * plus the item, section and photo dialogs; structural editing is the chrome
+ * `DocSection` draws plus the whole-surface drag and drop owned here. Every
+ * mutation writes through a `resumeStore` action, never `setStore` (see
+ * `docEdits.ts`), and every drop resolves through the pure functions in
+ * `lib/docDnd.ts` — one drop, one action, one undo entry; a drag that ends
+ * where it started writes nothing.
  *
  * Overflow is *reported*, never absorbed. A column that cannot fit its sections
  * is clipped and flagged; moving a section to another page is a `metadata.layout`
- * decision the user makes elsewhere, so nothing here reflows.
+ * decision the user makes on this surface, so nothing here reflows.
  */
 
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
+import {
+  DragDropProvider,
+  DragDropSensors,
+  DragOverlay,
+  closestCenter,
+  createDroppable,
+  type CollisionDetector,
+  type DragEvent,
+} from "@thisbeyond/solid-dnd";
 import { CustomSectionDialog } from "./CustomSectionDialog";
 import { DocHeader } from "./DocHeader";
 import { DocSection } from "./DocSection";
+import { ItemDialog } from "./ItemDialog";
+import { applyLayout, moveItemAcrossSections, reorderItem } from "./docEdits";
+import { itemNoun } from "./itemFields";
 import {
+  adjacentCustomSectionId,
+  canMoveEntryAcross,
+  entryStep,
+  moveSectionInLayout,
+  moveSectionStep,
+  resolveEntryDrop,
+  resolveSectionDropOnColumn,
+  resolveSectionDropOnSection,
+  sectionItemList,
+  type MoveStep,
+} from "../../lib/docDnd";
+import {
+  editorPages,
+  findSectionPlacement,
   layoutColumns,
-  renderPages,
+  layoutPages,
+  sectionTitle,
+  type EditorSectionView,
   type LayoutColumn,
   type TemplateLayout,
 } from "../../lib/docLayout";
+import { reorderAnnouncement } from "../../lib/reorderAnnounce";
+import { LiveRegion, announceLive } from "../ui/LiveRegion";
 import type { ResumeData } from "../../wasm/types";
 import "./docSheet.css";
+
+/** What a drag carries: the thing being moved. */
+type SheetDragData =
+  | { type: "section"; sectionId: string }
+  | { type: "entry"; sectionId: string; itemId: string };
+
+/** What a droppable is: where the dragged thing may land. */
+type SheetDropData =
+  | { type: "section"; sectionId: string; itemId?: undefined }
+  | { type: "entry"; sectionId: string; itemId: string }
+  | { type: "column"; page: number; column: number }
+  | { type: "new-page" };
+
+/** Whether `drop` is a meaningful target for `drag`. */
+function acceptsDrop(drag: SheetDragData, drop: SheetDropData): boolean {
+  if (drag.type === "section") {
+    return drop.type === "section" || drop.type === "column" || drop.type === "new-page";
+  }
+  if (drop.type === "entry" || drop.type === "section") {
+    return drop.sectionId === drag.sectionId || canMoveEntryAcross(drag.sectionId, drop.sectionId);
+  }
+  return false;
+}
 
 /** A page's columns in the order the template paints them, left to right. */
 function visualColumns(columns: LayoutColumn[]): LayoutColumn[] {
@@ -60,6 +117,105 @@ function profileLinks(resume: ResumeData): { id: string; label: string }[] {
     .filter((link) => link.label !== "");
 }
 
+/** Head-line fields an entry might carry, in announcement preference order. */
+const ENTRY_LABEL_KEYS = [
+  "name",
+  "company",
+  "institution",
+  "title",
+  "network",
+  "organization",
+] as const;
+
+/** A short human name for an entry, for announcements and the drag overlay. */
+function entryLabel(resume: ResumeData, sectionId: string, itemId: string): string {
+  const item = sectionItemList(resume, sectionId).find((entry) => entry.id === itemId) as
+    | Record<string, unknown>
+    | undefined;
+  for (const key of ENTRY_LABEL_KEYS) {
+    const value = item?.[key];
+    if (typeof value === "string" && value.trim() !== "") return value;
+  }
+  return "Item";
+}
+
+/** A section placed in a column but not drawn there — an add-block target. */
+interface AddTarget {
+  id: string;
+  noun: string;
+}
+
+/** One column of one page: the droppable frame plus its add-block. */
+function SheetColumn(props: {
+  pageIndex: number;
+  column: LayoutColumn;
+  addTargets: AddTarget[];
+  onAdd: (sectionId: string) => void;
+  children: JSX.Element;
+}): JSX.Element {
+  const droppable = createDroppable(`drop:column:${props.pageIndex}:${props.column.index}`, {
+    type: "column",
+    page: props.pageIndex,
+    column: props.column.index,
+  });
+
+  return (
+    <div
+      ref={droppable.ref}
+      class="doc-sheet__column"
+      classList={{
+        "doc-sheet__column--sidebar": props.column.role === "sidebar",
+        "doc-sheet__column--drop": droppable.isActiveDroppable,
+      }}
+      data-testid="doc-sheet-column"
+      data-column-index={props.column.index}
+      data-column-role={props.column.role}
+      data-page-index={props.pageIndex}
+      style={{ "flex-basis": `${props.column.width * 100}%` }}
+    >
+      {props.children}
+      <Show when={props.addTargets.length > 0}>
+        <div class="doc-sheet__add-block" data-testid="doc-sheet-add-block">
+          <For each={props.addTargets}>
+            {(target) => (
+              <button
+                type="button"
+                class="doc-sheet__action"
+                onClick={() => props.onAdd(target.id)}
+              >
+                Add {target.noun}
+              </button>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+}
+
+/**
+ * The trailing drop zone that starts a new page. Always mounted so its
+ * droppable is registered before a drag begins; only *shown* while a section
+ * is being dragged, because that is the only drag it accepts.
+ */
+function NewPageZone(props: { active: boolean }): JSX.Element {
+  const droppable = createDroppable("drop:new-page", { type: "new-page" });
+  return (
+    <div
+      ref={droppable.ref}
+      class="doc-sheet__new-page"
+      classList={{
+        "doc-sheet__new-page--active": props.active,
+        "doc-sheet__new-page--drop": droppable.isActiveDroppable,
+      }}
+      data-testid="doc-sheet-new-page"
+      aria-hidden={props.active ? undefined : "true"}
+    >
+      Drop here to start a new page
+    </div>
+  );
+}
+
 export interface DocSheetProps {
   resume: ResumeData;
   /** Structural layout metadata for the resume's template. */
@@ -71,8 +227,11 @@ export interface DocSheetProps {
 }
 
 export function DocSheet(props: DocSheetProps): JSX.Element {
-  const pages = createMemo(() => {
-    const rendered = renderPages(props.resume, props.templateLayout);
+  // The layout the drops address, and the drawn view of it. `editorPages()`
+  // never drops a page or column, so the two are aligned index-for-index.
+  const layout = createMemo(() => layoutPages(props.resume, props.templateLayout));
+  const pages = createMemo<EditorSectionView[][][]>(() => {
+    const rendered = editorPages(props.resume, props.templateLayout);
     // An empty resume still gets one frame, so the sheet reads as a blank page
     // rather than as a failure to load.
     return rendered.length > 0 ? rendered : [[[]]];
@@ -81,7 +240,9 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
   const links = createMemo(() => {
     // `profiles` renders as a section wherever the layout places it; the header
     // only carries the links when no page does.
-    const placed = pages().some((page) => page.some((column) => column.includes("profiles")));
+    const placed = pages().some((page) =>
+      page.some((column) => column.some((section) => section.id === "profiles")),
+    );
     return placed ? [] : profileLinks(props.resume);
   });
 
@@ -89,7 +250,15 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
 
   const [overflowing, setOverflowing] = createSignal<number[]>([]);
   const [isSectionDialogOpen, setIsSectionDialogOpen] = createSignal(false);
+  /** Section an add-block is adding an item to, or `null`. */
+  const [addTarget, setAddTarget] = createSignal<string | null>(null);
+  const [activeDrag, setActiveDrag] = createSignal<SheetDragData | null>(null);
+  const [announcement, setAnnouncement] = createSignal("");
   let root: HTMLDivElement | undefined;
+
+  function announce(message: string): void {
+    announceLive(setAnnouncement, message);
+  }
 
   /**
    * Flag every page holding a clipped column.
@@ -130,117 +299,303 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
   createEffect(() => props.onOverflowChange?.(overflowing()));
   createEffect(() => props.onPageCountChange?.(pages().length));
 
+  /** Announce where `sectionId` landed in `nextLayout`. */
+  function announceSectionMove(sectionId: string, nextLayout: string[][][]): void {
+    const placement = findSectionPlacement(nextLayout, sectionId);
+    const title = sectionTitle(props.resume, sectionId);
+    if (!placement) {
+      announce(`${title} section moved`);
+      return;
+    }
+    announce(
+      `${title} section moved to position ${placement.index + 1} in column ` +
+        `${placement.column + 1} of page ${placement.page + 1}`,
+    );
+  }
+
+  /** One-step section move, shared by the move controls (click and keyboard). */
+  function moveSection(sectionId: string, step: MoveStep): void {
+    const next = moveSectionStep(layout(), sectionId, step);
+    if (!next) {
+      announce(`${sectionTitle(props.resume, sectionId)} section did not move`);
+      return;
+    }
+    applyLayout(next);
+    announceSectionMove(sectionId, next);
+    // Keep the user on the control they just used; it moved with the section.
+    requestAnimationFrame(() => {
+      root
+        ?.querySelector<HTMLButtonElement>(`[data-doc-move-section="${sectionId}:${step}"]`)
+        ?.focus();
+    });
+  }
+
+  /** One-step entry move, shared by the move controls (click and keyboard). */
+  function moveEntry(sectionId: string, itemId: string, step: MoveStep): void {
+    const label = entryLabel(props.resume, sectionId, itemId);
+    const items = sectionItemList(props.resume, sectionId);
+
+    if (step === "up" || step === "down") {
+      const move = entryStep(items, itemId, step);
+      if (!move) {
+        announce(`${label} did not move`);
+        return;
+      }
+      reorderItem(sectionId, move.fromIndex, move.toIndex);
+      announce(reorderAnnouncement(label, move.toIndex, items.length));
+    } else {
+      const targetId = adjacentCustomSectionId(layout(), sectionId, step);
+      const fromIndex = items.findIndex((item) => item.id === itemId);
+      if (targetId === null || fromIndex === -1) {
+        announce(`${label} did not move`);
+        return;
+      }
+      const targetItems = sectionItemList(props.resume, targetId);
+      moveItemAcrossSections(sectionId, fromIndex, targetId, targetItems.length);
+      announce(`${label} moved to ${sectionTitle(props.resume, targetId)}`);
+    }
+
+    requestAnimationFrame(() => {
+      root?.querySelector<HTMLButtonElement>(`[data-doc-move-entry="${itemId}:${step}"]`)?.focus();
+    });
+  }
+
+  // Only droppables that mean something for the active drag may catch it —
+  // a section drag must never land on an entry, nor an entry on a column.
+  const detectCollisions: CollisionDetector = (draggable, droppables, context) =>
+    closestCenter(
+      draggable,
+      droppables.filter((droppable) =>
+        acceptsDrop(draggable.data as SheetDragData, droppable.data as SheetDropData),
+      ),
+      context,
+    );
+
+  function onDragStart({ draggable }: DragEvent): void {
+    setActiveDrag(draggable.data as SheetDragData);
+  }
+
+  /** Resolve a finished drag to at most one store action. */
+  function onDragEnd({ draggable, droppable }: DragEvent): void {
+    setActiveDrag(null);
+    if (!droppable) return;
+    const drag = draggable.data as SheetDragData;
+    const drop = droppable.data as SheetDropData;
+    if (!acceptsDrop(drag, drop)) return;
+
+    if (drag.type === "section") {
+      let next: string[][][] | null = null;
+      if (drop.type === "section") {
+        next = resolveSectionDropOnSection(layout(), drag.sectionId, drop.sectionId);
+      } else if (drop.type === "column") {
+        next = resolveSectionDropOnColumn(layout(), drag.sectionId, drop.page, drop.column);
+      } else if (drop.type === "new-page") {
+        next = moveSectionInLayout(layout(), drag.sectionId, {
+          page: layout().length,
+          column: 0,
+          index: 0,
+        });
+      }
+      if (!next) return;
+      applyLayout(next);
+      announceSectionMove(drag.sectionId, next);
+      return;
+    }
+
+    if (drop.type !== "entry" && drop.type !== "section") return;
+    const resolved = resolveEntryDrop({
+      fromSectionId: drag.sectionId,
+      fromItems: sectionItemList(props.resume, drag.sectionId),
+      itemId: drag.itemId,
+      toSectionId: drop.sectionId,
+      toItems: sectionItemList(props.resume, drop.sectionId),
+      targetItemId: drop.type === "entry" ? drop.itemId : null,
+    });
+    if (!resolved) return;
+    const label = entryLabel(props.resume, drag.sectionId, drag.itemId);
+    if (resolved.kind === "reorder") {
+      reorderItem(resolved.sectionId, resolved.fromIndex, resolved.toIndex);
+      announce(
+        reorderAnnouncement(
+          label,
+          resolved.toIndex,
+          sectionItemList(props.resume, resolved.sectionId).length,
+        ),
+      );
+      return;
+    }
+    moveItemAcrossSections(
+      resolved.fromSectionId,
+      resolved.fromIndex,
+      resolved.toSectionId,
+      resolved.toIndex,
+    );
+    announce(`${label} moved to ${sectionTitle(props.resume, resolved.toSectionId)}`);
+  }
+
+  /** The placed-but-empty item sections of one column — its add-block targets. */
+  function addTargets(pageIndex: number, columnIndex: number): AddTarget[] {
+    const placed = layout()[pageIndex]?.[columnIndex] ?? [];
+    const drawn = new Set((pages()[pageIndex]?.[columnIndex] ?? []).map((section) => section.id));
+    return placed
+      .filter((id) => !drawn.has(id) && id !== "summary" && id !== "coverLetter")
+      .map((id) => ({ id, noun: itemNoun(sectionTitle(props.resume, id)) }));
+  }
+
+  const dragLabel = (): string => {
+    const drag = activeDrag();
+    if (!drag) return "";
+    if (drag.type === "section") {
+      return `${sectionTitle(props.resume, drag.sectionId)} section`;
+    }
+    return entryLabel(props.resume, drag.sectionId, drag.itemId);
+  };
+
   return (
-    <div
-      ref={(element) => {
-        root = element;
-        observer?.observe(element);
-      }}
-      class="doc-sheet"
-      data-testid="doc-sheet"
-      style={{
-        "--doc-sheet-bg": theme().background,
-        "--doc-sheet-text": theme().text,
-        "--doc-sheet-accent": theme().primary,
-      }}
+    <DragDropProvider
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      collisionDetector={detectCollisions}
     >
-      <For each={pages()}>
-        {(page, pageIndex) => {
-          const geometry = createMemo(() => layoutColumns(page, props.templateLayout));
-          const hasSidebar = () => geometry().some((column) => column.role === "sidebar");
-          const isFirst = () => pageIndex() === 0;
-          const identityIn = () => identityRegion(props.templateLayout, hasSidebar());
-          const contactIn = () => contactRegion(props.templateLayout, hasSidebar());
-
-          return (
-            <article
-              class="doc-sheet__page"
-              data-testid="doc-sheet-page"
-              aria-label={`Page ${pageIndex() + 1} of ${pages().length}`}
-              data-overflowing={overflowing().includes(pageIndex()) ? "true" : undefined}
-            >
-              <Show when={isFirst() && identityIn() === "top"}>
-                <DocHeader
-                  basics={props.resume.basics}
-                  headerStyle={props.templateLayout.headerStyle}
-                  showContact={contactIn() === "top"}
-                  profileLinks={links()}
-                />
-              </Show>
-              <Show when={isFirst() && identityIn() !== "top" && contactIn() === "top"}>
-                <DocHeader
-                  basics={props.resume.basics}
-                  headerStyle={props.templateLayout.headerStyle}
-                  showIdentity={false}
-                  showContact
-                  profileLinks={links()}
-                />
-              </Show>
-
-              <div class="doc-sheet__columns">
-                <For each={visualColumns(geometry())}>
-                  {(column) => (
-                    <div
-                      class="doc-sheet__column"
-                      classList={{ "doc-sheet__column--sidebar": column.role === "sidebar" }}
-                      data-testid="doc-sheet-column"
-                      data-column-index={column.index}
-                      data-column-role={column.role}
-                      data-page-index={pageIndex()}
-                      style={{ "flex-basis": `${column.width * 100}%` }}
-                    >
-                      <Show
-                        when={isFirst() && column.role === "sidebar" && identityIn() === "sidebar"}
-                      >
-                        <DocHeader
-                          basics={props.resume.basics}
-                          headerStyle="sidebar"
-                          showContact={contactIn() === "sidebar"}
-                          profileLinks={links()}
-                        />
-                      </Show>
-                      <Show
-                        when={
-                          isFirst() &&
-                          column.role === "sidebar" &&
-                          identityIn() !== "sidebar" &&
-                          contactIn() === "sidebar"
-                        }
-                      >
-                        <DocHeader
-                          basics={props.resume.basics}
-                          headerStyle="sidebar"
-                          showIdentity={false}
-                          showContact
-                          profileLinks={links()}
-                        />
-                      </Show>
-
-                      <For each={page[column.index] ?? []}>
-                        {(sectionId) => <DocSection resume={props.resume} sectionId={sectionId} />}
-                      </For>
-                    </div>
-                  )}
-                </For>
-              </div>
-            </article>
-          );
+      <DragDropSensors />
+      <div
+        ref={(element) => {
+          root = element;
+          observer?.observe(element);
         }}
-      </For>
+        class="doc-sheet"
+        data-testid="doc-sheet"
+        style={{
+          "--doc-sheet-bg": theme().background,
+          "--doc-sheet-text": theme().text,
+          "--doc-sheet-accent": theme().primary,
+        }}
+      >
+        <For each={pages()}>
+          {(page, pageIndex) => {
+            const geometry = createMemo(() => layoutColumns(page, props.templateLayout));
+            const hasSidebar = () => geometry().some((column) => column.role === "sidebar");
+            const isFirst = () => pageIndex() === 0;
+            const identityIn = () => identityRegion(props.templateLayout, hasSidebar());
+            const contactIn = () => contactRegion(props.templateLayout, hasSidebar());
 
-      {/* Sheet-level chrome: creating a section is not part of any one page. */}
-      <div class="doc-sheet__actions">
-        <button
-          type="button"
-          class="doc-sheet__action"
-          data-testid="doc-sheet-add-section"
-          onClick={() => setIsSectionDialogOpen(true)}
-        >
-          Add section
-        </button>
+            return (
+              <article
+                class="doc-sheet__page"
+                data-testid="doc-sheet-page"
+                aria-label={`Page ${pageIndex() + 1} of ${pages().length}`}
+                data-overflowing={overflowing().includes(pageIndex()) ? "true" : undefined}
+              >
+                <Show when={isFirst() && identityIn() === "top"}>
+                  <DocHeader
+                    basics={props.resume.basics}
+                    headerStyle={props.templateLayout.headerStyle}
+                    showContact={contactIn() === "top"}
+                    profileLinks={links()}
+                  />
+                </Show>
+                <Show when={isFirst() && identityIn() !== "top" && contactIn() === "top"}>
+                  <DocHeader
+                    basics={props.resume.basics}
+                    headerStyle={props.templateLayout.headerStyle}
+                    showIdentity={false}
+                    showContact
+                    profileLinks={links()}
+                  />
+                </Show>
+
+                <div class="doc-sheet__columns">
+                  <For each={visualColumns(geometry())}>
+                    {(column) => (
+                      <SheetColumn
+                        pageIndex={pageIndex()}
+                        column={column}
+                        addTargets={addTargets(pageIndex(), column.index)}
+                        onAdd={setAddTarget}
+                      >
+                        <Show
+                          when={
+                            isFirst() && column.role === "sidebar" && identityIn() === "sidebar"
+                          }
+                        >
+                          <DocHeader
+                            basics={props.resume.basics}
+                            headerStyle="sidebar"
+                            showContact={contactIn() === "sidebar"}
+                            profileLinks={links()}
+                          />
+                        </Show>
+                        <Show
+                          when={
+                            isFirst() &&
+                            column.role === "sidebar" &&
+                            identityIn() !== "sidebar" &&
+                            contactIn() === "sidebar"
+                          }
+                        >
+                          <DocHeader
+                            basics={props.resume.basics}
+                            headerStyle="sidebar"
+                            showIdentity={false}
+                            showContact
+                            profileLinks={links()}
+                          />
+                        </Show>
+
+                        <For each={page[column.index] ?? []}>
+                          {(section) => (
+                            <DocSection
+                              resume={props.resume}
+                              sectionId={section.id}
+                              hidden={section.hidden}
+                              onMoveSection={moveSection}
+                              onMoveEntry={moveEntry}
+                            />
+                          )}
+                        </For>
+                      </SheetColumn>
+                    )}
+                  </For>
+                </div>
+              </article>
+            );
+          }}
+        </For>
+
+        <NewPageZone active={activeDrag()?.type === "section"} />
+
+        {/* Sheet-level chrome: creating a section is not part of any one page. */}
+        <div class="doc-sheet__actions">
+          <button
+            type="button"
+            class="doc-sheet__action"
+            data-testid="doc-sheet-add-section"
+            onClick={() => setIsSectionDialogOpen(true)}
+          >
+            Add section
+          </button>
+        </div>
+
+        <CustomSectionDialog open={isSectionDialogOpen()} onOpenChange={setIsSectionDialogOpen} />
+
+        {/* Add-block target: adds the first item of a placed-but-empty section. */}
+        <ItemDialog
+          open={addTarget() !== null}
+          sectionId={addTarget() ?? ""}
+          sectionTitle={sectionTitle(props.resume, addTarget() ?? "")}
+          onOpenChange={(open) => {
+            if (!open) setAddTarget(null);
+          }}
+        />
+
+        <LiveRegion message={announcement()} politeness="polite" />
       </div>
 
-      <CustomSectionDialog open={isSectionDialogOpen()} onOpenChange={setIsSectionDialogOpen} />
-    </div>
+      <DragOverlay>
+        <Show when={activeDrag()}>
+          <div class="doc-sheet__drag-overlay">{dragLabel()}</div>
+        </Show>
+      </DragOverlay>
+    </DragDropProvider>
   );
 }

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -318,9 +318,15 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
       announce(`${title} section moved`);
       return;
     }
+    // Speak the visual column position, not the stored index: sidebar-left
+    // templates paint column 1 second, and what is spoken must match what
+    // is seen.
+    const geometry = layoutColumns(nextLayout[position.page], props.templateLayout);
+    const visualColumn =
+      (geometry.find((column) => column.index === position.column)?.order ?? position.column) + 1;
     announce(
       `${title} section moved to position ${position.index + 1} of ${position.total} ` +
-        `in column ${position.column + 1} of page ${position.page + 1}`,
+        `in column ${visualColumn} of page ${position.page + 1}`,
     );
   }
 

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -571,6 +571,7 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
                               hidden={section.hidden}
                               onMoveSection={moveSection}
                               onMoveEntry={moveEntry}
+                              onAnnounce={announce}
                             />
                           )}
                         </For>

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -37,6 +37,7 @@ import { itemNoun } from "./itemFields";
 import {
   adjacentCustomSectionId,
   canMoveEntryAcross,
+  drawnSectionPosition,
   entryStep,
   moveSectionInLayout,
   moveSectionStep,
@@ -48,7 +49,6 @@ import {
 } from "../../lib/docDnd";
 import {
   editorPages,
-  findSectionPlacement,
   layoutColumns,
   layoutPages,
   sectionTitle,
@@ -299,23 +299,36 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
   createEffect(() => props.onOverflowChange?.(overflowing()));
   createEffect(() => props.onPageCountChange?.(pages().length));
 
-  /** Announce where `sectionId` landed in `nextLayout`. */
+  // The cards the sheet draws. Drawn-ness depends on content and visibility,
+  // never on placement — so the set stays valid for a layout about to change.
+  const drawnIds = createMemo(
+    () => new Set(pages().flatMap((page) => page.flatMap((column) => column.map((s) => s.id)))),
+  );
+  const isDrawn = (id: string): boolean => drawnIds().has(id);
+
+  /**
+   * Announce where `sectionId` landed in `nextLayout`, in drawn-card terms:
+   * what is spoken must match what is seen, so positions count the cards the
+   * sheet draws, not the slots the layout stores.
+   */
   function announceSectionMove(sectionId: string, nextLayout: string[][][]): void {
-    const placement = findSectionPlacement(nextLayout, sectionId);
+    const position = drawnSectionPosition(nextLayout, sectionId, isDrawn);
     const title = sectionTitle(props.resume, sectionId);
-    if (!placement) {
+    if (!position) {
       announce(`${title} section moved`);
       return;
     }
     announce(
-      `${title} section moved to position ${placement.index + 1} in column ` +
-        `${placement.column + 1} of page ${placement.page + 1}`,
+      `${title} section moved to position ${position.index + 1} of ${position.total} ` +
+        `in column ${position.column + 1} of page ${position.page + 1}`,
     );
   }
 
   /** One-step section move, shared by the move controls (click and keyboard). */
   function moveSection(sectionId: string, step: MoveStep): void {
-    const next = moveSectionStep(layout(), sectionId, step);
+    // Stepping is drawn-aware: slots the sheet does not draw are skipped, so
+    // a press never announces a move with zero visual change.
+    const next = moveSectionStep(layout(), sectionId, step, isDrawn);
     if (!next) {
       announce(`${sectionTitle(props.resume, sectionId)} section did not move`);
       return;
@@ -361,15 +374,23 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
   }
 
   // Only droppables that mean something for the active drag may catch it —
-  // a section drag must never land on an entry, nor an entry on a column.
-  const detectCollisions: CollisionDetector = (draggable, droppables, context) =>
-    closestCenter(
-      draggable,
-      droppables.filter((droppable) =>
-        acceptsDrop(draggable.data as SheetDragData, droppable.data as SheetDropData),
-      ),
-      context,
+  // a section drag must never land on an entry, nor an entry on a column —
+  // and only droppables the dragged card actually overlaps count at all, so a
+  // sloppy release over dead space cancels instead of snapping to the nearest
+  // centre. Among the overlapping targets, closest-centre keeps the familiar
+  // card-versus-column selection.
+  const detectCollisions: CollisionDetector = (draggable, droppables, context) => {
+    const dragged = draggable.transformed;
+    const touching = droppables.filter(
+      (droppable) =>
+        acceptsDrop(draggable.data as SheetDragData, droppable.data as SheetDropData) &&
+        dragged.left < droppable.layout.right &&
+        dragged.right > droppable.layout.left &&
+        dragged.top < droppable.layout.bottom &&
+        dragged.bottom > droppable.layout.top,
     );
+    return touching.length > 0 ? closestCenter(draggable, touching, context) : null;
+  };
 
   function onDragStart({ draggable }: DragEvent): void {
     setActiveDrag(draggable.data as SheetDragData);

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -1,0 +1,360 @@
+/**
+ * The structural chrome of #729: section cards, entry action rows, add-blocks
+ * and the single-pointer/keyboard move controls that mirror the drags.
+ *
+ * Pointer drags themselves are exercised against the pure resolvers in
+ * `lib/__tests__/docDnd.test.ts`; here the assertions are that every control
+ * routes to exactly the right store action — one action per operation — and
+ * that moves are announced.
+ */
+
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { loadDocEditorFixture, SIDEBAR_TEMPLATE } from "../../../test/docEditorFixture";
+import { DocSheet } from "../DocSheet";
+import type { ResumeData } from "../../../wasm/types";
+
+const store = vi.hoisted(() => ({
+  store: { resume: null as unknown },
+  updateBasics: vi.fn(),
+  updateSummary: vi.fn(),
+  updateCoverLetter: vi.fn(),
+  updateSectionName: vi.fn(),
+  updateSectionItem: vi.fn(),
+  addSectionItem: vi.fn(),
+  removeSectionItem: vi.fn(),
+  reorderSectionItem: vi.fn(),
+  duplicateSectionItem: vi.fn(),
+  toggleSectionVisibility: vi.fn(),
+  updateCustomSection: vi.fn(),
+  addCustomSection: vi.fn(() => "custom-1"),
+  removeCustomSection: vi.fn(),
+  addCustomSectionItem: vi.fn(),
+  updateCustomSectionItem: vi.fn(),
+  removeCustomSectionItem: vi.fn(),
+  reorderCustomSectionItem: vi.fn(),
+  duplicateCustomSectionItem: vi.fn(),
+  moveCustomSectionItem: vi.fn(),
+  updateLayout: vi.fn(),
+}));
+
+vi.mock("../../../stores/resume", () => ({ resumeStore: store }));
+
+/** Total writes recorded across every mocked store action. */
+function writeCount(): number {
+  return Object.entries(store)
+    .filter(([key]) => key !== "store")
+    .reduce((total, [, action]) => total + (action as Mock).mock.calls.length, 0);
+}
+
+function liveRegionText(): string {
+  return [...document.querySelectorAll('[aria-live="polite"]')]
+    .map((element) => element.textContent)
+    .join(" ");
+}
+
+describe("document sheet structural chrome", () => {
+  let resume: ResumeData;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resume = loadDocEditorFixture();
+    store.store.resume = resume;
+  });
+
+  function renderSheet() {
+    return render(() => <DocSheet resume={resume} templateLayout={SIDEBAR_TEMPLATE} />);
+  }
+
+  describe("section cards", () => {
+    it("hides a fixed section through toggleSectionVisibility", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Hide Experience section" }));
+
+      expect(store.toggleSectionVisibility).toHaveBeenCalledExactlyOnceWith("experience");
+      expect(writeCount()).toBe(1);
+    });
+
+    it("hides a custom section through updateCustomSection", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Hide Talks & Workshops section" }));
+
+      expect(store.updateCustomSection).toHaveBeenCalledExactlyOnceWith("speaking", {
+        visible: false,
+      });
+    });
+
+    it("keeps a hidden section on the surface, flagged, with a Show control", () => {
+      resume.sections.experience.visible = false;
+      renderSheet();
+
+      const section = document.querySelector('[data-section-id="experience"]');
+      expect(section).toBeTruthy();
+      expect(section?.classList.contains("doc-sheet__section--hidden")).toBe(true);
+
+      fireEvent.click(screen.getByRole("button", { name: "Show Experience section" }));
+
+      expect(store.toggleSectionVisibility).toHaveBeenCalledExactlyOnceWith("experience");
+    });
+
+    it("deletes a custom section through removeCustomSection", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Delete Talks & Workshops section" }));
+
+      expect(store.removeCustomSection).toHaveBeenCalledExactlyOnceWith("speaking");
+      expect(writeCount()).toBe(1);
+    });
+
+    it("offers no delete for fixed sections", () => {
+      renderSheet();
+
+      expect(screen.queryByRole("button", { name: "Delete Experience section" })).toBeNull();
+    });
+
+    it("renames a custom section through its dialog", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Rename Talks & Workshops section" }));
+      fireEvent.input(screen.getByRole("textbox", { name: "Section name" }), {
+        target: { value: "Talks" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+      expect(store.updateCustomSection).toHaveBeenCalledExactlyOnceWith("speaking", {
+        name: "Talks",
+      });
+    });
+  });
+
+  describe("section move controls", () => {
+    it("moves a section one step down through one updateLayout call", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Move Experience section down" }));
+
+      expect(store.updateLayout).toHaveBeenCalledExactlyOnceWith([
+        [
+          ["summary", "education", "experience", "projects"],
+          ["profiles", "skills", "speaking"],
+        ],
+        [
+          ["publications", "volunteer", "awards"],
+          ["languages", "interests", "certifications", "advisory"],
+        ],
+      ]);
+      expect(writeCount()).toBe(1);
+    });
+
+    it("moves a section to the next column, across pages", () => {
+      renderSheet();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Move Talks & Workshops section to the next column" }),
+      );
+
+      const [layout] = store.updateLayout.mock.calls[0] as [string[][][]];
+      expect(layout[0][1]).toEqual(["profiles", "skills"]);
+      expect(layout[1][0]).toEqual(["publications", "volunteer", "awards", "speaking"]);
+    });
+
+    it("announces the move", async () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Move Experience section down" }));
+
+      await waitFor(() => {
+        expect(liveRegionText()).toMatch(/Experience section moved to position 3 in column 1/i);
+      });
+    });
+
+    it("writes nothing at a boundary, and says so", async () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Move Summary section up" }));
+
+      expect(store.updateLayout).not.toHaveBeenCalled();
+      expect(writeCount()).toBe(0);
+      await waitFor(() => {
+        expect(liveRegionText()).toMatch(/Summary section did not move/i);
+      });
+    });
+  });
+
+  describe("entry actions", () => {
+    it("duplicates an entry through duplicateSectionItem", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Duplicate Lumen Health" }));
+
+      expect(store.duplicateSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0);
+      expect(writeCount()).toBe(1);
+    });
+
+    it("deletes the right entry through removeSectionItem", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Delete Lumen Health" }));
+
+      expect(store.removeSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0);
+    });
+
+    it("hides an entry, keeps it drawn, and can show it again", () => {
+      renderSheet();
+      fireEvent.click(screen.getByRole("button", { name: "Hide Lumen Health" }));
+      expect(store.updateSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, {
+        visible: false,
+      });
+
+      // Redraw with the item actually hidden: still present, now as chrome.
+      resume.sections.experience.items[0].visible = false;
+      vi.clearAllMocks();
+      renderSheet();
+
+      expect(screen.getByRole("button", { name: "Show Lumen Health" })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Show Lumen Health" }));
+      expect(store.updateSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, {
+        visible: true,
+      });
+    });
+
+    it("routes a custom entry's actions to the custom store actions", () => {
+      renderSheet();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Duplicate Design Tokens Beyond Colour" }),
+      );
+
+      expect(store.duplicateCustomSectionItem).toHaveBeenCalledExactlyOnceWith("speaking", 0);
+    });
+  });
+
+  describe("entry move controls", () => {
+    it("reorders within the section through one reorderSectionItem call", async () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Move Lumen Health down" }));
+
+      expect(store.reorderSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, 1);
+      expect(writeCount()).toBe(1);
+      await waitFor(() => {
+        expect(liveRegionText()).toMatch(/Lumen Health moved to position 2 of \d+/i);
+      });
+    });
+
+    it("performs the same mutation as the equivalent drag would", () => {
+      // The drag path resolves through `entryStep`/`resolveEntryDrop` to a
+      // (from, to) pair; the control must hand the store the identical pair.
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Move Lumen Health down" }));
+      const [sectionId, from, to] = store.reorderSectionItem.mock.calls[0] as [
+        string,
+        number,
+        number,
+      ];
+      expect([sectionId, from, to]).toEqual(["experience", 0, 1]);
+    });
+
+    it("offers lateral moves only where a cross-section drag exists", () => {
+      renderSheet();
+
+      // Fixed sections share no item shape with anything: vertical moves only.
+      expect(
+        screen.queryByRole("button", { name: "Move Lumen Health to the next section" }),
+      ).toBeNull();
+      // Custom entries can drag to another custom section, so the keyboard
+      // and single-pointer path exists too.
+      expect(
+        screen.getByRole("button", {
+          name: "Move Design Tokens Beyond Colour to the next section",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("moves a custom entry to the adjacent custom section in one action", async () => {
+      renderSheet();
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Move Design Tokens Beyond Colour to the next section",
+        }),
+      );
+
+      const advisoryLength = resume.sections.custom.advisory.items.length;
+      expect(store.moveCustomSectionItem).toHaveBeenCalledExactlyOnceWith(
+        "speaking",
+        0,
+        "advisory",
+        advisoryLength,
+      );
+      expect(writeCount()).toBe(1);
+      await waitFor(() => {
+        expect(liveRegionText()).toMatch(/Design Tokens Beyond Colour moved to/i);
+      });
+    });
+
+    it("writes nothing at a boundary", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Move Lumen Health up" }));
+
+      expect(writeCount()).toBe(0);
+    });
+  });
+
+  describe("add-blocks", () => {
+    it("offers a placed-but-empty section as an add affordance", () => {
+      resume.sections.projects.items = [];
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Add project" }));
+      fireEvent.input(screen.getByRole("textbox", { name: "Name" }), {
+        target: { value: "Halo" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Add project", hidden: false }));
+
+      expect(store.addSectionItem).toHaveBeenCalledOnce();
+      const [sectionId, item] = store.addSectionItem.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
+      expect(sectionId).toBe("projects");
+      expect(item.name).toBe("Halo");
+      expect(item.visible).toBe(true);
+    });
+
+    it("draws no add-block when every placed section has content", () => {
+      renderSheet();
+
+      expect(screen.queryByTestId("doc-sheet-add-block")).toBeNull();
+    });
+  });
+
+  describe("drag chrome", () => {
+    it("gives cards and entries drag handles rather than surface capture", () => {
+      renderSheet();
+
+      expect(
+        screen.getByRole("button", { name: "Drag Experience section to move it" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Drag Lumen Health to move it" }),
+      ).toBeInTheDocument();
+      // The section surface itself must not be a drag activator, or text
+      // selection and inline editing would fight the drag sensor.
+      const section = document.querySelector('[data-section-id="experience"]');
+      expect(section?.getAttribute("draggable")).toBeNull();
+    });
+
+    it("keeps the new-page drop zone mounted but inert until a section drag", () => {
+      renderSheet();
+
+      const zone = screen.getByTestId("doc-sheet-new-page");
+      expect(zone.getAttribute("aria-hidden")).toBe("true");
+      expect(zone.classList.contains("doc-sheet__new-page--active")).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -187,7 +187,7 @@ describe("document sheet structural chrome", () => {
 
       await waitFor(() => {
         expect(liveRegionText()).toMatch(
-          /Experience section moved to position 3 of 4 in column 1 of page 1/i,
+          /Experience section moved to position 3 of 4 in column 2 of page 1/i,
         );
       });
     });
@@ -216,7 +216,7 @@ describe("document sheet structural chrome", () => {
       expect(layout[0][0]).toEqual(["summary", "education", "projects", "experience"]);
       await waitFor(() => {
         expect(liveRegionText()).toMatch(
-          /Experience section moved to position 3 of 3 in column 1 of page 1/i,
+          /Experience section moved to position 3 of 3 in column 2 of page 1/i,
         );
       });
     });
@@ -398,12 +398,15 @@ describe("document sheet structural chrome", () => {
     it("gives cards and entries drag handles rather than surface capture", () => {
       renderSheet();
 
-      expect(
-        screen.getByRole("button", { name: "Drag Experience section to move it" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Drag Lumen Health to move it" }),
-      ).toBeInTheDocument();
+      // Handles are pointer-only chrome: out of the tab order and hidden from
+      // assistive tech (the move buttons are the keyboard/SR path), so they
+      // are found by title rather than accessible name.
+      const sectionHandle = screen.getByTitle("Drag Experience section to move it");
+      const entryHandle = screen.getByTitle("Drag Lumen Health to move it");
+      expect(sectionHandle).toBeInTheDocument();
+      expect(entryHandle).toBeInTheDocument();
+      expect(sectionHandle.getAttribute("tabindex")).toBe("-1");
+      expect(entryHandle.getAttribute("aria-hidden")).toBe("true");
       // The section surface itself must not be a drag activator, or text
       // selection and inline editing would fight the drag sensor.
       const section = document.querySelector('[data-section-id="experience"]');

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -202,13 +202,15 @@ describe("document sheet structural chrome", () => {
     });
 
     it("hides an entry, keeps it drawn, and can show it again", () => {
-      renderSheet();
+      const first = renderSheet();
       fireEvent.click(screen.getByRole("button", { name: "Hide Lumen Health" }));
       expect(store.updateSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, {
         visible: false,
       });
 
       // Redraw with the item actually hidden: still present, now as chrome.
+      // Unmounted first, so the queries below see exactly one sheet.
+      first.unmount();
       resume.sections.experience.items[0].visible = false;
       vi.clearAllMocks();
       renderSheet();

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -406,6 +406,8 @@ describe("document sheet structural chrome", () => {
       expect(sectionHandle).toBeInTheDocument();
       expect(entryHandle).toBeInTheDocument();
       expect(sectionHandle.getAttribute("tabindex")).toBe("-1");
+      expect(sectionHandle.getAttribute("aria-hidden")).toBe("true");
+      expect(entryHandle.getAttribute("tabindex")).toBe("-1");
       expect(entryHandle.getAttribute("aria-hidden")).toBe("true");
       // The section surface itself must not be a drag activator, or text
       // selection and inline editing would fight the drag sensor.

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -176,13 +176,34 @@ describe("document sheet structural chrome", () => {
       expect(layout[1][0]).toEqual(["publications", "volunteer", "awards", "speaking"]);
     });
 
-    it("announces the move", async () => {
+    it("announces the move in drawn-card terms", async () => {
       renderSheet();
 
       fireEvent.click(screen.getByRole("button", { name: "Move Experience section down" }));
 
       await waitFor(() => {
-        expect(liveRegionText()).toMatch(/Experience section moved to position 3 in column 1/i);
+        expect(liveRegionText()).toMatch(
+          /Experience section moved to position 3 of 4 in column 1 of page 1/i,
+        );
+      });
+    });
+
+    it("steps past a placed-but-undrawn section, and counts only drawn cards", async () => {
+      // `education` keeps its layout slot but has nothing to draw, so one
+      // press on Experience must clear it in a single visible step — and the
+      // announced position must match the three cards on screen, not the four
+      // slots in the layout.
+      resume.sections.education.items = [];
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Move Experience section down" }));
+
+      const [layout] = store.updateLayout.mock.calls[0] as [string[][][]];
+      expect(layout[0][0]).toEqual(["summary", "education", "projects", "experience"]);
+      await waitFor(() => {
+        expect(liveRegionText()).toMatch(
+          /Experience section moved to position 3 of 3 in column 1 of page 1/i,
+        );
       });
     });
 

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { loadDocEditorFixture, SIDEBAR_TEMPLATE } from "../../../test/docEditorFixture";
 import { DocSheet } from "../DocSheet";
 import type { ResumeData } from "../../../wasm/types";
@@ -329,10 +329,12 @@ describe("document sheet structural chrome", () => {
       renderSheet();
 
       fireEvent.click(screen.getByRole("button", { name: "Add project" }));
-      fireEvent.input(screen.getByRole("textbox", { name: "Name" }), {
+      // Scoped to the dialog: the add-block trigger shares the same name.
+      const dialog = screen.getByRole("dialog");
+      fireEvent.input(within(dialog).getByRole("textbox", { name: "Name" }), {
         target: { value: "Halo" },
       });
-      fireEvent.click(screen.getByRole("button", { name: "Add project", hidden: false }));
+      fireEvent.click(within(dialog).getByRole("button", { name: "Add project" }));
 
       expect(store.addSectionItem).toHaveBeenCalledOnce();
       const [sectionId, item] = store.addSectionItem.mock.calls[0] as [

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -10,6 +10,7 @@
 
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import { entryStep } from "../../../lib/docDnd";
 import { loadDocEditorFixture, SIDEBAR_TEMPLATE } from "../../../test/docEditorFixture";
 import { DocSheet } from "../DocSheet";
 import type { ResumeData } from "../../../wasm/types";
@@ -67,13 +68,16 @@ describe("document sheet structural chrome", () => {
   }
 
   describe("section cards", () => {
-    it("hides a fixed section through toggleSectionVisibility", () => {
+    it("hides a fixed section through toggleSectionVisibility, and says so", async () => {
       renderSheet();
 
       fireEvent.click(screen.getByRole("button", { name: "Hide Experience section" }));
 
       expect(store.toggleSectionVisibility).toHaveBeenCalledExactlyOnceWith("experience");
       expect(writeCount()).toBe(1);
+      await waitFor(() => {
+        expect(liveRegionText()).toMatch(/Experience section hidden/i);
+      });
     });
 
     it("hides a custom section through updateCustomSection", () => {
@@ -188,6 +192,16 @@ describe("document sheet structural chrome", () => {
       });
     });
 
+    it("hands focus back to the control that was used", async () => {
+      renderSheet();
+      const control = screen.getByRole("button", { name: "Move Experience section down" });
+
+      fireEvent.click(control);
+
+      // The refocus rides requestAnimationFrame, after the sheet redraws.
+      await waitFor(() => expect(document.activeElement).toBe(control));
+    });
+
     it("steps past a placed-but-undrawn section, and counts only drawn cards", async () => {
       // `education` keeps its layout slot but has nothing to draw, so one
       // press on Experience must clear it in a single visible step — and the
@@ -230,12 +244,15 @@ describe("document sheet structural chrome", () => {
       expect(writeCount()).toBe(1);
     });
 
-    it("deletes the right entry through removeSectionItem", () => {
+    it("deletes the right entry through removeSectionItem, and says so", async () => {
       renderSheet();
 
       fireEvent.click(screen.getByRole("button", { name: "Delete Lumen Health" }));
 
       expect(store.removeSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0);
+      await waitFor(() => {
+        expect(liveRegionText()).toMatch(/Lumen Health deleted/i);
+      });
     });
 
     it("hides an entry, keeps it drawn, and can show it again", () => {
@@ -284,17 +301,20 @@ describe("document sheet structural chrome", () => {
     });
 
     it("performs the same mutation as the equivalent drag would", () => {
-      // The drag path resolves through `entryStep`/`resolveEntryDrop` to a
-      // (from, to) pair; the control must hand the store the identical pair.
       renderSheet();
 
       fireEvent.click(screen.getByRole("button", { name: "Move Lumen Health down" }));
-      const [sectionId, from, to] = store.reorderSectionItem.mock.calls[0] as [
-        string,
-        number,
-        number,
-      ];
-      expect([sectionId, from, to]).toEqual(["experience", 0, 1]);
+
+      // The drag path resolves through `entryStep` to a (from, to) pair; the
+      // control must hand the store the identical pair.
+      const items = resume.sections.experience.items.map(({ id, visible }) => ({ id, visible }));
+      const expected = entryStep(items, items[0].id, "down");
+      expect(expected).not.toBeNull();
+      expect(store.reorderSectionItem).toHaveBeenCalledExactlyOnceWith(
+        "experience",
+        expected!.fromIndex,
+        expected!.toIndex,
+      );
     });
 
     it("offers lateral moves only where a cross-section drag exists", () => {

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -99,6 +99,22 @@ describe("document sheet structural chrome", () => {
       expect(store.toggleSectionVisibility).toHaveBeenCalledExactlyOnceWith("experience");
     });
 
+    it("keeps a hidden, empty summary on the surface with a Show control", () => {
+      // Regression: rich text has no add-block, so if hiding an empty summary
+      // dropped its card, nothing on the sheet could ever show it again.
+      resume.sections.summary.content = "";
+      resume.sections.summary.visible = false;
+      renderSheet();
+
+      const summary = document.querySelector('[data-section-id="summary"]');
+      expect(summary).toBeTruthy();
+      expect(summary?.classList.contains("doc-sheet__section--hidden")).toBe(true);
+
+      fireEvent.click(screen.getByRole("button", { name: "Show Summary section" }));
+
+      expect(store.toggleSectionVisibility).toHaveBeenCalledExactlyOnceWith("summary");
+    });
+
     it("deletes a custom section through removeCustomSection", () => {
       renderSheet();
 

--- a/apps/web/src/components/doc-editor/docEdits.ts
+++ b/apps/web/src/components/doc-editor/docEdits.ts
@@ -84,3 +84,76 @@ export function addItem(sectionId: string, item: ItemUpdates): void {
   }
   resumeStore.addSectionItem(sectionId as SectionKey, item as never);
 }
+
+/**
+ * Flip a section between shown and hidden.
+ *
+ * Hidden means "not rendered to PDF": the section stays on the editing surface
+ * as chrome, which is also what makes this toggle reversible from the sheet.
+ */
+export function toggleSection(sectionId: string): void {
+  if (isCustomId(sectionId)) {
+    const section = resumeStore.store.resume?.sections.custom[sectionId];
+    if (!section) return;
+    resumeStore.updateCustomSection(sectionId, { visible: !section.visible });
+    return;
+  }
+  resumeStore.toggleSectionVisibility(sectionId as LayoutSectionKey);
+}
+
+/** Delete a custom section. Fixed sections can only be hidden, never deleted. */
+export function removeSection(sectionId: string): void {
+  if (!isCustomId(sectionId)) return;
+  resumeStore.removeCustomSection(sectionId);
+}
+
+/** Show or hide one item. Same rule as sections: hidden items stay as chrome. */
+export function setItemVisibility(sectionId: string, index: number, visible: boolean): void {
+  updateItem(sectionId, index, { visible });
+}
+
+/** Clone the item at `index` with a fresh id, inserted right after it. */
+export function duplicateItem(sectionId: string, index: number): void {
+  if (isCustomId(sectionId)) {
+    resumeStore.duplicateCustomSectionItem(sectionId, index);
+    return;
+  }
+  resumeStore.duplicateSectionItem(sectionId as SectionKey, index);
+}
+
+/** Delete one item of a section. */
+export function removeItem(sectionId: string, index: number): void {
+  if (isCustomId(sectionId)) {
+    resumeStore.removeCustomSectionItem(sectionId, index);
+    return;
+  }
+  resumeStore.removeSectionItem(sectionId as SectionKey, index);
+}
+
+/** Reorder one item within its section. */
+export function reorderItem(sectionId: string, fromIndex: number, toIndex: number): void {
+  if (isCustomId(sectionId)) {
+    resumeStore.reorderCustomSectionItem(sectionId, fromIndex, toIndex);
+    return;
+  }
+  resumeStore.reorderSectionItem(sectionId as SectionKey, fromIndex, toIndex);
+}
+
+/**
+ * Move an item between two custom sections — one store action, one undo entry.
+ * The only cross-section pair with a shared item shape (see `docDnd.ts`).
+ */
+export function moveItemAcrossSections(
+  fromSectionId: string,
+  fromIndex: number,
+  toSectionId: string,
+  toIndex: number,
+): void {
+  if (!isCustomId(fromSectionId) || !isCustomId(toSectionId)) return;
+  resumeStore.moveCustomSectionItem(fromSectionId, fromIndex, toSectionId, toIndex);
+}
+
+/** Replace `metadata.layout` wholesale — one drop, one layout write. */
+export function applyLayout(layout: string[][][]): void {
+  resumeStore.updateLayout(layout);
+}

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -435,14 +435,14 @@
 }
 
 /* Square icon control — arrows and drag handles. Sized in em so it scales
-   with the page, with a floor near the SC 2.5.8 24px target size. */
+   with the page, with a hard floor at the SC 2.5.8 24px target size. */
 .doc-sheet__action--icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0.15em;
-  min-width: 1.5em;
-  min-height: 1.5em;
+  min-width: max(1.5em, 24px);
+  min-height: max(1.5em, 24px);
 }
 
 .doc-sheet__action--icon svg {
@@ -522,9 +522,10 @@
   padding: 0.1em 0.4em;
 }
 
-/* Drop feedback: the card (or column) the drag would land on. */
-.doc-sheet__section--drop,
-.doc-sheet__item--drop {
+/* Drop feedback: the card (or column) the drag would land on. Doubled class
+   so it outweighs the hover outline above while the pointer is over it. */
+.doc-sheet__section.doc-sheet__section--drop,
+.doc-sheet__item.doc-sheet__item--drop {
   outline: 2px solid var(--doc-sheet-accent);
   outline-offset: 0.35em;
 }

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -429,28 +429,171 @@
   outline-offset: 1px;
 }
 
-/*
- * Per-item controls stay out of the document's way until the item is hovered
- * or something inside it takes focus. `opacity` rather than `display`, so the
- * control is always focusable and always announced.
+.doc-sheet__action--danger {
+  color: var(--turbo-state-error, #b3261e);
+  border-color: currentcolor;
+}
+
+/* Square icon control — arrows and drag handles. Sized in em so it scales
+   with the page, with a floor near the SC 2.5.8 24px target size. */
+.doc-sheet__action--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15em;
+  min-width: 1.5em;
+  min-height: 1.5em;
+}
+
+.doc-sheet__action--icon svg {
+  width: 1em;
+  height: 1em;
+}
+
+.doc-sheet__drag-handle {
+  cursor: grab;
+  touch-action: none;
+}
+
+.doc-sheet__drag-handle:active {
+  cursor: grabbing;
+}
+
+/* ── Structural chrome ─────────────────────────────────────────────────────
+ *
+ * Card and entry controls stay out of the document's way until their card is
+ * hovered or something inside it takes focus. `opacity` rather than `display`,
+ * so every control is always focusable and always announced.
  */
-.doc-sheet__action--item {
-  align-self: flex-start;
+
+.doc-sheet__section-chrome,
+.doc-sheet__item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3em;
   opacity: 0;
 }
 
-.doc-sheet__item:hover .doc-sheet__action--item,
-.doc-sheet__item:focus-within .doc-sheet__action--item {
+.doc-sheet__section:hover > .doc-sheet__section-chrome,
+.doc-sheet__section:focus-within > .doc-sheet__section-chrome,
+.doc-sheet__item:hover .doc-sheet__item-actions,
+.doc-sheet__item:focus-within .doc-sheet__item-actions {
   opacity: 1;
 }
 
 /*
- * Without hover there is nothing to reveal it, and this is the only route to
- * the fields the sheet has no room to draw — so a touch user would be left
- * with an invisible control sitting on a tappable rect.
+ * Without hover there is nothing to reveal them, and this is the only route to
+ * duplicating, hiding or deleting — so a touch user would be left with
+ * invisible controls sitting on tappable rects.
  */
 @media (hover: none) {
-  .doc-sheet__action--item {
+  .doc-sheet__section-chrome,
+  .doc-sheet__item-actions {
     opacity: 1;
   }
+}
+
+/* Card affordances: a quiet outline that declares the card on hover/focus. */
+.doc-sheet__section {
+  border-radius: 0.25em;
+  outline: 1px dashed transparent;
+  outline-offset: 0.35em;
+}
+
+.doc-sheet__section:hover,
+.doc-sheet__section:focus-within {
+  outline-color: var(--doc-sheet-rule);
+}
+
+/* Hidden means "not rendered to PDF" — still on the surface, dimmed. */
+.doc-sheet__section--hidden > :not(.doc-sheet__section-chrome),
+.doc-sheet__item--hidden > :not(.doc-sheet__item-actions) {
+  opacity: 0.45;
+}
+
+.doc-sheet__hidden-badge {
+  font-size: 0.7em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--doc-sheet-muted);
+  border: 1px solid var(--doc-sheet-rule);
+  border-radius: 0.2em;
+  padding: 0.1em 0.4em;
+}
+
+/* Drop feedback: the card (or column) the drag would land on. */
+.doc-sheet__section--drop,
+.doc-sheet__item--drop {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 0.35em;
+}
+
+.doc-sheet__section--dragging,
+.doc-sheet__item--dragging {
+  opacity: 0.35;
+}
+
+.doc-sheet__column--drop {
+  background: var(--doc-sheet-tint);
+  box-shadow: inset 0 0 0 2px var(--doc-sheet-accent);
+}
+
+/* ── Add-blocks ────────────────────────────────────────────────────────── */
+
+.doc-sheet__add-block {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4em;
+  margin-top: auto;
+  padding-top: 0.6em;
+}
+
+/* ── New-page drop zone ────────────────────────────────────────────────── */
+
+.doc-sheet__new-page {
+  width: var(--doc-sheet-page-width);
+  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  color: var(--color-ink, inherit);
+  border: 2px dashed var(--color-border);
+  border-radius: 0.375rem;
+  transition: opacity 150ms;
+  /* Mounted before any drag so the droppable is registered; shown only while
+     a section drag — the one thing it accepts — is under way. */
+  height: 0;
+  padding: 0;
+  margin: 0;
+  border-width: 0;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.doc-sheet__new-page--active {
+  height: auto;
+  padding: 1.25rem;
+  border-width: 2px;
+  opacity: 1;
+}
+
+.doc-sheet__new-page--drop {
+  border-color: var(--doc-sheet-accent);
+  background: var(--doc-sheet-tint);
+}
+
+/* ── Drag overlay ──────────────────────────────────────────────────────── */
+
+.doc-sheet__drag-overlay {
+  pointer-events: none;
+  display: inline-block;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-ink, inherit);
+  background: var(--color-paper, #fff);
+  border: 1px solid var(--doc-sheet-accent);
+  border-radius: 0.375rem;
+  box-shadow: 0 4px 16px var(--color-shadow);
 }

--- a/apps/web/src/lib/__tests__/docDnd.test.ts
+++ b/apps/web/src/lib/__tests__/docDnd.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, it } from "vitest";
+import {
+  adjacentCustomSectionId,
+  canMoveEntryAcross,
+  entryStep,
+  moveSectionInLayout,
+  moveSectionStep,
+  resolveEntryDrop,
+  resolveSectionDropOnColumn,
+  resolveSectionDropOnSection,
+  sectionItemList,
+  type EntryListItem,
+} from "../docDnd";
+import { editorPages, layoutPages } from "../docLayout";
+import { loadDocEditorFixture, SIDEBAR_TEMPLATE } from "../../test/docEditorFixture";
+
+/** The fixture's stored layout: two pages of two columns each. */
+const LAYOUT: string[][][] = [
+  [
+    ["summary", "experience", "education", "projects"],
+    ["profiles", "skills", "speaking"],
+  ],
+  [
+    ["publications", "volunteer", "awards"],
+    ["languages", "interests", "certifications", "advisory"],
+  ],
+];
+
+function items(...ids: string[]): EntryListItem[] {
+  return ids.map((id) => ({ id, visible: true }));
+}
+
+describe("moveSectionInLayout", () => {
+  it("moves a section to an explicit position in another column", () => {
+    const next = moveSectionInLayout(LAYOUT, "experience", { page: 0, column: 1, index: 1 });
+
+    expect(next?.[0][0]).toEqual(["summary", "education", "projects"]);
+    expect(next?.[0][1]).toEqual(["profiles", "experience", "skills", "speaking"]);
+  });
+
+  it("moves a section across pages", () => {
+    const next = moveSectionInLayout(LAYOUT, "summary", { page: 1, column: 0, index: 0 });
+
+    expect(next?.[0][0]).toEqual(["experience", "education", "projects"]);
+    expect(next?.[1][0]).toEqual(["summary", "publications", "volunteer", "awards"]);
+  });
+
+  it("starts a new page when targeted one past the end", () => {
+    const next = moveSectionInLayout(LAYOUT, "awards", { page: 2, column: 0, index: 0 });
+
+    expect(next).toHaveLength(3);
+    // The new page mirrors the last page's column count.
+    expect(next?.[2]).toEqual([["awards"], []]);
+  });
+
+  it("materializes a drawn column the stored layout does not carry", () => {
+    const layout = [[["summary", "experience"]]];
+
+    const next = moveSectionInLayout(layout, "experience", { page: 0, column: 1, index: 0 });
+
+    expect(next).toEqual([[["summary"], ["experience"]]]);
+  });
+
+  it("prunes a page the move left empty", () => {
+    const layout = [[["summary"]], [["experience"]]];
+
+    const next = moveSectionInLayout(layout, "experience", { page: 0, column: 0, index: 1 });
+
+    expect(next).toEqual([[["summary", "experience"]]]);
+  });
+
+  it("returns null when the drop changes nothing", () => {
+    expect(moveSectionInLayout(LAYOUT, "experience", { page: 0, column: 0, index: 1 })).toBeNull();
+    // Dropping just after itself is the same order too.
+    expect(moveSectionInLayout(LAYOUT, "experience", { page: 0, column: 0, index: 2 })).toBeNull();
+  });
+
+  it("returns null for a section the layout does not place", () => {
+    expect(moveSectionInLayout(LAYOUT, "missing", { page: 0, column: 0, index: 0 })).toBeNull();
+  });
+
+  it("never mutates its input", () => {
+    const before = JSON.parse(JSON.stringify(LAYOUT));
+    moveSectionInLayout(LAYOUT, "summary", { page: 1, column: 1, index: 2 });
+    expect(LAYOUT).toEqual(before);
+  });
+});
+
+describe("resolveSectionDropOnSection", () => {
+  it("lands after the target when dragged down within a column", () => {
+    const next = resolveSectionDropOnSection(LAYOUT, "summary", "education");
+
+    expect(next?.[0][0]).toEqual(["experience", "education", "summary", "projects"]);
+  });
+
+  it("lands before the target when dragged up within a column", () => {
+    const next = resolveSectionDropOnSection(LAYOUT, "projects", "experience");
+
+    expect(next?.[0][0]).toEqual(["summary", "projects", "experience", "education"]);
+  });
+
+  it("lands before a target in another column", () => {
+    const next = resolveSectionDropOnSection(LAYOUT, "education", "skills");
+
+    expect(next?.[0][0]).toEqual(["summary", "experience", "projects"]);
+    expect(next?.[0][1]).toEqual(["profiles", "education", "skills", "speaking"]);
+  });
+
+  it("returns null when dropped on itself", () => {
+    expect(resolveSectionDropOnSection(LAYOUT, "summary", "summary")).toBeNull();
+  });
+});
+
+describe("resolveSectionDropOnColumn", () => {
+  it("appends to the target column", () => {
+    const next = resolveSectionDropOnColumn(LAYOUT, "summary", 1, 1);
+
+    expect(next?.[1][1]).toEqual([
+      "languages",
+      "interests",
+      "certifications",
+      "advisory",
+      "summary",
+    ]);
+  });
+
+  it("returns null when the section is already last in that column", () => {
+    expect(resolveSectionDropOnColumn(LAYOUT, "projects", 0, 0)).toBeNull();
+  });
+
+  it("returns null for a page the layout does not have", () => {
+    expect(resolveSectionDropOnColumn(LAYOUT, "summary", 5, 0)).toBeNull();
+  });
+});
+
+describe("moveSectionStep", () => {
+  it("swaps with its neighbours within the column", () => {
+    expect(moveSectionStep(LAYOUT, "experience", "up")?.[0][0]).toEqual([
+      "experience",
+      "summary",
+      "education",
+      "projects",
+    ]);
+    expect(moveSectionStep(LAYOUT, "experience", "down")?.[0][0]).toEqual([
+      "summary",
+      "education",
+      "experience",
+      "projects",
+    ]);
+  });
+
+  it("returns null at the column boundaries", () => {
+    expect(moveSectionStep(LAYOUT, "summary", "up")).toBeNull();
+    expect(moveSectionStep(LAYOUT, "projects", "down")).toBeNull();
+  });
+
+  it("appends to the adjacent column, crossing pages when needed", () => {
+    // Page 0 sidebar -> page 1 main: the next column in page-then-column order.
+    const next = moveSectionStep(LAYOUT, "speaking", "next");
+    expect(next?.[1][0]).toEqual(["publications", "volunteer", "awards", "speaking"]);
+
+    const previous = moveSectionStep(LAYOUT, "publications", "previous");
+    expect(previous?.[0][1]).toEqual(["profiles", "skills", "speaking", "publications"]);
+  });
+
+  it("returns null before the first column", () => {
+    expect(moveSectionStep(LAYOUT, "summary", "previous")).toBeNull();
+  });
+
+  it("starts a new page past the last column", () => {
+    const next = moveSectionStep(LAYOUT, "languages", "next");
+
+    expect(next).toHaveLength(3);
+    expect(next?.[2][0]).toEqual(["languages"]);
+  });
+});
+
+describe("canMoveEntryAcross", () => {
+  it("permits custom-to-custom only — the one pair with a shared item shape", () => {
+    expect(canMoveEntryAcross("speaking", "advisory")).toBe(true);
+    expect(canMoveEntryAcross("speaking", "speaking")).toBe(false);
+    expect(canMoveEntryAcross("experience", "education")).toBe(false);
+    expect(canMoveEntryAcross("speaking", "experience")).toBe(false);
+    expect(canMoveEntryAcross("experience", "speaking")).toBe(false);
+  });
+});
+
+describe("resolveEntryDrop", () => {
+  const list = items("a", "b", "c");
+
+  it("reorders within a section, landing on the target's index", () => {
+    expect(
+      resolveEntryDrop({
+        fromSectionId: "experience",
+        fromItems: list,
+        itemId: "a",
+        toSectionId: "experience",
+        toItems: list,
+        targetItemId: "c",
+      }),
+    ).toEqual({ kind: "reorder", sectionId: "experience", fromIndex: 0, toIndex: 2 });
+  });
+
+  it("reorders to the end when dropped on the section itself", () => {
+    expect(
+      resolveEntryDrop({
+        fromSectionId: "experience",
+        fromItems: list,
+        itemId: "a",
+        toSectionId: "experience",
+        toItems: list,
+        targetItemId: null,
+      }),
+    ).toEqual({ kind: "reorder", sectionId: "experience", fromIndex: 0, toIndex: 2 });
+  });
+
+  it("moves across custom sections", () => {
+    expect(
+      resolveEntryDrop({
+        fromSectionId: "speaking",
+        fromItems: list,
+        itemId: "b",
+        toSectionId: "advisory",
+        toItems: items("x"),
+        targetItemId: "x",
+      }),
+    ).toEqual({
+      kind: "move",
+      fromSectionId: "speaking",
+      fromIndex: 1,
+      toSectionId: "advisory",
+      toIndex: 0,
+    });
+  });
+
+  it("appends when dropped on the target section itself", () => {
+    expect(
+      resolveEntryDrop({
+        fromSectionId: "speaking",
+        fromItems: list,
+        itemId: "b",
+        toSectionId: "advisory",
+        toItems: items("x"),
+        targetItemId: null,
+      }),
+    ).toEqual({
+      kind: "move",
+      fromSectionId: "speaking",
+      fromIndex: 1,
+      toSectionId: "advisory",
+      toIndex: 1,
+    });
+  });
+
+  it("returns null for a drop that changes nothing", () => {
+    expect(
+      resolveEntryDrop({
+        fromSectionId: "experience",
+        fromItems: list,
+        itemId: "b",
+        toSectionId: "experience",
+        toItems: list,
+        targetItemId: "b",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for an incompatible cross-section drop", () => {
+    expect(
+      resolveEntryDrop({
+        fromSectionId: "experience",
+        fromItems: list,
+        itemId: "a",
+        toSectionId: "education",
+        toItems: items("x"),
+        targetItemId: "x",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("entryStep", () => {
+  const list = items("a", "b", "c");
+
+  it("steps one position in either direction", () => {
+    expect(entryStep(list, "b", "up")).toEqual({ fromIndex: 1, toIndex: 0 });
+    expect(entryStep(list, "b", "down")).toEqual({ fromIndex: 1, toIndex: 2 });
+  });
+
+  it("returns null at the boundaries and for unknown ids", () => {
+    expect(entryStep(list, "a", "up")).toBeNull();
+    expect(entryStep(list, "c", "down")).toBeNull();
+    expect(entryStep(list, "missing", "down")).toBeNull();
+  });
+});
+
+describe("adjacentCustomSectionId", () => {
+  it("walks custom sections in flattened layout order", () => {
+    expect(adjacentCustomSectionId(LAYOUT, "speaking", "next")).toBe("advisory");
+    expect(adjacentCustomSectionId(LAYOUT, "advisory", "previous")).toBe("speaking");
+  });
+
+  it("returns null at the ends and for unknown sections", () => {
+    expect(adjacentCustomSectionId(LAYOUT, "speaking", "previous")).toBeNull();
+    expect(adjacentCustomSectionId(LAYOUT, "advisory", "next")).toBeNull();
+    expect(adjacentCustomSectionId(LAYOUT, "experience", "next")).toBeNull();
+  });
+});
+
+describe("sectionItemList", () => {
+  it("reads fixed and custom sections through the shared item shape", () => {
+    const resume = loadDocEditorFixture();
+
+    expect(sectionItemList(resume, "experience").length).toBeGreaterThan(0);
+    expect(sectionItemList(resume, "speaking").length).toBeGreaterThan(0);
+    expect(sectionItemList(resume, "not-a-section")).toEqual([]);
+  });
+});
+
+describe("editorPages", () => {
+  it("stays aligned index-for-index with layoutPages", () => {
+    const resume = loadDocEditorFixture();
+
+    const layout = layoutPages(resume, SIDEBAR_TEMPLATE);
+    const drawn = editorPages(resume, SIDEBAR_TEMPLATE);
+
+    expect(drawn).toHaveLength(layout.length);
+    drawn.forEach((page, pageIndex) => {
+      expect(page).toHaveLength(layout[pageIndex].length);
+    });
+  });
+
+  it("keeps a hidden section drawn, flagged as chrome", () => {
+    const resume = loadDocEditorFixture();
+    resume.sections.experience.visible = false;
+
+    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
+
+    expect(drawn.find((section) => section.id === "experience")).toEqual({
+      id: "experience",
+      hidden: true,
+    });
+  });
+
+  it("keeps a section whose items are all hidden — the items are chrome too", () => {
+    const resume = loadDocEditorFixture();
+    for (const item of resume.sections.experience.items) {
+      item.visible = false;
+    }
+
+    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
+
+    expect(drawn.some((section) => section.id === "experience")).toBe(true);
+  });
+
+  it("drops an item section with no items at all", () => {
+    const resume = loadDocEditorFixture();
+    resume.sections.experience.items = [];
+
+    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
+
+    expect(drawn.some((section) => section.id === "experience")).toBe(false);
+  });
+
+  it("keeps an empty rich-text section reachable while it is visible", () => {
+    const resume = loadDocEditorFixture();
+    resume.sections.summary.content = "";
+    resume.sections.summary.visible = true;
+
+    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
+
+    expect(drawn.some((section) => section.id === "summary")).toBe(true);
+  });
+});

--- a/apps/web/src/lib/__tests__/docDnd.test.ts
+++ b/apps/web/src/lib/__tests__/docDnd.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   adjacentCustomSectionId,
   canMoveEntryAcross,
+  drawnSectionPosition,
   entryStep,
   moveSectionInLayout,
   moveSectionStep,
@@ -172,6 +173,53 @@ describe("moveSectionStep", () => {
 
     expect(next).toHaveLength(3);
     expect(next?.[2][0]).toEqual(["languages"]);
+  });
+
+  it("steps past slots the sheet does not draw", () => {
+    // `experience` is placed but not drawn: one press must still make exactly
+    // one visible change, so `summary` steps past it to the nearest drawn
+    // card — never announcing a move nothing on screen reflects.
+    const isDrawn = (id: string): boolean => id !== "experience";
+
+    const next = moveSectionStep(LAYOUT, "summary", "down", isDrawn);
+    expect(next?.[0][0]).toEqual(["experience", "education", "summary", "projects"]);
+
+    const back = moveSectionStep(LAYOUT, "education", "up", isDrawn);
+    expect(back?.[0][0]).toEqual(["education", "summary", "experience", "projects"]);
+  });
+
+  it("returns null when only undrawn slots remain in the step's direction", () => {
+    const isDrawn = (id: string): boolean => id !== "projects";
+
+    expect(moveSectionStep(LAYOUT, "education", "down", isDrawn)).toBeNull();
+  });
+});
+
+describe("drawnSectionPosition", () => {
+  it("counts drawn cards rather than layout slots", () => {
+    // `experience` is placed but not drawn, so `education` is the second of
+    // three cards on screen even though it holds the third layout slot.
+    const isDrawn = (id: string): boolean => id !== "experience";
+
+    expect(drawnSectionPosition(LAYOUT, "education", isDrawn)).toEqual({
+      page: 0,
+      column: 0,
+      index: 1,
+      total: 3,
+    });
+  });
+
+  it("always counts the section itself as drawn", () => {
+    expect(drawnSectionPosition(LAYOUT, "speaking", () => false)).toEqual({
+      page: 0,
+      column: 1,
+      index: 0,
+      total: 1,
+    });
+  });
+
+  it("returns null for a section the layout does not place", () => {
+    expect(drawnSectionPosition(LAYOUT, "missing")).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/__tests__/docDnd.test.ts
+++ b/apps/web/src/lib/__tests__/docDnd.test.ts
@@ -80,6 +80,12 @@ describe("moveSectionInLayout", () => {
     expect(moveSectionInLayout(LAYOUT, "missing", { page: 0, column: 0, index: 0 })).toBeNull();
   });
 
+  it("returns null for out-of-range targets", () => {
+    expect(moveSectionInLayout(LAYOUT, "summary", { page: -1, column: 0, index: 0 })).toBeNull();
+    expect(moveSectionInLayout(LAYOUT, "summary", { page: 0, column: -1, index: 0 })).toBeNull();
+    expect(moveSectionInLayout(LAYOUT, "summary", { page: 5, column: 0, index: 0 })).toBeNull();
+  });
+
   it("never mutates its input", () => {
     const before = JSON.parse(JSON.stringify(LAYOUT));
     moveSectionInLayout(LAYOUT, "summary", { page: 1, column: 1, index: 2 });

--- a/apps/web/src/lib/__tests__/docDnd.test.ts
+++ b/apps/web/src/lib/__tests__/docDnd.test.ts
@@ -371,4 +371,20 @@ describe("editorPages", () => {
 
     expect(drawn.some((section) => section.id === "summary")).toBe(true);
   });
+
+  it("keeps a hidden, empty rich-text section drawn so hiding is reversible", () => {
+    // Regression: hiding an empty summary used to drop the card entirely —
+    // and rich text has no add-block, so nothing on the sheet could show it
+    // again. A placed rich-text section must always draw.
+    const resume = loadDocEditorFixture();
+    resume.sections.summary.content = "";
+    resume.sections.summary.visible = false;
+
+    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
+
+    expect(drawn.find((section) => section.id === "summary")).toEqual({
+      id: "summary",
+      hidden: true,
+    });
+  });
 });

--- a/apps/web/src/lib/docDnd.ts
+++ b/apps/web/src/lib/docDnd.ts
@@ -166,26 +166,38 @@ function columnSequence(
 /**
  * Move `sectionId` one step, mirroring what a drag of the same distance does.
  *
- * `up`/`down` reorder within the column; `previous`/`next` append the section
- * to the adjacent column in page-then-column order. `next` past the final
- * column starts a new page, exactly like the sheet's new-page drop zone.
+ * `up`/`down` reorder within the column, past the nearest *drawn* neighbour —
+ * `isDrawn` names the sections the sheet actually draws, and slots the layout
+ * places but the sheet does not draw are stepped over, so one press is always
+ * one visible change. `previous`/`next` append the section to the adjacent
+ * column in page-then-column order; `next` past the final column starts a new
+ * page, exactly like the sheet's new-page drop zone.
  */
 export function moveSectionStep(
   layout: readonly (readonly (readonly string[])[])[],
   sectionId: string,
   step: MoveStep,
+  isDrawn: (id: string) => boolean = () => true,
 ): string[][][] | null {
   const placement = findSectionPlacement(layout, sectionId);
   if (!placement) return null;
   const column = layout[placement.page][placement.column];
 
   if (step === "up") {
-    if (placement.index === 0) return null;
-    return resolveSectionDropOnSection(layout, sectionId, column[placement.index - 1]);
+    for (let index = placement.index - 1; index >= 0; index--) {
+      if (isDrawn(column[index])) {
+        return resolveSectionDropOnSection(layout, sectionId, column[index]);
+      }
+    }
+    return null;
   }
   if (step === "down") {
-    if (placement.index >= column.length - 1) return null;
-    return resolveSectionDropOnSection(layout, sectionId, column[placement.index + 1]);
+    for (let index = placement.index + 1; index < column.length; index++) {
+      if (isDrawn(column[index])) {
+        return resolveSectionDropOnSection(layout, sectionId, column[index]);
+      }
+    }
+    return null;
   }
 
   const sequence = columnSequence(layout);
@@ -202,6 +214,39 @@ export function moveSectionStep(
     return resolveSectionDropOnColumn(layout, sectionId, next.page, next.column);
   }
   return moveSectionInLayout(layout, sectionId, { page: layout.length, column: 0, index: 0 });
+}
+
+/** Where a section sits among the *drawn* cards of its column. */
+export interface DrawnSectionPosition {
+  page: number;
+  column: number;
+  /** 0-based position among the column's drawn cards. */
+  index: number;
+  /** How many cards the column draws. */
+  total: number;
+}
+
+/**
+ * `sectionId`'s position in `layout`, counted in drawn cards rather than
+ * layout slots, so an announcement matches what is on screen. The section
+ * itself always counts as drawn — only drawn cards carry move controls.
+ */
+export function drawnSectionPosition(
+  layout: readonly (readonly (readonly string[])[])[],
+  sectionId: string,
+  isDrawn: (id: string) => boolean = () => true,
+): DrawnSectionPosition | null {
+  const placement = findSectionPlacement(layout, sectionId);
+  if (!placement) return null;
+  const drawn = layout[placement.page][placement.column].filter(
+    (id) => id === sectionId || isDrawn(id),
+  );
+  return {
+    page: placement.page,
+    column: placement.column,
+    index: drawn.indexOf(sectionId),
+    total: drawn.length,
+  };
 }
 
 /**

--- a/apps/web/src/lib/docDnd.ts
+++ b/apps/web/src/lib/docDnd.ts
@@ -83,7 +83,9 @@ export function moveSectionInLayout(
   target: SectionDropTarget,
 ): string[][][] | null {
   const placement = findSectionPlacement(layout, sectionId);
-  if (!placement || target.page < 0 || target.page > layout.length) return null;
+  if (!placement || target.page < 0 || target.page > layout.length || target.column < 0) {
+    return null;
+  }
 
   const next = cloneLayout(layout);
   next[placement.page][placement.column].splice(placement.index, 1);

--- a/apps/web/src/lib/docDnd.ts
+++ b/apps/web/src/lib/docDnd.ts
@@ -1,0 +1,300 @@
+/**
+ * Drop resolution for the document sheet's drag and drop.
+ *
+ * Pure functions from the current layout (or item list) plus a drag descriptor
+ * to the *next* layout (or index pair) — nothing here reads a store, touches
+ * the DOM, or knows about pointer events, which is what makes the interesting
+ * logic unit-testable. Every resolver returns `null` for a drop that would
+ * change nothing, and the callers write nothing for `null`: one drop is one
+ * store action, and a drag that ends where it started is no action at all.
+ *
+ * Layout coordinates are the `metadata.layout` shape (`pages -> columns ->
+ * section ids`) as produced by `layoutPages()` in `docLayout.ts`. Item indices
+ * address a section's own unfiltered `items` array — the editor draws hidden
+ * items as chrome, so drawn order and stored order coincide.
+ */
+
+import { findSectionPlacement, isCustomId } from "./docLayout";
+import type { ResumeData } from "../wasm/types";
+
+/** One step a move control can take. Lateral steps follow column index order. */
+export type MoveStep = "up" | "down" | "previous" | "next";
+
+/** Where a section is asked to land, in pre-removal layout coordinates. */
+export interface SectionDropTarget {
+  /** Target page; `layout.length` asks for a new page at the end. */
+  page: number;
+  /** Target column within that page. */
+  column: number;
+  /** Position within the column, counted before the section is removed. */
+  index: number;
+}
+
+/** The `id`/`visible` shape every section item shares. */
+export interface EntryListItem {
+  id: string;
+  visible: boolean;
+}
+
+/** A resolved entry drop: a reorder within one section, or a move across two. */
+export type EntryDrop =
+  | { kind: "reorder"; sectionId: string; fromIndex: number; toIndex: number }
+  | {
+      kind: "move";
+      fromSectionId: string;
+      fromIndex: number;
+      toSectionId: string;
+      toIndex: number;
+    };
+
+function cloneLayout(layout: readonly (readonly (readonly string[])[])[]): string[][][] {
+  return layout.map((page) => page.map((column) => [...column]));
+}
+
+function layoutsEqual(
+  a: readonly (readonly (readonly string[])[])[],
+  b: readonly (readonly (readonly string[])[])[],
+): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Drop pages left with nothing in any column, keeping at least one page.
+ *
+ * Empty pages only ever arise from a move that vacated one, so pruning here
+ * keeps `metadata.layout` free of junk the templates would have to skip.
+ */
+function pruneEmptyPages(layout: string[][][]): string[][][] {
+  const pruned = layout.filter((page) => page.some((column) => column.length > 0));
+  return pruned.length > 0 ? pruned : layout.slice(0, 1);
+}
+
+/**
+ * Move `sectionId` to `target`, returning the next layout — or `null` when the
+ * section is not placed or the move changes nothing.
+ *
+ * `target` is expressed in pre-removal coordinates: "insert before whatever is
+ * at this position now". A target page of `layout.length` appends a fresh page
+ * with the same column count as the last existing page.
+ */
+export function moveSectionInLayout(
+  layout: readonly (readonly (readonly string[])[])[],
+  sectionId: string,
+  target: SectionDropTarget,
+): string[][][] | null {
+  const placement = findSectionPlacement(layout, sectionId);
+  if (!placement || target.page < 0 || target.page > layout.length) return null;
+
+  const next = cloneLayout(layout);
+  next[placement.page][placement.column].splice(placement.index, 1);
+
+  if (target.page === next.length) {
+    const columnCount = Math.max(1, next[next.length - 1]?.length ?? 1);
+    next.push(Array.from({ length: columnCount }, () => []));
+  }
+
+  const page = next[target.page];
+  // A template can draw more columns than the stored layout carries (a sidebar
+  // page stored as one column, say); dropping on such a column materializes it.
+  while (page.length <= target.column) {
+    page.push([]);
+  }
+  const column = page[target.column];
+
+  let index = target.index;
+  if (
+    target.page === placement.page &&
+    target.column === placement.column &&
+    placement.index < index
+  ) {
+    // The removal above shifted everything after the section up by one.
+    index -= 1;
+  }
+  column.splice(Math.max(0, Math.min(index, column.length)), 0, sectionId);
+
+  const pruned = pruneEmptyPages(next);
+  return layoutsEqual(pruned, layout) ? null : pruned;
+}
+
+/**
+ * Resolve dropping `sectionId` onto another section's card.
+ *
+ * Standard list-reorder semantics: dragged from above the target, the section
+ * lands *after* it; from anywhere else, *before* it — so dragging one step in
+ * either direction always changes the order.
+ */
+export function resolveSectionDropOnSection(
+  layout: readonly (readonly (readonly string[])[])[],
+  sectionId: string,
+  targetSectionId: string,
+): string[][][] | null {
+  if (sectionId === targetSectionId) return null;
+  const source = findSectionPlacement(layout, sectionId);
+  const target = findSectionPlacement(layout, targetSectionId);
+  if (!source || !target) return null;
+
+  const sameColumn = source.page === target.page && source.column === target.column;
+  const index = sameColumn && source.index < target.index ? target.index + 1 : target.index;
+  return moveSectionInLayout(layout, sectionId, {
+    page: target.page,
+    column: target.column,
+    index,
+  });
+}
+
+/** Resolve dropping `sectionId` onto a column's open area: append to its end. */
+export function resolveSectionDropOnColumn(
+  layout: readonly (readonly (readonly string[])[])[],
+  sectionId: string,
+  page: number,
+  column: number,
+): string[][][] | null {
+  if (page < 0 || page >= layout.length || column < 0) return null;
+  const length = layout[page][column]?.length ?? 0;
+  return moveSectionInLayout(layout, sectionId, { page, column, index: length });
+}
+
+/** Every column of `layout` in page-then-column order. */
+function columnSequence(
+  layout: readonly (readonly (readonly string[])[])[],
+): { page: number; column: number }[] {
+  return layout.flatMap((page, pageIndex) =>
+    page.map((_, columnIndex) => ({ page: pageIndex, column: columnIndex })),
+  );
+}
+
+/**
+ * Move `sectionId` one step, mirroring what a drag of the same distance does.
+ *
+ * `up`/`down` reorder within the column; `previous`/`next` append the section
+ * to the adjacent column in page-then-column order. `next` past the final
+ * column starts a new page, exactly like the sheet's new-page drop zone.
+ */
+export function moveSectionStep(
+  layout: readonly (readonly (readonly string[])[])[],
+  sectionId: string,
+  step: MoveStep,
+): string[][][] | null {
+  const placement = findSectionPlacement(layout, sectionId);
+  if (!placement) return null;
+  const column = layout[placement.page][placement.column];
+
+  if (step === "up") {
+    if (placement.index === 0) return null;
+    return resolveSectionDropOnSection(layout, sectionId, column[placement.index - 1]);
+  }
+  if (step === "down") {
+    if (placement.index >= column.length - 1) return null;
+    return resolveSectionDropOnSection(layout, sectionId, column[placement.index + 1]);
+  }
+
+  const sequence = columnSequence(layout);
+  const position = sequence.findIndex(
+    (entry) => entry.page === placement.page && entry.column === placement.column,
+  );
+  if (step === "previous") {
+    const previous = sequence[position - 1];
+    if (!previous) return null;
+    return resolveSectionDropOnColumn(layout, sectionId, previous.page, previous.column);
+  }
+  const next = sequence[position + 1];
+  if (next) {
+    return resolveSectionDropOnColumn(layout, sectionId, next.page, next.column);
+  }
+  return moveSectionInLayout(layout, sectionId, { page: layout.length, column: 0, index: 0 });
+}
+
+/**
+ * Whether an entry may leave `fromSectionId` for `toSectionId`.
+ *
+ * Only custom sections share an item shape, so they are the only pair a move
+ * is defined for; a fixed section's items would be structurally wrong anywhere
+ * else, and no store action exists to put them there.
+ */
+export function canMoveEntryAcross(fromSectionId: string, toSectionId: string): boolean {
+  return fromSectionId !== toSectionId && isCustomId(fromSectionId) && isCustomId(toSectionId);
+}
+
+/**
+ * Resolve an entry drop onto another entry (or a section's tail) as index
+ * pairs into the sections' unfiltered `items` arrays.
+ *
+ * `targetItemId: null` addresses the end of the target section. Within one
+ * section the usual reorder rule applies — dropping onto the entry below lands
+ * after it, onto the entry above lands before it (which is what the store's
+ * splice-based reorder computes from a plain target index).
+ */
+export function resolveEntryDrop(args: {
+  fromSectionId: string;
+  fromItems: readonly EntryListItem[];
+  itemId: string;
+  toSectionId: string;
+  toItems: readonly EntryListItem[];
+  targetItemId: string | null;
+}): EntryDrop | null {
+  const fromIndex = args.fromItems.findIndex((item) => item.id === args.itemId);
+  if (fromIndex === -1) return null;
+
+  if (args.fromSectionId === args.toSectionId) {
+    const toIndex =
+      args.targetItemId === null
+        ? args.toItems.length - 1
+        : args.toItems.findIndex((item) => item.id === args.targetItemId);
+    if (toIndex === -1 || toIndex === fromIndex) return null;
+    return { kind: "reorder", sectionId: args.fromSectionId, fromIndex, toIndex };
+  }
+
+  if (!canMoveEntryAcross(args.fromSectionId, args.toSectionId)) return null;
+  const toIndex =
+    args.targetItemId === null
+      ? args.toItems.length
+      : args.toItems.findIndex((item) => item.id === args.targetItemId);
+  if (toIndex === -1) return null;
+  return {
+    kind: "move",
+    fromSectionId: args.fromSectionId,
+    fromIndex,
+    toSectionId: args.toSectionId,
+    toIndex,
+  };
+}
+
+/** One-step reorder of an entry within its section, or `null` at a boundary. */
+export function entryStep(
+  items: readonly EntryListItem[],
+  itemId: string,
+  step: "up" | "down",
+): { fromIndex: number; toIndex: number } | null {
+  const fromIndex = items.findIndex((item) => item.id === itemId);
+  if (fromIndex === -1) return null;
+  const toIndex = step === "up" ? fromIndex - 1 : fromIndex + 1;
+  if (toIndex < 0 || toIndex >= items.length) return null;
+  return { fromIndex, toIndex };
+}
+
+/**
+ * The custom section an entry moves to for a lateral keyboard step: the
+ * previous or next custom section in flattened layout order, or `null` when
+ * there is none — the keyboard mirror of a cross-section drag.
+ */
+export function adjacentCustomSectionId(
+  layout: readonly (readonly (readonly string[])[])[],
+  fromSectionId: string,
+  step: "previous" | "next",
+): string | null {
+  const customIds = layout.flat(2).filter((id) => isCustomId(id));
+  const position = customIds.indexOf(fromSectionId);
+  if (position === -1) return null;
+  return customIds[step === "previous" ? position - 1 : position + 1] ?? null;
+}
+
+/** The `items` list of any section, read through the shape they all share. */
+export function sectionItemList(resume: ResumeData, sectionId: string): EntryListItem[] {
+  if (isCustomId(sectionId)) {
+    return resume.sections.custom?.[sectionId]?.items ?? [];
+  }
+  const section = resume.sections[sectionId as keyof typeof resume.sections] as
+    | { items?: EntryListItem[] }
+    | undefined;
+  return section?.items ?? [];
+}

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -352,8 +352,9 @@ function sectionItemCount(resume: ResumeData, sectionId: string): number {
  * Unlike {@link renderPages}, hidden sections stay drawn (flagged, as chrome):
  * hidden means "not rendered to PDF", not "gone from the editing surface". Item
  * sections are drawn whenever they hold any item — hidden items are chrome too —
- * and rich-text sections whenever they have content or are switched on, so an
- * empty summary still offers its click-to-edit surface.
+ * and a placed rich-text section always draws, whatever its content or
+ * visibility, so a hidden or empty summary keeps its click-to-edit surface and
+ * hiding it stays reversible.
  */
 export function editorPages(
   resume: ResumeData,

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -336,7 +336,7 @@ function sectionHasItems(resume: ResumeData, sectionId: string): boolean {
 /** How many items a section holds, hidden ones included. Zero for rich text. */
 function sectionItemCount(resume: ResumeData, sectionId: string): number {
   if (isCustomId(sectionId)) {
-    return resume.sections.custom?.[sectionId]?.items.length ?? 0;
+    return resume.sections.custom?.[sectionId]?.items?.length ?? 0;
   }
   if (!FIXED_SECTION_ID_SET.has(sectionId)) return 0;
   const section = resume.sections[sectionId as FixedSectionId] as { items?: unknown[] } | undefined;

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -321,6 +321,58 @@ export function renderPages(resume: ResumeData, templateLayout: TemplateLayout):
     .filter((page) => page.some((column) => column.length > 0));
 }
 
+/** A section as the editing surface draws it. */
+export interface EditorSectionView {
+  id: string;
+  /** Switched off — kept on the surface as chrome, but absent from the PDF. */
+  hidden: boolean;
+}
+
+/** Whether a section holds any items at all, hidden ones included. */
+function sectionHasItems(resume: ResumeData, sectionId: string): boolean {
+  return sectionItemCount(resume, sectionId) > 0;
+}
+
+/** How many items a section holds, hidden ones included. Zero for rich text. */
+function sectionItemCount(resume: ResumeData, sectionId: string): number {
+  if (isCustomId(sectionId)) {
+    return resume.sections.custom?.[sectionId]?.items.length ?? 0;
+  }
+  if (!FIXED_SECTION_ID_SET.has(sectionId)) return 0;
+  const section = resume.sections[sectionId as FixedSectionId] as { items?: unknown[] } | undefined;
+  return section?.items?.length ?? 0;
+}
+
+/**
+ * {@link layoutPages} as the *editing* surface draws it, aligned index-for-index
+ * with the layout — no page or column is dropped, so a drop target's page and
+ * column indices address `metadata.layout` directly, and no second layout model
+ * exists for drag and drop.
+ *
+ * Unlike {@link renderPages}, hidden sections stay drawn (flagged, as chrome):
+ * hidden means "not rendered to PDF", not "gone from the editing surface". Item
+ * sections are drawn whenever they hold any item — hidden items are chrome too —
+ * and rich-text sections whenever they have content or are switched on, so an
+ * empty summary still offers its click-to-edit surface.
+ */
+export function editorPages(
+  resume: ResumeData,
+  templateLayout: TemplateLayout,
+): EditorSectionView[][][] {
+  return layoutPages(resume, templateLayout).map((page) =>
+    page.map((column) =>
+      column
+        .filter((id) => {
+          if (id === "summary" || id === "coverLetter") {
+            return sectionHasContent(resume, id) || sectionVisible(resume, id);
+          }
+          return sectionHasItems(resume, id);
+        })
+        .map((id) => ({ id, hidden: !sectionVisible(resume, id) })),
+    ),
+  );
+}
+
 /**
  * Column geometry for one page of a layout.
  *
@@ -329,7 +381,8 @@ export function renderPages(resume: ResumeData, templateLayout: TemplateLayout):
  * of them, shared out evenly.
  */
 export function layoutColumns(
-  page: readonly string[][],
+  // Only the column count matters, so any drawn column shape is accepted.
+  page: readonly (readonly unknown[])[],
   templateLayout: TemplateLayout,
 ): LayoutColumn[] {
   const modeColumns = templateLayout.layoutMode === "single" ? 1 : 2;
@@ -363,7 +416,7 @@ export function layoutColumns(
 
 /** Where `sectionId` sits in `layout`, or `null` when it is not placed. */
 export function findSectionPlacement(
-  layout: readonly (readonly string[][])[],
+  layout: readonly (readonly (readonly string[])[])[],
   sectionId: string,
 ): SectionPlacement | null {
   for (let page = 0; page < layout.length; page++) {

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -364,7 +364,11 @@ export function editorPages(
       column
         .filter((id) => {
           if (id === "summary" || id === "coverLetter") {
-            return sectionHasContent(resume, id) || sectionVisible(resume, id);
+            // A placed rich-text section always draws: its editing surface is
+            // the card itself, and an add-block cannot resurface rich text —
+            // dropping a hidden, empty one would make hiding it irreversible
+            // from the sheet.
+            return true;
           }
           return sectionHasItems(resume, id);
         })

--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -113,8 +113,8 @@ describe("DocEditor sheet", () => {
       ["main", ["summary", "experience", "education", "projects"]],
     ]);
     expect(pageColumns(second)).toEqual([
-      // `advisory` is placed by the layout but switched off, so it never draws.
-      ["sidebar", ["languages", "interests", "certifications"]],
+      // `advisory` is switched off but stays drawn as chrome (see below).
+      ["sidebar", ["languages", "interests", "certifications", "advisory"]],
       ["main", ["publications", "volunteer", "awards"]],
     ]);
   });
@@ -162,12 +162,17 @@ describe("DocEditor sheet", () => {
     ).toBeInTheDocument();
   });
 
-  it("omits hidden sections", async () => {
+  it("keeps hidden sections on the surface as flagged chrome", async () => {
     await renderSheet();
 
-    // Both are present in the fixture and switched off — one fixed, one custom.
+    // `advisory` is placed and switched off: hidden means "not rendered to
+    // PDF", not "gone from the editing surface" — the section stays drawn,
+    // dimmed and flagged, so it can be shown again from the sheet.
+    const advisory = document.querySelector('[data-section-id="advisory"]');
+    expect(advisory).not.toBeNull();
+    expect(advisory?.classList.contains("doc-sheet__section--hidden")).toBe(true);
+    // A section the layout never places is genuinely absent.
     expect(document.querySelector('[data-section-id="references"]')).toBeNull();
-    expect(screen.queryByRole("heading", { name: "Advisory & Standards Work" })).toBeNull();
   });
 
   it("offers every drawn value as a keyboard-reachable editing affordance", async () => {

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { createRoot } from "solid-js";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 import { createDefaultResume } from "../../wasm/defaults";
 import { useResumeStore } from "../resume";
 import type { CustomItem, Skill } from "../../wasm/types";
@@ -59,20 +59,30 @@ describe("duplicateSectionItem", () => {
     });
   });
 
-  it("does nothing for an index that holds no item", () => {
-    createRoot((dispose) => {
-      const { store, createNewResume, duplicateSectionItem } = useResumeStore();
-      createNewResume("dup-2");
-      const before = store.resume!.sections.skills.items.length;
+  it("does nothing for an index that holds no item", async () => {
+    const { saveResume } = await import("../../wasm");
+    vi.useFakeTimers();
+    try {
+      createRoot((dispose) => {
+        const { store, createNewResume, duplicateSectionItem } = useResumeStore();
+        createNewResume("dup-2");
+        const before = store.resume!.sections.skills.items.length;
 
-      const dirtyBefore = store.isDirty;
-      duplicateSectionItem("skills", 99);
+        const dirtyBefore = store.isDirty;
+        const savesBefore = (saveResume as Mock).mock.calls.length;
+        duplicateSectionItem("skills", 99);
 
-      expect(store.resume!.sections.skills.items.length).toBe(before);
-      // A no-op must not record a change, dirty the store, or schedule a save.
-      expect(store.isDirty).toBe(dirtyBefore);
-      dispose();
-    });
+        expect(store.resume!.sections.skills.items.length).toBe(before);
+        // A no-op must not record a change, dirty the store, or schedule a
+        // save — even after the save debounce would have fired.
+        expect(store.isDirty).toBe(dirtyBefore);
+        vi.advanceTimersByTime(1500);
+        expect((saveResume as Mock).mock.calls.length).toBe(savesBefore);
+        dispose();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -66,6 +66,9 @@ describe("duplicateSectionItem", () => {
       createRoot((dispose) => {
         const { store, createNewResume, duplicateSectionItem } = useResumeStore();
         createNewResume("dup-2");
+        // Drain the setup's own scheduled save so the baseline below measures
+        // only what the no-op adds.
+        vi.advanceTimersByTime(1500);
         const before = store.resume!.sections.skills.items.length;
 
         const dirtyBefore = store.isDirty;

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -140,6 +140,31 @@ describe("moveCustomSectionItem", () => {
     });
   });
 
+  it("clamps an out-of-range destination index to the section's end", () => {
+    createRoot((dispose) => {
+      const {
+        store,
+        createNewResume,
+        addCustomSection,
+        addCustomSectionItem,
+        moveCustomSectionItem,
+      } = useResumeStore();
+      createNewResume("move-4");
+      const talks = addCustomSection("Talks");
+      const advisory = addCustomSection("Advisory");
+      addCustomSectionItem(talks, customItem("t1", "First"));
+      addCustomSectionItem(advisory, customItem("a1", "Board"));
+
+      moveCustomSectionItem(talks, 0, advisory, 99);
+
+      expect(store.resume!.sections.custom[advisory].items.map((item) => item.id)).toEqual([
+        "a1",
+        "t1",
+      ]);
+      dispose();
+    });
+  });
+
   it("refuses a move onto the same section", () => {
     createRoot((dispose) => {
       const {

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -1,0 +1,173 @@
+/**
+ * The structural item actions the document editor's cards call: duplicate,
+ * and the single-action cross-section move — each one store action, so each
+ * one undo entry.
+ */
+
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import { createDefaultResume } from "../../wasm/defaults";
+import { useResumeStore } from "../resume";
+import type { CustomItem, Skill } from "../../wasm/types";
+
+vi.mock("../../wasm", () => ({
+  createEmptyResume: () => createDefaultResume(),
+  saveResume: vi.fn().mockResolvedValue(undefined),
+  getResume: vi.fn(),
+  isWasmReady: () => false,
+  ensureWasmReady: async () => false,
+}));
+
+function skill(id: string, name: string): Skill {
+  return { id, visible: true, name, description: "", level: 3, keywords: ["k"] };
+}
+
+function customItem(id: string, name: string): CustomItem {
+  return {
+    id,
+    visible: true,
+    name,
+    description: "",
+    date: "",
+    location: "",
+    summary: "",
+    keywords: [],
+    url: { label: "", href: "" },
+  };
+}
+
+describe("duplicateSectionItem", () => {
+  it("inserts a copy with a distinct id right after the original", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, addSectionItem, duplicateSectionItem } = useResumeStore();
+      createNewResume("dup-1");
+      addSectionItem("skills", skill("skill-a", "Alpha"));
+      addSectionItem("skills", skill("skill-b", "Beta"));
+      const base = store.resume!.sections.skills.items.length - 2;
+
+      duplicateSectionItem("skills", base);
+
+      const items = store.resume!.sections.skills.items;
+      expect(items[base].name).toBe("Alpha");
+      expect(items[base + 1].name).toBe("Alpha");
+      expect(items[base + 1].id).not.toBe(items[base].id);
+      expect(items[base + 1].id).not.toBe("");
+      // The copy owns its own arrays — editing one must not edit the other.
+      expect(items[base + 1].keywords).not.toBe(items[base].keywords);
+      expect(items[base + 2].name).toBe("Beta");
+      dispose();
+    });
+  });
+
+  it("does nothing for an index that holds no item", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, duplicateSectionItem } = useResumeStore();
+      createNewResume("dup-2");
+      const before = store.resume!.sections.skills.items.length;
+
+      duplicateSectionItem("skills", 99);
+
+      expect(store.resume!.sections.skills.items.length).toBe(before);
+      dispose();
+    });
+  });
+});
+
+describe("duplicateCustomSectionItem", () => {
+  it("inserts a copy with a distinct id right after the original", () => {
+    createRoot((dispose) => {
+      const {
+        store,
+        createNewResume,
+        addCustomSection,
+        addCustomSectionItem,
+        duplicateCustomSectionItem,
+      } = useResumeStore();
+      createNewResume("dup-3");
+      const sectionId = addCustomSection("Talks");
+      addCustomSectionItem(sectionId, customItem("t1", "First"));
+      addCustomSectionItem(sectionId, customItem("t2", "Second"));
+
+      duplicateCustomSectionItem(sectionId, 0);
+
+      const items = store.resume!.sections.custom[sectionId].items;
+      expect(items.map((item) => item.name)).toEqual(["First", "First", "Second"]);
+      expect(items[1].id).not.toBe(items[0].id);
+      dispose();
+    });
+  });
+});
+
+describe("moveCustomSectionItem", () => {
+  it("moves an item between custom sections in one action", () => {
+    createRoot((dispose) => {
+      const {
+        store,
+        createNewResume,
+        addCustomSection,
+        addCustomSectionItem,
+        moveCustomSectionItem,
+      } = useResumeStore();
+      createNewResume("move-1");
+      const talks = addCustomSection("Talks");
+      const advisory = addCustomSection("Advisory");
+      addCustomSectionItem(talks, customItem("t1", "First"));
+      addCustomSectionItem(talks, customItem("t2", "Second"));
+      addCustomSectionItem(advisory, customItem("a1", "Board"));
+
+      moveCustomSectionItem(talks, 0, advisory, 1);
+
+      expect(store.resume!.sections.custom[talks].items.map((item) => item.id)).toEqual(["t2"]);
+      expect(store.resume!.sections.custom[advisory].items.map((item) => item.id)).toEqual([
+        "a1",
+        "t1",
+      ]);
+      dispose();
+    });
+  });
+
+  it("refuses a move onto the same section", () => {
+    createRoot((dispose) => {
+      const {
+        store,
+        createNewResume,
+        addCustomSection,
+        addCustomSectionItem,
+        moveCustomSectionItem,
+      } = useResumeStore();
+      createNewResume("move-2");
+      const talks = addCustomSection("Talks");
+      addCustomSectionItem(talks, customItem("t1", "First"));
+      addCustomSectionItem(talks, customItem("t2", "Second"));
+
+      moveCustomSectionItem(talks, 0, talks, 1);
+
+      expect(store.resume!.sections.custom[talks].items.map((item) => item.id)).toEqual([
+        "t1",
+        "t2",
+      ]);
+      dispose();
+    });
+  });
+
+  it("does nothing when either section or the item is missing", () => {
+    createRoot((dispose) => {
+      const {
+        store,
+        createNewResume,
+        addCustomSection,
+        addCustomSectionItem,
+        moveCustomSectionItem,
+      } = useResumeStore();
+      createNewResume("move-3");
+      const talks = addCustomSection("Talks");
+      addCustomSectionItem(talks, customItem("t1", "First"));
+
+      moveCustomSectionItem(talks, 5, "nope", 0);
+      moveCustomSectionItem("nope", 0, talks, 0);
+
+      expect(store.resume!.sections.custom[talks].items.map((item) => item.id)).toEqual(["t1"]);
+      dispose();
+    });
+  });
+});

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -65,9 +65,12 @@ describe("duplicateSectionItem", () => {
       createNewResume("dup-2");
       const before = store.resume!.sections.skills.items.length;
 
+      const dirtyBefore = store.isDirty;
       duplicateSectionItem("skills", 99);
 
       expect(store.resume!.sections.skills.items.length).toBe(before);
+      // A no-op must not record a change, dirty the store, or schedule a save.
+      expect(store.isDirty).toBe(dirtyBefore);
       dispose();
     });
   });

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -96,6 +96,20 @@ describe("duplicateCustomSectionItem", () => {
       dispose();
     });
   });
+
+  it("does nothing for an index that holds no item", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, addCustomSection, duplicateCustomSectionItem } =
+        useResumeStore();
+      createNewResume("dup-4");
+      const sectionId = addCustomSection("Talks");
+
+      duplicateCustomSectionItem(sectionId, 99);
+
+      expect(store.resume!.sections.custom[sectionId].items.length).toBe(0);
+      dispose();
+    });
+  });
 });
 
 describe("moveCustomSectionItem", () => {

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -603,15 +603,17 @@ export function useResumeStore() {
      * the copy right after the original, as one action and one undo entry.
      */
     duplicateSectionItem<K extends SectionKey>(sectionKey: K, index: number) {
+      const section = store.resume?.sections[sectionKey] as Section<{ id: string }> | undefined;
+      if (!section?.items[index]) return;
       setStore(
         produce((s) => {
           if (!s.resume) return;
-          const section = s.resume.sections[sectionKey] as Section<{ id: string }>;
-          const item = section.items[index];
+          const target = s.resume.sections[sectionKey] as Section<{ id: string }>;
+          const item = target.items[index];
           if (!item) return;
           const clone = JSON.parse(JSON.stringify(item)) as { id: string };
           clone.id = generateId();
-          section.items.splice(index + 1, 0, clone);
+          target.items.splice(index + 1, 0, clone);
         }),
       );
       markDirty();

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -11,6 +11,7 @@ import type {
   CustomItem,
   CoverLetterRecipient,
 } from "../wasm/types";
+import { generateId } from "../wasm/types";
 import {
   createEmptyResume,
   createEmptyPicture,
@@ -597,6 +598,25 @@ export function useResumeStore() {
       markDirty();
     },
 
+    /**
+     * Clone the item at `index` — fresh id, same everything else — and insert
+     * the copy right after the original, as one action and one undo entry.
+     */
+    duplicateSectionItem<K extends SectionKey>(sectionKey: K, index: number) {
+      setStore(
+        produce((s) => {
+          if (!s.resume) return;
+          const section = s.resume.sections[sectionKey] as Section<{ id: string }>;
+          const item = section.items[index];
+          if (!item) return;
+          const clone = JSON.parse(JSON.stringify(item)) as { id: string };
+          clone.id = generateId();
+          section.items.splice(index + 1, 0, clone);
+        }),
+      );
+      markDirty();
+    },
+
     reorderSectionItem<K extends SectionKey>(sectionKey: K, fromIndex: number, toIndex: number) {
       setStore(
         produce((s) => {
@@ -706,6 +726,49 @@ export function useResumeStore() {
       if (!item) return;
       nextItems.splice(toIndex, 0, item);
       setStore("resume", "sections", "custom", sectionId, "items", nextItems);
+      markDirty();
+    },
+
+    /** Custom-section counterpart of `duplicateSectionItem`. */
+    duplicateCustomSectionItem(sectionId: string, index: number) {
+      const items = store.resume?.sections.custom[sectionId]?.items;
+      const item = items?.[index];
+      if (!items || !item) return;
+      const clone = JSON.parse(JSON.stringify(item)) as CustomItem;
+      clone.id = generateId();
+      const nextItems = [...items];
+      nextItems.splice(index + 1, 0, clone);
+      setStore("resume", "sections", "custom", sectionId, "items", nextItems);
+      markDirty();
+    },
+
+    /**
+     * Move an item between two custom sections as **one** action — removal and
+     * insertion together, so a cross-section drag is a single undo entry.
+     * Custom sections only: they are the only sections sharing an item shape.
+     */
+    moveCustomSectionItem(
+      fromSectionId: string,
+      fromIndex: number,
+      toSectionId: string,
+      toIndex: number,
+    ) {
+      if (fromSectionId === toSectionId) return;
+      const fromItems = store.resume?.sections.custom[fromSectionId]?.items;
+      const toItems = store.resume?.sections.custom[toSectionId]?.items;
+      const item = fromItems?.[fromIndex];
+      if (!fromItems || !toItems || !item) return;
+      setStore(
+        produce((s) => {
+          if (!s.resume) return;
+          const source = s.resume.sections.custom[fromSectionId];
+          const target = s.resume.sections.custom[toSectionId];
+          if (!source || !target) return;
+          const [moved] = source.items.splice(fromIndex, 1);
+          if (!moved) return;
+          target.items.splice(Math.max(0, Math.min(toIndex, target.items.length)), 0, moved);
+        }),
+      );
       markDirty();
     },
 


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add section cards, add-blocks, and whole-surface drag and drop
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The structural editing layer of the document-as-editor epic (#721), on top of click-to-edit (#728):

- **Section cards** — hover/focus chrome on every drawn section: drag handle, one-step move controls (up/down/previous-column/next-column), hide/show, and rename + delete for custom sections. Hidden sections stay drawn as dimmed, flagged chrome — hidden means "not rendered to PDF", not "gone from the editing surface" — so hiding is reversible from the sheet.
- **Entry actions** — a per-item action row: drag handle, move controls, edit, duplicate, hide/show, delete. Hidden items are drawn as chrome too, which also keeps drawn order identical to stored order.
- **Add blocks** — placed-but-empty item sections surface per column as "Add experience"-style affordances that open the item dialog seeded by `emptyItemFor()`.
- **Whole-surface drag and drop** via `@thisbeyond/solid-dnd` (already a dependency, existing manual chunk): entries within a section, entries across custom sections, and sections across columns, pages, and onto a fresh page via a new-page drop zone. Drop targets derive from the same `editorPages()` model the sheet draws — index-aligned with `metadata.layout`, no second layout model.
- **One drop = one store action = one undo entry.** Drop resolution lives in pure functions (`lib/docDnd.ts`); a drag that ends where it started resolves to `null` and writes nothing.
- **Keyboard + single-pointer parity** — every mouse move has a matching move control (focusable button, one complete action per press, mirroring the `LayoutEditor` SC 2.5.7 pattern), with polite live-region announcements built on `reorderAnnounce.ts`.

New store actions: `duplicateSectionItem`, `duplicateCustomSectionItem`, and the single-action `moveCustomSectionItem` for cross-section moves. All sheet writes still route through `docEdits.ts` (decision 4); the store-contract guard test still passes.

### Decisions worth an owner look

- **Cross-section entry moves are custom↔custom only.** Fixed sections have mutually incompatible item shapes (an Experience is not an Education), so a cross-fixed-section move has no well-defined result; the collision filter refuses those targets so they never highlight. The issue's "entry across sections" class is implemented for the only pair with a shared shape.
- **Section-card "edit"**: renaming is the inline title editor (all sections) plus a rename dialog for custom sections; fixed sections have no section-level dialog in #728 to open.
- **Keyboard moves are per-press store actions** (like `LayoutEditor`'s move controls), not a pick-up/drop transaction — so a three-step keyboard move is three undo entries, while a drag of the same distance is one.
- The per-column add-block covers placed-but-empty item sections; creating a *custom* section stays on the sheet-level "Add section" button, since `addCustomSection` places new sections itself.
- Empty visible rich-text sections (summary/cover letter) now stay drawn so their click-to-edit surface is reachable; two `DocEditor` page tests were updated for hidden-sections-as-chrome.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` — health 100/100)

## Closes

- Closes #729
- Relates to #721

## Details

**Testing**: 839 vitest tests pass (66 new: 37 pure drop-resolution tests in `lib/__tests__/docDnd.test.ts` incl. same-section reorder, cross-section move, cross-column/cross-page/new-page section moves and no-op drops against fixture layouts; 7 store-action tests; 23 component tests in `sectionCards.test.tsx` covering card actions, entry actions, keyboard/pointer move controls, announcements, and add-blocks). `tsc --noEmit` (app + e2e configs) and `oxlint` clean. Playwright e2e not run locally — the doc editor route is feature-flag-gated off and no spec touches it; CI runs the suite.

**Pre-push AI review**: CodeRabbit CLI reviewed the branch (5 findings — 3 minor, 2 trivial) and all were applied in `fix(web): apply CodeRabbit findings…`. Greptile CLI was rate-limited (`free_reviews_limit_reached`), so it did not run pre-push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop and keyboard controls for rearranging sections and content across pages and columns.
  * Added visibility controls, duplication, deletion, renaming, and cross-section moves for sections and items.
  * Hidden sections and items remain visible in the editor with clear indicators.
  * Added controls for inserting content into empty sections and new pages.
  * Added live announcements for structural editing actions.

* **Bug Fixes**
  * Improved handling of hidden, empty, and newly created sections.

* **Tests**
  * Expanded coverage for editing actions, layout behavior, visibility, and drag-and-drop interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-ups

Post-review fixes:

- `201d959` — a placed rich-text section (summary/cover letter) now always draws, so hiding an empty one leaves a dimmed card with a Show control instead of vanishing irrecoverably. Regression tests added for the hide-empty-summary path.
- `4a23e43` — CodeRabbit verification-pass findings (dialog-scoped test queries, destination-index clamping coverage, docstring).
- `453925c` — keyboard section moves and announcements now operate in drawn-card terms: a press steps past placed-but-undrawn layout slots (one press = one visible change) and announcements count positions among the cards on screen, not layout slots. The collision detector also requires the dragged card to actually overlap a target, so a sloppy release over dead space cancels rather than snapping to the nearest centre; among overlapping targets, closest-centre selection is unchanged.

- `2256805` — third CodeRabbit pass: duplicate/hide/delete actions on entries and sections now announce through the live region (no silent one-click actions for screen-reader users), `moveSectionInLayout` rejects a negative target column, the drag-parity test derives its expectation from `entryStep`, and focus restoration of the move controls is covered.

Acknowledged, left as-is deliberately:

- CodeRabbit flagged that item action rows inside a *hidden* section inherit the card's 45% dimming. CSS opacity composes through ancestors, so exempting nested rows would mean restructuring the card DOM; the section-level chrome — which holds the Show control, the actual recovery path — is already exempt.
- Typing the test mock against the full `resumeStore` surface, an undo round-trip test for the new store actions, and moving the custom-section visibility read into a dedicated store action were skipped: the mock is intentionally partial, undo wiring is exercised by the existing `undoHistory` tests (all actions share the same `markDirty` path), and `updateCustomSection` already is the single store action performing the write (same pattern as `renameSection`).
