### PR TITLE
feat(web): integrate the PDF preview pane into the document editor

### DIFF
--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -402,6 +402,10 @@ export function Preview(props: PreviewProps) {
         setPreviewUrl(result.url);
         setLastCachedUrl(result.url);
         setTotalPages(result.totalPages);
+        // Clamp page index when content shrinks (e.g., user deletes text)
+        if (ui.previewPage >= result.totalPages) {
+          setPreviewPage(Math.max(0, result.totalPages - 1));
+        }
         setError(null);
         lastToastedError = "";
       })

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -23,7 +23,16 @@ import {
 } from "./previewPan";
 import { prefetchPrintStackPages } from "./printStack";
 
-export function Preview() {
+export interface PreviewProps {
+  /**
+   * Reports the page count of the latest successful server render. The doc
+   * editor uses it to keep its page-count pill on the ground truth rather than
+   * the sheet's own client-side pagination.
+   */
+  onTotalPagesChange?: (totalPages: number) => void;
+}
+
+export function Preview(props: PreviewProps) {
   const { store } = resumeStore;
   const { store: ui, setPreviewPage, setPreviewZoom, zoomIn, zoomOut } = uiStore;
   const isOnline = useOnline();
@@ -112,15 +121,31 @@ export function Preview() {
   });
 
   // Viewport resizes can leave a previously valid pan out of bounds.
-  const resizeObserver = new ResizeObserver(() => reclampPan());
+  // Guarded like DocSheet's observer: jsdom has no ResizeObserver.
+  const resizeObserver =
+    typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => reclampPan());
   createEffect(() => {
-    if (viewportRef) resizeObserver.observe(viewportRef);
+    if (viewportRef) resizeObserver?.observe(viewportRef);
   });
-  onCleanup(() => resizeObserver.disconnect());
+  onCleanup(() => resizeObserver?.disconnect());
+
+  // Surface the rendered page count to the host page (doc editor pill). Gated
+  // on a completed render so the placeholder initial value never reports.
+  createEffect(() => {
+    if (!previewUrl()) return;
+    props.onTotalPagesChange?.(totalPages());
+  });
 
   // Request ID to guard against race conditions
   let resumeRequestId = 0;
   let pageRequestId = 0;
+
+  // Key of the last request either fetch effect started, so the two effects
+  // never duplicate the same render. On mount both run with identical inputs
+  // (the debounced resume snapshot initialises to the current store value);
+  // without this guard that means two identical fetches for one paint. Reset
+  // whenever a request fails or is skipped offline so retries still happen.
+  let lastRequestedKey = "";
 
   // Dedup guard to prevent toast spam on repeated preview errors
   let lastToastedError = "";
@@ -286,6 +311,7 @@ export function Preview() {
     // Skip if offline — invalidate in-flight requests, keep cached preview
     if (!isOnline()) {
       ++resumeRequestId;
+      lastRequestedKey = "";
       setIsLoading(false);
       if (lastCachedUrl()) {
         setPreviewUrl(lastCachedUrl());
@@ -296,11 +322,18 @@ export function Preview() {
       return;
     }
 
+    const requestKey = `${untrack(() => ui.previewPage)}|${resumeJson}`;
+    if (requestKey === lastRequestedKey) return;
+    lastRequestedKey = requestKey;
+
     const currentRequestId = ++resumeRequestId;
     setIsLoading(true);
     setError(null);
 
-    renderPreview(store.resume, ui.previewPage)
+    renderPreview(
+      store.resume,
+      untrack(() => ui.previewPage),
+    )
       .then((result) => {
         if (currentRequestId !== resumeRequestId) return;
         setPreviewUrl(result.url);
@@ -315,6 +348,7 @@ export function Preview() {
       })
       .catch((e) => {
         if (currentRequestId !== resumeRequestId) return;
+        lastRequestedKey = "";
         console.error("Preview error:", e);
         const msg = e instanceof Error ? e.message : String(e) || "Failed to load preview";
         setError(msg);
@@ -342,6 +376,7 @@ export function Preview() {
     // Skip if offline — invalidate in-flight requests, keep cached preview
     if (!isOnline()) {
       ++pageRequestId;
+      lastRequestedKey = "";
       setIsLoading(false);
       if (lastCachedUrl()) {
         setPreviewUrl(lastCachedUrl());
@@ -351,6 +386,10 @@ export function Preview() {
       }
       return;
     }
+
+    const requestKey = `${page}|${untrack(() => JSON.stringify(store.resume))}`;
+    if (requestKey === lastRequestedKey) return;
+    lastRequestedKey = requestKey;
 
     const currentRequestId = ++pageRequestId;
     setIsLoading(true);
@@ -367,6 +406,7 @@ export function Preview() {
       })
       .catch((e) => {
         if (currentRequestId !== pageRequestId) return;
+        lastRequestedKey = "";
         console.error("Preview error:", e);
         const msg = e instanceof Error ? e.message : String(e) || "Failed to load preview";
         setError(msg);

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -136,9 +136,10 @@ export function Preview(props: PreviewProps) {
     props.onTotalPagesChange?.(totalPages());
   });
 
-  // Request ID to guard against race conditions
-  let resumeRequestId = 0;
-  let pageRequestId = 0;
+  // One shared render generation for both fetch effects: whichever effect
+  // starts (or invalidates) a request last wins, so a slow stale response from
+  // one effect can never overwrite a newer render started by the other.
+  let previewRequestId = 0;
 
   // Key of the last request either fetch effect started, so the two effects
   // never duplicate the same render. On mount both run with identical inputs
@@ -310,7 +311,7 @@ export function Preview(props: PreviewProps) {
 
     // Skip if offline — invalidate in-flight requests, keep cached preview
     if (!isOnline()) {
-      ++resumeRequestId;
+      ++previewRequestId;
       lastRequestedKey = "";
       setIsLoading(false);
       if (lastCachedUrl()) {
@@ -326,7 +327,7 @@ export function Preview(props: PreviewProps) {
     if (requestKey === lastRequestedKey) return;
     lastRequestedKey = requestKey;
 
-    const currentRequestId = ++resumeRequestId;
+    const currentRequestId = ++previewRequestId;
     setIsLoading(true);
     setError(null);
 
@@ -335,7 +336,7 @@ export function Preview(props: PreviewProps) {
       untrack(() => ui.previewPage),
     )
       .then((result) => {
-        if (currentRequestId !== resumeRequestId) return;
+        if (currentRequestId !== previewRequestId) return;
         setPreviewUrl(result.url);
         setLastCachedUrl(result.url);
         setTotalPages(result.totalPages);
@@ -347,7 +348,7 @@ export function Preview(props: PreviewProps) {
         lastToastedError = "";
       })
       .catch((e) => {
-        if (currentRequestId !== resumeRequestId) return;
+        if (currentRequestId !== previewRequestId) return;
         lastRequestedKey = "";
         console.error("Preview error:", e);
         const msg = e instanceof Error ? e.message : String(e) || "Failed to load preview";
@@ -362,7 +363,7 @@ export function Preview(props: PreviewProps) {
         }
       })
       .finally(() => {
-        if (currentRequestId === resumeRequestId) {
+        if (currentRequestId === previewRequestId) {
           setIsLoading(false);
         }
       });
@@ -375,7 +376,7 @@ export function Preview(props: PreviewProps) {
 
     // Skip if offline — invalidate in-flight requests, keep cached preview
     if (!isOnline()) {
-      ++pageRequestId;
+      ++previewRequestId;
       lastRequestedKey = "";
       setIsLoading(false);
       if (lastCachedUrl()) {
@@ -391,13 +392,13 @@ export function Preview(props: PreviewProps) {
     if (requestKey === lastRequestedKey) return;
     lastRequestedKey = requestKey;
 
-    const currentRequestId = ++pageRequestId;
+    const currentRequestId = ++previewRequestId;
     setIsLoading(true);
     setError(null);
 
     renderPreview(store.resume, page)
       .then((result) => {
-        if (currentRequestId !== pageRequestId) return;
+        if (currentRequestId !== previewRequestId) return;
         setPreviewUrl(result.url);
         setLastCachedUrl(result.url);
         setTotalPages(result.totalPages);
@@ -405,7 +406,7 @@ export function Preview(props: PreviewProps) {
         lastToastedError = "";
       })
       .catch((e) => {
-        if (currentRequestId !== pageRequestId) return;
+        if (currentRequestId !== previewRequestId) return;
         lastRequestedKey = "";
         console.error("Preview error:", e);
         const msg = e instanceof Error ? e.message : String(e) || "Failed to load preview";
@@ -419,7 +420,7 @@ export function Preview(props: PreviewProps) {
         }
       })
       .finally(() => {
-        if (currentRequestId === pageRequestId) {
+        if (currentRequestId === previewRequestId) {
           setIsLoading(false);
         }
       });

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -3,6 +3,7 @@ import { toast } from "../ui";
 import { resumeStore } from "../../stores/resume";
 import { uiStore } from "../../stores/ui";
 import { renderPreview } from "../../api/render";
+import type { ResumeData } from "../../wasm/types";
 import { useDebounce } from "../../hooks/useDebounce";
 import { useOnline } from "../../hooks/useOnline";
 import { clearPrintPageFormat, setPrintPageFormat } from "../../lib/printFormat";
@@ -331,8 +332,11 @@ export function Preview(props: PreviewProps) {
     setIsLoading(true);
     setError(null);
 
+    // Pass a plain snapshot, never the store proxy: renderPreview stringifies
+    // its argument synchronously, and doing that to the proxy inside this
+    // effect's tracking scope would deep-subscribe it to every resume field.
     renderPreview(
-      store.resume,
+      JSON.parse(resumeJson) as ResumeData,
       untrack(() => ui.previewPage),
     )
       .then((result) => {
@@ -388,7 +392,8 @@ export function Preview(props: PreviewProps) {
       return;
     }
 
-    const requestKey = `${page}|${untrack(() => JSON.stringify(store.resume))}`;
+    const resumeJson = untrack(() => JSON.stringify(store.resume));
+    const requestKey = `${page}|${resumeJson}`;
     if (requestKey === lastRequestedKey) return;
     lastRequestedKey = requestKey;
 
@@ -396,7 +401,10 @@ export function Preview(props: PreviewProps) {
     setIsLoading(true);
     setError(null);
 
-    renderPreview(store.resume, page)
+    // Same snapshot rule as the resume effect: the proxy must never be read
+    // inside the tracking scope, or this effect deep-subscribes and every
+    // keystroke bypasses the debounce from the first page interaction on.
+    renderPreview(JSON.parse(resumeJson) as ResumeData, page)
       .then((result) => {
         if (currentRequestId !== previewRequestId) return;
         setPreviewUrl(result.url);

--- a/apps/web/src/components/preview/Preview.tsx
+++ b/apps/web/src/components/preview/Preview.tsx
@@ -305,26 +305,24 @@ export function Preview(props: PreviewProps) {
     500,
   );
 
-  // Fetch preview when resume changes
-  createEffect(() => {
-    const resumeJson = debouncedResume();
-    if (!resumeJson || !store.resume) return;
-
-    // Skip if offline — invalidate in-flight requests, keep cached preview
-    if (!isOnline()) {
-      ++previewRequestId;
-      lastRequestedKey = "";
-      setIsLoading(false);
-      if (lastCachedUrl()) {
-        setPreviewUrl(lastCachedUrl());
-        setError(null);
-      } else {
-        setError("Preview unavailable offline");
-      }
-      return;
+  // Invalidate in-flight requests while offline and fall back to the cache.
+  const handleOffline = () => {
+    ++previewRequestId;
+    lastRequestedKey = "";
+    setIsLoading(false);
+    if (lastCachedUrl()) {
+      setPreviewUrl(lastCachedUrl());
+      setError(null);
+    } else {
+      setError("Preview unavailable offline");
     }
+  };
 
-    const requestKey = `${untrack(() => ui.previewPage)}|${resumeJson}`;
+  // Deduplicated render-request lifecycle shared by both fetch effects: build
+  // the request key, bail on the in-flight duplicate, claim the render
+  // generation, then apply the result only if no newer request started since.
+  const startRender = (page: number, resumeJson: string) => {
+    const requestKey = `${page}|${resumeJson}`;
     if (requestKey === lastRequestedKey) return;
     lastRequestedKey = requestKey;
 
@@ -333,12 +331,10 @@ export function Preview(props: PreviewProps) {
     setError(null);
 
     // Pass a plain snapshot, never the store proxy: renderPreview stringifies
-    // its argument synchronously, and doing that to the proxy inside this
-    // effect's tracking scope would deep-subscribe it to every resume field.
-    renderPreview(
-      JSON.parse(resumeJson) as ResumeData,
-      untrack(() => ui.previewPage),
-    )
+    // its argument synchronously, and doing that to the proxy inside the
+    // calling effect's tracking scope would deep-subscribe it to every resume
+    // field, bypassing the debounce from the first page interaction on.
+    renderPreview(JSON.parse(resumeJson) as ResumeData, page)
       .then((result) => {
         if (currentRequestId !== previewRequestId) return;
         setPreviewUrl(result.url);
@@ -371,71 +367,34 @@ export function Preview(props: PreviewProps) {
           setIsLoading(false);
         }
       });
+  };
+
+  // Fetch preview when the (debounced) resume changes
+  createEffect(() => {
+    const resumeJson = debouncedResume();
+    if (!resumeJson || !store.resume) return;
+    if (!isOnline()) {
+      handleOffline();
+      return;
+    }
+    startRender(
+      untrack(() => ui.previewPage),
+      resumeJson,
+    );
   });
 
-  // Also refresh when page changes
+  // Also refresh when the page changes, rendering the current resume snapshot
   createEffect(() => {
     const page = ui.previewPage;
     if (!store.resume) return;
-
-    // Skip if offline — invalidate in-flight requests, keep cached preview
     if (!isOnline()) {
-      ++previewRequestId;
-      lastRequestedKey = "";
-      setIsLoading(false);
-      if (lastCachedUrl()) {
-        setPreviewUrl(lastCachedUrl());
-        setError(null);
-      } else {
-        setError("Preview unavailable offline");
-      }
+      handleOffline();
       return;
     }
-
-    const resumeJson = untrack(() => JSON.stringify(store.resume));
-    const requestKey = `${page}|${resumeJson}`;
-    if (requestKey === lastRequestedKey) return;
-    lastRequestedKey = requestKey;
-
-    const currentRequestId = ++previewRequestId;
-    setIsLoading(true);
-    setError(null);
-
-    // Same snapshot rule as the resume effect: the proxy must never be read
-    // inside the tracking scope, or this effect deep-subscribes and every
-    // keystroke bypasses the debounce from the first page interaction on.
-    renderPreview(JSON.parse(resumeJson) as ResumeData, page)
-      .then((result) => {
-        if (currentRequestId !== previewRequestId) return;
-        setPreviewUrl(result.url);
-        setLastCachedUrl(result.url);
-        setTotalPages(result.totalPages);
-        // Clamp page index when content shrinks (e.g., user deletes text)
-        if (ui.previewPage >= result.totalPages) {
-          setPreviewPage(Math.max(0, result.totalPages - 1));
-        }
-        setError(null);
-        lastToastedError = "";
-      })
-      .catch((e) => {
-        if (currentRequestId !== previewRequestId) return;
-        lastRequestedKey = "";
-        console.error("Preview error:", e);
-        const msg = e instanceof Error ? e.message : String(e) || "Failed to load preview";
-        setError(msg);
-        if (msg !== lastToastedError) {
-          lastToastedError = msg;
-          toast.error("Preview rendering failed");
-        }
-        if (lastCachedUrl()) {
-          setPreviewUrl(lastCachedUrl());
-        }
-      })
-      .finally(() => {
-        if (currentRequestId === previewRequestId) {
-          setIsLoading(false);
-        }
-      });
+    startRender(
+      page,
+      untrack(() => JSON.stringify(store.resume)),
+    );
   });
 
   createEffect(() => {

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -134,11 +134,13 @@ export default function DocEditor() {
   const [renderedPageCount, setRenderedPageCount] = createSignal(0);
   const displayedPageCount = () => renderedPageCount() || pageCount();
 
-  // A different document must not inherit the previous one's rendered count:
-  // drop back to the sheet's own pagination until its first render lands.
+  // A different document must not inherit the previous one's counts: drop all
+  // document-scoped display state until the new sheet and render report in.
   createEffect(() => {
     void params.id;
     setRenderedPageCount(0);
+    setPageCount(0);
+    setOverflowingPages([]);
   });
 
   const overflowMessage = () => {

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -1,9 +1,9 @@
 /**
  * The flag-gated document editor at `/edit/:id`.
  *
- * This slice is read-only: it draws the resume as a paper sheet and reports
- * what does not fit. Editing affordances (#728) and the PDF preview pane (#732)
- * land on top of it; until then the right pane is a placeholder.
+ * The left pane is the editable paper sheet (structure fidelity); the right
+ * pane mounts the server-rendered `Preview` — the ground-truth Typst render,
+ * refreshed off resume-store mutations through the preview's own debounce.
  *
  * Reached only when `isDocEditorEnabled()` is true — see `src/lib/flags.ts` and
  * the route swap in `src/index.tsx`.
@@ -31,6 +31,10 @@ const VersionHistory = lazy(() =>
   })),
 );
 
+const Preview = lazy(() =>
+  import("../components/preview").then((module) => ({ default: module.Preview })),
+);
+
 /**
  * Layout used when the template's own metadata cannot be fetched.
  *
@@ -45,19 +49,6 @@ export const FALLBACK_TEMPLATE_LAYOUT: TemplateLayout = {
   contactIn: "header",
   sidebarWidth: null,
 };
-
-function PreviewPlaceholder() {
-  return (
-    <div
-      class="h-full flex items-center justify-center border-l border-border bg-surface/40 p-6"
-      data-testid="doc-editor-preview-placeholder"
-    >
-      <p class="max-w-xs text-center text-sm text-stone">
-        The rendered PDF preview appears here once it lands.
-      </p>
-    </div>
-  );
-}
 
 export default function DocEditor() {
   const params = useParams<{ id: string }>();
@@ -129,6 +120,12 @@ export default function DocEditor() {
   const [pageCount, setPageCount] = createSignal(0);
   const [overflowingPages, setOverflowingPages] = createSignal<number[]>([]);
 
+  // Ground truth from the server render. The sheet's own pagination drives the
+  // sheet; the pill prefers what Typst actually produced, falling back to the
+  // sheet's count until the first render lands.
+  const [renderedPageCount, setRenderedPageCount] = createSignal(0);
+  const displayedPageCount = () => renderedPageCount() || pageCount();
+
   const overflowMessage = () => {
     const pages = overflowingPages();
     if (pages.length === 0) return "";
@@ -137,6 +134,20 @@ export default function DocEditor() {
       ? `Content overflows page ${labels}`
       : `Content overflows pages ${labels}`;
   };
+
+  const PreviewPane = () => (
+    <div class="h-full border-l border-border" data-testid="doc-editor-preview-pane">
+      <Suspense
+        fallback={
+          <div class="h-full flex items-center justify-center bg-surface/40">
+            <Spinner />
+          </div>
+        }
+      >
+        <Preview onTotalPagesChange={setRenderedPageCount} />
+      </Suspense>
+    </div>
+  );
 
   const SheetPane = () => (
     <div class="h-full overflow-auto bg-surface/30" data-testid="doc-editor-sheet-pane">
@@ -166,8 +177,8 @@ export default function DocEditor() {
         <p class="font-mono text-xs text-stone" data-testid="doc-editor-page-count">
           {/* No count until a sheet exists — otherwise this reads "0 pages"
               while loading and behind the load-error screen. */}
-          <Show when={pageCount() > 0}>
-            {pageCount() === 1 ? "1 page" : `${pageCount()} pages`}
+          <Show when={displayedPageCount() > 0}>
+            {displayedPageCount() === 1 ? "1 page" : `${displayedPageCount()} pages`}
           </Show>
         </p>
         <div class="flex items-center gap-2">
@@ -278,7 +289,7 @@ export default function DocEditor() {
             </div>
           }
         >
-          <SplitPane defaultRatio={0.6} left={<SheetPane />} right={<PreviewPlaceholder />} />
+          <SplitPane defaultRatio={0.6} left={<SheetPane />} right={<PreviewPane />} />
         </Show>
       </div>
 

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -193,8 +193,10 @@ export default function DocEditor() {
       <div class="h-12 flex items-center justify-between gap-4 border-b border-border bg-paper px-4">
         <p class="font-mono text-xs text-stone" data-testid="doc-editor-page-count">
           {/* No count until a sheet exists — otherwise this reads "0 pages"
-              while loading and behind the load-error screen. */}
-          <Show when={displayedPageCount() > 0}>
+              while loading and behind the load-error screen. Also hidden while
+              a same-document reload is in flight so a stale count never shows
+              over the loading state. */}
+          <Show when={!isLoading() && !loadError() && displayedPageCount() > 0}>
             {displayedPageCount() === 1 ? "1 page" : `${displayedPageCount()} pages`}
           </Show>
         </p>
@@ -204,7 +206,7 @@ export default function DocEditor() {
             class="font-mono text-xs text-[var(--turbo-state-warning)]"
             data-testid="doc-editor-overflow"
           >
-            {overflowMessage()}
+            {!isLoading() && !loadError() ? overflowMessage() : ""}
           </p>
           <Button
             variant="ghost"

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -9,7 +9,15 @@
  * the route swap in `src/index.tsx`.
  */
 
-import { Show, Suspense, createMemo, createResource, createSignal, lazy } from "solid-js";
+import {
+  Show,
+  Suspense,
+  createEffect,
+  createMemo,
+  createResource,
+  createSignal,
+  lazy,
+} from "solid-js";
 import { useNavigate, useParams } from "@solidjs/router";
 import { Button, Spinner, toast } from "../components/ui";
 import { DocSheet } from "../components/doc-editor";
@@ -126,6 +134,13 @@ export default function DocEditor() {
   const [renderedPageCount, setRenderedPageCount] = createSignal(0);
   const displayedPageCount = () => renderedPageCount() || pageCount();
 
+  // A different document must not inherit the previous one's rendered count:
+  // drop back to the sheet's own pagination until its first render lands.
+  createEffect(() => {
+    void params.id;
+    setRenderedPageCount(0);
+  });
+
   const overflowMessage = () => {
     const pages = overflowingPages();
     if (pages.length === 0) return "";
@@ -140,7 +155,7 @@ export default function DocEditor() {
       <Suspense
         fallback={
           <div class="h-full flex items-center justify-center bg-surface/40">
-            <Spinner />
+            <Spinner ariaLabel="Loading preview" />
           </div>
         }
       >

--- a/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
@@ -85,9 +85,13 @@ function renderAt(component: Component) {
   ));
 }
 
-/** Real-time wait that outlasts the preview's 500 ms resume debounce. */
+/**
+ * Real-time wait that outlasts the preview's 500 ms resume debounce with a
+ * wide margin for CI load. Needed because several assertions here are
+ * negative ("no further fetch happened"), which `waitFor` cannot express.
+ */
 function settleDebounce() {
-  return new Promise((resolve) => setTimeout(resolve, 750));
+  return new Promise((resolve) => setTimeout(resolve, 1100));
 }
 
 async function renderEditorWithPreview() {
@@ -193,6 +197,34 @@ describe("DocEditor preview pane", () => {
     );
   });
 
+  it("clamps the page index when a page-driven render reports fewer pages", async () => {
+    const pending: Array<(result: { url: string; totalPages: number }) => void> = [];
+    vi.mocked(renderPreview).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          pending.push(resolve);
+        }),
+    );
+
+    await renderEditorWithPreview();
+    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(1));
+    pending[0]({ url: "blob:initial", totalPages: 3 });
+    await waitFor(() =>
+      expect(screen.getByRole("img", { name: "Resume preview" })).toHaveAttribute(
+        "src",
+        "blob:initial",
+      ),
+    );
+
+    // Flip to the last page; the server now says the content shrank to 2
+    // pages, so the page-driven fetch must clamp the index back in range.
+    uiStore.setPreviewPage(2);
+    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(2));
+    pending[1]({ url: "blob:page-3", totalPages: 2 });
+
+    await waitFor(() => expect(uiStore.store.previewPage).toBe(1));
+  });
+
   it("surfaces a render failure through the error toast", async () => {
     vi.mocked(renderPreview).mockRejectedValue(new Error("typst blew up"));
 
@@ -200,6 +232,6 @@ describe("DocEditor preview pane", () => {
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Preview rendering failed"));
     // The pill falls back to the sheet's own pagination when no render lands.
-    expect(screen.getByTestId("doc-editor-page-count")).not.toHaveTextContent("3 pages");
+    expect(screen.getByTestId("doc-editor-page-count")).toHaveTextContent("2 pages");
   });
 });

--- a/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * The doc editor's right pane: the live server-rendered preview (#732).
+ *
+ * Unlike `DocEditor.test.tsx`, these tests mount the real `Preview` component
+ * (API mocked) to pin the integration contract: one render per paint — no
+ * double fetch on mount, one debounced refresh per burst of store mutations —
+ * the pill synced to the rendered page count, and failures surfaced through
+ * the toast.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import { MemoryRouter, Route, createMemoryHistory } from "@solidjs/router";
+import { Suspense, type Component } from "solid-js";
+import { loadDocEditorFixture, SIDEBAR_TEMPLATE } from "../../test/docEditorFixture";
+import { renderPreview } from "../../api/render";
+import { toast } from "../../components/ui";
+import { resumeStore } from "../../stores/resume";
+import DocEditor from "../DocEditor";
+
+const { fixture, resumeId } = vi.hoisted(() => ({
+  fixture: { value: null as unknown },
+  // `resumeStore` is a module singleton and `useResumeRouteLoad` skips the load
+  // when the route id already matches what it holds. A fresh id per test forces
+  // the reload, so a test that writes through the store cannot leak into the
+  // next one's fixture.
+  resumeId: { value: "doc-editor-preview-fixture-0" },
+}));
+
+vi.mock("../../lib/flags", () => ({
+  isDocEditorEnabled: () => true,
+}));
+
+vi.mock("../../wasm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../wasm")>();
+  return {
+    ...actual,
+    getResume: vi.fn(() => Promise.resolve(fixture.value)),
+    isWasmReady: () => true,
+    ensureWasmReady: async () => true,
+    saveResume: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("../../api/render", () => ({
+  fetchTemplateLayouts: vi.fn(() => Promise.resolve({ ditto: SIDEBAR_TEMPLATE })),
+  renderPreview: vi.fn(),
+  downloadPdf: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../components/ui")>();
+  return {
+    ...actual,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../../stores/auth", () => ({
+  authStore: {
+    get state() {
+      return { loading: false, cloudEnabled: false, requireAuth: false, user: null };
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    displayName: () => "User",
+  },
+}));
+
+function renderAt(component: Component) {
+  const history = createMemoryHistory();
+  history.set({ value: `/edit/${resumeId.value}`, scroll: false, replace: true });
+
+  return render(() => (
+    <Suspense fallback={<p>Loading route</p>}>
+      <MemoryRouter history={history}>
+        <Route path="/edit/:id" component={component} />
+      </MemoryRouter>
+    </Suspense>
+  ));
+}
+
+/** Real-time wait that outlasts the preview's 500 ms resume debounce. */
+function settleDebounce() {
+  return new Promise((resolve) => setTimeout(resolve, 750));
+}
+
+async function renderEditorWithPreview() {
+  const result = renderAt(DocEditor);
+  await waitFor(() => expect(screen.getByTestId("doc-editor-preview-pane")).toBeInTheDocument());
+  return result;
+}
+
+describe("DocEditor preview pane", () => {
+  let renderCount = 0;
+
+  beforeEach(() => {
+    fixture.value = loadDocEditorFixture();
+    resumeId.value = `doc-editor-preview-fixture-${++renderCount}`;
+    vi.mocked(renderPreview).mockReset();
+    vi.mocked(renderPreview).mockResolvedValue({ url: "blob:preview-1", totalPages: 3 });
+    vi.mocked(toast.error).mockClear();
+  });
+
+  it("mounts the live preview with exactly one render fetch", async () => {
+    await renderEditorWithPreview();
+
+    await waitFor(() =>
+      expect(screen.getByRole("img", { name: "Resume preview" })).toBeInTheDocument(),
+    );
+    // Let the resume-debounce window close: the second fetch effect must
+    // recognise the mount render as already requested and stay quiet.
+    await settleDebounce();
+
+    expect(renderPreview).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("doc-editor-preview-placeholder")).toBeNull();
+  });
+
+  it("syncs the page-count pill with the rendered page count", async () => {
+    await renderEditorWithPreview();
+
+    // The sheet's own pagination says 2 pages; the server render says 3. The
+    // pill must report the ground truth.
+    await waitFor(() =>
+      expect(screen.getByTestId("doc-editor-page-count")).toHaveTextContent("3 pages"),
+    );
+  });
+
+  it("refreshes the preview once, debounced, after a burst of store mutations", async () => {
+    await renderEditorWithPreview();
+    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(1));
+    await settleDebounce();
+
+    resumeStore.updateBasics("name", "Mireille Okafor-Reyes");
+    resumeStore.updateBasics("headline", "Staff Design Systems Engineer");
+    await settleDebounce();
+
+    expect(renderPreview).toHaveBeenCalledTimes(2);
+    const [resume] = vi.mocked(renderPreview).mock.calls[1];
+    expect(resume.basics.name).toBe("Mireille Okafor-Reyes");
+    expect(resume.basics.headline).toBe("Staff Design Systems Engineer");
+  });
+
+  it("surfaces a render failure through the error toast", async () => {
+    vi.mocked(renderPreview).mockRejectedValue(new Error("typst blew up"));
+
+    await renderEditorWithPreview();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Preview rendering failed"));
+    // The pill falls back to the sheet's own pagination when no render lands.
+    expect(screen.getByTestId("doc-editor-page-count")).not.toHaveTextContent("3 pages");
+  });
+});

--- a/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
@@ -61,6 +61,18 @@ vi.mock("../../components/ui", async (importOriginal) => {
   };
 });
 
+// The print-stack prefetch debounces off the preview URL and, on a slow CI
+// runner, its window elapses mid-test and injects extra renderPreview calls —
+// breaking the exact call counts these tests pin. It has its own unit tests
+// (printStack.test.ts), so stub it to keep the counts deterministic.
+vi.mock("../../components/preview/printStack", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../components/preview/printStack")>();
+  return {
+    ...actual,
+    prefetchPrintStackPages: vi.fn().mockResolvedValue({ urls: [], hasHardFailure: false }),
+  };
+});
+
 vi.mock("../../stores/auth", () => ({
   authStore: {
     get state() {

--- a/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
@@ -16,6 +16,7 @@ import { loadDocEditorFixture, SIDEBAR_TEMPLATE } from "../../test/docEditorFixt
 import { renderPreview } from "../../api/render";
 import { toast } from "../../components/ui";
 import { resumeStore } from "../../stores/resume";
+import { uiStore } from "../../stores/ui";
 import DocEditor from "../DocEditor";
 
 const { fixture, resumeId } = vi.hoisted(() => ({
@@ -104,6 +105,9 @@ describe("DocEditor preview pane", () => {
     vi.mocked(renderPreview).mockReset();
     vi.mocked(renderPreview).mockResolvedValue({ url: "blob:preview-1", totalPages: 3 });
     vi.mocked(toast.error).mockClear();
+    // `uiStore` is a module singleton; a page-flipping test must not leak its
+    // page index into the next test's mount fetch.
+    uiStore.setPreviewPage(0);
   });
 
   it("mounts the live preview with exactly one render fetch", async () => {
@@ -143,6 +147,50 @@ describe("DocEditor preview pane", () => {
     const [resume] = vi.mocked(renderPreview).mock.calls[1];
     expect(resume.basics.name).toBe("Mireille Okafor-Reyes");
     expect(resume.basics.headline).toBe("Staff Design Systems Engineer");
+  });
+
+  it("ignores a stale resume render that resolves after a newer page render", async () => {
+    const pending: Array<(result: { url: string; totalPages: number }) => void> = [];
+    vi.mocked(renderPreview).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          pending.push(resolve);
+        }),
+    );
+
+    await renderEditorWithPreview();
+    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(1));
+    pending[0]({ url: "blob:initial", totalPages: 3 });
+    await waitFor(() =>
+      expect(screen.getByRole("img", { name: "Resume preview" })).toHaveAttribute(
+        "src",
+        "blob:initial",
+      ),
+    );
+
+    // A debounced resume render goes out and hangs...
+    resumeStore.updateBasics("name", "Mireille Okafor-Reyes");
+    await settleDebounce();
+    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(2));
+
+    // ...the user flips the page meanwhile, and that newer render lands first.
+    uiStore.setPreviewPage(1);
+    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(3));
+    pending[2]({ url: "blob:page-1", totalPages: 3 });
+    await waitFor(() =>
+      expect(screen.getByRole("img", { name: "Resume preview" })).toHaveAttribute(
+        "src",
+        "blob:page-1",
+      ),
+    );
+
+    // The stale resume response must not clobber the newer page render.
+    pending[1]({ url: "blob:stale", totalPages: 3 });
+    await settleDebounce();
+    expect(screen.getByRole("img", { name: "Resume preview" })).toHaveAttribute(
+      "src",
+      "blob:page-1",
+    );
   });
 
   it("surfaces a render failure through the error toast", async () => {

--- a/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
@@ -245,6 +245,35 @@ describe("DocEditor preview pane", () => {
     await waitLong(() => expect(uiStore.store.previewPage).toBe(1));
   }, 20_000);
 
+  it("keeps refreshes debounced after a page flip, under production mock physics", async () => {
+    // The real renderPreview stringifies its resume argument synchronously
+    // (cloneResumeForApi). A mock that never touches the proxy cannot form
+    // the deep subscription that once let the page effect bypass the
+    // debounce, so this mock reproduces that read.
+    vi.mocked(renderPreview).mockImplementation((resume) => {
+      JSON.stringify(resume);
+      return Promise.resolve({ url: "blob:preview-1", totalPages: 3 });
+    });
+
+    await renderEditorWithPreview();
+    await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(1));
+    await settleDebounce();
+
+    // A page flip runs the page-driven fetch...
+    uiStore.setPreviewPage(1);
+    await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(2));
+
+    // ...after which store mutations must still refresh once, debounced —
+    // not immediately per keystroke via a page-effect deep subscription.
+    resumeStore.updateBasics("name", "Mireille Okafor-Reyes");
+    resumeStore.updateBasics("headline", "Staff Design Systems Engineer");
+    expect(renderPreview).toHaveBeenCalledTimes(2);
+    await settleDebounce();
+    await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(3));
+    await settleDebounce();
+    expect(renderPreview).toHaveBeenCalledTimes(3);
+  }, 20_000);
+
   it("surfaces a render failure through the error toast", async () => {
     vi.mocked(renderPreview).mockRejectedValue(new Error("typst blew up"));
 

--- a/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
@@ -106,9 +106,17 @@ function settleDebounce() {
   return new Promise((resolve) => setTimeout(resolve, 1100));
 }
 
+/**
+ * `waitFor` with a generous window: the shared coverage runner starves the
+ * event loop well past the 1 s default when test files run in parallel.
+ */
+function waitLong<T>(callback: () => T) {
+  return waitFor(callback, { timeout: 10_000 });
+}
+
 async function renderEditorWithPreview() {
   const result = renderAt(DocEditor);
-  await waitFor(() => expect(screen.getByTestId("doc-editor-preview-pane")).toBeInTheDocument());
+  await waitLong(() => expect(screen.getByTestId("doc-editor-preview-pane")).toBeInTheDocument());
   return result;
 }
 
@@ -129,7 +137,7 @@ describe("DocEditor preview pane", () => {
   it("mounts the live preview with exactly one render fetch", async () => {
     await renderEditorWithPreview();
 
-    await waitFor(() =>
+    await waitLong(() =>
       expect(screen.getByRole("img", { name: "Resume preview" })).toBeInTheDocument(),
     );
     // Let the resume-debounce window close: the second fetch effect must
@@ -138,21 +146,21 @@ describe("DocEditor preview pane", () => {
 
     expect(renderPreview).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId("doc-editor-preview-placeholder")).toBeNull();
-  });
+  }, 20_000);
 
   it("syncs the page-count pill with the rendered page count", async () => {
     await renderEditorWithPreview();
 
     // The sheet's own pagination says 2 pages; the server render says 3. The
     // pill must report the ground truth.
-    await waitFor(() =>
+    await waitLong(() =>
       expect(screen.getByTestId("doc-editor-page-count")).toHaveTextContent("3 pages"),
     );
-  });
+  }, 20_000);
 
   it("refreshes the preview once, debounced, after a burst of store mutations", async () => {
     await renderEditorWithPreview();
-    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(1));
+    await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(1));
     await settleDebounce();
 
     resumeStore.updateBasics("name", "Mireille Okafor-Reyes");
@@ -163,7 +171,7 @@ describe("DocEditor preview pane", () => {
     const [resume] = vi.mocked(renderPreview).mock.calls[1];
     expect(resume.basics.name).toBe("Mireille Okafor-Reyes");
     expect(resume.basics.headline).toBe("Staff Design Systems Engineer");
-  });
+  }, 20_000);
 
   it("ignores a stale resume render that resolves after a newer page render", async () => {
     const pending: Array<(result: { url: string; totalPages: number }) => void> = [];
@@ -175,9 +183,9 @@ describe("DocEditor preview pane", () => {
     );
 
     await renderEditorWithPreview();
-    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(1));
+    await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(1));
     pending[0]({ url: "blob:initial", totalPages: 3 });
-    await waitFor(() =>
+    await waitLong(() =>
       expect(screen.getByRole("img", { name: "Resume preview" })).toHaveAttribute(
         "src",
         "blob:initial",
@@ -187,13 +195,13 @@ describe("DocEditor preview pane", () => {
     // A debounced resume render goes out and hangs...
     resumeStore.updateBasics("name", "Mireille Okafor-Reyes");
     await settleDebounce();
-    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(2));
+    await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(2));
 
     // ...the user flips the page meanwhile, and that newer render lands first.
     uiStore.setPreviewPage(1);
-    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(3));
+    await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(3));
     pending[2]({ url: "blob:page-1", totalPages: 3 });
-    await waitFor(() =>
+    await waitLong(() =>
       expect(screen.getByRole("img", { name: "Resume preview" })).toHaveAttribute(
         "src",
         "blob:page-1",
@@ -207,7 +215,7 @@ describe("DocEditor preview pane", () => {
       "src",
       "blob:page-1",
     );
-  });
+  }, 20_000);
 
   it("clamps the page index when a page-driven render reports fewer pages", async () => {
     const pending: Array<(result: { url: string; totalPages: number }) => void> = [];
@@ -219,9 +227,9 @@ describe("DocEditor preview pane", () => {
     );
 
     await renderEditorWithPreview();
-    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(1));
+    await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(1));
     pending[0]({ url: "blob:initial", totalPages: 3 });
-    await waitFor(() =>
+    await waitLong(() =>
       expect(screen.getByRole("img", { name: "Resume preview" })).toHaveAttribute(
         "src",
         "blob:initial",
@@ -231,19 +239,19 @@ describe("DocEditor preview pane", () => {
     // Flip to the last page; the server now says the content shrank to 2
     // pages, so the page-driven fetch must clamp the index back in range.
     uiStore.setPreviewPage(2);
-    await waitFor(() => expect(renderPreview).toHaveBeenCalledTimes(2));
+    await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(2));
     pending[1]({ url: "blob:page-3", totalPages: 2 });
 
-    await waitFor(() => expect(uiStore.store.previewPage).toBe(1));
-  });
+    await waitLong(() => expect(uiStore.store.previewPage).toBe(1));
+  }, 20_000);
 
   it("surfaces a render failure through the error toast", async () => {
     vi.mocked(renderPreview).mockRejectedValue(new Error("typst blew up"));
 
     await renderEditorWithPreview();
 
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Preview rendering failed"));
+    await waitLong(() => expect(toast.error).toHaveBeenCalledWith("Preview rendering failed"));
     // The pill falls back to the sheet's own pagination when no render lands.
     expect(screen.getByTestId("doc-editor-page-count")).toHaveTextContent("2 pages");
-  });
+  }, 20_000);
 });

--- a/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditorPreview.test.tsx
@@ -146,7 +146,7 @@ describe("DocEditor preview pane", () => {
 
     expect(renderPreview).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId("doc-editor-preview-placeholder")).toBeNull();
-  }, 20_000);
+  }, 60_000);
 
   it("syncs the page-count pill with the rendered page count", async () => {
     await renderEditorWithPreview();
@@ -156,7 +156,7 @@ describe("DocEditor preview pane", () => {
     await waitLong(() =>
       expect(screen.getByTestId("doc-editor-page-count")).toHaveTextContent("3 pages"),
     );
-  }, 20_000);
+  }, 60_000);
 
   it("refreshes the preview once, debounced, after a burst of store mutations", async () => {
     await renderEditorWithPreview();
@@ -171,7 +171,7 @@ describe("DocEditor preview pane", () => {
     const [resume] = vi.mocked(renderPreview).mock.calls[1];
     expect(resume.basics.name).toBe("Mireille Okafor-Reyes");
     expect(resume.basics.headline).toBe("Staff Design Systems Engineer");
-  }, 20_000);
+  }, 60_000);
 
   it("ignores a stale resume render that resolves after a newer page render", async () => {
     const pending: Array<(result: { url: string; totalPages: number }) => void> = [];
@@ -215,7 +215,7 @@ describe("DocEditor preview pane", () => {
       "src",
       "blob:page-1",
     );
-  }, 20_000);
+  }, 60_000);
 
   it("clamps the page index when a page-driven render reports fewer pages", async () => {
     const pending: Array<(result: { url: string; totalPages: number }) => void> = [];
@@ -243,7 +243,7 @@ describe("DocEditor preview pane", () => {
     pending[1]({ url: "blob:page-3", totalPages: 2 });
 
     await waitLong(() => expect(uiStore.store.previewPage).toBe(1));
-  }, 20_000);
+  }, 60_000);
 
   it("keeps refreshes debounced after a page flip, under production mock physics", async () => {
     // The real renderPreview stringifies its resume argument synchronously
@@ -272,7 +272,7 @@ describe("DocEditor preview pane", () => {
     await waitLong(() => expect(renderPreview).toHaveBeenCalledTimes(3));
     await settleDebounce();
     expect(renderPreview).toHaveBeenCalledTimes(3);
-  }, 20_000);
+  }, 60_000);
 
   it("surfaces a render failure through the error toast", async () => {
     vi.mocked(renderPreview).mockRejectedValue(new Error("typst blew up"));
@@ -282,5 +282,5 @@ describe("DocEditor preview pane", () => {
     await waitLong(() => expect(toast.error).toHaveBeenCalledWith("Preview rendering failed"));
     // The pill falls back to the sheet's own pagination when no render lands.
     expect(screen.getByTestId("doc-editor-page-count")).toHaveTextContent("2 pages");
-  }, 20_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(web): integrate the PDF preview pane into the document editor`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Mounts the existing server-rendered `Preview` as the doc editor's right pane, replacing the read-only slice's placeholder (design decision 5: structure fidelity on the left, Typst ground truth on the right).

- `DocEditor` lazy-loads `Preview` (same pattern as `Editor.tsx`) inside the `SplitPane` right side, wrapped in `Suspense` with a labelled spinner.
- Refreshes are driven by the preview's existing debounced store observation — verified it observes resume-store mutations; no parallel invalidation path was added.
- A shared request key dedupes the preview's two fetch effects, so mounting costs exactly one render (previously the debounced-resume and page effects both fetched on mount).
- The two fetch effects now share one render generation, so a slow stale response from one effect can never overwrite a newer render started by the other; the shrink clamp now also applies on the page-driven path.
- The page-count pill prefers the rendered (ground truth) page count via a new optional `onTotalPagesChange` prop, falling back to the sheet's own pagination until the first render lands; all document-scoped counts reset on route changes.
- Render failures surface through the preview's existing error/toast path; printing keeps working via the preview's own print stack. Download chrome is deferred: the doc editor page has no download affordance yet (it lives in the old Editor toolbar), and adding it belongs to a later wave of #721.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #732
- Relates to #721

## Details

- No DocSheet restructuring: composition is additive (pane swap at the page level) to stay conflict-free with #759.
- Nothing server-side changes; render requests keep going through the existing preview endpoints.
- New `DocEditorPreview.test.tsx` mounts the real `Preview` (API mocked): one fetch on mount (no double fetch), one debounced refresh per mutation burst, pill synced to the rendered count, stale out-of-order response ignored, shrink clamp on the page-driven path, and failure toast. Full web suite: 74 files / 778 tests green; typecheck and `lintro chk` clean.
- Preview's `ResizeObserver` is now guarded like DocSheet's (jsdom has none).

### AI review

- CodeRabbit: 2 runs. Run 1 found a real cross-effect stale-response race (fixed via shared render generation) plus two minors (spinner label, route-change count reset) — all addressed. Run 2 (verification) findings addressed except one dismissed: invalidating renders when `store.resume` becomes null mid-mount — unreachable, the route unmounts before the store empties.
- Greptile: rate-limited (`free_reviews_limit_reached`); `lintro review` unavailable on this machine (no `ANTHROPIC_API_KEY`). Interim fallback per convention: native review against py-lintro's checklist corpus (tier1 + ts/tsx/test tier2) — no P1s; accepted risks noted are the fixed-sleep debounce waits (needed for negative assertions, margin widened to 1100 ms) and the toast-literal wiring assertion (matches existing test convention). Re-run Greptile before merge if quota resets.

### CI notes

- Web Coverage failed twice on the shared 2-core coverage runner before two test-side hardenings landed: the print-stack prefetch (2.5 s debounce) is stubbed in `DocEditorPreview.test.tsx` so it cannot inject extra `renderPreview` calls into pinned call counts, and every async assertion got a 10 s `waitFor` window / 20 s test budget (reproduced locally with `CI=true` + coverage; vitest defaults are too tight under parallel coverage load). All checks green as of the final push.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a server-rendered document preview with a loading state.
  - Synchronized preview page counts with editor controls.
  - Pagination now resets when switching documents.
  - Added clearer rendering failure notifications.

- **Bug Fixes**
  - Improved reliability during offline states, failed renders, and rapid page changes.
  - Prevented stale preview results from replacing newer content.
  - Kept page selections within valid limits.
  - Hid pagination indicators while previews are loading or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->