### PR TITLE
fix(ci): recover cargo through rustup when the macOS image ships no shims

### DIFF
--- a/scripts/ci/release/build-binaries.sh
+++ b/scripts/ci/release/build-binaries.sh
@@ -43,6 +43,24 @@ if ! command -v "$BUILD_CMD" >/dev/null 2>&1 && [[ -x "$CARGO_BIN/$BUILD_CMD" ]]
 	export PATH="$CARGO_BIN:$PATH"
 fi
 
+# macos-15-intel again, one layer deeper (#774): rustup is on PATH but the
+# cargo shims never land in CARGO_HOME/bin at all. Ask rustup for the real
+# cargo, installing stable first if the image shipped rustup with no
+# toolchain. cross is exempt — it is installed by cargo-binstall, not rustup.
+if ! command -v "$BUILD_CMD" >/dev/null 2>&1 &&
+	[[ "$BUILD_CMD" == "cargo" ]] &&
+	command -v rustup >/dev/null 2>&1; then
+	if ! rustup which cargo >/dev/null 2>&1; then
+		rustup toolchain install stable --profile minimal >&2
+		rustup default stable >&2
+	fi
+	if TOOLCHAIN_CARGO="$(rustup which cargo 2>/dev/null)"; then
+		echo "cargo absent from $CARGO_BIN; using $(dirname "$TOOLCHAIN_CARGO") via rustup" >&2
+		PATH="$(dirname "$TOOLCHAIN_CARGO"):$PATH"
+		export PATH
+	fi
+fi
+
 if ! command -v "$BUILD_CMD" >/dev/null 2>&1; then
 	echo "$BUILD_CMD not found on PATH after checking $CARGO_BIN." >&2
 	echo "The Rust toolchain setup did not produce a usable $BUILD_CMD." >&2

--- a/scripts/ci/release/build-binaries.sh
+++ b/scripts/ci/release/build-binaries.sh
@@ -46,7 +46,8 @@ fi
 # macos-15-intel again, one layer deeper (#774): rustup is on PATH but the
 # cargo shims never land in CARGO_HOME/bin at all. Ask rustup for the real
 # cargo, installing stable first if the image shipped rustup with no
-# toolchain. cross is exempt — it is installed by cargo-binstall, not rustup.
+# toolchain. cross is exempt — it is installed separately (cargo install
+# cross --locked), never provided by rustup.
 if ! command -v "$BUILD_CMD" >/dev/null 2>&1 &&
 	[[ "$BUILD_CMD" == "cargo" ]] &&
 	command -v rustup >/dev/null 2>&1; then

--- a/tests/bats/unit/release/test_build_binaries.bats
+++ b/tests/bats/unit/release/test_build_binaries.bats
@@ -124,8 +124,13 @@ _write_cargo_stub() {
 			exit 1
 			;;
 		toolchain)
-			: >"${marker}"
-			exit 0
+			# Enforce the exact install contract the script promises.
+			if [[ "\$*" == "toolchain install stable --profile minimal" ]]; then
+				: >"${marker}"
+				exit 0
+			fi
+			echo "unexpected rustup toolchain args: \$*" >&2
+			exit 1
 			;;
 		esac
 		exit 0
@@ -147,11 +152,15 @@ _write_cargo_stub() {
 
 @test "cross does not trigger the rustup recovery" {
 	# A rustup that would resolve cargo must not be consulted for cross —
-	# cross is installed by cargo-binstall, not rustup.
+	# cross is installed separately (cargo install cross --locked), never
+	# provided by rustup. The stub records any invocation so a silent call
+	# cannot hide behind the expected final error.
 	local rustup_dir="${BATS_TEST_TMPDIR}/rustupbin3"
+	local called="${BATS_TEST_TMPDIR}/rustup-called"
 	mkdir -p "${rustup_dir}"
-	cat >"${rustup_dir}/rustup" <<-'EOF'
+	cat >"${rustup_dir}/rustup" <<-EOF
 		#!/usr/bin/env bash
+		: >"${called}"
 		echo "rustup should not be called for cross" >&2
 		exit 1
 	EOF
@@ -163,6 +172,10 @@ _write_cargo_stub() {
 
 	assert_failure
 	[[ "${output}" == *"cross not found on PATH"* ]]
+	[[ ! -f "${called}" ]] || {
+		echo "# rustup was invoked during a cross build" >&2
+		return 1
+	}
 }
 
 @test "defaults CARGO_HOME to ~/.cargo when unset" {

--- a/tests/bats/unit/release/test_build_binaries.bats
+++ b/tests/bats/unit/release/test_build_binaries.bats
@@ -74,6 +74,97 @@ _write_cargo_stub() {
 	grep -q -- "--target x86_64-apple-darwin" "${log}"
 }
 
+@test "recovers cargo through rustup when CARGO_HOME/bin has no shims (#774)" {
+	# macos-15-intel: rustup resolves but cargo shims never land in
+	# CARGO_HOME/bin. The script must ask rustup where cargo lives.
+	local rustup_dir="${BATS_TEST_TMPDIR}/rustupbin"
+	local toolchain_bin="${BATS_TEST_TMPDIR}/toolchain/bin"
+	mkdir -p "${rustup_dir}" "${toolchain_bin}"
+	_write_cargo_stub "${toolchain_bin}/cargo"
+	cat >"${rustup_dir}/rustup" <<-EOF
+		#!/usr/bin/env bash
+		if [[ "\${1:-}" == "which" ]]; then
+			echo "${toolchain_bin}/cargo"
+			exit 0
+		fi
+		exit 0
+	EOF
+	chmod +x "${rustup_dir}/rustup"
+	local log="${BATS_TEST_TMPDIR}/cargo-rustup.log"
+
+	run env PATH="${rustup_dir}:${MINIMAL_PATH}" CARGO_HOME="${FAKE_CARGO_HOME}" \
+		CARGO_STUB_LOG="${log}" TARGET=x86_64-apple-darwin \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	assert_success
+	[[ "${output}" == *"using ${toolchain_bin} via rustup"* ]] || {
+		echo "# expected the rustup recovery to be announced, got: ${output}" >&2
+		return 1
+	}
+	grep -q -- "-p rustume-cli" "${log}"
+	grep -q -- "--target x86_64-apple-darwin" "${log}"
+}
+
+@test "installs stable through rustup when no toolchain is present (#774)" {
+	# rustup exists but `rustup which cargo` fails until a toolchain is
+	# installed — the script must install stable, then retry.
+	local rustup_dir="${BATS_TEST_TMPDIR}/rustupbin2"
+	local toolchain_bin="${BATS_TEST_TMPDIR}/toolchain2/bin"
+	local marker="${BATS_TEST_TMPDIR}/installed"
+	mkdir -p "${rustup_dir}" "${toolchain_bin}"
+	_write_cargo_stub "${toolchain_bin}/cargo"
+	cat >"${rustup_dir}/rustup" <<-EOF
+		#!/usr/bin/env bash
+		case "\${1:-}" in
+		which)
+			if [[ -f "${marker}" ]]; then
+				echo "${toolchain_bin}/cargo"
+				exit 0
+			fi
+			exit 1
+			;;
+		toolchain)
+			: >"${marker}"
+			exit 0
+			;;
+		esac
+		exit 0
+	EOF
+	chmod +x "${rustup_dir}/rustup"
+	local log="${BATS_TEST_TMPDIR}/cargo-install.log"
+
+	run env PATH="${rustup_dir}:${MINIMAL_PATH}" CARGO_HOME="${FAKE_CARGO_HOME}" \
+		CARGO_STUB_LOG="${log}" TARGET=x86_64-apple-darwin \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	assert_success
+	[[ -f "${marker}" ]] || {
+		echo "# expected rustup toolchain install to be invoked" >&2
+		return 1
+	}
+	grep -q -- "-p rustume-server" "${log}"
+}
+
+@test "cross does not trigger the rustup recovery" {
+	# A rustup that would resolve cargo must not be consulted for cross —
+	# cross is installed by cargo-binstall, not rustup.
+	local rustup_dir="${BATS_TEST_TMPDIR}/rustupbin3"
+	mkdir -p "${rustup_dir}"
+	cat >"${rustup_dir}/rustup" <<-'EOF'
+		#!/usr/bin/env bash
+		echo "rustup should not be called for cross" >&2
+		exit 1
+	EOF
+	chmod +x "${rustup_dir}/rustup"
+
+	run env PATH="${rustup_dir}:${MINIMAL_PATH}" CARGO_HOME="${FAKE_CARGO_HOME}" \
+		TARGET=aarch64-unknown-linux-gnu USE_CROSS=true \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	assert_failure
+	[[ "${output}" == *"cross not found on PATH"* ]]
+}
+
 @test "defaults CARGO_HOME to ~/.cargo when unset" {
 	local home="${BATS_TEST_TMPDIR}/home"
 	mkdir -p "${home}/.cargo/bin"


### PR DESCRIPTION
## Summary

Fixes the deterministic `x86_64-apple-darwin` binary-build failure (#774) that has withheld the v0.60.0 and v0.61.0 GitHub releases: the updated macos-15-intel runner image leaves `rustup` on PATH while the cargo shims never appear in `CARGO_HOME/bin`, so `build-binaries.sh`'s existing recovery (which only checks that directory) fails before compiling — 18+ consecutive attempts across both tags.

## Changes

- `scripts/ci/release/build-binaries.sh`: when `cargo` is absent from PATH and `CARGO_HOME/bin` but `rustup` resolves, ask `rustup which cargo` for the real binary — installing `stable --profile minimal` first if the image shipped rustup with no toolchain — and prepend its directory to PATH. `cross` is exempt (installed by cargo-binstall, not rustup).
- `tests/bats/unit/release/test_build_binaries.bats`: three new tests — rustup-shim recovery, install-then-retry when no toolchain exists, and cross never consulting rustup. Suite is 8/8.

## Notes

- Root-caused after ruling out an lgtm-ci pin bump: `setup-rust` is byte-identical between the pinned v0.59.16 and v0.63.0, so the pin was never the problem (issue #774's original proposal is corrected by this PR).
- After merge: re-dispatch `publish-release-on-tag.yml` at tags `v0.60.0` and `v0.61.0` to publish the withheld releases. (Tag runs use the workflow at the tag's commit, so those two may need one more manual dispatch from a ref containing this fix — see follow-up in comments if the direct rerun still fails.)

Closes #774

## AI review

CodeRabbit hosted review expected on this PR; Greptile has been rate-limited all session (noted per convention).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release builds to recover automatically when Cargo is unavailable.
  * Ensures the stable Rust toolchain is installed and selected when needed.
  * Preserves existing behavior for cross-compilation workflows.

* **Tests**
  * Added coverage for Cargo recovery, toolchain installation, and cross-compilation safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->