### PR TITLE
feat(web): add templates drawer and sections panel backed by the registry API

### DIFF
--- a/apps/web/src/components/doc-editor/SectionsPanel.tsx
+++ b/apps/web/src/components/doc-editor/SectionsPanel.tsx
@@ -1,0 +1,131 @@
+/**
+ * The sections panel: chrome around the sheet for managing what the document
+ * carries.
+ *
+ * Visibility toggles cover every fixed and custom section — including sections
+ * currently hidden and therefore absent from the sheet, which is what makes a
+ * hidden section recoverable. Custom sections can be added (through the same
+ * dialog the sheet uses, so placement stays one undo entry) and removed. Notes
+ * are private scratch text that never renders to the PDF, so they are a plain
+ * text field — no rich editor, no markdown toolbar.
+ *
+ * Every mutation routes through `docEdits` (decision 4).
+ */
+
+import { For, Show, createSignal, type JSX } from "solid-js";
+import { Button, Drawer, Switch, TextArea } from "../ui";
+import { FIXED_SECTION_IDS, sectionTitle, sectionVisible } from "../../lib/docLayout";
+import { CustomSectionDialog } from "./CustomSectionDialog";
+import { removeSection, toggleSection, updateNotes } from "./docEdits";
+import type { ResumeData } from "../../wasm/types";
+
+export interface SectionsPanelProps {
+  resume: ResumeData;
+}
+
+export function SectionsPanel(props: SectionsPanelProps): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  const [adding, setAdding] = createSignal(false);
+
+  const customIds = (): string[] => Object.keys(props.resume.sections.custom ?? {});
+
+  return (
+    <>
+      <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
+        Sections
+      </Button>
+
+      <Drawer
+        open={open()}
+        onOpenChange={setOpen}
+        title="Sections"
+        description="Show, hide and manage the document's sections."
+        side="right"
+      >
+        <div class="flex flex-col gap-6" data-testid="sections-panel">
+          <section aria-label="Section visibility">
+            <h3 class="mb-2 font-mono text-xs uppercase tracking-wider text-stone">Sections</h3>
+            <ul class="flex flex-col gap-2">
+              <For each={FIXED_SECTION_IDS}>
+                {(sectionId) => (
+                  <li>
+                    <Switch
+                      label={sectionTitle(props.resume, sectionId)}
+                      checked={sectionVisible(props.resume, sectionId)}
+                      onChange={() => toggleSection(sectionId)}
+                    />
+                  </li>
+                )}
+              </For>
+            </ul>
+          </section>
+
+          <section aria-label="Custom sections">
+            <h3 class="mb-2 font-mono text-xs uppercase tracking-wider text-stone">
+              Custom sections
+            </h3>
+            <Show
+              when={customIds().length > 0}
+              fallback={<p class="text-sm text-stone">No custom sections yet.</p>}
+            >
+              <ul class="flex flex-col gap-2">
+                <For each={customIds()}>
+                  {(sectionId) => (
+                    <li class="flex items-center gap-2">
+                      <Switch
+                        class="flex-1"
+                        label={sectionTitle(props.resume, sectionId)}
+                        checked={sectionVisible(props.resume, sectionId)}
+                        onChange={() => toggleSection(sectionId)}
+                      />
+                      <button
+                        type="button"
+                        class="focus-ring rounded-lg p-1.5 text-stone transition-colors
+                          hover:bg-surface hover:text-red-600"
+                        aria-label={`Delete ${sectionTitle(props.resume, sectionId)} section`}
+                        onClick={() => removeSection(sectionId)}
+                      >
+                        <svg
+                          class="h-4 w-4"
+                          aria-hidden="true"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0
+                              01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0
+                              00-1 1v3M4 7h16"
+                          />
+                        </svg>
+                      </button>
+                    </li>
+                  )}
+                </For>
+              </ul>
+            </Show>
+            <Button variant="secondary" size="sm" class="mt-3" onClick={() => setAdding(true)}>
+              Add section
+            </Button>
+          </section>
+
+          <section aria-label="Notes">
+            <TextArea
+              label="Notes"
+              description="Private scratch text. Never rendered to the PDF."
+              placeholder="Interview prep, tailoring ideas, links..."
+              rows={6}
+              value={props.resume.metadata.notes}
+              onInput={updateNotes}
+            />
+          </section>
+        </div>
+      </Drawer>
+
+      <CustomSectionDialog open={adding()} onOpenChange={setAdding} />
+    </>
+  );
+}

--- a/apps/web/src/components/doc-editor/TemplatesDrawer.tsx
+++ b/apps/web/src/components/doc-editor/TemplatesDrawer.tsx
@@ -48,7 +48,12 @@ export function TemplatesDrawer(props: TemplatesDrawerProps): JSX.Element {
   );
 
   function select(template: TemplateInfo): void {
-    applyTemplate(template.id, template.layout ?? FALLBACK_TEMPLATE_LAYOUT);
+    // Re-picking the current template is a no-op: applyTemplate would rebuild
+    // `metadata.layout` onto one page, flattening manual page and column
+    // placement for no visible change — and burning an undo entry on it.
+    if (template.id !== props.resume.metadata.template) {
+      applyTemplate(template.id, template.layout ?? FALLBACK_TEMPLATE_LAYOUT);
+    }
     setOpen(false);
   }
 

--- a/apps/web/src/components/doc-editor/TemplatesDrawer.tsx
+++ b/apps/web/src/components/doc-editor/TemplatesDrawer.tsx
@@ -1,0 +1,177 @@
+/**
+ * The templates drawer: chrome around the sheet for switching templates.
+ *
+ * Cards come from the server template registry (`GET /api/templates`) — id,
+ * name, theme and the layout block — with server-rendered thumbnails. There is
+ * no client-side template table to drift from the server's.
+ *
+ * Switching goes through `applyTemplate` in `docEdits`, which lands
+ * `metadata.template` and the freshly derived `metadata.layout` as one store
+ * action — a single undo entry — re-placing custom sections the new template's
+ * defaults do not mention. The sheet re-renders from the new layout reactively;
+ * nothing here touches the page frames or their drop zones.
+ */
+
+import { For, Show, Suspense, createResource, createSignal, type JSX } from "solid-js";
+import { Button, Drawer, Spinner } from "../ui";
+import { fetchTemplates, getTemplateThumbnailUrl } from "../../api/render";
+import { FALLBACK_TEMPLATE_LAYOUT, type TemplateLayoutMode } from "../../lib/docLayout";
+import { applyTemplate } from "./docEdits";
+import type { ResumeData, TemplateInfo } from "../../wasm/types";
+
+const LAYOUT_MODE_LABELS: Readonly<Record<TemplateLayoutMode, string>> = {
+  single: "Single column",
+  "sidebar-left": "Left sidebar",
+  "sidebar-right": "Right sidebar",
+  "header-split": "Split header",
+};
+
+/** One line of layout metadata for a card, e.g. "Left sidebar · 180pt sidebar". */
+function layoutSummary(template: TemplateInfo): string {
+  const layout = template.layout;
+  if (!layout) return "";
+  const mode = LAYOUT_MODE_LABELS[layout.layoutMode];
+  return layout.sidebarWidth === null ? mode : `${mode} · ${layout.sidebarWidth}pt sidebar`;
+}
+
+export interface TemplatesDrawerProps {
+  resume: ResumeData;
+}
+
+export function TemplatesDrawer(props: TemplatesDrawerProps): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  // Latches true on first open so the registry is fetched once, lazily.
+  const [requested, setRequested] = createSignal(false);
+  const [templates] = createResource(
+    () => requested() || undefined,
+    () => fetchTemplates(),
+  );
+
+  function select(template: TemplateInfo): void {
+    applyTemplate(template.id, template.layout ?? FALLBACK_TEMPLATE_LAYOUT);
+    setOpen(false);
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => {
+          setRequested(true);
+          setOpen(true);
+        }}
+      >
+        Templates
+      </Button>
+
+      <Drawer
+        open={open()}
+        onOpenChange={setOpen}
+        title="Templates"
+        description="Pick a design from the registry; your sections come along."
+        side="left"
+      >
+        <Suspense
+          fallback={
+            <div class="flex items-center justify-center py-12">
+              <Spinner />
+            </div>
+          }
+        >
+          <Show
+            when={!templates.error}
+            fallback={
+              <p class="py-8 text-center text-sm text-red-600" role="alert">
+                Failed to load templates. Check that the server is running and try again.
+              </p>
+            }
+          >
+            <Show
+              when={templates()?.length}
+              fallback={<p class="py-8 text-center text-sm text-stone">No templates available.</p>}
+            >
+              <ul class="grid grid-cols-2 gap-3" data-testid="templates-drawer-list">
+                <For each={templates()}>
+                  {(template) => (
+                    <li>
+                      <TemplateCard
+                        template={template}
+                        isCurrent={props.resume.metadata.template === template.id}
+                        onSelect={select}
+                      />
+                    </li>
+                  )}
+                </For>
+              </ul>
+            </Show>
+          </Show>
+        </Suspense>
+      </Drawer>
+    </>
+  );
+}
+
+function TemplateCard(props: {
+  template: TemplateInfo;
+  isCurrent: boolean;
+  onSelect: (template: TemplateInfo) => void;
+}): JSX.Element {
+  const [imageLoaded, setImageLoaded] = createSignal(false);
+  const [imageError, setImageError] = createSignal(false);
+
+  return (
+    <button
+      type="button"
+      class={`focus-ring group w-full overflow-hidden rounded-lg border-2 text-left
+        transition-colors hover:border-accent
+        ${props.isCurrent ? "border-accent ring-2 ring-accent/20" : "border-border"}`}
+      aria-label={`Use ${props.template.name} template`}
+      aria-pressed={props.isCurrent}
+      onClick={() => props.onSelect(props.template)}
+    >
+      <div class="relative aspect-[3/4] bg-surface">
+        <Show when={!imageError()}>
+          <img
+            src={getTemplateThumbnailUrl(props.template.id)}
+            alt=""
+            loading="lazy"
+            class={`h-full w-full object-cover object-top transition-opacity duration-300
+              ${imageLoaded() ? "opacity-100" : "opacity-0"}`}
+            onLoad={() => setImageLoaded(true)}
+            onError={() => setImageError(true)}
+          />
+        </Show>
+        {/* Lightweight placeholder while the server thumbnail loads (or fails):
+            the template's own theme swatches, so the card is never blank. */}
+        <Show when={!imageLoaded() || imageError()}>
+          <div
+            class="absolute inset-0 flex items-center justify-center gap-1.5"
+            data-testid="template-thumbnail-placeholder"
+          >
+            <span
+              class="h-6 w-6 rounded border border-border/50"
+              style={{ background: props.template.theme.background }}
+            />
+            <span class="h-6 w-6 rounded" style={{ background: props.template.theme.primary }} />
+            <span class="h-6 w-6 rounded" style={{ background: props.template.theme.text }} />
+          </div>
+        </Show>
+      </div>
+
+      <div class="border-t border-border bg-paper p-2">
+        <p class="font-display text-sm font-semibold capitalize text-ink">
+          {props.template.name}
+          <Show when={props.isCurrent}>
+            <span class="ml-1.5 font-mono text-[10px] uppercase tracking-wider text-accent">
+              Current
+            </span>
+          </Show>
+        </p>
+        <Show when={layoutSummary(props.template)}>
+          {(summary) => <p class="mt-0.5 text-xs text-stone">{summary()}</p>}
+        </Show>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/components/doc-editor/TemplatesDrawer.tsx
+++ b/apps/web/src/components/doc-editor/TemplatesDrawer.tsx
@@ -42,7 +42,7 @@ export function TemplatesDrawer(props: TemplatesDrawerProps): JSX.Element {
   const [open, setOpen] = createSignal(false);
   // Latches true on first open so the registry is fetched once, lazily.
   const [requested, setRequested] = createSignal(false);
-  const [templates] = createResource(
+  const [templates, { refetch }] = createResource(
     () => requested() || undefined,
     () => fetchTemplates(),
   );
@@ -82,9 +82,14 @@ export function TemplatesDrawer(props: TemplatesDrawerProps): JSX.Element {
           <Show
             when={!templates.error}
             fallback={
-              <p class="py-8 text-center text-sm text-red-600" role="alert">
-                Failed to load templates. Check that the server is running and try again.
-              </p>
+              <div class="flex flex-col items-center gap-3 py-8">
+                <p class="text-center text-sm text-red-600" role="alert">
+                  Failed to load templates. Check that the server is running and try again.
+                </p>
+                <Button variant="secondary" size="sm" onClick={() => void refetch()}>
+                  Retry
+                </Button>
+              </div>
             }
           >
             <Show

--- a/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * The registry-backed chrome of #731: the templates drawer and sections panel.
+ *
+ * Cards are asserted against a mocked `GET /api/templates` response — one card
+ * per template, layout metadata included — and every control must route to
+ * exactly the right store action, one action per operation, with a template
+ * switch landing template and layout as a single combined write.
+ */
+
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import { loadDocEditorFixture } from "../../../test/docEditorFixture";
+import { SectionsPanel } from "../SectionsPanel";
+import { TemplatesDrawer } from "../TemplatesDrawer";
+import type { ResumeData, TemplateInfo } from "../../../wasm/types";
+
+const store = vi.hoisted(() => ({
+  store: { resume: null as unknown },
+  applyTemplate: vi.fn(),
+  toggleSectionVisibility: vi.fn(),
+  updateCustomSection: vi.fn(),
+  addCustomSection: vi.fn(() => "custom-1"),
+  removeCustomSection: vi.fn(),
+  updateMetadata: vi.fn(),
+  updateLayout: vi.fn(),
+}));
+
+vi.mock("../../../stores/resume", () => ({ resumeStore: store }));
+
+const TEMPLATES: TemplateInfo[] = [
+  {
+    id: "aurora",
+    name: "Aurora",
+    theme: { background: "#ffffff", text: "#1c1917", primary: "#7c3aed" },
+    layout: {
+      layoutMode: "sidebar-left",
+      defaultColumns: [
+        ["summary", "experience", "education", "projects"],
+        ["profiles", "skills", "languages", "interests"],
+      ],
+      headerStyle: "sidebar",
+      contactIn: "sidebar",
+      sidebarWidth: 180,
+    },
+  },
+  {
+    // An older self-hosted server: no layout block on the wire at all.
+    id: "plainstone",
+    name: "Plainstone",
+    theme: { background: "#fafaf9", text: "#0c0a09", primary: "#0d9488" },
+  },
+];
+
+const api = vi.hoisted(() => ({
+  fetchTemplates: vi.fn(),
+  getTemplateThumbnailUrl: vi.fn((id: string) => `/api/templates/${id}/thumbnail`),
+}));
+
+vi.mock("../../../api/render", () => api);
+
+/** Total writes recorded across every mocked store action. */
+function writeCount(): number {
+  return Object.entries(store)
+    .filter(([key]) => key !== "store")
+    .reduce((total, [, action]) => total + (action as Mock).mock.calls.length, 0);
+}
+
+describe("document editor panels", () => {
+  let resume: ResumeData;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.fetchTemplates.mockResolvedValue(TEMPLATES);
+    resume = loadDocEditorFixture();
+    store.store.resume = resume;
+  });
+
+  describe("templates drawer", () => {
+    async function openDrawer() {
+      render(() => <TemplatesDrawer resume={resume} />);
+      fireEvent.click(screen.getByRole("button", { name: "Templates" }));
+      await waitFor(() => expect(screen.getByTestId("templates-drawer-list")).toBeInTheDocument());
+    }
+
+    it("renders one card per template from the registry, layout metadata included", async () => {
+      await openDrawer();
+
+      const list = screen.getByTestId("templates-drawer-list");
+      const cards = within(list).getAllByRole("button");
+      expect(cards).toHaveLength(2);
+      expect(within(list).getByRole("button", { name: "Use Aurora template" })).toBeInTheDocument();
+      // The layout block renders as card metadata — sidebar width is in points.
+      expect(list.textContent).toContain("Left sidebar · 180pt sidebar");
+      // Thumbnails come from the server endpoint, per template.
+      expect(api.getTemplateThumbnailUrl).toHaveBeenCalledWith("aurora");
+      expect(api.getTemplateThumbnailUrl).toHaveBeenCalledWith("plainstone");
+    });
+
+    it("marks the resume's current template", async () => {
+      resume.metadata.template = "aurora";
+      await openDrawer();
+
+      const current = screen.getByRole("button", { name: "Use Aurora template" });
+      expect(current).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: "Use Plainstone template" })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    it("switches template and layout through one combined store action", async () => {
+      await openDrawer();
+
+      fireEvent.click(screen.getByRole("button", { name: "Use Aurora template" }));
+
+      expect(store.applyTemplate).toHaveBeenCalledOnce();
+      expect(writeCount()).toBe(1);
+      const [templateId, layout] = store.applyTemplate.mock.calls[0] as [string, string[][][]];
+      expect(templateId).toBe("aurora");
+      // The new template's page-0 defaults win...
+      expect(layout).toHaveLength(1);
+      expect(layout[0][0].slice(0, 4)).toEqual(["summary", "experience", "education", "projects"]);
+      // ...and custom sections the defaults do not mention are re-placed,
+      // never dropped.
+      const placed = layout.flat(2);
+      expect(placed).toContain("speaking");
+      expect(placed).toContain("advisory");
+    });
+
+    it("falls back to the single-column layout for a template without metadata", async () => {
+      await openDrawer();
+
+      fireEvent.click(screen.getByRole("button", { name: "Use Plainstone template" }));
+
+      const [templateId, layout] = store.applyTemplate.mock.calls[0] as [string, string[][][]];
+      expect(templateId).toBe("plainstone");
+      expect(layout).toHaveLength(1);
+      expect(layout[0]).toHaveLength(1);
+      expect(layout[0][0]).toContain("summary");
+      expect(layout[0][0]).toContain("speaking");
+      expect(layout[0][0]).toContain("advisory");
+    });
+
+    it("reports a registry failure instead of an empty drawer", async () => {
+      api.fetchTemplates.mockRejectedValue(new Error("down"));
+      render(() => <TemplatesDrawer resume={resume} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Templates" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(/failed to load templates/i);
+      });
+    });
+  });
+
+  describe("sections panel", () => {
+    function openPanel() {
+      render(() => <SectionsPanel resume={resume} />);
+      fireEvent.click(screen.getByRole("button", { name: "Sections" }));
+      return screen.getByTestId("sections-panel");
+    }
+
+    it("toggles a fixed section through toggleSectionVisibility", () => {
+      const panel = openPanel();
+
+      fireEvent.click(within(panel).getByRole("switch", { name: "Experience" }));
+
+      expect(store.toggleSectionVisibility).toHaveBeenCalledExactlyOnceWith("experience");
+      expect(writeCount()).toBe(1);
+    });
+
+    it("re-shows a custom section that starts hidden", () => {
+      // `advisory` is switched off in the fixture, so it has no card on the
+      // sheet — the panel is the only way back.
+      const panel = openPanel();
+      const toggle = within(panel).getByRole("switch", { name: "Advisory & Standards Work" });
+      expect(toggle).not.toBeChecked();
+
+      fireEvent.click(toggle);
+
+      expect(store.updateCustomSection).toHaveBeenCalledExactlyOnceWith("advisory", {
+        visible: true,
+      });
+      expect(writeCount()).toBe(1);
+    });
+
+    it("adds a custom section through the shared dialog", async () => {
+      const panel = openPanel();
+
+      fireEvent.click(within(panel).getByRole("button", { name: "Add section" }));
+      const dialog = await screen.findByRole("dialog", { name: "Add section" });
+      fireEvent.input(within(dialog).getByRole("textbox", { name: "Section name" }), {
+        target: { value: "Patents" },
+      });
+      fireEvent.click(within(dialog).getByRole("button", { name: "Add section" }));
+
+      expect(store.addCustomSection).toHaveBeenCalledExactlyOnceWith("Patents");
+      expect(writeCount()).toBe(1);
+    });
+
+    it("removes a custom section through removeCustomSection", () => {
+      const panel = openPanel();
+
+      fireEvent.click(
+        within(panel).getByRole("button", { name: "Delete Talks & Workshops section" }),
+      );
+
+      expect(store.removeCustomSection).toHaveBeenCalledExactlyOnceWith("speaking");
+      expect(writeCount()).toBe(1);
+    });
+
+    it("commits notes as plain text, with no rich-text controls", () => {
+      const panel = openPanel();
+
+      const notes = within(panel).getByRole("textbox", { name: "Notes" });
+      expect(notes.tagName).toBe("TEXTAREA");
+      // Plain scratch text: no rich editor, no markdown toolbar.
+      expect(panel.querySelector("[contenteditable]")).toBeNull();
+      expect(within(panel).queryByRole("toolbar")).toBeNull();
+
+      fireEvent.input(notes, { target: { value: "Ask about the design-systems team." } });
+
+      expect(store.updateMetadata).toHaveBeenCalledExactlyOnceWith(
+        "notes",
+        "Ask about the design-systems team.",
+      );
+    });
+  });
+});

--- a/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
@@ -141,7 +141,7 @@ describe("document editor panels", () => {
       expect(layout[0][0]).toContain("advisory");
     });
 
-    it("reports a registry failure instead of an empty drawer", async () => {
+    it("reports a registry failure, and retries without reopening", async () => {
       api.fetchTemplates.mockRejectedValue(new Error("down"));
       render(() => <TemplatesDrawer resume={resume} />);
 
@@ -149,6 +149,13 @@ describe("document editor panels", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("alert")).toHaveTextContent(/failed to load templates/i);
+      });
+
+      api.fetchTemplates.mockResolvedValue(TEMPLATES);
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("templates-drawer-list")).toBeInTheDocument();
       });
     });
   });

--- a/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
@@ -127,6 +127,19 @@ describe("document editor panels", () => {
       expect(placed).toContain("advisory");
     });
 
+    it("treats re-picking the current template as a no-op", async () => {
+      // Regression: applyTemplate rebuilds metadata.layout onto one page, so
+      // activating the Current card must write nothing — otherwise a stray
+      // click flattens manual page/column placement and burns an undo entry.
+      resume.metadata.template = "aurora";
+      await openDrawer();
+
+      fireEvent.click(screen.getByRole("button", { name: "Use Aurora template" }));
+
+      expect(store.applyTemplate).not.toHaveBeenCalled();
+      expect(writeCount()).toBe(0);
+    });
+
     it("falls back to the single-column layout for a template without metadata", async () => {
       await openDrawer();
 

--- a/apps/web/src/components/doc-editor/docEdits.ts
+++ b/apps/web/src/components/doc-editor/docEdits.ts
@@ -12,7 +12,7 @@
  * once, on save, rather than per keystroke.
  */
 
-import { isCustomId } from "../../lib/docLayout";
+import { isCustomId, layoutForTemplate, type TemplateLayout } from "../../lib/docLayout";
 import { resumeStore, type LayoutSectionKey, type SectionKey } from "../../stores/resume";
 import type { Basics, CustomItem, Picture } from "../../wasm/types";
 
@@ -156,4 +156,22 @@ export function moveItemAcrossSections(
 /** Replace `metadata.layout` wholesale — one drop, one layout write. */
 export function applyLayout(layout: string[][][]): void {
   resumeStore.updateLayout(layout);
+}
+
+/**
+ * Switch the resume to `templateId` — one store action, one undo entry.
+ *
+ * The fresh `metadata.layout` is derived from the new template's default
+ * columns by `layoutForTemplate`, which re-places custom sections (and fixed
+ * sections the defaults do not mention) rather than dropping them.
+ */
+export function applyTemplate(templateId: string, templateLayout: TemplateLayout): void {
+  const resume = resumeStore.store.resume;
+  if (!resume) return;
+  resumeStore.applyTemplate(templateId, layoutForTemplate(resume, templateLayout));
+}
+
+/** Replace the private notes scratch text. Plain text; never rendered to PDF. */
+export function updateNotes(notes: string): void {
+  resumeStore.updateMetadata("notes", notes);
 }

--- a/apps/web/src/components/doc-editor/index.ts
+++ b/apps/web/src/components/doc-editor/index.ts
@@ -7,3 +7,5 @@ export { MarkdownEditor, type MarkdownEditorProps } from "./MarkdownEditor";
 export { ItemDialog, type ItemDialogProps } from "./ItemDialog";
 export { CustomSectionDialog, type CustomSectionDialogProps } from "./CustomSectionDialog";
 export { PhotoDialog, type PhotoDialogProps } from "./PhotoDialog";
+export { TemplatesDrawer, type TemplatesDrawerProps } from "./TemplatesDrawer";
+export { SectionsPanel, type SectionsPanelProps } from "./SectionsPanel";

--- a/apps/web/src/components/ui/Drawer.tsx
+++ b/apps/web/src/components/ui/Drawer.tsx
@@ -44,7 +44,13 @@ export const Drawer: ParentComponent<DrawerProps> = (props) => {
             class="focus-ring absolute top-3 right-3 rounded-lg p-2 text-stone transition-colors
               hover:bg-surface hover:text-ink"
           >
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg
+              class="w-5 h-5"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"

--- a/apps/web/src/components/ui/Drawer.tsx
+++ b/apps/web/src/components/ui/Drawer.tsx
@@ -16,7 +16,10 @@ export interface DrawerProps {
  * edge so it reads as chrome around the page rather than an interruption.
  */
 export const Drawer: ParentComponent<DrawerProps> = (props) => {
-  const sideClass = () => (props.side === "left" ? "left-0 border-r" : "right-0 border-l");
+  const sideClass = () =>
+    props.side === "left"
+      ? "left-0 border-r animate-slide-in-left"
+      : "right-0 border-l animate-slide-in-right";
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
@@ -24,7 +27,7 @@ export const Drawer: ParentComponent<DrawerProps> = (props) => {
         <Dialog.Overlay class="fixed inset-0 bg-ink/40 backdrop-blur-sm z-40 animate-fade-in" />
         <Dialog.Content
           class={`fixed inset-y-0 z-50 flex w-full max-w-sm flex-col border-border bg-paper
-            shadow-elevated animate-fade-in ${sideClass()}`}
+            shadow-elevated ${sideClass()}`}
         >
           <div class="border-b border-border px-5 py-4">
             <Dialog.Title class="font-display text-lg font-semibold text-ink">

--- a/apps/web/src/components/ui/Drawer.tsx
+++ b/apps/web/src/components/ui/Drawer.tsx
@@ -1,0 +1,60 @@
+import { Dialog } from "@kobalte/core/dialog";
+import { type ParentComponent, Show } from "solid-js";
+
+export interface DrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  /** Edge the drawer slides in from. Defaults to `right`. */
+  side?: "left" | "right";
+}
+
+/**
+ * A side sheet built on the same Kobalte dialog as `Modal` — focus trap,
+ * Escape-to-close and ARIA labelling for free — but anchored to a screen
+ * edge so it reads as chrome around the page rather than an interruption.
+ */
+export const Drawer: ParentComponent<DrawerProps> = (props) => {
+  const sideClass = () => (props.side === "left" ? "left-0 border-r" : "right-0 border-l");
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay class="fixed inset-0 bg-ink/40 backdrop-blur-sm z-40 animate-fade-in" />
+        <Dialog.Content
+          class={`fixed inset-y-0 z-50 flex w-full max-w-sm flex-col border-border bg-paper
+            shadow-elevated animate-fade-in ${sideClass()}`}
+        >
+          <div class="border-b border-border px-5 py-4">
+            <Dialog.Title class="font-display text-lg font-semibold text-ink">
+              {props.title}
+            </Dialog.Title>
+            <Show when={props.description}>
+              <Dialog.Description class="mt-1 text-sm text-stone">
+                {props.description}
+              </Dialog.Description>
+            </Show>
+          </div>
+
+          <div class="flex-1 overflow-y-auto px-5 py-4">{props.children}</div>
+
+          <Dialog.CloseButton
+            aria-label="Close"
+            class="focus-ring absolute top-3 right-3 rounded-lg p-2 text-stone transition-colors
+              hover:bg-surface hover:text-ink"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </Dialog.CloseButton>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
+  );
+};

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -7,6 +7,7 @@ export {
   type RichTextEditorProps,
 } from "./LazyRichTextEditor";
 export { Modal, type ModalProps } from "./Modal";
+export { Drawer, type DrawerProps } from "./Drawer";
 export { Accordion, type AccordionProps, type AccordionItemData } from "./Accordion";
 export { Switch, type SwitchProps } from "./Switch";
 export { Spinner, type SpinnerProps } from "./Spinner";

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -76,6 +76,8 @@
   /* Animations */
   --animate-fade-in: fade-in 0.4s ease-out;
   --animate-slide-up: slide-up 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+  --animate-slide-in-left: slide-in-left 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  --animate-slide-in-right: slide-in-right 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   --animate-ink-drop: ink-drop 0.6s ease-out;
   --animate-pulse-subtle: pulse-subtle 2s ease-in-out infinite;
 }
@@ -105,6 +107,25 @@
   }
   to {
     transform: translateY(0);
+  }
+}
+
+/* Edge-anchored drawers. Like `slide-up`, movement only — drawers carry text. */
+@keyframes slide-in-left {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
   }
 }
 

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -115,6 +115,22 @@ export interface TemplateLayout {
   sidebarWidth: number | null;
 }
 
+/**
+ * Layout used when a template's own metadata cannot be fetched.
+ *
+ * A single column holding every section in canonical order — the same shape a
+ * single-column template declares — so the sheet still draws a faithful,
+ * complete document when `GET /api/templates` is unavailable, or when a
+ * template served by an older self-hosted server carries no layout block.
+ */
+export const FALLBACK_TEMPLATE_LAYOUT: TemplateLayout = {
+  layoutMode: "single",
+  defaultColumns: [[...FIXED_SECTION_IDS, CUSTOM_SECTION_SENTINEL], []],
+  headerStyle: "left",
+  contactIn: "header",
+  sidebarWidth: null,
+};
+
 /** Where a section sits inside a `metadata.layout` array. */
 export interface SectionPlacement {
   /** Index of the page. */

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -43,8 +43,6 @@ const Preview = lazy(() =>
   import("../components/preview").then((module) => ({ default: module.Preview })),
 );
 
-export { FALLBACK_TEMPLATE_LAYOUT };
-
 export default function DocEditor() {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -20,7 +20,7 @@ import {
 } from "solid-js";
 import { useNavigate, useParams } from "@solidjs/router";
 import { Button, Spinner, toast } from "../components/ui";
-import { DocSheet } from "../components/doc-editor";
+import { DocSheet, SectionsPanel, TemplatesDrawer } from "../components/doc-editor";
 import { SplitPane } from "../components/layout/SplitPane";
 import { CustomCssInjector } from "../components/templates/CustomCssInjector";
 import { useHotkeys, type Shortcut } from "../hooks/useHotkeys";
@@ -28,7 +28,7 @@ import { usePageTitle } from "../hooks/usePageTitle";
 import { useNavigationGuard } from "../hooks/useNavigationGuard";
 import { useResumeRouteLoad } from "../hooks/useResumeRouteLoad";
 import { fetchTemplateLayouts } from "../api/render";
-import { CUSTOM_SECTION_SENTINEL, FIXED_SECTION_IDS, type TemplateLayout } from "../lib/docLayout";
+import { FALLBACK_TEMPLATE_LAYOUT, type TemplateLayout } from "../lib/docLayout";
 import { resumeStore } from "../stores/resume";
 import { uiStore } from "../stores/ui";
 import { undoHistoryStore } from "../stores/undoHistory";
@@ -43,20 +43,7 @@ const Preview = lazy(() =>
   import("../components/preview").then((module) => ({ default: module.Preview })),
 );
 
-/**
- * Layout used when the template's own metadata cannot be fetched.
- *
- * A single column holding every section in canonical order — the same shape a
- * single-column template declares — so the sheet still draws a faithful,
- * complete document when `GET /api/templates` is unavailable.
- */
-export const FALLBACK_TEMPLATE_LAYOUT: TemplateLayout = {
-  layoutMode: "single",
-  defaultColumns: [[...FIXED_SECTION_IDS, CUSTOM_SECTION_SENTINEL], []],
-  headerStyle: "left",
-  contactIn: "header",
-  sidebarWidth: null,
-};
+export { FALLBACK_TEMPLATE_LAYOUT };
 
 export default function DocEditor() {
   const params = useParams<{ id: string }>();
@@ -191,6 +178,18 @@ export default function DocEditor() {
         decision made elsewhere.
       */}
       <div class="h-12 flex items-center justify-between gap-4 border-b border-border bg-paper px-4">
+        {/* Panel chrome around the sheet: the drawers overlay the surface and
+            never disturb the page frames or their drop zones. */}
+        <div class="flex items-center gap-2">
+          <Show when={store.resume}>
+            {(resume) => (
+              <>
+                <TemplatesDrawer resume={resume()} />
+                <SectionsPanel resume={resume()} />
+              </>
+            )}
+          </Show>
+        </div>
         <p class="font-mono text-xs text-stone" data-testid="doc-editor-page-count">
           {/* No count until a sheet exists — otherwise this reads "0 pages"
               while loading and behind the load-error screen. Also hidden while

--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -34,6 +34,17 @@ vi.mock("../../wasm", async (importOriginal) => {
 
 vi.mock("../../api/render", () => ({
   fetchTemplateLayouts: vi.fn(() => Promise.resolve({ ditto: SIDEBAR_TEMPLATE })),
+  fetchTemplates: vi.fn(() =>
+    Promise.resolve([
+      {
+        id: "ditto",
+        name: "Ditto",
+        theme: { background: "#ffffff", text: "#1c1917", primary: "#7c3aed" },
+        layout: SIDEBAR_TEMPLATE,
+      },
+    ]),
+  ),
+  getTemplateThumbnailUrl: vi.fn((id: string) => `/api/templates/${id}/thumbnail`),
   renderPreview: vi.fn().mockResolvedValue(new Blob()),
   downloadPdf: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -226,3 +226,47 @@ describe("moveCustomSectionItem", () => {
     });
   });
 });
+
+describe("applyTemplate", () => {
+  it("lands template and layout in one write", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, addCustomSection, applyTemplate } = useResumeStore();
+      createNewResume("tpl-1");
+      const sectionId = addCustomSection("Talks");
+
+      applyTemplate("aurora", [[["summary", "experience"], [sectionId]]]);
+
+      expect(store.resume!.metadata.template).toBe("aurora");
+      expect(store.resume!.metadata.layout).toEqual([[["summary", "experience"], [sectionId]]]);
+      dispose();
+    });
+  });
+
+  it("is a single undo entry: undoing restores template and layout together", () => {
+    vi.useFakeTimers();
+    try {
+      createRoot((dispose) => {
+        const { store, createNewResume, applyTemplate, undo } = useResumeStore();
+        createNewResume("tpl-2");
+        // Settle the undo debounce so the switch opens its own edit burst.
+        vi.advanceTimersByTime(600);
+        const templateBefore = store.resume!.metadata.template;
+        const layoutBefore = JSON.parse(
+          JSON.stringify(store.resume!.metadata.layout),
+        ) as string[][][];
+
+        applyTemplate("aurora", [[["summary"], []]]);
+        vi.advanceTimersByTime(600);
+
+        expect(undo()).toBe(true);
+        expect(store.resume!.metadata.template).toBe(templateBefore);
+        expect(store.resume!.metadata.layout).toEqual(layoutBefore);
+        // One entry, not two: a second undo has nothing of this switch left.
+        expect(undo()).toBe(false);
+        dispose();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -797,6 +797,24 @@ export function useResumeStore() {
       markDirty();
     },
 
+    /**
+     * Switch templates as **one** action: `metadata.template` and the fresh
+     * `metadata.layout` land in a single write, so the switch is a single
+     * undo entry — undoing it restores the previous template and its layout
+     * together.
+     */
+    applyTemplate(template: string, layout: string[][][]) {
+      setStore(
+        produce((s) => {
+          if (s.resume) {
+            s.resume.metadata.template = template;
+            s.resume.metadata.layout = layout;
+          }
+        }),
+      );
+      markDirty();
+    },
+
     updateTheme(theme: Partial<Metadata["theme"]>) {
       setStore(
         produce((s) => {

--- a/apps/web/src/wasm/types.ts
+++ b/apps/web/src/wasm/types.ts
@@ -1,5 +1,8 @@
 // TypeScript types matching the Rust ResumeData schema
 
+// Type-only: erased at runtime, so no module cycle with `lib/docLayout`.
+import type { TemplateLayout } from "../lib/docLayout";
+
 export interface Url {
   label: string;
   href: string;
@@ -312,6 +315,12 @@ export interface TemplateInfo {
   id: string;
   name: string;
   theme: Theme;
+  /**
+   * Structural layout metadata from the registry (`GET /api/templates`).
+   * Absent when the server predates the field — callers fall back to
+   * `FALLBACK_TEMPLATE_LAYOUT`.
+   */
+  layout?: TemplateLayout;
 }
 
 export interface ValidationResult {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): add templates drawer and sections panel backed by the registry API
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds the two remaining pieces of document-editor chrome from the #721 epic: a
**templates drawer** and a **sections panel**, both driven by the server
template registry rather than any client-side table.

### Templates drawer

- Cards built from the `GET /api/templates` response — id, name, theme and the
  layout block from #724 — via the app's existing `fetchTemplates` API helper
  (SWR-cached endpoint), fetched lazily on first open with an in-drawer retry
  on failure.
- Server-rendered thumbnails per card, with a theme-swatch placeholder while
  they load (or when they fail).
- Layout metadata rendered on each card (`Left sidebar · 180pt sidebar` — the
  registry's `sidebarWidth` is typographic points, surfaced as such).
- **Switching a template is one store action and one undo entry**: a new
  combined `resumeStore.applyTemplate(template, layout)` lands
  `metadata.template` and a fresh `metadata.layout` (derived by
  `docLayout.layoutForTemplate()` from the new template's `defaultColumns`) in
  a single write. Custom sections the defaults do not mention are re-placed,
  never dropped. The sheet re-renders from the new layout reactively, drop
  zones untouched.
- A template served without layout metadata (older self-hosted server) falls
  back to the shared single-column `FALLBACK_TEMPLATE_LAYOUT`, now hoisted from
  `pages/DocEditor.tsx` into `lib/docLayout.ts` (re-exported for compatibility).

### Sections panel

- Visibility toggles for every fixed and custom section — including sections
  currently hidden and therefore absent from the sheet, which is what makes a
  hidden section recoverable.
- Custom-section add (through the same `CustomSectionDialog` the sheet uses, so
  layout placement stays one undo entry) and remove.
- Notes as a plain multi-line text field bound to `metadata.notes` — no rich
  editor, no markdown toolbar — replacing the form builder's rich
  `NotesEditor` dependency so #735 can delete it.

### Plumbing

- New `Drawer` UI primitive on the same Kobalte dialog as `Modal` (focus trap,
  Escape, ARIA labelling) styled as an edge-anchored side sheet.
- Both panels are chrome around the sheet, mounted additively in the editor's
  top bar; `DocSheet` and the #729 DnD surface are untouched, and every
  mutation routes through `docEdits` (decision 4 — the store-contract test
  still passes over the new files).
- Theme colours and custom CSS remain with `ThemeEditor` / `CustomCssInjector`
  (out of scope per the issue).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` 100/100; full web vitest suite green)

## Closes

- Closes #731
- Relates to #721

## Details

**Testing**

- `apps/web/src/components/doc-editor/__tests__/panels.test.tsx` (new):
  cards render one per template from a mocked registry payload with layout
  metadata; switching emits exactly one combined store write with every custom
  section still placed; fallback layout for a template without metadata;
  registry-failure + retry; fixed/custom visibility toggles (including
  re-showing a section that starts hidden); custom add/remove; notes commit as
  plain text with an assertion that no rich-text controls render.
- `apps/web/src/stores/__tests__/structuralActions.test.ts`: `applyTemplate`
  lands template + layout in one write, and a single `undo()` restores both
  together (and a second `undo()` finds nothing — proving one undo entry).
- Full web suite: **77 files / 864 tests passing**; `tsc --noEmit` clean for
  app and e2e configs.

**Pre-push AI review**

- CodeRabbit: 3 findings. Fixed: `aria-hidden` on the drawer close icon;
  in-drawer retry for a failed registry fetch. Deliberately skipped: the
  suggestion to rewire the form builder's `TemplatePicker` onto
  `applyTemplate` — that component is bound to the builder flow and is deleted
  wholesale by #735; changing its template/theme/undo semantics is out of
  scope for this issue and would collide with the builder-retirement lane.
- Greptile: unavailable this run (`free_reviews_limit_reached`).

**Known limitation (pre-existing, surfaced — not introduced — by this PR)**

Toggling ON a fixed section that is absent from a non-empty
`metadata.layout` is a silent no-op: `toggleSectionVisibility` flips the
section's `visible` flag but nothing places its id back into the layout, and
store normalization back-fills only *custom* ids. This is reachable only via
legacy or pruned layouts; the sections panel is simply the first UI where such
a toggle can be attempted. A follow-up issue is being considered to back-fill
missing fixed ids (or place-on-show) rather than widening this PR's scope.

**Parallel-lane notes**

- No changes to `resumeStore`'s undo/save internals (#730 lane) — the new
  `applyTemplate` action is purely additive next to `updateTemplate`.
- `components/preview/Preview.tsx` untouched and `pages/DocEditor.tsx` touched
  additively only (imports + a button group in the top bar), to stay clear of
  PR #765.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added template browsing with thumbnails, layout previews, loading states, and retry handling.
  * Added a sections panel for showing, hiding, creating, and removing document sections.
  * Added private notes editing within the document editor.
  * Added reusable drawer panels with accessible controls and slide-in animations.
  * Applying a template now updates its layout while preserving existing content.
  * Added a fallback layout for templates without layout metadata.

* **Tests**
  * Added coverage for template selection, section management, notes, error handling, and undo behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->