### PR TITLE
feat(web): default the document editor on with a form-builder escape hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ make test
 - **📥 Import Support** - JSON Resume, LinkedIn export, Reactive Resume V3
 - **🐳 Docker Ready** - Containerized server with OpenAPI docs
 
+## ✍️ Editing
+
+Resumes open in the **document editor** — a paged, WYSIWYG-style sheet where
+you click into the document itself to edit, with drag-and-drop sections, undo,
+autosave, and a live PDF preview. The legacy form builder remains available
+for one milestone as an escape hatch: open any resume with `?ff=form-builder`
+to switch back (persisted until you visit with `?ff=off`).
+
 ## 💻 CLI Usage
 
 ```bash

--- a/apps/web/e2e/doc-editor-default.spec.ts
+++ b/apps/web/e2e/doc-editor-default.spec.ts
@@ -46,6 +46,11 @@ test.describe("document editor default", () => {
     await test.step("?ff=off clears the override back to the default", async () => {
       await docEditorPage.openWithFlag(id, "off");
       await docEditorPage.assertDocEditorOpen();
+
+      // A plain revisit proves the persisted override was cleared, not
+      // merely bypassed for the ?ff=off request itself.
+      await docEditorPage.open(id);
+      await docEditorPage.assertDocEditorOpen();
     });
   });
 

--- a/apps/web/e2e/doc-editor-default.spec.ts
+++ b/apps/web/e2e/doc-editor-default.spec.ts
@@ -1,0 +1,72 @@
+import { test } from "./support/fixtures";
+
+/**
+ * The document editor is the default `/edit/:id` surface (#734), with
+ * `?ff=form-builder` as the temporary escape hatch back to the legacy form
+ * editor. These tests run without the suite-wide override seed so they see
+ * the real default. TODO(#735): fold into the main suites once the form
+ * builder is retired.
+ */
+test.use({ formBuilderOverride: false });
+
+test.describe("document editor default", () => {
+  test("a fresh browser gets the document editor at /edit/:id", async ({
+    homePage,
+    docEditorPage,
+  }) => {
+    await homePage.open();
+    await homePage.createResume();
+
+    await docEditorPage.assertUrl(/\/edit\/[\w-]+$/);
+    await docEditorPage.assertDocEditorOpen();
+  });
+
+  test("?ff=form-builder restores the legacy editor and persists until ?ff=off", async ({
+    page,
+    homePage,
+    builderPage,
+    docEditorPage,
+  }) => {
+    await homePage.open();
+    await homePage.createResume();
+    await docEditorPage.assertUrl(/\/edit\/[\w-]+$/);
+    const editUrl = new URL(page.url());
+    const id = editUrl.pathname.split("/").pop() as string;
+
+    await test.step("the escape hatch serves the form editor", async () => {
+      await docEditorPage.openWithFlag(id, "form-builder");
+      await builderPage.assertFormSurface();
+    });
+
+    await test.step("the override persists across a plain visit", async () => {
+      await builderPage.open(id);
+      await builderPage.assertEditorOpen();
+    });
+
+    await test.step("?ff=off clears the override back to the default", async () => {
+      await docEditorPage.openWithFlag(id, "off");
+      await docEditorPage.assertDocEditorOpen();
+    });
+  });
+
+  test("the transition-era ?ff=doc-editor request forgets a persisted override", async ({
+    page,
+    homePage,
+    builderPage,
+    docEditorPage,
+  }) => {
+    await homePage.open();
+    await homePage.createResume();
+    await docEditorPage.assertUrl(/\/edit\/[\w-]+$/);
+    const id = new URL(page.url()).pathname.split("/").pop() as string;
+
+    await docEditorPage.openWithFlag(id, "form-builder");
+    await builderPage.assertFormSurface();
+
+    await docEditorPage.openWithFlag(id, "doc-editor");
+    await docEditorPage.assertDocEditorOpen();
+
+    await docEditorPage.open(id);
+    await docEditorPage.assertDocEditorOpen();
+  });
+});

--- a/apps/web/e2e/pages/BuilderPage.ts
+++ b/apps/web/e2e/pages/BuilderPage.ts
@@ -35,6 +35,11 @@ export default class BuilderPage extends BasePage {
     await expect(this.basicsHeading).toBeVisible();
   }
 
+  /** The form-editor surface renders, regardless of query parameters. */
+  async assertFormSurface(): Promise<void> {
+    await expect(this.basicsHeading).toBeVisible();
+  }
+
   async fillFullName(name: string): Promise<void> {
     await this.fullNameInput.fill(name);
   }

--- a/apps/web/e2e/pages/BuilderPage.ts
+++ b/apps/web/e2e/pages/BuilderPage.ts
@@ -35,9 +35,10 @@ export default class BuilderPage extends BasePage {
     await expect(this.basicsHeading).toBeVisible();
   }
 
-  /** The form-editor surface renders, regardless of query parameters. */
+  /** The form-editor surface renders (and the document sheet does not). */
   async assertFormSurface(): Promise<void> {
     await expect(this.basicsHeading).toBeVisible();
+    await expect(this.page.getByTestId("doc-sheet")).toBeHidden();
   }
 
   async fillFullName(name: string): Promise<void> {

--- a/apps/web/e2e/pages/DocEditorPage.ts
+++ b/apps/web/e2e/pages/DocEditorPage.ts
@@ -1,0 +1,30 @@
+import { expect, type Locator } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import BasePage from "./BasePage";
+
+/** Document editor (/edit/:id): the paged sheet surface, default since #734. */
+export default class DocEditorPage extends BasePage {
+  readonly sheet: Locator;
+  readonly sheetPane: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.sheet = page.getByTestId("doc-sheet");
+    this.sheetPane = page.getByTestId("doc-editor-sheet-pane");
+  }
+
+  async open(id: string): Promise<void> {
+    await this.page.goto(`/edit/${id}`);
+  }
+
+  /** `/edit/:id` with a flag request, e.g. `form-builder` or `off`. */
+  async openWithFlag(id: string, flag: string): Promise<void> {
+    await this.page.goto(`/edit/${id}?ff=${flag}`);
+  }
+
+  /** The document sheet serves the route (and the form editor does not). */
+  async assertDocEditorOpen(): Promise<void> {
+    await expect(this.sheet).toBeVisible();
+    await expect(this.sheetPane).toBeVisible();
+  }
+}

--- a/apps/web/e2e/pages/DocEditorPage.ts
+++ b/apps/web/e2e/pages/DocEditorPage.ts
@@ -26,5 +26,8 @@ export default class DocEditorPage extends BasePage {
   async assertDocEditorOpen(): Promise<void> {
     await expect(this.sheet).toBeVisible();
     await expect(this.sheetPane).toBeVisible();
+    await expect(
+      this.page.getByRole("heading", { name: "Personal Information", exact: true }),
+    ).toBeHidden();
   }
 }

--- a/apps/web/e2e/support/fixtures.ts
+++ b/apps/web/e2e/support/fixtures.ts
@@ -1,6 +1,7 @@
 import { test as base } from "@playwright/test";
 import HomePage from "../pages/HomePage";
 import BuilderPage from "../pages/BuilderPage";
+import DocEditorPage from "../pages/DocEditorPage";
 import AccountPage from "../pages/AccountPage";
 import TemplatePickerModal from "../pages/TemplatePickerModal";
 import ExportModal from "../pages/ExportModal";
@@ -70,10 +71,21 @@ export const DEFAULT_TEMPLATE_ID = "rhyhorn";
 interface Fixtures {
   homePage: HomePage;
   builderPage: BuilderPage;
+  docEditorPage: DocEditorPage;
   accountPage: AccountPage;
   templatePickerModal: TemplatePickerModal;
   exportModal: ExportModal;
   importModal: ImportModal;
+}
+
+interface Options {
+  /**
+   * Seed the `?ff=form-builder` escape hatch so `/edit/:id` serves the legacy
+   * form editor these suites were written against. The document editor is the
+   * default since #734; `doc-editor-default.spec.ts` opts out to prove it.
+   * TODO(#735): remove alongside the form builder and migrate the suites.
+   */
+  formBuilderOverride: boolean;
 }
 
 /**
@@ -83,8 +95,14 @@ interface Fixtures {
  * a deterministic stub so the client-side pipeline can be asserted end to
  * end without a server.
  */
-export const test = base.extend<Fixtures>({
-  page: async ({ page }, use) => {
+export const test = base.extend<Fixtures & Options>({
+  formBuilderOverride: [true, { option: true }],
+  page: async ({ page, formBuilderOverride }, use) => {
+    if (formBuilderOverride) {
+      await page.addInitScript(() => {
+        localStorage.setItem("ff.form-builder", "true");
+      });
+    }
     await page.route(AUTH_PROBE_ROUTE, (route) => route.fulfill({ status: 404 }));
     await page.route(PREVIEW_ROUTE, (route) =>
       route.fulfill({
@@ -121,6 +139,9 @@ export const test = base.extend<Fixtures>({
   },
   builderPage: async ({ page }, use) => {
     await use(new BuilderPage(page));
+  },
+  docEditorPage: async ({ page }, use) => {
+    await use(new DocEditorPage(page));
   },
   accountPage: async ({ page }, use) => {
     await use(new AccountPage(page));

--- a/apps/web/src/lib/__tests__/flags.test.ts
+++ b/apps/web/src/lib/__tests__/flags.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { FEATURE_FLAGS, isDocEditorEnabled, isFlagEnabled } from "../flags";
 
-const KEY = "ff.doc-editor";
+const DOC_EDITOR_KEY = "ff.doc-editor";
+const FORM_BUILDER_KEY = "ff.form-builder";
 
 /** An in-memory `Storage` so a test can assert on what was written. */
 function createStorage(seed: Record<string, string> = {}): Storage {
@@ -29,50 +30,65 @@ describe("isDocEditorEnabled", () => {
     localStorage.clear();
   });
 
-  it("defaults to off with no query parameter and nothing persisted", () => {
-    expect(isDocEditorEnabled({ search: "", storage: createStorage() })).toBe(false);
+  it("defaults to on with no query parameter and nothing persisted", () => {
+    expect(isDocEditorEnabled({ search: "", storage: createStorage() })).toBe(true);
   });
 
-  it("enables and persists when the flag is requested", () => {
+  it("disables and persists the override when ?ff=form-builder is requested", () => {
     const storage = createStorage();
+
+    expect(isDocEditorEnabled({ search: "?ff=form-builder", storage })).toBe(false);
+    expect(storage.getItem(FORM_BUILDER_KEY)).toBe("true");
+  });
+
+  it("keeps the form builder for a later visit with no query parameter", () => {
+    const storage = createStorage();
+    isDocEditorEnabled({ search: "?ff=form-builder", storage });
+
+    expect(isDocEditorEnabled({ search: "", storage })).toBe(false);
+  });
+
+  it("restores the default (on) and clears the override on ?ff=off", () => {
+    const storage = createStorage({ [FORM_BUILDER_KEY]: "true" });
+
+    expect(isDocEditorEnabled({ search: "?ff=off", storage })).toBe(true);
+    expect(storage.getItem(FORM_BUILDER_KEY)).toBeNull();
+  });
+
+  it("lets ?ff=off win over a simultaneous form-builder request", () => {
+    const storage = createStorage({ [FORM_BUILDER_KEY]: "true" });
+
+    expect(isDocEditorEnabled({ search: "?ff=form-builder&ff=off", storage })).toBe(true);
+    expect(storage.getItem(FORM_BUILDER_KEY)).toBeNull();
+  });
+
+  it("still honors the transition-era ?ff=doc-editor and forgets the override", () => {
+    const storage = createStorage({ [FORM_BUILDER_KEY]: "true" });
 
     expect(isDocEditorEnabled({ search: "?ff=doc-editor", storage })).toBe(true);
-    expect(storage.getItem(KEY)).toBe("true");
+    expect(storage.getItem(FORM_BUILDER_KEY)).toBeNull();
+    expect(storage.getItem(DOC_EDITOR_KEY)).toBe("true");
   });
 
-  it("stays on for a later visit with no query parameter", () => {
-    const storage = createStorage();
-    isDocEditorEnabled({ search: "?ff=doc-editor", storage });
-
-    expect(isDocEditorEnabled({ search: "", storage })).toBe(true);
-  });
-
-  it("clears the persisted value on ?ff=off", () => {
-    const storage = createStorage({ [KEY]: "true" });
-
-    expect(isDocEditorEnabled({ search: "?ff=off", storage })).toBe(false);
-    expect(storage.getItem(KEY)).toBeNull();
-  });
-
-  it("lets ?ff=off win over a simultaneous enable request", () => {
-    const storage = createStorage({ [KEY]: "true" });
-
-    expect(isDocEditorEnabled({ search: "?ff=doc-editor&ff=off", storage })).toBe(false);
-    expect(storage.getItem(KEY)).toBeNull();
-  });
-
-  it("ignores unrelated query parameters and unknown flag tokens", () => {
+  it("lets a form-builder request win over a simultaneous doc-editor request", () => {
     const storage = createStorage();
 
-    expect(isDocEditorEnabled({ search: "?page=2&ff=some-other-flag", storage })).toBe(false);
-    expect(storage.getItem(KEY)).toBeNull();
+    expect(isDocEditorEnabled({ search: "?ff=doc-editor&ff=form-builder", storage })).toBe(false);
+    expect(storage.getItem(FORM_BUILDER_KEY)).toBe("true");
   });
 
-  it("treats a malformed stored value as off without throwing", () => {
-    const storage = createStorage({ [KEY]: "{not-json" });
+  it("stays on despite unrelated query parameters and unknown flag tokens", () => {
+    const storage = createStorage();
+
+    expect(isDocEditorEnabled({ search: "?page=2&ff=some-other-flag", storage })).toBe(true);
+    expect(storage.getItem(FORM_BUILDER_KEY)).toBeNull();
+  });
+
+  it("treats a malformed stored override as absent without throwing", () => {
+    const storage = createStorage({ [FORM_BUILDER_KEY]: "{not-json" });
 
     expect(() => isDocEditorEnabled({ search: "", storage })).not.toThrow();
-    expect(isDocEditorEnabled({ search: "", storage })).toBe(false);
+    expect(isDocEditorEnabled({ search: "", storage })).toBe(true);
   });
 
   it("survives a storage that throws on every operation", () => {
@@ -93,36 +109,52 @@ describe("isDocEditorEnabled", () => {
       key: () => null,
     };
 
-    expect(isDocEditorEnabled({ search: "", storage: denied })).toBe(false);
-    expect(isDocEditorEnabled({ search: "?ff=doc-editor", storage: denied })).toBe(true);
+    expect(isDocEditorEnabled({ search: "", storage: denied })).toBe(true);
+    expect(isDocEditorEnabled({ search: "?ff=form-builder", storage: denied })).toBe(false);
   });
 
   it("resolves without persistence when storage is null", () => {
-    expect(isDocEditorEnabled({ search: "?ff=doc-editor", storage: null })).toBe(true);
-    expect(isDocEditorEnabled({ search: "", storage: null })).toBe(false);
+    expect(isDocEditorEnabled({ search: "?ff=form-builder", storage: null })).toBe(false);
+    expect(isDocEditorEnabled({ search: "", storage: null })).toBe(true);
   });
 
   it("falls back to the live location and localStorage when no environment is given", () => {
     const original = `${window.location.pathname}${window.location.search}`;
-    window.history.replaceState(null, "", "/edit/abc?ff=doc-editor");
+    window.history.replaceState(null, "", "/edit/abc?ff=form-builder");
 
-    expect(isDocEditorEnabled()).toBe(true);
-    expect(localStorage.getItem(KEY)).toBe("true");
+    expect(isDocEditorEnabled()).toBe(false);
+    expect(localStorage.getItem(FORM_BUILDER_KEY)).toBe("true");
 
     window.history.replaceState(null, "", "/edit/abc");
+    expect(isDocEditorEnabled()).toBe(false);
+
+    window.history.replaceState(null, "", "/edit/abc?ff=off");
     expect(isDocEditorEnabled()).toBe(true);
+    expect(localStorage.getItem(FORM_BUILDER_KEY)).toBeNull();
 
     window.history.replaceState(null, "", original);
   });
 });
 
 describe("isFlagEnabled", () => {
-  it("is the general primitive the named accessors delegate to", () => {
+  it("stays the default-off primitive for opt-in flags", () => {
     const storage = createStorage();
 
-    expect(isFlagEnabled(FEATURE_FLAGS.docEditor, { search: "?ff=doc-editor", storage })).toBe(
+    expect(isFlagEnabled(FEATURE_FLAGS.formBuilder, { search: "", storage })).toBe(false);
+    expect(isFlagEnabled(FEATURE_FLAGS.formBuilder, { search: "?ff=form-builder", storage })).toBe(
       true,
     );
-    expect(isDocEditorEnabled({ search: "", storage })).toBe(true);
+    expect(isFlagEnabled(FEATURE_FLAGS.formBuilder, { search: "", storage })).toBe(true);
+  });
+
+  it("clears every registered flag on ?ff=off", () => {
+    const storage = createStorage({
+      [DOC_EDITOR_KEY]: "true",
+      [FORM_BUILDER_KEY]: "true",
+    });
+
+    expect(isFlagEnabled(FEATURE_FLAGS.docEditor, { search: "?ff=off", storage })).toBe(false);
+    expect(storage.getItem(DOC_EDITOR_KEY)).toBeNull();
+    expect(storage.getItem(FORM_BUILDER_KEY)).toBeNull();
   });
 });

--- a/apps/web/src/lib/__tests__/flags.test.ts
+++ b/apps/web/src/lib/__tests__/flags.test.ts
@@ -121,6 +121,7 @@ describe("isDocEditorEnabled", () => {
   it("falls back to the live location and localStorage when no environment is given", () => {
     const original = `${window.location.pathname}${window.location.search}`;
     const storedBefore = localStorage.getItem(FORM_BUILDER_KEY);
+    const docEditorStoredBefore = localStorage.getItem(DOC_EDITOR_KEY);
     try {
       window.history.replaceState(null, "", "/edit/abc?ff=form-builder");
 
@@ -139,6 +140,11 @@ describe("isDocEditorEnabled", () => {
         localStorage.removeItem(FORM_BUILDER_KEY);
       } else {
         localStorage.setItem(FORM_BUILDER_KEY, storedBefore);
+      }
+      if (docEditorStoredBefore === null) {
+        localStorage.removeItem(DOC_EDITOR_KEY);
+      } else {
+        localStorage.setItem(DOC_EDITOR_KEY, docEditorStoredBefore);
       }
     }
   });

--- a/apps/web/src/lib/__tests__/flags.test.ts
+++ b/apps/web/src/lib/__tests__/flags.test.ts
@@ -120,19 +120,27 @@ describe("isDocEditorEnabled", () => {
 
   it("falls back to the live location and localStorage when no environment is given", () => {
     const original = `${window.location.pathname}${window.location.search}`;
-    window.history.replaceState(null, "", "/edit/abc?ff=form-builder");
+    const storedBefore = localStorage.getItem(FORM_BUILDER_KEY);
+    try {
+      window.history.replaceState(null, "", "/edit/abc?ff=form-builder");
 
-    expect(isDocEditorEnabled()).toBe(false);
-    expect(localStorage.getItem(FORM_BUILDER_KEY)).toBe("true");
+      expect(isDocEditorEnabled()).toBe(false);
+      expect(localStorage.getItem(FORM_BUILDER_KEY)).toBe("true");
 
-    window.history.replaceState(null, "", "/edit/abc");
-    expect(isDocEditorEnabled()).toBe(false);
+      window.history.replaceState(null, "", "/edit/abc");
+      expect(isDocEditorEnabled()).toBe(false);
 
-    window.history.replaceState(null, "", "/edit/abc?ff=off");
-    expect(isDocEditorEnabled()).toBe(true);
-    expect(localStorage.getItem(FORM_BUILDER_KEY)).toBeNull();
-
-    window.history.replaceState(null, "", original);
+      window.history.replaceState(null, "", "/edit/abc?ff=off");
+      expect(isDocEditorEnabled()).toBe(true);
+      expect(localStorage.getItem(FORM_BUILDER_KEY)).toBeNull();
+    } finally {
+      window.history.replaceState(null, "", original);
+      if (storedBefore === null) {
+        localStorage.removeItem(FORM_BUILDER_KEY);
+      } else {
+        localStorage.setItem(FORM_BUILDER_KEY, storedBefore);
+      }
+    }
   });
 });
 

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -2,9 +2,14 @@
  * Runtime feature flags.
  *
  * A flag is off for everyone until a URL opts in: `?ff=<flag>` turns it on and
- * remembers the choice, `?ff=off` turns everything off again and forgets it.
- * That is the whole mechanism — it exists so unfinished surfaces can ship to
- * `main` in small reviewable slices while staying invisible to normal traffic.
+ * remembers the choice, `?ff=off` clears every persisted choice and returns
+ * everything to its default. That is the whole mechanism — it exists so
+ * unfinished surfaces can ship to `main` in small reviewable slices while
+ * staying invisible to normal traffic.
+ *
+ * The document editor has graduated: it is on by default, and the flag that
+ * remains is the temporary `?ff=form-builder` escape hatch back to the legacy
+ * form editor (see {@link isDocEditorEnabled}).
  *
  * Nothing here runs at import time: every resolution reads `location` and
  * `localStorage` through {@link FlagEnvironment}, which tests supply directly.
@@ -28,8 +33,17 @@ const ENABLED_VALUE = "true";
  * `ff.<token>` storage key.
  */
 export const FEATURE_FLAGS = {
-  /** The read-only document sheet at `/edit/:id` (#727). */
+  /**
+   * The document sheet at `/edit/:id` (#727). Default on since #734; the
+   * token is still recognized so transition-era URLs keep working.
+   */
   docEditor: "doc-editor",
+  /**
+   * Escape hatch back to the legacy form editor at `/edit/:id`.
+   * TODO(v0.62.0): remove the form-builder override once the doc editor has
+   * held the default for a milestone (#735 retires the form builder).
+   */
+  formBuilder: "form-builder",
 } as const;
 
 /** A flag's wire token, e.g. `"doc-editor"`. */
@@ -134,7 +148,39 @@ export function isFlagEnabled(
   return readStored(storage, flag);
 }
 
-/** Whether the read-only document sheet replaces the form editor at `/edit/:id`. */
-export function isDocEditorEnabled(env?: FlagEnvironment): boolean {
-  return isFlagEnabled(FEATURE_FLAGS.docEditor, env);
+/**
+ * Whether the document sheet serves `/edit/:id`. On by default since #734.
+ *
+ * Resolution order: `?ff=off` clears every persisted flag and restores the
+ * default (on); `?ff=form-builder` opts back into the legacy form editor and
+ * persists that choice; `?ff=doc-editor` — kept for transition-era URLs —
+ * re-enables the sheet and forgets a persisted form-builder override;
+ * otherwise a persisted override decides; otherwise on.
+ *
+ * TODO(v0.62.0): remove the form-builder override (and this bespoke
+ * resolution) when #735 retires the form builder.
+ */
+export function isDocEditorEnabled(env: FlagEnvironment = defaultEnvironment()): boolean {
+  const storage = env.storage === undefined ? defaultStorage() : env.storage;
+  const requested = requestedFlags(env.search);
+
+  if (requested.includes(OFF_TOKEN)) {
+    for (const known of Object.values(FEATURE_FLAGS)) {
+      writeStored(storage, known, false);
+    }
+    return true;
+  }
+
+  if (requested.includes(FEATURE_FLAGS.formBuilder)) {
+    writeStored(storage, FEATURE_FLAGS.formBuilder, true);
+    return false;
+  }
+
+  if (requested.includes(FEATURE_FLAGS.docEditor)) {
+    writeStored(storage, FEATURE_FLAGS.docEditor, true);
+    writeStored(storage, FEATURE_FLAGS.formBuilder, false);
+    return true;
+  }
+
+  return !readStored(storage, FEATURE_FLAGS.formBuilder);
 }

--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -272,7 +272,7 @@ describe("/edit/:id route swap", () => {
     fixture.value = loadDocEditorFixture();
   });
 
-  it("renders the form editor when the flag is off", async () => {
+  it("renders the form editor when the form-builder override is active", async () => {
     docEditorEnabled.value = false;
     const { resolveEditRoute } = await import("../editRoute");
 
@@ -284,7 +284,7 @@ describe("/edit/:id route swap", () => {
     expect(screen.queryByTestId("doc-sheet")).toBeNull();
   }, 15000);
 
-  it("renders the document sheet when the flag is on", async () => {
+  it("renders the document sheet by default", async () => {
     docEditorEnabled.value = true;
     const { resolveEditRoute } = await import("../editRoute");
 

--- a/apps/web/src/pages/editRoute.ts
+++ b/apps/web/src/pages/editRoute.ts
@@ -12,8 +12,9 @@ const Editor = lazy(() => import("./Editor"));
 const DocEditor = lazy(() => import("./DocEditor"));
 
 /**
- * The document sheet when the `doc-editor` flag is on, the form editor
- * otherwise. Resolved once at startup, from the URL the app was opened with.
+ * The document sheet by default, the form editor only while the temporary
+ * `?ff=form-builder` override is active (removed by #735). Resolved once at
+ * startup, from the URL the app was opened with.
  */
 export function resolveEditRoute(): Component {
   return isDocEditorEnabled() ? DocEditor : Editor;

--- a/crates/server/tests/doc_editor_e2e.rs
+++ b/crates/server/tests/doc_editor_e2e.rs
@@ -1,0 +1,127 @@
+//! End-to-end gate for the document editor default flip (#734).
+//!
+//! Boots the real axum router in-process (self-hosted stateless mode — no
+//! database, no auth) and drives the full document-editor happy path: the
+//! shared markdown fixture, an edit shaped exactly as the web store persists
+//! it, and `POST /api/render/pdf` through to a real PDF. If this path breaks,
+//! the editor must not be the default.
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use rustume_parser::{Parser, ReactiveResumeV3Parser};
+use rustume_schema::{ContentFormat, ResumeData};
+use rustume_server::create_router;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+use tower::ServiceExt;
+
+/// Path to the shared document-editor fixture at the workspace root.
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("CARGO_MANIFEST_DIR should have a parent (crates/)")
+        .parent()
+        .expect("crates/ should have a parent (workspace root)")
+        .join("tests")
+        .join("fixtures")
+        .join("v3")
+        .join("doc-editor.json")
+}
+
+/// The fixture as the web store holds it: parsed from the v3 wire format into
+/// `ResumeData`, exactly like an import does.
+fn load_fixture() -> ResumeData {
+    let data = fs::read(fixture_path()).expect("Failed to read doc-editor.json fixture");
+    ReactiveResumeV3Parser
+        .parse(&data)
+        .expect("Failed to parse doc-editor.json fixture")
+}
+
+/// Apply the edit the gate is about, on the persisted JSON itself: rename the
+/// basics and append an experience item with a markdown summary, shaped field
+/// for field like `SectionEditor`'s `createItem` output that the web store
+/// persists and sends to `/api/render/pdf`.
+fn apply_web_store_edit(resume: &mut Value) {
+    resume["basics"]["name"] = json!("Mireille Okafor-Reyes");
+
+    let items = resume["sections"]["experience"]["items"]
+        .as_array_mut()
+        .expect("fixture should carry an experience items array");
+    items.push(json!({
+        "id": "exp-doc-editor-e2e",
+        "visible": true,
+        "company": "Lumen Health",
+        "position": "Principal Engineer, Design Systems",
+        "location": "Lisbon, Portugal",
+        "date": "2026 — Present",
+        "summary": "Leading **Halo** end to end:\n\n- Shipped the *token pipeline* powering every surface\n- Wrote the rollout notes at [okafor.design/notes](https://okafor.design/notes)",
+        "url": { "label": "", "href": "" },
+    }));
+}
+
+/// Pages in a PDF whose page dictionaries sit in the plain object table (as
+/// typst's writer emits them): `/Type /Page` entries, with or without the
+/// separating space, excluding the `/Type /Pages` tree node.
+fn count_pdf_pages(pdf: &[u8]) -> usize {
+    [b"/Type /Page".as_slice(), b"/Type/Page".as_slice()]
+        .iter()
+        .map(|needle| {
+            pdf.windows(needle.len())
+                .enumerate()
+                .filter(|(idx, window)| {
+                    window == needle && pdf.get(idx + needle.len()) != Some(&b's')
+                })
+                .count()
+        })
+        .sum()
+}
+
+#[tokio::test]
+async fn doc_editor_edit_renders_a_real_pdf_end_to_end() {
+    // The fixture must exercise the markdown adapter path: the flip is only
+    // proven if markdown flows through the real renderer.
+    let parsed = load_fixture();
+    assert_eq!(
+        parsed.metadata.content_format(),
+        ContentFormat::Markdown,
+        "fixture should declare markdown so the render takes the markdown path"
+    );
+
+    let mut resume = serde_json::to_value(&parsed).expect("ResumeData should serialize");
+    apply_web_store_edit(&mut resume);
+
+    let body = json!({ "resume": resume, "template": "onyx" });
+
+    let app = create_router();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/render/pdf")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request should build"),
+        )
+        .await
+        .expect("router should answer");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("response should carry a content type"),
+        "application/pdf"
+    );
+
+    let pdf = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should collect");
+
+    assert!(pdf.starts_with(b"%PDF-"), "response is not a PDF");
+    assert!(
+        count_pdf_pages(&pdf) >= 1,
+        "rendered PDF should contain at least one page"
+    );
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): default the document editor on with a form-builder escape hatch
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The document editor graduates from behind `?ff=doc-editor` to the default `/edit/:id` surface, gated on a new server-side end-to-end proof of the full editing pipeline.

- **Server e2e gate** (`crates/server/tests/doc_editor_e2e.rs`): boots the real axum router in-process (stateless mode, no DB), parses the shared `tests/fixtures/v3/doc-editor.json` markdown fixture, applies an edit shaped exactly like the web store's persisted output (rename + new experience item with a markdown summary), POSTs `/api/render/pdf` with `{"resume": …, "template": "onyx"}`, and asserts 200, `application/pdf`, the `%PDF-` magic, and ≥ 1 page. Runs under plain `cargo test --workspace` — no new workflows.
- **Flag flip** (`apps/web/src/lib/flags.ts`): `isDocEditorEnabled()` now defaults to on. `?ff=form-builder` opts back into the legacy form editor for one milestone and persists (marked `TODO(v0.62.0)`, removed by #735); `?ff=off` clears every persisted flag and restores the default; transition-era `?ff=doc-editor` URLs keep working. Flags tests rewritten to assert the new default, the override, its persistence, precedence, and storage-failure behavior.
- **Playwright coverage** (`apps/web/e2e/doc-editor-default.spec.ts` + `DocEditorPage` POM): a fresh browser gets the document sheet at `/edit/:id`; the escape hatch serves the form editor, persists across plain visits, and `?ff=off` / `?ff=doc-editor` both recover the default. The shared fixture seeds `ff.form-builder` so the existing form-builder suites keep passing until #735 migrates them.
- **Docs**: README gains a short Editing section describing the document editor and the temporary override.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`make test` and `uv run lintro chk`)

## Closes

- Closes #734
- Relates to #735

## Details

Verification run before push, all green:

- `uv run lintro fmt` / `uv run lintro chk` — 0 issues (health 100/100)
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test --workspace` — 20 suites, 0 failures (includes the new `doc_editor_e2e`)
- `apps/web`: `bun run test` — 884 tests / 79 files passed; `bun run lint`, `bun run typecheck` — clean
- `bun run test:e2e` — 70 passed, 5 visual-regression skips (platform-gated)

The flag resolution for the doc editor is bespoke (default-on with a persisted opt-out) while `isFlagEnabled` stays the default-off primitive for future flags; both are removed together when #735 retires the form builder.