### PR TITLE
fix(web): place fixed sections on toggle-on and back-fill legacy layouts

### DIFF
--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -121,7 +121,9 @@ describe("DocEditor sheet", () => {
     expect(pageColumns(first)).toEqual([
       // `sidebar-left` paints the sidebar column first.
       ["sidebar", ["profiles", "skills", "speaking"]],
-      ["main", ["summary", "experience", "education", "projects"]],
+      // `coverLetter` and `references` are absent from the stored layout, so
+      // normalization back-fills them into the first main column (#770).
+      ["main", ["summary", "experience", "education", "projects", "coverLetter", "references"]],
     ]);
     expect(pageColumns(second)).toEqual([
       // `advisory` is switched off but stays drawn as chrome (see below).
@@ -182,8 +184,12 @@ describe("DocEditor sheet", () => {
     const advisory = document.querySelector('[data-section-id="advisory"]');
     expect(advisory).not.toBeNull();
     expect(advisory?.classList.contains("doc-sheet__section--hidden")).toBe(true);
-    // A section the layout never places is genuinely absent.
-    expect(document.querySelector('[data-section-id="references"]')).toBeNull();
+    // A section the stored layout never placed is back-filled by
+    // normalization (#770), so it surfaces as hidden chrome too instead of
+    // being silently unreachable from the sheet.
+    const references = document.querySelector('[data-section-id="references"]');
+    expect(references).not.toBeNull();
+    expect(references?.classList.contains("doc-sheet__section--hidden")).toBe(true);
   });
 
   it("offers every drawn value as a keyboard-reachable editing affordance", async () => {

--- a/apps/web/src/pages/__tests__/DocEditor.undo.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.undo.test.tsx
@@ -187,17 +187,26 @@ describe("DocEditor undo, autosave, and version history", () => {
   it("round-trips a section move as a single undo entry", async () => {
     await renderSheet();
     const before = mainColumnSections();
-    expect(before).toEqual(["summary", "experience", "education", "projects"]);
+    // `coverLetter` and `references` are back-filled by normalization (#770).
+    const moved = ["summary", "education", "experience", "projects", "coverLetter", "references"];
+    expect(before).toEqual([
+      "summary",
+      "experience",
+      "education",
+      "projects",
+      "coverLetter",
+      "references",
+    ]);
 
     fireEvent.click(screen.getByRole("button", { name: "Move Experience section down" }));
     await settleDebounce();
-    expect(mainColumnSections()).toEqual(["summary", "education", "experience", "projects"]);
+    expect(mainColumnSections()).toEqual(moved);
 
     fireEvent.click(undoButton());
     expect(mainColumnSections()).toEqual(before);
 
     fireEvent.click(redoButton());
-    expect(mainColumnSections()).toEqual(["summary", "education", "experience", "projects"]);
+    expect(mainColumnSections()).toEqual(moved);
   });
 
   it("collapses a rapid edit burst into one undo entry", async () => {

--- a/apps/web/src/stores/__tests__/resume.test.ts
+++ b/apps/web/src/stores/__tests__/resume.test.ts
@@ -389,7 +389,14 @@ describe("useResumeStore", () => {
 
       importResume(imported);
 
-      expect(store.resume!.metadata.layout[0]).toEqual([["experience", "custom-speaking"]]);
+      const missing = ["summary", "coverLetter", ...FIXED_LAYOUT_SECTION_KEYS].filter(
+        (id) => id !== "experience",
+      );
+      // Placed fixed ids keep their order, absent ones are back-filled (#770),
+      // custom ids come last.
+      expect(store.resume!.metadata.layout[0]).toEqual([
+        ["experience", ...missing, "custom-speaking"],
+      ]);
       expect(
         store.resume!.metadata.layout.flat(2).filter((id) => id === "experience"),
       ).toHaveLength(1);
@@ -406,7 +413,10 @@ describe("useResumeStore", () => {
 
       importResume(imported);
 
-      expect(store.resume!.metadata.layout[0]).toEqual([["coverLetter", "experience"]]);
+      const missing = ["summary", "coverLetter", ...FIXED_LAYOUT_SECTION_KEYS].filter(
+        (id) => !["coverLetter", "experience"].includes(id),
+      );
+      expect(store.resume!.metadata.layout[0]).toEqual([["coverLetter", "experience", ...missing]]);
       expect(
         store.resume!.metadata.layout.flat(2).filter((id) => id === "coverLetter"),
       ).toHaveLength(1);
@@ -581,7 +591,11 @@ describe("useResumeStore", () => {
 
       importResume(imported);
 
-      expect(store.resume!.metadata.layout).toEqual([[[]], [[]]]);
+      expect(store.resume!.metadata.layout).toEqual([
+        // Nothing was placed, so every fixed id is back-filled (#770).
+        [["summary", "coverLetter", ...FIXED_LAYOUT_SECTION_KEYS]],
+        [[]],
+      ]);
       expect(store.resume!.metadata.layout.flat(2)).not.toContain("custom");
       dispose();
     });
@@ -612,7 +626,12 @@ describe("useResumeStore", () => {
       importResume(imported);
       const sectionId = addCustomSection("Writing");
 
-      expect(store.resume!.metadata.layout[0]).toEqual([["education", "skills", sectionId]]);
+      const missing = ["summary", "coverLetter", ...FIXED_LAYOUT_SECTION_KEYS].filter(
+        (id) => !["education", "skills"].includes(id),
+      );
+      expect(store.resume!.metadata.layout[0]).toEqual([
+        ["education", "skills", ...missing, sectionId],
+      ]);
       expect(store.resume!.metadata.layout.flat(2).filter((id) => id === "education")).toHaveLength(
         1,
       );
@@ -1280,6 +1299,19 @@ describe("unplaced fixed sections (#770)", () => {
       // An empty layout renders the template's default columns, which place
       // every fixed section already — nothing to repair.
       expect(store.resume!.metadata.layout).toEqual([]);
+      dispose();
+    });
+  });
+
+  it("toggling on seeds the main column when page 0 has no columns", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, updateLayout, toggleSectionVisibility } = useResumeStore();
+      createNewResume("place-5");
+      updateLayout([[], [["experience"]]]);
+
+      toggleSectionVisibility("coverLetter");
+
+      expect(store.resume!.metadata.layout).toEqual([[["coverLetter"]], [["experience"]]]);
       dispose();
     });
   });

--- a/apps/web/src/stores/__tests__/resume.test.ts
+++ b/apps/web/src/stores/__tests__/resume.test.ts
@@ -2,6 +2,7 @@ import { createRoot } from "solid-js";
 import { createDefaultResume } from "../../wasm/defaults";
 import type { ResumeData } from "../../wasm/types";
 import { FIXED_LAYOUT_SECTION_KEYS } from "../../lib/resumeSections";
+import { editorPages, FALLBACK_TEMPLATE_LAYOUT } from "../../lib/docLayout";
 import {
   isResumeEmpty,
   useResumeStore,
@@ -490,7 +491,16 @@ describe("useResumeStore", () => {
       importResume(imported);
 
       expect(store.resume!.metadata.layout).toEqual([
-        [["summary", "custom-speaking", "custom-writing"]],
+        [
+          [
+            "summary",
+            "custom-speaking",
+            "custom-writing",
+            // Missing fixed ids are back-filled after the sentinel expands.
+            "coverLetter",
+            ...FIXED_LAYOUT_SECTION_KEYS,
+          ],
+        ],
       ]);
       expect(store.resume!.metadata.layout.flat(2)).not.toContain("custom");
       dispose();
@@ -553,7 +563,11 @@ describe("useResumeStore", () => {
 
       importResume(imported);
 
-      expect(store.resume!.metadata.layout).toEqual([[["summary"]], [[]]]);
+      expect(store.resume!.metadata.layout).toEqual([
+        // Missing fixed ids are back-filled once the sentinel is dropped.
+        [["summary", "coverLetter", ...FIXED_LAYOUT_SECTION_KEYS]],
+        [[]],
+      ]);
       expect(store.resume!.metadata.layout.flat(2)).not.toContain("custom");
       dispose();
     });
@@ -1173,5 +1187,137 @@ describe("section editor parity — all section types", () => {
         dispose();
       });
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #770 — a visible fixed section must always be placed in a non-empty layout
+// ---------------------------------------------------------------------------
+
+describe("unplaced fixed sections (#770)", () => {
+  it("importResume back-fills fixed ids missing from a non-empty layout", () => {
+    createRoot((dispose) => {
+      const { store, importResume } = useResumeStore();
+      const imported = createDefaultResume();
+      // A legacy layout saved before most fixed sections existed.
+      imported.metadata.layout = [[["summary", "experience"], ["skills"]]];
+
+      importResume(imported);
+
+      const missing = ["summary", "coverLetter", ...FIXED_LAYOUT_SECTION_KEYS].filter(
+        (id) => !["summary", "experience", "skills"].includes(id),
+      );
+      // Back-filled into the first (main) column; the sidebar is untouched.
+      expect(store.resume!.metadata.layout).toEqual([
+        [["summary", "experience", ...missing], ["skills"]],
+      ]);
+      dispose();
+    });
+  });
+
+  it("normalization back-fill is idempotent", () => {
+    createRoot((dispose) => {
+      const { store, importResume } = useResumeStore();
+      const imported = createDefaultResume();
+      imported.metadata.layout = [[["summary", "experience"], ["skills"]]];
+
+      importResume(imported);
+      const first = JSON.parse(JSON.stringify(store.resume!)) as ResumeData;
+      importResume(first);
+
+      expect(store.resume!.metadata.layout).toEqual(first.metadata.layout);
+      dispose();
+    });
+  });
+
+  it("toggling on an unplaced fixed section places it in the first main column", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, updateLayout, toggleSectionVisibility } = useResumeStore();
+      createNewResume("place-1");
+      // Drop coverLetter from the layout the way a legacy document would.
+      updateLayout([[["summary", "experience"], ["skills"]]]);
+      expect(store.resume!.sections.coverLetter.visible).toBe(false);
+
+      toggleSectionVisibility("coverLetter");
+
+      expect(store.resume!.sections.coverLetter.visible).toBe(true);
+      expect(store.resume!.metadata.layout).toEqual([
+        [["summary", "experience", "coverLetter"], ["skills"]],
+      ]);
+      // The sheet draws only placed ids — the section must actually appear.
+      const drawnIds = editorPages(store.resume!, FALLBACK_TEMPLATE_LAYOUT)
+        .flat(2)
+        .map((section) => section.id);
+      expect(drawnIds).toContain("coverLetter");
+      dispose();
+    });
+  });
+
+  it("toggling the same section off leaves its placement alone", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, updateLayout, toggleSectionVisibility } = useResumeStore();
+      createNewResume("place-2");
+      updateLayout([[["summary", "experience"], ["skills"]]]);
+
+      // `experience` defaults to visible, so this flips it off.
+      toggleSectionVisibility("experience");
+
+      expect(store.resume!.sections.experience.visible).toBe(false);
+      expect(store.resume!.metadata.layout).toEqual([[["summary", "experience"], ["skills"]]]);
+      dispose();
+    });
+  });
+
+  it("toggling on with an empty layout leaves the template default in charge", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, updateLayout, toggleSectionVisibility } = useResumeStore();
+      createNewResume("place-3");
+      updateLayout([]);
+
+      toggleSectionVisibility("coverLetter");
+
+      expect(store.resume!.sections.coverLetter.visible).toBe(true);
+      // An empty layout renders the template's default columns, which place
+      // every fixed section already — nothing to repair.
+      expect(store.resume!.metadata.layout).toEqual([]);
+      dispose();
+    });
+  });
+
+  it("is a single undo entry: undoing reverts visibility and placement together", () => {
+    vi.useFakeTimers();
+    try {
+      createRoot((dispose) => {
+        const { store, createNewResume, updateLayout, toggleSectionVisibility, undo } =
+          useResumeStore();
+        createNewResume("place-4");
+        updateLayout([[["summary", "experience"], ["skills"]]]);
+        // Settle the undo debounce so the toggle opens its own edit burst.
+        vi.advanceTimersByTime(600);
+
+        toggleSectionVisibility("coverLetter");
+        vi.advanceTimersByTime(600);
+
+        expect(undo()).toBe(true);
+        // The visibility flip is reverted. The restored snapshot passes
+        // through load normalization, which back-fills the pruned fixed ids
+        // again — so the id stays placed, but hidden, exactly as a reload
+        // of the pre-toggle document would leave it.
+        expect(store.resume!.sections.coverLetter.visible).toBe(false);
+        const missing = ["summary", "coverLetter", ...FIXED_LAYOUT_SECTION_KEYS].filter(
+          (id) => !["summary", "experience", "skills"].includes(id),
+        );
+        expect(store.resume!.metadata.layout).toEqual([
+          [["summary", "experience", ...missing], ["skills"]],
+        ]);
+        // Flip and placement were one entry: the next undo reverts the
+        // updateLayout write, and a third finds nothing left.
+        expect(undo()).toBe(true);
+        expect(undo()).toBe(false);
+        dispose();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -120,12 +120,18 @@ function uniqueLayoutIds(ids: string[]): string[] {
  * sheet and the PDF draw only placed ids).
  */
 function placeFixedSectionId(layout: string[][][], sectionId: string): void {
-  const page0 = layout[0];
-  if (!page0 || page0.length === 0) return;
+  if (layout.length === 0) return;
   for (const page of layout) {
     for (const column of page) {
       if (column.includes(sectionId)) return;
     }
+  }
+  const page0 = layout[0];
+  if (!page0 || page0.length === 0) {
+    // Degenerate but reachable via updateLayout: pages exist, page 0 has no
+    // columns. Seed the main column rather than dropping the placement.
+    layout[0] = [[sectionId]];
+    return;
   }
   page0[0].push(sectionId);
 }
@@ -263,7 +269,10 @@ function normalizeResumeForStore(resume: ResumeData): ResumeData {
     const fixedIds = uniqueLayoutIds(
       resume.metadata.layout.flat(2).filter((id) => FIXED_LAYOUT_SECTION_KEY_SET.has(id)),
     );
-    const page0Ids = uniqueLayoutIds([...fixedIds, ...customIds]);
+    // Fixed ids absent from every page get back-filled here too, so this
+    // branch upholds the same invariant as the non-empty page-0 path below.
+    const absentFixedIds = ALL_FIXED_LAYOUT_SECTION_IDS.filter((id) => !layoutIds.has(id));
+    const page0Ids = uniqueLayoutIds([...fixedIds, ...absentFixedIds, ...customIds]);
     resume.metadata.layout[0] = [page0Ids];
     removeLayoutIdsFromLaterPages(resume.metadata.layout, page0Ids);
     return resume;

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -101,7 +101,7 @@ const ALL_FIXED_LAYOUT_SECTION_IDS: readonly string[] = [
   ...FIXED_LAYOUT_SECTION_KEYS,
 ];
 
-const FIXED_LAYOUT_SECTION_KEY_SET = new Set<string>(ALL_FIXED_LAYOUT_SECTION_IDS);
+const ALL_FIXED_LAYOUT_SECTION_ID_SET = new Set<string>(ALL_FIXED_LAYOUT_SECTION_IDS);
 
 function uniqueLayoutIds(ids: string[]): string[] {
   const seen = new Set<string>();
@@ -267,7 +267,7 @@ function normalizeResumeForStore(resume: ResumeData): ResumeData {
   const page0 = resume.metadata.layout[0];
   if (!page0 || page0.length === 0) {
     const fixedIds = uniqueLayoutIds(
-      resume.metadata.layout.flat(2).filter((id) => FIXED_LAYOUT_SECTION_KEY_SET.has(id)),
+      resume.metadata.layout.flat(2).filter((id) => ALL_FIXED_LAYOUT_SECTION_ID_SET.has(id)),
     );
     // Fixed ids absent from every page get back-filled here too, so this
     // branch upholds the same invariant as the non-empty page-0 path below.
@@ -694,7 +694,9 @@ export function useResumeStore() {
           const page = s.resume.metadata.layout[0] ?? [];
           if (!page || page.length === 0) {
             const fixedIds = uniqueLayoutIds(
-              s.resume.metadata.layout.flat(2).filter((id) => FIXED_LAYOUT_SECTION_KEY_SET.has(id)),
+              s.resume.metadata.layout
+                .flat(2)
+                .filter((id) => ALL_FIXED_LAYOUT_SECTION_ID_SET.has(id)),
             );
             const page0Ids = uniqueLayoutIds([...fixedIds, section.id]);
             s.resume.metadata.layout[0] = [page0Ids];

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -94,11 +94,14 @@ export function isNotFoundError(error: unknown): boolean {
   return false;
 }
 
-const FIXED_LAYOUT_SECTION_KEY_SET = new Set<string>([
+/** Every fixed section id a layout can place, in canonical order. */
+const ALL_FIXED_LAYOUT_SECTION_IDS: readonly string[] = [
   "summary",
   "coverLetter",
   ...FIXED_LAYOUT_SECTION_KEYS,
-]);
+];
+
+const FIXED_LAYOUT_SECTION_KEY_SET = new Set<string>(ALL_FIXED_LAYOUT_SECTION_IDS);
 
 function uniqueLayoutIds(ids: string[]): string[] {
   const seen = new Set<string>();
@@ -107,6 +110,24 @@ function uniqueLayoutIds(ids: string[]): string[] {
     seen.add(id);
     return true;
   });
+}
+
+/**
+ * Append a fixed section id to page 0's first (main) column when the id is
+ * absent from a non-empty layout. An empty layout renders the template's
+ * default columns, which already place every fixed section, so it needs no
+ * repair. A visible-but-unplaced section would otherwise never render (the
+ * sheet and the PDF draw only placed ids).
+ */
+function placeFixedSectionId(layout: string[][][], sectionId: string): void {
+  const page0 = layout[0];
+  if (!page0 || page0.length === 0) return;
+  for (const page of layout) {
+    for (const column of page) {
+      if (column.includes(sectionId)) return;
+    }
+  }
+  page0[0].push(sectionId);
 }
 
 function removeLayoutIdsFromLaterPages(layout: string[][][], ids: readonly string[]): void {
@@ -246,6 +267,15 @@ function normalizeResumeForStore(resume: ResumeData): ResumeData {
     resume.metadata.layout[0] = [page0Ids];
     removeLayoutIdsFromLaterPages(resume.metadata.layout, page0Ids);
     return resume;
+  }
+
+  // Back-fill fixed ids missing from a non-empty layout (legacy/pruned
+  // layouts saved before a fixed section existed). Hidden sections do not
+  // render, so this only guarantees a visibility toggle has somewhere to
+  // land. Column 0 is always the main column.
+  const missingFixedIds = ALL_FIXED_LAYOUT_SECTION_IDS.filter((id) => !layoutIds.has(id));
+  if (missingFixedIds.length > 0) {
+    page0[0].push(...missingFixedIds);
   }
 
   if (customIds.length === 0) return resume;
@@ -449,7 +479,10 @@ export function useResumeStore() {
     },
 
     createNewResume(id: string) {
-      const resume = createEmptyResume();
+      // Normalize even the factory default: the local fallback default's
+      // layout places only a subset of the fixed sections, and every other
+      // path into the store (load, import, undo) already normalizes.
+      const resume = normalizeResumeForStore(createEmptyResume());
       batch(() => {
         setStore("resume", resume);
         setStore("id", id);
@@ -517,20 +550,22 @@ export function useResumeStore() {
     toggleSectionVisibility(sectionKey: LayoutSectionKey) {
       setStore(
         produce((s) => {
-          if (s.resume) {
-            if (sectionKey === "summary") {
-              s.resume.sections.summary.visible = !s.resume.sections.summary.visible;
-            } else if (sectionKey === "coverLetter") {
-              s.resume.sections.coverLetter.visible = !s.resume.sections.coverLetter.visible;
-            } else if (sectionKey === "custom") {
-              const sections = Object.values(s.resume.sections.custom);
-              const nextVisible = !sections.some((section) => section.visible);
-              for (const section of sections) {
-                section.visible = nextVisible;
-              }
-            } else {
-              s.resume.sections[sectionKey].visible = !s.resume.sections[sectionKey].visible;
+          if (!s.resume) return;
+          if (sectionKey === "custom") {
+            const sections = Object.values(s.resume.sections.custom);
+            const nextVisible = !sections.some((section) => section.visible);
+            for (const section of sections) {
+              section.visible = nextVisible;
             }
+            return;
+          }
+          const section = s.resume.sections[sectionKey];
+          section.visible = !section.visible;
+          // A section toggled visible must also be placed, or the sheet and
+          // the PDF silently never draw it. Same write as the flip, so the
+          // toggle stays one action and one undo entry.
+          if (section.visible) {
+            placeFixedSectionId(s.resume.metadata.layout, sectionKey);
           }
         }),
       );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(web): place fixed sections on toggle-on and back-fill legacy layouts`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Toggling a fixed section visible when its id is absent from a non-empty `metadata.layout` was a permanent, silent no-op: the visibility flag flipped, but the document sheet and the PDF draw only placed ids, so nothing ever changed and a reload did not repair it. Surfaced by the #731 sections panel (PR #768); the bug predates it and reaches legacy/pruned layouts (e.g. layouts saved before `coverLetter` existed).

Two-sided fix in the store/normalization layer:

- **Normalization back-fill** — `normalizeResumeForStore` now back-fills missing fixed ids into page 0's first (main) column of a non-empty layout, mirroring the existing custom-id back-fill, so existing documents are repaired on load. The empty-page-0 rebuild branch back-fills absent fixed ids too.
- **Toggle-side placement** — `toggleSectionVisibility` places an unplaced fixed id in the same `setStore(produce(...))` write as the visibility flip: one action, one `markDirty()`, one undo entry. When pages exist but page 0 has no columns, the main column is seeded.
- **`createNewResume` normalizes the factory default** — the local (WASM-unavailable) fallback default places only a subset of fixed sections; every other path into the store (load, import, undo) already normalizes, so this keeps the "a visible section is always placed" invariant on every path.

Back-filled sections stay hidden, so nothing new renders to PDF; `editorPages` draws item sections only when they hold items, so empty back-filled sections do not clutter the sheet either.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`bun run --cwd apps/web test -- --run`, `bunx tsc --noEmit -p apps/web`, `uv run lintro chk` 100/100)

## Closes

- Closes #770
- Relates to #731
- Relates to #721

## Details

- Regression suite in `apps/web/src/stores/__tests__/resume.test.ts` (`unplaced fixed sections (#770)`): toggle-on places the id in the first main column and it appears in `editorPages()`; toggle-off and empty layouts stay untouched; page-0-without-columns seeds the main column; the flip and placement revert as a single undo entry; the normalization back-fill is idempotent.
- Layout-exactness expectations updated where normalization now back-fills (store sentinel tests, DocEditor sheet/undo tests — the shared fixture's stored layout omits `coverLetter` and `references`, which now surface as hidden chrome instead of being unreachable).
- Full web suite green: 888 tests, 79 files. `tsc` clean, lintro 100/100.
- AI review: CodeRabbit run 1 → 2 major findings (both the empty-page-0 edge), fixed in `ec07485`; run 2 → 0 findings. Greptile unavailable this change set (`free_reviews_limit_reached`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume layout normalization to restore missing fixed sections, including summaries and cover letters.
  * Ensured newly created resumes receive a valid initial layout.
  * Fixed visibility toggles so restored fixed sections are correctly placed and displayed.
  * Improved handling of empty or incomplete pages and legacy layouts.
* **Tests**
  * Expanded coverage for layout normalization, section visibility, rendering, and undo/redo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->