### PR TITLE
refactor(web): content-sized sheet engine with section and entry chrome (#794)

### DIFF
--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -28,6 +28,7 @@ name: Quality - Lint & Format
       - ".lintro-ignore"
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
 
 permissions: {}

--- a/apps/web/e2e/doc-editor.spec.ts
+++ b/apps/web/e2e/doc-editor.spec.ts
@@ -131,10 +131,10 @@ test.describe("single-surface document editor", () => {
     await expect(summary).not.toContainText("<strong>");
     await expect(summary.locator("strong")).toHaveText("eleven years");
 
-    // Profiles render one entry per profile (#787): the username appears
-    // once, not stacked as title, subtitle and link.
+    // Profiles render one compact row per profile (#787, #794): a brand
+    // glyph plus the username once — not stacked as title, subtitle and link.
     const profiles = docEditorPage.sheet.locator('[data-section-id="profiles"]');
-    await expect(profiles).toContainText("GitHub");
     await expect(profiles.getByText("lgtm-hq")).toHaveCount(1);
+    await expect(profiles.locator("svg").first()).toBeVisible();
   });
 });

--- a/apps/web/e2e/doc-editor.spec.ts
+++ b/apps/web/e2e/doc-editor.spec.ts
@@ -135,6 +135,6 @@ test.describe("single-surface document editor", () => {
     // glyph plus the username once — not stacked as title, subtitle and link.
     const profiles = docEditorPage.sheet.locator('[data-section-id="profiles"]');
     await expect(profiles.getByText("lgtm-hq")).toHaveCount(1);
-    await expect(profiles.locator("svg").first()).toBeVisible();
+    await expect(profiles.locator("svg.doc-sheet__row-ico").first()).toBeVisible();
   });
 });

--- a/apps/web/src/components/doc-editor/DocHeader.tsx
+++ b/apps/web/src/components/doc-editor/DocHeader.tsx
@@ -1,42 +1,33 @@
 /**
- * The sheet's header region: avatar, name, headline, contact details and — when
- * the resume does not place `profiles` as a section — its profile links.
+ * The sheet's identity and contact chrome (#794, spec §1.4): `NameHeader`,
+ * `SheetAvatar` and `ContactBlock` — the pieces each template's page
+ * compositor places per its `headerStyle` / `contactIn` metadata.
  *
- * Placement is the template's decision, not this component's: `headerStyle`
- * says where and how the name block is drawn (`banner`, `sidebar`, `boxed`,
- * `left`, `center`) and `contactIn` says which of those regions prints the
- * contact details. Both arrive as layout metadata from `GET /api/templates`.
- *
- * Everything the header draws is editable in place. The core contact fields
- * (email, phone, location) are drawn even when empty, as muted placeholders, so
- * a blank resume still offers somewhere to type; the personal URL and the
- * resume's own custom fields appear only once they carry a value, because they
- * are additions rather than expected parts of a document.
+ * `ContactBlock` is the one piece of section chrome the template owns
+ * outright: it reuses {@link SectionChrome} with no grip, no pencil and no
+ * menu, and is never draggable. Its core fields (email, phone, location) draw
+ * even when empty in edit mode, as placeholders, so a blank resume still
+ * offers somewhere to type; the personal URL and custom fields appear once
+ * they carry a value. `SheetAvatar` falls back to an initials disc and opens
+ * the photo dialog — #788's `PhotoDialog` with `lib/imageUpload` processing,
+ * kept as the superset of the prototype's modal.
  */
 
 import { For, Show, createSignal, type JSX } from "solid-js";
 import { InlineText } from "./InlineText";
 import { PhotoDialog } from "./PhotoDialog";
+import { SectionChrome } from "./SectionChrome";
+import { ContactIcon, type ContactIconKind } from "./icons";
 import { updateBasicsField } from "./docEdits";
 import { useSheetEditable } from "./sheetMode";
-import type { TemplateHeaderStyle } from "../../lib/docLayout";
+import { SHEET_PX_PER_PT } from "../../lib/docLayout";
 import type { Basics, CustomField, Picture, Url } from "../../wasm/types";
 
-/** One contact line: an optional label, the value, and where it writes back. */
-interface ContactEntry {
-  key: string;
-  label?: string;
-  value: string;
-  /** Field name announced by the inline editor. */
-  fieldLabel: string;
-  commit: (value: string) => void;
-  /** Whether the line is drawn even when the value is empty. */
-  alwaysShown?: boolean;
-}
+/** Largest avatar the sheet draws, whatever the stored size (spec §1.4). */
+const MAX_SHEET_AVATAR_PX = 120;
 
 /**
  * Visible text for a URL — label, else href. Mirrors `url-display-label`.
- *
  * Both fields are read defensively: imported resumes reach the store with one
  * or the other missing.
  */
@@ -45,17 +36,155 @@ function urlLabel(url: Url | undefined): string {
   return label.trim() !== "" ? label : (url?.href ?? "");
 }
 
+/** `customFields` with one field's value replaced — committed as one action. */
+function replaceField(basics: Basics, id: string, value: string): CustomField[] {
+  return basics.customFields.map((field) => (field.id === id ? { ...field, value } : field));
+}
+
+/** Whether a picture is set and not switched off. Mirrors `has-visible-picture`. */
+function pictureVisible(picture: Picture | undefined): boolean {
+  return picture !== undefined && picture.url.trim() !== "" && !picture.effects.hidden;
+}
+
+/** The name block: display name over the accent headline (spec §1.4). */
+export function NameHeader(props: { basics: Basics; isInSidebar?: boolean }): JSX.Element {
+  const isEditable = useSheetEditable();
+  return (
+    <header
+      class="doc-sheet__head"
+      classList={{ "doc-sheet__head--in-side": props.isInSidebar === true }}
+      data-testid="doc-sheet-header"
+    >
+      <Show when={isEditable() || props.basics.name.trim() !== ""}>
+        <h2 class="doc-sheet__name">
+          <InlineText
+            value={props.basics.name}
+            label="Name"
+            placeholder="Your name"
+            triggerId="doc-header-name"
+            onCommit={(value) => updateBasicsField("name", value)}
+          />
+        </h2>
+      </Show>
+      <Show when={isEditable() || props.basics.headline.trim() !== ""}>
+        <p class="doc-sheet__headline">
+          <InlineText
+            value={props.basics.headline}
+            label="Headline"
+            placeholder="Your headline"
+            triggerId="doc-header-headline"
+            onCommit={(value) => updateBasicsField("headline", value)}
+          />
+        </p>
+      </Show>
+    </header>
+  );
+}
+
+/** The avatar's stored geometry, in sheet pixels. */
+function avatarStyle(picture: Picture): JSX.CSSProperties {
+  const size = Math.min(Math.round(picture.size * SHEET_PX_PER_PT), MAX_SHEET_AVATAR_PX);
+  const radius = Math.min(Math.round(picture.borderRadius * SHEET_PX_PER_PT), size / 2);
+  const effects = picture.effects;
+  const borderColor =
+    effects.borderColor.trim() === "" ? "var(--doc-sheet-accent)" : effects.borderColor;
+  const shadowOffset = (effects.shadowSize || 0) / 2;
+  return {
+    width: `${size}px`,
+    height: `${size}px`,
+    "border-radius": `${radius}px`,
+    filter: effects.grayscale ? "grayscale(1)" : undefined,
+    transform: effects.rotation === 0 ? undefined : `rotate(${effects.rotation}deg)`,
+    border:
+      effects.border && effects.borderWidth > 0
+        ? `${effects.borderWidth}px solid ${borderColor}`
+        : "none",
+    "box-shadow":
+      effects.shadowSize > 0
+        ? `${shadowOffset}px ${shadowOffset}px 0 ${effects.shadowColor || "#00000040"}`
+        : "none",
+    "object-fit": "cover",
+  };
+}
+
 /**
- * Contact entries in template order.
- *
- * `build-contact-items` in `_common.typ` emits email, phone then location, and
- * templates append the personal URL after it; the resume's custom fields
- * follow, as the templates that print them do.
+ * The avatar: photo when set, an initials disc otherwise. In edit mode the
+ * whole avatar is a button that opens the photo dialog; in Done mode it is
+ * inert (and absent entirely while it holds no photo).
+ */
+export function SheetAvatar(props: { basics: Basics }): JSX.Element {
+  const isEditable = useSheetEditable();
+  const [isPhotoOpen, setIsPhotoOpen] = createSignal(false);
+
+  const picture = (): Picture => props.basics.picture;
+  const hasPhoto = (): boolean => pictureVisible(picture());
+  const initials = (): string =>
+    props.basics.name
+      .split(/\s+/)
+      .filter((word) => word !== "")
+      .slice(0, 2)
+      .map((word) => (word[0] ?? "").toUpperCase())
+      .join("") || "·";
+
+  return (
+    <Show when={hasPhoto() || isEditable()}>
+      <button
+        type="button"
+        class="doc-sheet__avatar-btn"
+        title={isEditable() ? "Edit profile photo" : undefined}
+        disabled={!isEditable()}
+        onClick={() => setIsPhotoOpen(true)}
+      >
+        <Show
+          when={hasPhoto()}
+          fallback={
+            <span class="doc-sheet__avatar-initials" aria-hidden="true">
+              {initials()}
+            </span>
+          }
+        >
+          <img
+            class="doc-sheet__avatar-img"
+            src={picture().url}
+            alt={
+              props.basics.name.trim() === ""
+                ? "Profile picture"
+                : `Profile picture of ${props.basics.name}`
+            }
+            style={avatarStyle(picture())}
+          />
+        </Show>
+      </button>
+
+      <Show when={isEditable()}>
+        <PhotoDialog open={isPhotoOpen()} picture={picture()} onOpenChange={setIsPhotoOpen} />
+      </Show>
+    </Show>
+  );
+}
+
+/** One contact line: glyph kind, value, and where it writes back. */
+interface ContactEntry {
+  key: string;
+  kind: ContactIconKind;
+  /** Text label for custom fields, drawn instead of a glyph. */
+  label?: string;
+  value: string;
+  fieldLabel: string;
+  commit: (value: string) => void;
+  /** Whether the line is drawn even when the value is empty (edit mode). */
+  alwaysShown?: boolean;
+}
+
+/**
+ * Contact entries in template order: email, phone, location, then the
+ * personal URL and the resume's custom fields (`build-contact-items`).
  */
 function contactEntries(basics: Basics): ContactEntry[] {
   const entries: ContactEntry[] = [
     {
       key: "email",
+      kind: "email",
       value: basics.email,
       fieldLabel: "Email",
       commit: (value) => updateBasicsField("email", value),
@@ -63,6 +192,7 @@ function contactEntries(basics: Basics): ContactEntry[] {
     },
     {
       key: "phone",
+      kind: "phone",
       value: basics.phone,
       fieldLabel: "Phone",
       commit: (value) => updateBasicsField("phone", value),
@@ -70,6 +200,7 @@ function contactEntries(basics: Basics): ContactEntry[] {
     },
     {
       key: "location",
+      kind: "location",
       value: basics.location,
       fieldLabel: "Location",
       commit: (value) => updateBasicsField("location", value),
@@ -84,11 +215,10 @@ function contactEntries(basics: Basics): ContactEntry[] {
     const hasLabel = (basics.url?.label ?? "").trim() !== "";
     entries.push({
       key: "url",
+      kind: "link",
       value: url,
       fieldLabel: hasLabel ? "Website label" : "Website URL",
       commit: (value) =>
-        // Spreading a missing `url` alone would drop the other half of the
-        // required `{label, href}` shape.
         updateBasicsField("url", {
           ...(basics.url ?? { label: "", href: "" }),
           [hasLabel ? "label" : "href"]: value,
@@ -100,6 +230,7 @@ function contactEntries(basics: Basics): ContactEntry[] {
     if (field.value.trim() === "") continue;
     entries.push({
       key: `custom:${field.id}`,
+      kind: "link",
       label: field.name,
       value: field.value,
       fieldLabel: field.name === "" ? "Custom field" : field.name,
@@ -110,200 +241,63 @@ function contactEntries(basics: Basics): ContactEntry[] {
   return entries;
 }
 
-/** `customFields` with one field's value replaced — committed as one action. */
-function replaceField(basics: Basics, id: string, value: string): CustomField[] {
-  return basics.customFields.map((field) => (field.id === id ? { ...field, value } : field));
-}
-
-/** Whether a picture is set and not switched off. Mirrors `has-visible-picture`. */
-function pictureVisible(picture: Picture | undefined): boolean {
-  return picture !== undefined && picture.url.trim() !== "" && !picture.effects.hidden;
+export interface ContactBlockProps {
+  basics: Basics;
+  /** Wrapping inline row for header/banner placements; column list otherwise. */
+  isCompact?: boolean;
+  /** Draw the avatar above the block (sidebar placement). */
+  withAvatar?: boolean;
 }
 
 /**
- * The stored avatar, drawn at its stored size and shape.
- *
- * Sizes are stored in typographic points, so they are expressed against the
- * page's own `--doc-sheet-pt` unit and scale with the sheet, exactly as they do
- * in the rendered PDF. Like `render-picture`, the frame is square and the image
- * is cropped to fill it; `aspectRatio` records the source image's proportions
- * and is not a display setting.
+ * The contact card: a `SectionChrome` whose body is icon rows. Template-owned
+ * chrome — no grip, no pencil, no menu, never draggable (spec §1.4).
  */
-function Avatar(props: { picture: Picture; name: string }): JSX.Element {
-  const size = () => `calc(var(--doc-sheet-pt) * ${props.picture.size})`;
-  const effects = () => props.picture.effects;
-  const radius = () =>
-    `calc(var(--doc-sheet-pt) * ${Math.min(props.picture.borderRadius, props.picture.size / 2)})`;
-
-  return (
-    <img
-      class="doc-sheet__avatar"
-      src={props.picture.url}
-      alt={props.name.trim() === "" ? "Profile picture" : `Profile picture of ${props.name}`}
-      style={{
-        width: size(),
-        height: size(),
-        "border-radius": radius(),
-        "border-width": effects().border
-          ? `calc(var(--doc-sheet-pt) * ${effects().borderWidth})`
-          : "0",
-        "border-color": effects().borderColor === "" ? undefined : effects().borderColor,
-        filter: effects().grayscale ? "grayscale(1)" : undefined,
-        transform: effects().rotation === 0 ? undefined : `rotate(${effects().rotation}deg)`,
-      }}
-    />
-  );
-}
-
-export interface DocHeaderProps {
-  basics: Basics;
-  /** How the template presents the name block. */
-  headerStyle: TemplateHeaderStyle;
-  /**
-   * Whether to draw the avatar, name and headline.
-   *
-   * False for the second header a template needs when it prints its name block
-   * and its contact details in different regions.
-   */
-  showIdentity?: boolean;
-  /** Whether this region is the one the template prints contact details in. */
-  showContact: boolean;
-  /**
-   * Profile links to print in the header.
-   *
-   * Empty when the resume places `profiles` as a section, so a profile is never
-   * drawn twice on the same sheet.
-   */
-  profileLinks?: { id: string; label: string }[];
-}
-
-export function DocHeader(props: DocHeaderProps): JSX.Element {
+export function ContactBlock(props: ContactBlockProps): JSX.Element {
   const isEditable = useSheetEditable();
-  const [isPhotoOpen, setIsPhotoOpen] = createSignal(false);
-
-  // `alwaysShown` entries are editing placeholders; the rendered document
-  // (Done mode) only prints contact details that hold a value.
-  const entries = () =>
+  const entries = (): ContactEntry[] =>
     contactEntries(props.basics).filter(
       (entry) => (isEditable() && entry.alwaysShown === true) || entry.value.trim() !== "",
     );
-  const links = () => props.profileLinks ?? [];
-  const stacked = () => props.headerStyle === "sidebar";
-  const showIdentity = () => props.showIdentity ?? true;
 
   return (
-    <header
-      class="doc-sheet__header"
-      classList={{
-        "doc-sheet__header--left": props.headerStyle === "left",
-        "doc-sheet__header--center": props.headerStyle === "center",
-        "doc-sheet__header--banner": props.headerStyle === "banner",
-        "doc-sheet__header--boxed": props.headerStyle === "boxed",
-        "doc-sheet__header--sidebar": stacked(),
-      }}
-      data-testid="doc-sheet-header"
-    >
-      <Show when={showIdentity()}>
-        {/* Identity is one region so the header styles can arrange the photo
-            the way their template does: beside the name for `left`, above it
-            for `center`/`boxed`/`banner`/`sidebar`. */}
-        <div class="doc-sheet__identity">
-          <Show
-            when={pictureVisible(props.basics.picture)}
-            fallback={
-              <Show when={isEditable()}>
-                <button
-                  type="button"
-                  class="doc-sheet__action"
-                  onClick={() => setIsPhotoOpen(true)}
-                >
-                  Add photo
-                </button>
-              </Show>
-            }
+    <>
+      <Show when={props.withAvatar === true}>
+        <SheetAvatar basics={props.basics} />
+      </Show>
+      <Show when={entries().length > 0}>
+        <SectionChrome sectionId="basics" title="Contact" isFocused={false} onFocus={() => {}}>
+          <ul
+            class="doc-sheet__contact"
+            classList={{
+              "doc-sheet__contact--inline": props.isCompact === true,
+              "doc-sheet__contact--list": props.isCompact !== true,
+            }}
+            data-testid="doc-sheet-contact"
           >
-            <Show
-              when={isEditable()}
-              fallback={<Avatar picture={props.basics.picture} name={props.basics.name} />}
-            >
-              <button
-                type="button"
-                class="doc-sheet__editable doc-sheet__avatar-button"
-                title="Edit photo"
-                onClick={() => setIsPhotoOpen(true)}
-              >
-                <Avatar picture={props.basics.picture} name={props.basics.name} />
-              </button>
-            </Show>
-          </Show>
-
-          <div class="doc-sheet__identity-text">
-            {/* Rendered (Done) mode drops the wrappers of empty fields: an
-                empty heading is announced as a nameless landmark stop. */}
-            <Show when={isEditable() || props.basics.name.trim() !== ""}>
-              <h2 class="doc-sheet__name">
-                <InlineText
-                  value={props.basics.name}
-                  label="Name"
-                  placeholder="Your name"
-                  triggerId="doc-header-name"
-                  onCommit={(value) => updateBasicsField("name", value)}
-                />
-              </h2>
-            </Show>
-
-            <Show when={isEditable() || props.basics.headline.trim() !== ""}>
-              <p class="doc-sheet__headline">
-                <InlineText
-                  value={props.basics.headline}
-                  label="Headline"
-                  placeholder="Your headline"
-                  triggerId="doc-header-headline"
-                  onCommit={(value) => updateBasicsField("headline", value)}
-                />
-              </p>
-            </Show>
-          </div>
-        </div>
-
-        {/* Editing chrome: unmounted in Done mode even when its open flag was
-            left set by a mid-dialog mode switch. */}
-        <Show when={isEditable()}>
-          <PhotoDialog
-            open={isPhotoOpen()}
-            picture={props.basics.picture}
-            onOpenChange={setIsPhotoOpen}
-          />
-        </Show>
+            <For each={entries()}>
+              {(entry) => (
+                <li class="doc-sheet__icon-row">
+                  <Show
+                    when={entry.label === undefined}
+                    fallback={<span class="doc-sheet__contact-label">{entry.label}: </span>}
+                  >
+                    <ContactIcon kind={entry.kind} />
+                    <span class="sr-only">{entry.fieldLabel}</span>
+                  </Show>
+                  <InlineText
+                    value={entry.value}
+                    label={entry.fieldLabel}
+                    class="doc-sheet__side-val"
+                    triggerId={`doc-header-${entry.key}`}
+                    onCommit={entry.commit}
+                  />
+                </li>
+              )}
+            </For>
+          </ul>
+        </SectionChrome>
       </Show>
-
-      <Show when={props.showContact && entries().length > 0}>
-        <ul class="doc-sheet__contact" classList={{ "doc-sheet__contact--stacked": stacked() }}>
-          <For each={entries()}>
-            {(entry) => (
-              <li>
-                <Show when={entry.label}>
-                  <span class="doc-sheet__contact-label">{entry.label}: </span>
-                </Show>
-                <InlineText
-                  value={entry.value}
-                  label={entry.fieldLabel}
-                  triggerId={`doc-header-${entry.key}`}
-                  onCommit={entry.commit}
-                />
-              </li>
-            )}
-          </For>
-        </ul>
-      </Show>
-
-      <Show when={props.showContact && links().length > 0}>
-        <ul class="doc-sheet__contact" classList={{ "doc-sheet__contact--stacked": stacked() }}>
-          {/* Profile links mirror the `profiles` section, which is edited where
-              the layout places it rather than twice over. */}
-          <For each={links()}>{(link) => <li>{link.label}</li>}</For>
-        </ul>
-      </Show>
-    </header>
+    </>
   );
 }

--- a/apps/web/src/components/doc-editor/DocHeader.tsx
+++ b/apps/web/src/components/doc-editor/DocHeader.tsx
@@ -81,14 +81,19 @@ export function NameHeader(props: { basics: Basics; isInSidebar?: boolean }): JS
   );
 }
 
-/** The avatar's stored geometry, in sheet pixels. */
+/**
+ * The avatar's stored geometry, in sheet pixels. All stored lengths — size,
+ * radius, border width, shadow size — are points, so every one of them scales
+ * through {@link SHEET_PX_PER_PT} and the on-sheet avatar matches the PDF.
+ */
 function avatarStyle(picture: Picture): JSX.CSSProperties {
   const size = Math.min(Math.round(picture.size * SHEET_PX_PER_PT), MAX_SHEET_AVATAR_PX);
   const radius = Math.min(Math.round(picture.borderRadius * SHEET_PX_PER_PT), size / 2);
   const effects = picture.effects;
   const borderColor =
     effects.borderColor.trim() === "" ? "var(--doc-sheet-accent)" : effects.borderColor;
-  const shadowOffset = (effects.shadowSize || 0) / 2;
+  const borderWidth = effects.borderWidth * SHEET_PX_PER_PT;
+  const shadowOffset = ((effects.shadowSize || 0) * SHEET_PX_PER_PT) / 2;
   return {
     width: `${size}px`,
     height: `${size}px`,
@@ -97,11 +102,11 @@ function avatarStyle(picture: Picture): JSX.CSSProperties {
     transform: effects.rotation === 0 ? undefined : `rotate(${effects.rotation}deg)`,
     border:
       effects.border && effects.borderWidth > 0
-        ? `${effects.borderWidth}px solid ${borderColor}`
+        ? `${borderWidth.toFixed(2)}px solid ${borderColor}`
         : "none",
     "box-shadow":
       effects.shadowSize > 0
-        ? `${shadowOffset}px ${shadowOffset}px 0 ${effects.shadowColor || "#00000040"}`
+        ? `${shadowOffset.toFixed(2)}px ${shadowOffset.toFixed(2)}px 0 ${effects.shadowColor || "#00000040"}`
         : "none",
     "object-fit": "cover",
   };

--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -1,80 +1,75 @@
 /**
- * Section views for the document sheet, with editing in place.
+ * Section views for the document sheet, with editing in place (#794).
  *
- * Each section type is reduced to one {@link ItemView} descriptor and drawn by
- * a single renderer, so field *order* lives in one obvious place. That order is
- * taken from the Typst templates in
- * `crates/render/src/typst_engine/templates/*.typ`, which are authoritative for
- * what a section shows and in which sequence.
+ * Every section renders inside {@link SectionChrome} — the universal dashed
+ * card with grip, pencil menu and add-block — and every structured item inside
+ * {@link SortableEntry} row chrome. The body layouts follow spec §1.7 exactly:
  *
- * Every slot the renderer draws carries the item key it came from, which is
- * what makes click-to-edit possible without a second mapping: committing a slot
- * writes that one key through `docEdits`. Slots the sheet derives from more than
- * one field (a degree, say) carry no key and are edited in the item dialog
- * instead, which is also where the fields the sheet has no room for live.
+ * - `experience`: position over a company · date meta row, a location row with
+ *   a pin glyph, then the rich summary, tag chips and extra fields.
+ * - `education`: degree over `institution · area`, a mono date, summary.
+ * - `profiles` / `languages` / `skills`: compact rows — brand or name plus
+ *   proficiency dots; the whole row is the edit affordance (spec §1.9).
+ * - `interests`: a plain list, managed through the add-block and dialog.
+ * - custom sections: chip lists with an inline remove.
+ * - everything else: a generic entry — name with a right-aligned date, an
+ *   optional one-line description, then summary, chips and extra fields.
  *
- * Structural chrome lives here too: each section is a card with hover/focus
- * controls (move, hide, rename, delete) and each entry carries its own action
- * row. Drags start from the handles only — never from the surface — so text
- * selection and inline editing keep working; the sheet (`DocSheet`) owns the
- * drag-drop context, drop resolution and announcements, and every mutation
- * still goes through `docEdits`.
- *
- * URLs still render as text rather than anchors: the sheet is a document
- * surface, not a navigation surface, and a link inside an item would compete
- * with the item's own click targets. Markdown fields render formatted via
- * {@link MarkdownView} — the sheet *is* the rendered document (#785).
+ * Bound slots stay inline-editable exactly as in #788 (the inline-editing
+ * rework is #795's); a slot the sheet derives from several fields is read-only
+ * and edited in the item dialog. Every mutation still routes through
+ * `docEdits` — one action, one undo entry.
  */
 
 import { For, Show, createSignal, type JSX } from "solid-js";
 import { createDraggable, createDroppable } from "@thisbeyond/solid-dnd";
-import { CustomSectionDialog } from "./CustomSectionDialog";
 import { InlineMarkdown } from "./InlineMarkdown";
 import { InlineText } from "./InlineText";
 import { ItemDialog } from "./ItemDialog";
 import { MarkdownView } from "./MarkdownView";
+import { SectionChrome, sectionTitleTriggerId, type SectionMenuActions } from "./SectionChrome";
+import { SortableEntry } from "./SortableEntry";
+import { ContactIcon, ProfileIcon } from "./icons";
 import { useSheetEditable } from "./sheetMode";
 import {
+  duplicateItem,
   removeItem,
-  removeSection,
   renameSection,
   setItemVisibility,
   toggleSection,
-  duplicateItem,
   updateCoverLetter,
   updateItem,
   updateSummary,
 } from "./docEdits";
 import { itemNoun } from "./itemFields";
-import type { MoveStep } from "../../lib/docDnd";
+import { entryStep, type MoveStep } from "../../lib/docDnd";
 import { isCustomId, sectionTitle } from "../../lib/docLayout";
 import type {
   Award,
-  Certification,
-  CustomItem,
+  CustomField,
   Education,
   Experience,
-  Interest,
   Language,
   Profile,
-  Project,
-  Publication,
-  Reference,
   ResumeData,
   Skill,
   Url,
-  Volunteer,
 } from "../../wasm/types";
 
 /** Highest level a skill or language can carry. Mirrors `clamp-level`. */
 const MAX_LEVEL = 5;
 
-/**
- * One drawn slot of an item.
- *
- * `field` names the item key the slot writes to; a slot without one is derived
- * from several fields and is therefore read-only on the sheet.
- */
+/** Add-block labels per fixed section (spec §1.7); customs fall back to noun. */
+const ADD_LABELS: Readonly<Record<string, string>> = {
+  experience: "Add experience",
+  education: "Add education",
+  profiles: "Add profile",
+  languages: "Add language",
+  skills: "Add skill",
+  interests: "Add interest",
+};
+
+/** A drawn slot: `field` names the writable key; without one it is derived. */
 interface ItemField {
   value: string;
   /** Human label, announced by the inline editor. */
@@ -82,226 +77,26 @@ interface ItemField {
   field?: string;
 }
 
-/**
- * One item of any section, flattened to the slots the sheet draws.
- *
- * The slots render in declaration order: title/subtitle and meta share the
- * head row, then details, then body, then keywords, level and url.
- */
-interface ItemView {
-  /** Primary line — company, institution, name, title. */
-  title: ItemField;
-  /**
-   * Draw title and subtitle as one inline run rather than stacked lines.
-   *
-   * Profiles use this: templates print a profile as one `network username`
-   * entry (`render-profile-entry` in `_common.typ`), so stacking the same
-   * strings as title, subtitle and link reads as duplication (#787).
-   */
-  inline?: boolean;
-  /** Secondary line under the title. */
-  subtitle?: ItemField;
-  /** Right-aligned head-row entries, typically date then location. */
-  meta?: ItemField[];
-  /** Short plain lines between the head row and the body. */
-  details?: ItemField[];
-  /** Rich-text (markdown) fields, in template order. */
-  body?: ItemField[];
-  keywords?: string[];
-  /** 0–5 proficiency, drawn as dots. Absent for sections without a level. */
-  level?: number;
-  url?: Url;
-}
-
-/**
- * A slot bound to one item key.
- *
- * The value is read defensively: imported resumes reach the store with fields
- * the schema declares but the import never filled in.
- */
 function bind(value: string | undefined, label: string, field: string): ItemField {
   return { value: value ?? "", label, field };
 }
 
-/** A slot the sheet derives rather than stores, so it cannot be edited inline. */
-function derived(value: string | undefined, label: string): ItemField {
-  return { value: value ?? "", label };
+function hasText(value: string | undefined): boolean {
+  return (value ?? "").trim() !== "";
 }
 
-function nonEmpty(fields: ItemField[]): ItemField[] {
-  return fields.filter((entry) => entry.value.trim() !== "");
-}
-
-/** `studyType in area`, matching `format-degree` in `_common.typ`. */
-function formatDegree(studyType: string, area: string): string {
-  if (studyType !== "" && area !== "") return `${studyType} in ${area}`;
-  return area !== "" ? area : studyType;
-}
-
-/**
- * Visible text for a URL — label, else href. Mirrors `url-display-label`.
- *
- * Both fields are read defensively: imported resumes reach the store with one
- * or the other missing.
- */
-function urlLabel(url: Url | undefined): string {
-  const label = url?.label ?? "";
-  return label.trim() !== "" ? label : (url?.href ?? "");
-}
-
-function experienceView(item: Experience): ItemView {
-  return {
-    title: bind(item.company, "Company", "company"),
-    subtitle: bind(item.position, "Position", "position"),
-    meta: nonEmpty([bind(item.date, "Date", "date"), bind(item.location, "Location", "location")]),
-    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
-    url: item.url,
-  };
-}
-
-function educationView(item: Education): ItemView {
-  return {
-    title: bind(item.institution, "Institution", "institution"),
-    // `studyType in area` — two fields in one line, so the dialog owns it.
-    // Absent rather than empty when neither is set: a derived slot is truthy
-    // whatever its value, and `<Show>` would draw a blank line for it.
-    subtitle: nonEmpty([derived(formatDegree(item.studyType, item.area), "Degree")])[0],
-    meta: nonEmpty([bind(item.date, "Date", "date")]),
-    details: nonEmpty([bind(item.score, "Score", "score")]),
-    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
-    url: item.url,
-  };
-}
-
-function skillView(item: Skill): ItemView {
-  return {
-    title: bind(item.name, "Name", "name"),
-    body: nonEmpty([bind(item.description, "Description", "description")]),
-    level: item.level,
-    keywords: item.keywords,
-  };
-}
-
-function projectView(item: Project): ItemView {
-  return {
-    title: bind(item.name, "Name", "name"),
-    meta: nonEmpty([bind(item.date, "Date", "date")]),
-    body: nonEmpty([
-      bind(item.description, "Description", "description"),
-      bind(item.summary, "Summary", "summary"),
-    ]),
-    keywords: item.keywords,
-    url: item.url,
-  };
-}
-
-function profileView(item: Profile): ItemView {
-  // One entry per profile — network label plus the linked username, the way
-  // every template draws it. The URL itself is edited in the item dialog; a
-  // third line repeating the username-shaped href is exactly the duplication
-  // this view exists to avoid (#787).
-  return {
-    title: bind(item.network, "Network", "network"),
-    subtitle: bind(item.username, "Username", "username"),
-    inline: true,
-  };
-}
-
-function awardView(item: Award): ItemView {
-  return {
-    title: bind(item.title, "Title", "title"),
-    subtitle: bind(item.awarder, "Awarder", "awarder"),
-    meta: nonEmpty([bind(item.date, "Date", "date")]),
-    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
-    url: item.url,
-  };
-}
-
-function certificationView(item: Certification): ItemView {
-  return {
-    title: bind(item.name, "Name", "name"),
-    subtitle: bind(item.issuer, "Issuer", "issuer"),
-    meta: nonEmpty([bind(item.date, "Date", "date")]),
-    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
-    url: item.url,
-  };
-}
-
-function publicationView(item: Publication): ItemView {
-  return {
-    title: bind(item.name, "Name", "name"),
-    subtitle: bind(item.publisher, "Publisher", "publisher"),
-    meta: nonEmpty([bind(item.date, "Date", "date")]),
-    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
-    url: item.url,
-  };
-}
-
-function languageView(item: Language): ItemView {
-  return {
-    title: bind(item.name, "Name", "name"),
-    subtitle: bind(item.description, "Description", "description"),
-    level: item.level,
-  };
-}
-
-function interestView(item: Interest): ItemView {
-  return { title: bind(item.name, "Name", "name"), keywords: item.keywords };
-}
-
-function volunteerView(item: Volunteer): ItemView {
-  return {
-    title: bind(item.organization, "Organization", "organization"),
-    subtitle: bind(item.position, "Position", "position"),
-    meta: nonEmpty([bind(item.date, "Date", "date")]),
-    details: nonEmpty([bind(item.location, "Location", "location")]),
-    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
-    url: item.url,
-  };
-}
-
-function referenceView(item: Reference): ItemView {
-  return {
-    title: bind(item.name, "Name", "name"),
-    subtitle: bind(item.description, "Description", "description"),
-    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
-    url: item.url,
-  };
-}
-
-function customView(item: CustomItem): ItemView {
-  return {
-    title: bind(item.name, "Name", "name"),
-    subtitle: bind(item.description, "Description", "description"),
-    meta: nonEmpty([bind(item.date, "Date", "date")]),
-    details: nonEmpty([bind(item.location, "Location", "location")]),
-    body: nonEmpty([bind(item.summary, "Summary", "summary")]),
-    keywords: item.keywords,
-    url: item.url,
-  };
-}
-
-/** Every item-bearing section's adapter, keyed by section id. */
-const ITEM_VIEWS = {
-  experience: experienceView,
-  education: educationView,
-  skills: skillView,
-  projects: projectView,
-  profiles: profileView,
-  awards: awardView,
-  certifications: certificationView,
-  publications: publicationView,
-  languages: languageView,
-  interests: interestView,
-  volunteer: volunteerView,
-  references: referenceView,
-} as const;
-
-type ItemSectionId = keyof typeof ITEM_VIEWS;
-
-interface VisibleItem {
+/** A generic item as the sheet reads it — every field optional. */
+interface AnyItem {
   id: string;
   visible: boolean;
+  name?: string;
+  description?: string;
+  date?: string;
+  summary?: string;
+  keywords?: string[];
+  customFields?: CustomField[];
+  level?: number;
+  url?: Url;
 }
 
 /** A drawn item, plus where it sits in the section's own `items` array. */
@@ -311,53 +106,34 @@ interface ItemEntry {
   index: number;
   /** Switched off — drawn as chrome, but absent from the PDF. */
   hidden: boolean;
-  item: Record<string, unknown>;
-  view: ItemView;
+  item: AnyItem;
 }
 
-/**
- * The items of `sectionId`, already flattened to {@link ItemView}.
- *
- * Item shapes differ per section, and the adapter table above is the only
- * place that knows which is which — so the lookup is done once, here, behind a
- * cast the table's own keys justify. Hidden items stay in the drawing as
- * flagged chrome — hidden means "not rendered to PDF", not "gone from the
- * editing surface" — which also keeps drawn order identical to stored order.
- */
-function itemEntries(resume: ResumeData, sectionId: string): ItemEntry[] {
-  const adapter = isCustomId(sectionId)
-    ? (customView as (item: VisibleItem) => ItemView)
-    : (ITEM_VIEWS[sectionId as ItemSectionId] as ((item: VisibleItem) => ItemView) | undefined);
-  if (!adapter) return [];
+/** Head-line fields an entry might carry, in announcement preference order. */
+const ENTRY_LABEL_KEYS = ["name", "position", "institution", "title", "network"] as const;
 
+function entryLabel(entry: ItemEntry, noun: string): string {
+  const record = entry.item as unknown as Record<string, unknown>;
+  for (const key of ENTRY_LABEL_KEYS) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim() !== "") return value;
+  }
+  return noun;
+}
+
+/** The items of `sectionId`, with their stored indices. */
+function itemEntries(resume: ResumeData, sectionId: string): ItemEntry[] {
   const section = isCustomId(sectionId)
     ? resume.sections.custom?.[sectionId]
-    : (resume.sections[sectionId as ItemSectionId] as { items?: VisibleItem[] } | undefined);
-
+    : (resume.sections[sectionId as keyof ResumeData["sections"]] as
+        | { items?: AnyItem[] }
+        | undefined);
   return (section?.items ?? []).map((item, index) => ({
     id: item.id,
     index,
     hidden: !item.visible,
-    item: item as unknown as Record<string, unknown>,
-    view: adapter(item),
+    item,
   }));
-}
-
-function Level(props: { value: number }): JSX.Element {
-  const level = () => Math.min(MAX_LEVEL, Math.max(0, Math.round(props.value)));
-  return (
-    <span class="doc-sheet__level" role="img" aria-label={`Level ${level()} of ${MAX_LEVEL}`}>
-      <For each={Array.from({ length: MAX_LEVEL }, (_, index) => index)}>
-        {(index) => (
-          <span
-            class="doc-sheet__level-dot"
-            classList={{ "doc-sheet__level-dot--filled": index < level() }}
-            aria-hidden="true"
-          />
-        )}
-      </For>
-    </span>
-  );
 }
 
 /** A bound slot as an inline editor; a derived slot as plain text. */
@@ -369,7 +145,7 @@ function Slot(props: {
   onCommit: (field: string, value: string) => void;
 }): JSX.Element {
   return (
-    <Show when={props.field.field} fallback={props.field.value}>
+    <Show when={props.field.field} fallback={<span class={props.class}>{props.field.value}</span>}>
       {(key) => (
         <InlineText
           value={props.field.value}
@@ -383,246 +159,74 @@ function Slot(props: {
   );
 }
 
-/** Icon paths for the chrome controls, drawn on a 24x24 grid. */
-const CHROME_ICONS = {
-  handle: "M9 6h.01M15 6h.01M9 12h.01M15 12h.01M9 18h.01M15 18h.01",
-  up: "M5 15l7-7 7 7",
-  down: "M19 9l-7 7-7-7",
-  previous: "M15 19l-7-7 7-7",
-  next: "M9 5l7 7-7 7",
-} as const;
-
-function ChromeIcon(props: { path: string }): JSX.Element {
+/** Soft accent pill per keyword (spec §1.7); hidden when empty. */
+function TagChips(props: { tags?: string[] }): JSX.Element {
+  const tags = (): string[] => (props.tags ?? []).filter((tag) => tag.trim() !== "");
   return (
-    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={props.path} />
-    </svg>
+    <Show when={tags().length > 0}>
+      <ul class="doc-sheet__tag-chips">
+        <For each={tags()}>{(tag) => <li class="doc-sheet__tag-chip">{tag}</li>}</For>
+      </ul>
+    </Show>
   );
 }
 
-/** The one-step move controls: label suffix per step, in render order. */
-const STEP_WORDS: Record<MoveStep, string> = {
-  up: "up",
-  down: "down",
-  previous: "to the previous section",
-  next: "to the next section",
-};
+/** Uppercase label + value rows for an item's extra fields (spec §1.7). */
+function ExtraFieldsView(props: { fields?: CustomField[] }): JSX.Element {
+  const fields = (): CustomField[] =>
+    (props.fields ?? []).filter((field) => hasText(field.name) || hasText(field.value));
+  return (
+    <Show when={fields().length > 0}>
+      <div class="doc-sheet__extra-view">
+        <For each={fields()}>
+          {(field) => (
+            <div class="doc-sheet__extra-row">
+              <span class="doc-sheet__extra-label">
+                {hasText(field.name) ? field.name : "Field"}
+              </span>
+              <span class="doc-sheet__extra-val">{field.value}</span>
+            </div>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+}
 
-function Item(props: {
-  sectionId: string;
-  entry: ItemEntry;
-  /** Singular noun for this section's items, used in the controls' labels. */
-  noun: string;
-  onEdit: (entry: ItemEntry) => void;
-  onMove: (itemId: string, step: MoveStep) => void;
-  /** Announce a completed action to the sheet's live region. */
-  onAnnounce: (message: string) => void;
+/** Five proficiency dots, filled to `value` (compact rows, spec §1.7). */
+function LevelDots(props: { value: number }): JSX.Element {
+  const level = (): number => Math.min(MAX_LEVEL, Math.max(0, Math.round(props.value)));
+  return (
+    <span class="doc-sheet__lang-dots" role="img" aria-label={`Level ${level()} of ${MAX_LEVEL}`}>
+      <For each={Array.from({ length: MAX_LEVEL }, (_, index) => index)}>
+        {(index) => (
+          <i classList={{ "doc-sheet__lang-dot--on": index < level() }} aria-hidden="true" />
+        )}
+      </For>
+    </span>
+  );
+}
+
+/** The rich summary of an item: inline-editable markdown, formatted in Done. */
+function EntrySummary(props: {
+  value: string;
+  idPrefix: string;
+  onCommit: (value: string) => void;
 }): JSX.Element {
   const isEditable = useSheetEditable();
-  const view = () => props.entry.view;
-  // Stable across redraws: the item's own id, not its position. Inline editors
-  // use it to find their trigger again after a commit redraws the section.
-  const idPrefix = () => `doc-${props.sectionId}-${props.entry.id}`;
-  const meta = () => view().meta ?? [];
-  const keywords = () => (view().keywords ?? []).filter((keyword) => keyword.trim() !== "");
-  const url = () => urlLabel(view().url);
-  const label = () => (view().title.value.trim() === "" ? props.noun : view().title.value);
-
-  const draggable = createDraggable(`drag:entry:${props.sectionId}:${props.entry.id}`, {
-    type: "entry",
-    sectionId: props.sectionId,
-    itemId: props.entry.id,
-  });
-  const droppable = createDroppable(`drop:entry:${props.sectionId}:${props.entry.id}`, {
-    type: "entry",
-    sectionId: props.sectionId,
-    itemId: props.entry.id,
-  });
-
-  // Lateral steps mirror the cross-section drag, which only custom sections
-  // support — the only pair with a shared item shape.
-  const steps = (): MoveStep[] =>
-    isCustomId(props.sectionId) ? ["up", "down", "previous", "next"] : ["up", "down"];
-
-  const commit = (field: string, value: string): void => {
-    updateItem(props.sectionId, props.entry.index, { [field]: value });
-  };
-
   return (
-    <article
-      ref={(element) => {
-        draggable.ref(element);
-        droppable.ref(element);
-      }}
-      class="doc-sheet__item"
-      classList={{
-        "doc-sheet__item--hidden": props.entry.hidden,
-        "doc-sheet__item--drop": droppable.isActiveDroppable,
-        "doc-sheet__item--dragging": draggable.isActiveDraggable,
-      }}
-      data-entry-id={props.entry.id}
-    >
-      <Show
-        when={!view().inline}
-        fallback={
-          <p class="doc-sheet__item-inline">
-            <span class="doc-sheet__item-inline-label">
-              <Slot field={view().title} idPrefix={idPrefix()} onCommit={commit} />
-            </span>
-            <Show when={view().subtitle}>
-              {(subtitle) => (
-                <span class="doc-sheet__item-inline-value">
-                  <Slot field={subtitle()} idPrefix={idPrefix()} onCommit={commit} />
-                </span>
-              )}
-            </Show>
-          </p>
-        }
-      >
-        <div class="doc-sheet__item-head">
-          <div>
-            <h4 class="doc-sheet__item-title">
-              <Slot field={view().title} idPrefix={idPrefix()} onCommit={commit} />
-            </h4>
-            <Show when={view().subtitle}>
-              {(subtitle) => (
-                <p class="doc-sheet__item-subtitle">
-                  <Slot field={subtitle()} idPrefix={idPrefix()} onCommit={commit} />
-                </p>
-              )}
-            </Show>
-          </div>
-          <Show when={meta().length > 0}>
-            <div class="doc-sheet__item-meta">
-              <For each={meta()}>
-                {(entry) => (
-                  <span>
-                    <Slot field={entry} idPrefix={idPrefix()} onCommit={commit} />
-                  </span>
-                )}
-              </For>
-            </div>
-          </Show>
-        </div>
-      </Show>
-
-      <For each={view().details ?? []}>
-        {(detail) => (
-          <p class="doc-sheet__item-detail">
-            <Slot field={detail} idPrefix={idPrefix()} onCommit={commit} />
-          </p>
-        )}
-      </For>
-
-      <For each={view().body ?? []}>
-        {(text) => (
-          <Show
-            when={text.field}
-            fallback={
-              <div class="doc-sheet__rich-text">
-                <MarkdownView value={text.value} />
-              </div>
-            }
-          >
-            {(key) => (
-              <InlineMarkdown
-                value={text.value}
-                label={text.label}
-                triggerId={`${idPrefix()}-${key()}`}
-                onCommit={(value) => commit(key(), value)}
-              />
-            )}
-          </Show>
-        )}
-      </For>
-
-      <Show when={view().level !== undefined && (view().level ?? 0) > 0}>
-        <Level value={view().level ?? 0} />
-      </Show>
-
-      <Show when={keywords().length > 0}>
-        <ul class="doc-sheet__keywords">
-          <For each={keywords()}>{(keyword) => <li class="doc-sheet__keyword">{keyword}</li>}</For>
-        </ul>
-      </Show>
-
-      <Show when={url() !== ""}>
-        <p class="doc-sheet__url">{url()}</p>
-      </Show>
-
-      <Show when={isEditable()}>
-        <div class="doc-sheet__item-actions" role="group" aria-label={`${label()} actions`}>
-          <button
-            type="button"
-            class="doc-sheet__action doc-sheet__action--icon doc-sheet__drag-handle"
-            aria-hidden="true"
-            tabindex="-1"
-            title={`Drag ${label()} to move it`}
-            {...draggable.dragActivators}
-          >
-            <ChromeIcon path={CHROME_ICONS.handle} />
-          </button>
-          <For each={steps()}>
-            {(step) => (
-              <button
-                type="button"
-                class="doc-sheet__action doc-sheet__action--icon"
-                data-doc-move-entry={`${props.entry.id}:${step}`}
-                aria-label={`Move ${label()} ${STEP_WORDS[step]}`}
-                title={`Move ${label()} ${STEP_WORDS[step]}`}
-                onClick={() => props.onMove(props.entry.id, step)}
-              >
-                <ChromeIcon path={CHROME_ICONS[step]} />
-              </button>
-            )}
-          </For>
-          <button
-            type="button"
-            class="doc-sheet__action"
-            aria-label={`Edit ${label()} details`}
-            onClick={() => props.onEdit(props.entry)}
-          >
-            Edit
-          </button>
-          <button
-            type="button"
-            class="doc-sheet__action"
-            aria-label={`Duplicate ${label()}`}
-            onClick={() => {
-              duplicateItem(props.sectionId, props.entry.index);
-              props.onAnnounce(`${label()} duplicated`);
-            }}
-          >
-            Duplicate
-          </button>
-          <button
-            type="button"
-            class="doc-sheet__action"
-            aria-label={`${props.entry.hidden ? "Show" : "Hide"} ${label()}`}
-            onClick={() => {
-              setItemVisibility(props.sectionId, props.entry.index, props.entry.hidden);
-              props.onAnnounce(`${label()} ${props.entry.hidden ? "shown" : "hidden"}`);
-            }}
-          >
-            {props.entry.hidden ? "Show" : "Hide"}
-          </button>
-          <button
-            type="button"
-            class="doc-sheet__action doc-sheet__action--danger"
-            aria-label={`Delete ${label()}`}
-            onClick={() => {
-              removeItem(props.sectionId, props.entry.index);
-              props.onAnnounce(`${label()} deleted`);
-            }}
-          >
-            Delete
-          </button>
-          <Show when={props.entry.hidden}>
-            <span class="doc-sheet__hidden-badge">Hidden</span>
-          </Show>
-        </div>
-      </Show>
-    </article>
+    <Show when={isEditable() || hasText(props.value)}>
+      <div class="doc-sheet__entry-sum">
+        <Show when={isEditable()} fallback={<MarkdownView value={props.value} />}>
+          <InlineMarkdown
+            value={props.value}
+            label="Summary"
+            triggerId={`${props.idPrefix}-summary`}
+            onCommit={props.onCommit}
+          />
+        </Show>
+      </div>
+    </Show>
   );
 }
 
@@ -630,60 +234,52 @@ export interface DocSectionProps {
   resume: ResumeData;
   /** A fixed section id, or a custom section's own id. */
   sectionId: string;
-  /** Switched off — drawn as chrome, but absent from the PDF. */
-  hidden: boolean;
+  /** Last-clicked section card, drawn with a solid accent border. */
+  focusedSection: string | null;
+  onFocusSection: (sectionId: string) => void;
+  /** Whether a one-step move in `step` direction would change anything. */
+  canMoveSection: (sectionId: string, step: MoveStep) => boolean;
   /** Perform (and announce) a one-step section move. */
   onMoveSection: (sectionId: string, step: MoveStep) => void;
+  /** The cross-column move's target name, or `null` on single-column pages. */
+  otherColumnLabel: string | null;
+  onMoveSectionToOtherColumn: (sectionId: string) => void;
   /** Perform (and announce) a one-step entry move. */
   onMoveEntry: (sectionId: string, itemId: string, step: MoveStep) => void;
   /** Announce a completed action to the sheet's live region. */
   onAnnounce: (message: string) => void;
 }
 
-/** The section move controls' label suffixes. */
-const SECTION_STEP_WORDS: Record<MoveStep, string> = {
-  up: "up",
-  down: "down",
-  previous: "to the previous column",
-  next: "to the next column",
-};
-
-/**
- * One section of the sheet: a card with structural chrome around an editable
- * view of its content.
- *
- * `summary` and `coverLetter` carry rich text; every other section carries
- * items. Hidden sections and items are drawn dimmed, as chrome — the editor
- * keeps them reachable, the PDF drops them.
- */
+/** One section of the sheet: the universal card around a spec-§1.7 body. */
 export function DocSection(props: DocSectionProps): JSX.Element {
   const isEditable = useSheetEditable();
   const [editing, setEditing] = createSignal<ItemEntry | null>(null);
   const [isDialogOpen, setIsDialogOpen] = createSignal(false);
-  const [isRenameOpen, setIsRenameOpen] = createSignal(false);
 
-  const title = () => sectionTitle(props.resume, props.sectionId);
-  const isRichText = () => props.sectionId === "summary" || props.sectionId === "coverLetter";
-  const richText = () => {
-    if (props.sectionId === "summary") return props.resume.sections.summary?.content ?? "";
-    if (props.sectionId === "coverLetter") return props.resume.sections.coverLetter?.content ?? "";
+  const id = (): string => props.sectionId;
+  const title = (): string => sectionTitle(props.resume, id());
+  const isRichText = (): boolean => id() === "summary" || id() === "coverLetter";
+  const isChips = (): boolean => isCustomId(id());
+  const noun = (): string => itemNoun(title());
+  const addLabel = (): string => ADD_LABELS[id()] ?? `Add ${noun()}`;
+
+  // Done mode mirrors the PDF: hidden items are dropped, not dimmed.
+  const entries = (): ItemEntry[] =>
+    itemEntries(props.resume, id()).filter((entry) => isEditable() || !entry.hidden);
+
+  const richText = (): string => {
+    if (id() === "summary") return props.resume.sections.summary?.content ?? "";
+    if (id() === "coverLetter") return props.resume.sections.coverLetter?.content ?? "";
     return "";
   };
-  // Done mode mirrors the PDF: hidden items are dropped, not dimmed —
-  // `renderPages` already drops hidden *sections*, this is the item-level
-  // half of the same rule.
-  const entries = () =>
-    itemEntries(props.resume, props.sectionId).filter((entry) => isEditable() || !entry.hidden);
-  const noun = () => itemNoun(title());
-  const isCustom = () => isCustomId(props.sectionId);
 
-  const draggable = createDraggable(`drag:section:${props.sectionId}`, {
+  const draggable = createDraggable(`drag:section:${id()}`, {
     type: "section",
-    sectionId: props.sectionId,
+    sectionId: id(),
   });
-  const droppable = createDroppable(`drop:section:${props.sectionId}`, {
+  const droppable = createDroppable(`drop:section:${id()}`, {
     type: "section",
-    sectionId: props.sectionId,
+    sectionId: id(),
   });
 
   function openAdd(): void {
@@ -696,151 +292,369 @@ export function DocSection(props: DocSectionProps): JSX.Element {
     setIsDialogOpen(true);
   }
 
-  return (
-    <section
-      ref={(element) => {
-        draggable.ref(element);
-        droppable.ref(element);
-      }}
-      class="doc-sheet__section"
-      classList={{
-        "doc-sheet__section--hidden": props.hidden,
-        "doc-sheet__section--drop": droppable.isActiveDroppable,
-        "doc-sheet__section--dragging": draggable.isActiveDraggable,
-      }}
-      data-section-id={props.sectionId}
-    >
-      <Show when={isEditable()}>
-        <div
-          class="doc-sheet__section-chrome"
-          role="group"
-          aria-label={`${title()} section controls`}
-        >
-          <button
-            type="button"
-            class="doc-sheet__action doc-sheet__action--icon doc-sheet__drag-handle"
-            aria-hidden="true"
-            tabindex="-1"
-            title={`Drag ${title()} section to move it`}
-            {...draggable.dragActivators}
-          >
-            <ChromeIcon path={CHROME_ICONS.handle} />
-          </button>
-          <For each={["up", "down", "previous", "next"] as MoveStep[]}>
-            {(step) => (
-              <button
-                type="button"
-                class="doc-sheet__action doc-sheet__action--icon"
-                data-doc-move-section={`${props.sectionId}:${step}`}
-                aria-label={`Move ${title()} section ${SECTION_STEP_WORDS[step]}`}
-                title={`Move ${title()} section ${SECTION_STEP_WORDS[step]}`}
-                onClick={() => props.onMoveSection(props.sectionId, step)}
-              >
-                <ChromeIcon path={CHROME_ICONS[step]} />
-              </button>
-            )}
-          </For>
-          <button
-            type="button"
-            class="doc-sheet__action"
-            aria-label={`${props.hidden ? "Show" : "Hide"} ${title()} section`}
-            onClick={() => {
-              toggleSection(props.sectionId);
-              props.onAnnounce(`${title()} section ${props.hidden ? "shown" : "hidden"}`);
-            }}
-          >
-            {props.hidden ? "Show" : "Hide"}
-          </button>
-          <Show when={isCustom()}>
-            <button
-              type="button"
-              class="doc-sheet__action"
-              aria-label={`Rename ${title()} section`}
-              onClick={() => setIsRenameOpen(true)}
-            >
-              Rename
-            </button>
-            <button
-              type="button"
-              class="doc-sheet__action doc-sheet__action--danger"
-              aria-label={`Delete ${title()} section`}
-              onClick={() => {
-                const name = title();
-                removeSection(props.sectionId);
-                props.onAnnounce(`${name} section deleted`);
-              }}
-            >
-              Delete
-            </button>
-          </Show>
-          <Show when={props.hidden}>
-            <span class="doc-sheet__hidden-badge">Hidden</span>
+  const commitFor =
+    (entry: ItemEntry) =>
+    (field: string, value: string): void => {
+      updateItem(id(), entry.index, { [field]: value });
+    };
+
+  /** Row-chrome action set for one entry; move handlers only at non-edges. */
+  function rowActions(entry: ItemEntry): {
+    label: string;
+    isHidden: boolean;
+    onEdit: () => void;
+    onRemove: () => void;
+    onDuplicate: () => void;
+    onToggleVisibility: () => void;
+    onMoveUp?: () => void;
+    onMoveDown?: () => void;
+  } {
+    const label = entryLabel(entry, noun());
+    const steps = (step: "up" | "down"): (() => void) | undefined => {
+      const items = itemEntries(props.resume, id()).map((each) => ({
+        id: each.id,
+        visible: !each.hidden,
+      }));
+      if (entryStep(items, entry.id, step) === null) return undefined;
+      return () => props.onMoveEntry(id(), entry.id, step);
+    };
+    return {
+      label,
+      isHidden: entry.hidden,
+      onEdit: () => openEdit(entry),
+      onRemove: () => {
+        removeItem(id(), entry.index);
+        props.onAnnounce(`${label} removed`);
+      },
+      onDuplicate: () => {
+        duplicateItem(id(), entry.index);
+        props.onAnnounce(`${label} duplicated`);
+      },
+      onToggleVisibility: () => {
+        setItemVisibility(id(), entry.index, entry.hidden);
+        props.onAnnounce(`${label} ${entry.hidden ? "shown" : "hidden"}`);
+      },
+      onMoveUp: steps("up"),
+      onMoveDown: steps("down"),
+    };
+  }
+
+  const menu = (): SectionMenuActions => ({
+    addLabel: isRichText() ? undefined : addLabel(),
+    onAdd: isRichText() ? undefined : openAdd,
+    canMoveUp: props.canMoveSection(id(), "up"),
+    canMoveDown: props.canMoveSection(id(), "down"),
+    onMoveUp: () => props.onMoveSection(id(), "up"),
+    onMoveDown: () => props.onMoveSection(id(), "down"),
+    otherColumnLabel: props.otherColumnLabel ?? undefined,
+    onMoveToOtherColumn:
+      props.otherColumnLabel === null ? undefined : () => props.onMoveSectionToOtherColumn(id()),
+    onRename: () => document.getElementById(sectionTitleTriggerId(id()))?.click(),
+    onHide: () => {
+      toggleSection(id());
+      props.onAnnounce(`${title()} section hidden`);
+    },
+  });
+
+  function experienceBody(entry: ItemEntry): JSX.Element {
+    const item = entry.item as Experience;
+    const idPrefix = `doc-${id()}-${entry.id}`;
+    const commit = commitFor(entry);
+    return (
+      <>
+        <div class="doc-sheet__entry-pos">
+          <Slot
+            field={bind(item.position, "Position", "position")}
+            idPrefix={idPrefix}
+            onCommit={commit}
+          />
+        </div>
+        <div class="doc-sheet__entry-meta">
+          <Slot
+            field={bind(item.company, "Company", "company")}
+            idPrefix={idPrefix}
+            class="doc-sheet__entry-co"
+            onCommit={commit}
+          />
+          <Show when={isEditable() || hasText(item.date)}>
+            <Slot
+              field={bind(item.date, "Date", "date")}
+              idPrefix={idPrefix}
+              class="doc-sheet__entry-date"
+              onCommit={commit}
+            />
           </Show>
         </div>
-      </Show>
-
-      <h3 class="doc-sheet__section-title">
-        <InlineText
-          value={title()}
-          label="Section title"
-          triggerId={`doc-${props.sectionId}-section-title`}
-          onCommit={(value) => renameSection(props.sectionId, value)}
+        <Show when={isEditable() || hasText(item.location)}>
+          <div class="doc-sheet__entry-loc">
+            <ContactIcon kind="location" />
+            <Slot
+              field={bind(item.location, "Location", "location")}
+              idPrefix={idPrefix}
+              onCommit={commit}
+            />
+          </div>
+        </Show>
+        <EntrySummary
+          value={item.summary ?? ""}
+          idPrefix={idPrefix}
+          onCommit={(value) => commit("summary", value)}
         />
-      </h3>
+        <TagChips tags={item.keywords} />
+        <ExtraFieldsView fields={item.customFields} />
+      </>
+    );
+  }
 
-      <Show when={isRichText()}>
-        <InlineMarkdown
-          value={richText()}
-          label={title()}
-          triggerId={`doc-${props.sectionId}-rich-text`}
-          onCommit={(value) =>
-            props.sectionId === "summary" ? updateSummary(value) : updateCoverLetter(value)
-          }
+  function educationBody(entry: ItemEntry): JSX.Element {
+    const item = entry.item as Education;
+    const idPrefix = `doc-${id()}-${entry.id}`;
+    const commit = commitFor(entry);
+    const school = (): string =>
+      [item.institution, item.area].filter((part) => hasText(part)).join(" · ");
+    return (
+      <>
+        <div class="doc-sheet__edu-degree">
+          <Slot
+            field={bind(item.studyType, "Degree", "studyType")}
+            idPrefix={idPrefix}
+            onCommit={commit}
+          />
+        </div>
+        {/* Derived from two fields, so the dialog owns it (spec §1.7). */}
+        <Show when={hasText(school())}>
+          <div class="doc-sheet__edu-school">{school()}</div>
+        </Show>
+        <Show when={isEditable() || hasText(item.date)}>
+          <div class="doc-sheet__edu-date">
+            <Slot field={bind(item.date, "Date", "date")} idPrefix={idPrefix} onCommit={commit} />
+          </div>
+        </Show>
+        <EntrySummary
+          value={item.summary ?? ""}
+          idPrefix={idPrefix}
+          onCommit={(value) => commit("summary", value)}
         />
-      </Show>
+        <TagChips tags={item.keywords} />
+        <ExtraFieldsView fields={item.customFields} />
+      </>
+    );
+  }
 
-      <Show when={entries().length > 0}>
-        <div class="doc-sheet__items">
+  function profileBody(entry: ItemEntry): JSX.Element {
+    const item = entry.item as Profile;
+    const text = (): string => (hasText(item.username) ? item.username : item.network);
+    const href = (): string | undefined => {
+      const value = item.url?.href ?? "";
+      return value.trim() === "" ? undefined : value;
+    };
+    return (
+      <div class="doc-sheet__icon-row">
+        <ProfileIcon network={item.network} icon={item.icon} />
+        {/* Live link in view mode; inert while editing (spec §1.7). */}
+        <a
+          class="doc-sheet__side-link"
+          href={href()}
+          target={href() === undefined ? undefined : "_blank"}
+          rel="noreferrer"
+          onClick={(event) => {
+            if (isEditable()) event.preventDefault();
+          }}
+        >
+          {text()}
+        </a>
+      </div>
+    );
+  }
+
+  function levelRowBody(entry: ItemEntry): JSX.Element {
+    const item = entry.item as Language | Skill;
+    return (
+      <>
+        <span class="doc-sheet__lang-name">{item.name}</span>
+        <Show when={(item.level ?? 0) > 0}>
+          <LevelDots value={item.level ?? 0} />
+        </Show>
+        <TagChips tags={(item as Skill).keywords} />
+      </>
+    );
+  }
+
+  function genericBody(entry: ItemEntry): JSX.Element {
+    const item = entry.item;
+    const idPrefix = `doc-${id()}-${entry.id}`;
+    const commit = commitFor(entry);
+    // Awards store their headline as `title`; everything else uses `name`.
+    const isAward = id() === "awards";
+    const nameField = isAward
+      ? bind((entry.item as unknown as Award).title, "Title", "title")
+      : bind(item.name, "Name", "name");
+    return (
+      <>
+        <div class="doc-sheet__entry-top">
+          <Slot
+            field={nameField}
+            idPrefix={idPrefix}
+            class="doc-sheet__entry-pos"
+            onCommit={commit}
+          />
+          <Show when={isEditable() || hasText(item.date)}>
+            <Slot
+              field={bind(item.date, "Date", "date")}
+              idPrefix={idPrefix}
+              class="doc-sheet__entry-date"
+              onCommit={commit}
+            />
+          </Show>
+        </div>
+        <Show when={isEditable() || hasText(item.description)}>
+          <div class="doc-sheet__entry-desc">
+            <Slot
+              field={bind(item.description, "Description", "description")}
+              idPrefix={idPrefix}
+              onCommit={commit}
+            />
+          </div>
+        </Show>
+        <EntrySummary
+          value={item.summary ?? ""}
+          idPrefix={idPrefix}
+          onCommit={(value) => commit("summary", value)}
+        />
+        <TagChips tags={item.keywords} />
+        <ExtraFieldsView fields={item.customFields} />
+      </>
+    );
+  }
+
+  /** Compact rows for the sidebar sections; full rows for everything else. */
+  const isCompact = (): boolean => id() === "profiles" || id() === "languages" || id() === "skills";
+
+  function rowClass(): string {
+    if (id() === "profiles") return "doc-sheet__profile-row";
+    if (id() === "languages" || id() === "skills") return "doc-sheet__lang-row";
+    if (id() === "education") return "doc-sheet__edu-entry";
+    return "doc-sheet__entry";
+  }
+
+  function bodyFor(entry: ItemEntry): JSX.Element {
+    if (id() === "experience") return experienceBody(entry);
+    if (id() === "education") return educationBody(entry);
+    if (id() === "profiles") return profileBody(entry);
+    if (id() === "languages" || id() === "skills") return levelRowBody(entry);
+    return genericBody(entry);
+  }
+
+  return (
+    <>
+      <SectionChrome
+        sectionId={id()}
+        title={title()}
+        onRenameCommit={(value) => renameSection(id(), value)}
+        isFocused={props.focusedSection === id()}
+        onFocus={() => props.onFocusSection(id())}
+        addLabel={isRichText() ? undefined : addLabel()}
+        onAdd={isRichText() ? undefined : openAdd}
+        menu={menu()}
+        gripActivators={draggable.dragActivators}
+        gripTitle={`Drag ${title()} section to move it`}
+        ref={(element) => {
+          draggable.ref(element);
+          droppable.ref(element);
+        }}
+        isDropTarget={droppable.isActiveDroppable}
+        isDragging={draggable.isActiveDraggable}
+      >
+        <Show when={isRichText()}>
+          <div class="doc-sheet__summary">
+            <InlineMarkdown
+              value={richText()}
+              label={title()}
+              triggerId={`doc-${id()}-rich-text`}
+              onCommit={(value) =>
+                id() === "summary" ? updateSummary(value) : updateCoverLetter(value)
+              }
+            />
+          </div>
+        </Show>
+
+        <Show when={id() === "interests"}>
+          <ul class="doc-sheet__custom-list">
+            <For each={entries()}>
+              {(entry) => (
+                <li
+                  data-entry-id={entry.id}
+                  classList={{ "doc-sheet__entry-row--hidden": entry.hidden }}
+                >
+                  {entry.item.name}
+                </li>
+              )}
+            </For>
+          </ul>
+        </Show>
+
+        <Show when={isChips()}>
+          <div class="doc-sheet__chip-list">
+            <For each={entries()}>
+              {(entry) => (
+                <span
+                  class="doc-sheet__skill-chip"
+                  classList={{ "doc-sheet__entry-row--hidden": entry.hidden }}
+                  data-entry-id={entry.id}
+                >
+                  {entry.item.name}
+                  <Show when={isEditable()}>
+                    <button
+                      type="button"
+                      class="doc-sheet__chip-x"
+                      aria-label={`Remove ${entryLabel(entry, noun())}`}
+                      onClick={() => {
+                        const label = entryLabel(entry, noun());
+                        removeItem(id(), entry.index);
+                        props.onAnnounce(`${label} removed`);
+                      }}
+                    >
+                      ×
+                    </button>
+                  </Show>
+                </span>
+              )}
+            </For>
+          </div>
+        </Show>
+
+        <Show when={!isRichText() && !isChips() && id() !== "interests"}>
           <For each={entries()}>
             {(entry) => (
-              <Item
-                sectionId={props.sectionId}
-                entry={entry}
-                noun={noun()}
-                onEdit={openEdit}
-                onMove={(itemId, step) => props.onMoveEntry(props.sectionId, itemId, step)}
-                onAnnounce={props.onAnnounce}
-              />
+              <SortableEntry
+                sectionId={id()}
+                itemId={entry.id}
+                class={rowClass()}
+                isCompact={isCompact()}
+                isHidden={entry.hidden}
+                actions={rowActions(entry)}
+              >
+                {bodyFor(entry)}
+              </SortableEntry>
             )}
           </For>
-        </div>
-      </Show>
+        </Show>
+
+        <Show when={!isRichText() && isEditable() && entries().length === 0}>
+          <p class="doc-sheet__empty-hint">No items yet — use + to add one.</p>
+        </Show>
+      </SectionChrome>
 
       <Show when={!isRichText() && isEditable()}>
-        <div class="doc-sheet__section-actions">
-          <button type="button" class="doc-sheet__action" onClick={openAdd}>
-            Add {noun()}
-          </button>
-        </div>
-
         <ItemDialog
           open={isDialogOpen()}
-          sectionId={props.sectionId}
+          sectionId={id()}
           sectionTitle={title()}
           index={editing()?.index}
-          item={editing()?.item}
+          item={editing()?.item as unknown as Record<string, unknown> | undefined}
           onOpenChange={setIsDialogOpen}
         />
       </Show>
-
-      <Show when={isCustom() && isEditable()}>
-        <CustomSectionDialog
-          open={isRenameOpen()}
-          sectionId={props.sectionId}
-          name={title()}
-          onOpenChange={setIsRenameOpen}
-        />
-      </Show>
-    </section>
+    </>
   );
 }

--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -42,7 +42,7 @@ import {
   updateSummary,
 } from "./docEdits";
 import { itemNoun } from "./itemFields";
-import { entryStep, type MoveStep } from "../../lib/docDnd";
+import { entryDisplayLabel, entryStep, type MoveStep } from "../../lib/docDnd";
 import { isCustomId, sectionTitle } from "../../lib/docLayout";
 import type {
   Award,
@@ -109,16 +109,9 @@ interface ItemEntry {
   item: AnyItem;
 }
 
-/** Head-line fields an entry might carry, in announcement preference order. */
-const ENTRY_LABEL_KEYS = ["name", "position", "institution", "title", "network"] as const;
-
+/** The entry's display name, shared with the sheet's announcements. */
 function entryLabel(entry: ItemEntry, noun: string): string {
-  const record = entry.item as unknown as Record<string, unknown>;
-  for (const key of ENTRY_LABEL_KEYS) {
-    const value = record[key];
-    if (typeof value === "string" && value.trim() !== "") return value;
-  }
-  return noun;
+  return entryDisplayLabel(entry.item, noun);
 }
 
 /** The items of `sectionId`, with their stored indices. */

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -41,6 +41,7 @@ import { SheetModeContext, type SheetMode } from "./sheetMode";
 import {
   canMoveEntryAcross,
   drawnSectionPosition,
+  entryDisplayLabel,
   entryStep,
   moveSectionStep,
   resolveEntryDrop,
@@ -98,27 +99,10 @@ function acceptsDrop(drag: SheetDragData, drop: SheetDropData): boolean {
   return false;
 }
 
-/** Head-line fields an entry might carry, in announcement preference order. */
-const ENTRY_LABEL_KEYS = [
-  "name",
-  "position",
-  "company",
-  "institution",
-  "title",
-  "network",
-  "organization",
-] as const;
-
 /** A short human name for an entry, for announcements and the drag overlay. */
 function entryLabel(resume: ResumeData, sectionId: string, itemId: string): string {
-  const item = sectionItemList(resume, sectionId).find((entry) => entry.id === itemId) as
-    | Record<string, unknown>
-    | undefined;
-  for (const key of ENTRY_LABEL_KEYS) {
-    const value = item?.[key];
-    if (typeof value === "string" && value.trim() !== "") return value;
-  }
-  return "Item";
+  const item = sectionItemList(resume, sectionId).find((entry) => entry.id === itemId);
+  return entryDisplayLabel(item, "Item");
 }
 
 /** The persisted sidebar width override, if any. */
@@ -287,6 +271,11 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
         sheet.querySelector<HTMLElement>(".doc-sheet__main, .doc-sheet__single"),
       );
       sideTotal += columnHeight(sheet.querySelector<HTMLElement>(".doc-sheet__side"));
+      // Legacy >2-column pages: the tallest column stands for the page.
+      const multiColumns = [...sheet.querySelectorAll<HTMLElement>(".doc-sheet__multi-col")].map(
+        (column) => columnHeight(column),
+      );
+      if (multiColumns.length > 0) mainTotal += Math.max(...multiColumns);
     }
     const byHeight = Math.max(1, Math.ceil(Math.max(mainTotal, sideTotal) / PAGE_HEIGHT_PX));
     setMeasuredPages(Math.max(sheets.length, byHeight));
@@ -586,6 +575,11 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
           setSidebarWidth(widthFromPointer(event.clientX));
         }}
         onPointerUp={(event) => {
+          dragOrigin = null;
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }}
+        onPointerCancel={(event) => {
+          // A cancelled press must not leave stray moves resizing the sidebar.
           dragOrigin = null;
           event.currentTarget.releasePointerCapture(event.pointerId);
         }}

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -1,21 +1,25 @@
 /**
- * The document sheet: A4 page frames, the template's column grid, the header
- * region, and an editable view of every placed section.
+ * The document sheet engine (#794): content-sized sheets composed from the
+ * template's layout metadata.
  *
- * The page/column structure comes straight from `editorPages()` and
- * `layoutColumns()` — this component draws that model and nothing else, and the
- * same model's indices address `metadata.layout` directly, so drag and drop
- * needs no second layout representation. Editing is click-to-edit in place
- * plus the item, section and photo dialogs; structural editing is the chrome
- * `DocSection` draws plus the whole-surface drag and drop owned here. Every
- * mutation writes through a `resumeStore` action, never `setStore` (see
- * `docEdits.ts`), and every drop resolves through the pure functions in
- * `lib/docDnd.ts` — one drop, one action, one undo entry; a drag that ends
- * where it started writes nothing.
+ * Sheets no longer clip to fixed A4 frames — each `.doc-sheet__page` sizes to
+ * its content, and A4 boundaries are communicated by dashed overflow guides at
+ * 1122px intervals plus the floating page-count pill (spec §3.1, §3.5).
+ * Explicit `metadata.layout` pages draw as separate sheets divided by
+ * page-break rules with "Page N" labels and (edit mode) a "Remove page break"
+ * action that merges the page into the one before it — the simple layout
+ * merge; `itemBreaks`-aware semantics arrive with #796.
  *
- * Overflow is *reported*, never absorbed. A column that cannot fit its sections
- * is clipped and flagged; moving a section to another page is a `metadata.layout`
- * decision the user makes on this surface, so nothing here reflows.
+ * The page body is composed per the template's `layoutMode` (spec §1.4,
+ * §3.6): `SingleColumn`, `MainColumn` + `SideColumn` grids, or the
+ * header-split banner over two columns. The template layer only picks the
+ * compositor and the palette; all behaviour lives in the shared components.
+ *
+ * Editing chrome — the drag-drop context, drop resolution, announcements, and
+ * the end-of-column Add-section blocks — is owned here; every mutation writes
+ * through a `resumeStore` action (see `docEdits.ts`). Drags start from grips
+ * only, never from the surface, so text selection and inline editing keep
+ * working; #796 replaces the drag mechanism wholesale.
  */
 
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
@@ -29,18 +33,15 @@ import {
   type DragEvent,
 } from "@thisbeyond/solid-dnd";
 import { CustomSectionDialog } from "./CustomSectionDialog";
-import { DocHeader } from "./DocHeader";
+import { ContactBlock, NameHeader, SheetAvatar } from "./DocHeader";
 import { DocSection } from "./DocSection";
-import { ItemDialog } from "./ItemDialog";
 import { applyLayout, moveItemAcrossSections, reorderItem } from "./docEdits";
-import { itemNoun } from "./itemFields";
+import { PlusIcon } from "./icons";
 import { SheetModeContext, type SheetMode } from "./sheetMode";
 import {
-  adjacentCustomSectionId,
   canMoveEntryAcross,
   drawnSectionPosition,
   entryStep,
-  moveSectionInLayout,
   moveSectionStep,
   resolveEntryDrop,
   resolveSectionDropOnColumn,
@@ -49,19 +50,31 @@ import {
   type MoveStep,
 } from "../../lib/docDnd";
 import {
+  PAGE_HEIGHT_PX,
+  SHEET_PX_PER_PT,
   editorPages,
+  findSectionPlacement,
   layoutColumns,
   layoutPages,
+  mergePageIntoPrevious,
   renderPages,
   sectionTitle,
-  type EditorSectionView,
-  type LayoutColumn,
   type TemplateLayout,
 } from "../../lib/docLayout";
 import { reorderAnnouncement } from "../../lib/reorderAnnounce";
 import { LiveRegion, announceLive } from "../ui/LiveRegion";
 import type { ResumeData } from "../../wasm/types";
 import "./docSheet.css";
+
+/** Sidebar width bounds for the resize handle (spec §3.2). */
+const SIDEBAR_MIN_PX = 160;
+const SIDEBAR_MAX_PX = 360;
+/** Fallback sidebar width when the template declares none: a third of A4. */
+const SIDEBAR_DEFAULT_PX = 287;
+/** Where a resized sidebar width persists, per the spec. */
+const SIDEBAR_WIDTH_STORAGE_KEY = "rustume.studio.sidebarWidth";
+/** Keyboard resize step for the handle. */
+const SIDEBAR_KEY_STEP_PX = 8;
 
 /** What a drag carries: the thing being moved. */
 type SheetDragData =
@@ -72,13 +85,12 @@ type SheetDragData =
 type SheetDropData =
   | { type: "section"; sectionId: string; itemId?: undefined }
   | { type: "entry"; sectionId: string; itemId: string }
-  | { type: "column"; page: number; column: number }
-  | { type: "new-page" };
+  | { type: "column"; page: number; column: number };
 
 /** Whether `drop` is a meaningful target for `drag`. */
 function acceptsDrop(drag: SheetDragData, drop: SheetDropData): boolean {
   if (drag.type === "section") {
-    return drop.type === "section" || drop.type === "column" || drop.type === "new-page";
+    return drop.type === "section" || drop.type === "column";
   }
   if (drop.type === "entry" || drop.type === "section") {
     return drop.sectionId === drag.sectionId || canMoveEntryAcross(drag.sectionId, drop.sectionId);
@@ -86,42 +98,10 @@ function acceptsDrop(drag: SheetDragData, drop: SheetDropData): boolean {
   return false;
 }
 
-/** A page's columns in the order the template paints them, left to right. */
-function visualColumns(columns: LayoutColumn[]): LayoutColumn[] {
-  return [...columns].sort((a, b) => a.order - b.order);
-}
-
-/**
- * Where the name block and the contact details are drawn.
- *
- * `headerStyle: "sidebar"` is the only style that puts the name block inside a
- * column; every other style draws it above the columns. Contact details follow
- * `contactIn` independently, so the two can land in different regions.
- */
-type HeaderRegion = "top" | "sidebar";
-
-function identityRegion(layout: TemplateLayout, hasSidebar: boolean): HeaderRegion {
-  return layout.headerStyle === "sidebar" && hasSidebar ? "sidebar" : "top";
-}
-
-function contactRegion(layout: TemplateLayout, hasSidebar: boolean): HeaderRegion {
-  return layout.contactIn === "sidebar" && hasSidebar ? "sidebar" : "top";
-}
-
-/** Profile links for the header, as `Network — username`. */
-function profileLinks(resume: ResumeData): { id: string; label: string }[] {
-  return (resume.sections.profiles?.items ?? [])
-    .filter((item) => item.visible)
-    .map((item) => ({
-      id: item.id,
-      label: [item.network, item.username].filter((part) => part.trim() !== "").join(" — "),
-    }))
-    .filter((link) => link.label !== "");
-}
-
 /** Head-line fields an entry might carry, in announcement preference order. */
 const ENTRY_LABEL_KEYS = [
   "name",
+  "position",
   "company",
   "institution",
   "title",
@@ -141,79 +121,68 @@ function entryLabel(resume: ResumeData, sectionId: string, itemId: string): stri
   return "Item";
 }
 
-/** A section placed in a column but not drawn there — an add-block target. */
-interface AddTarget {
-  id: string;
-  noun: string;
+/** The persisted sidebar width override, if any. */
+function storedSidebarWidth(): number | null {
+  try {
+    const raw = globalThis.localStorage?.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+    const value = raw === null || raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
 }
 
-/** One column of one page: the droppable frame plus its add-block. */
-function SheetColumn(props: {
-  pageIndex: number;
-  column: LayoutColumn;
-  addTargets: AddTarget[];
-  onAdd: (sectionId: string) => void;
-  children: JSX.Element;
-}): JSX.Element {
-  const droppable = createDroppable(`drop:column:${props.pageIndex}:${props.column.index}`, {
-    type: "column",
-    page: props.pageIndex,
-    column: props.column.index,
-  });
-
-  return (
-    <div
-      ref={droppable.ref}
-      class="doc-sheet__column"
-      classList={{
-        "doc-sheet__column--sidebar": props.column.role === "sidebar",
-        "doc-sheet__column--drop": droppable.isActiveDroppable,
-      }}
-      data-testid="doc-sheet-column"
-      data-column-index={props.column.index}
-      data-column-role={props.column.role}
-      data-page-index={props.pageIndex}
-      style={{ "flex-basis": `${props.column.width * 100}%` }}
-    >
-      {props.children}
-      <Show when={props.addTargets.length > 0}>
-        <div class="doc-sheet__add-block" data-testid="doc-sheet-add-block">
-          <For each={props.addTargets}>
-            {(target) => (
-              <button
-                type="button"
-                class="doc-sheet__action"
-                onClick={() => props.onAdd(target.id)}
-              >
-                Add {target.noun}
-              </button>
-            )}
-          </For>
-        </div>
-      </Show>
-    </div>
-  );
+function clampSidebarWidth(px: number): number {
+  return Math.min(SIDEBAR_MAX_PX, Math.max(SIDEBAR_MIN_PX, Math.round(px)));
 }
 
 /**
- * The trailing drop zone that starts a new page. Always mounted so its
- * droppable is registered before a drag begins; only *shown* while a section
- * is being dragged, because that is the only drag it accepts.
+ * Dashed A4 cut marks across one sheet at page-height intervals, measured
+ * from the sheet's own content height so the marks and the page-count pill
+ * always agree (spec §3.3).
  */
-function NewPageZone(props: { active: boolean }): JSX.Element {
-  const droppable = createDroppable("drop:new-page", { type: "new-page" });
+function SheetOverflowGuides(props: { sheet: () => HTMLElement | undefined }): JSX.Element {
+  const [lines, setLines] = createSignal<number[]>([]);
+
+  createEffect(() => {
+    const element = props.sheet();
+    if (!element) return;
+    const measure = (): void => {
+      let height = 0;
+      for (const child of element.children) {
+        if (child.classList.contains("doc-sheet__page-guide")) continue;
+        const box = child as HTMLElement;
+        height = Math.max(height, box.offsetTop + box.offsetHeight);
+      }
+      if (height <= 0) height = element.scrollHeight;
+      const count = height <= PAGE_HEIGHT_PX + 20 ? 0 : Math.ceil(height / PAGE_HEIGHT_PX) - 1;
+      setLines(
+        Array.from({ length: Math.max(0, count) }, (_, index) => (index + 1) * PAGE_HEIGHT_PX),
+      );
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    onCleanup(() => observer.disconnect());
+  });
+
   return (
-    <div
-      ref={droppable.ref}
-      class="doc-sheet__new-page"
-      classList={{
-        "doc-sheet__new-page--active": props.active,
-        "doc-sheet__new-page--drop": droppable.isActiveDroppable,
-      }}
-      data-testid="doc-sheet-new-page"
-      aria-hidden={props.active ? undefined : "true"}
-    >
-      Drop here to start a new page
+    <For each={lines()}>
+      {(top) => (
+        <div class="doc-sheet__page-guide" style={{ top: `${top}px` }} aria-hidden="true" />
+      )}
+    </For>
+  );
+}
+
+/** The floating measured page count (spec §3.5). */
+function PageCountPill(props: { count: number }): JSX.Element {
+  const count = (): number => Math.max(1, props.count);
+  return (
+    <div class="doc-sheet__page-pill" data-testid="doc-sheet-page-count" aria-live="polite">
+      <strong>{count()}</strong>
+      <span>{count() === 1 ? "page" : "pages"}</span>
     </div>
   );
 }
@@ -228,106 +197,122 @@ export interface DocSheetProps {
    * exactly as the PDF drops them. Defaults to Edit.
    */
   mode?: SheetMode;
-  /** Reports the 0-based indices of pages whose content is clipped. */
-  onOverflowChange?: (pages: number[]) => void;
-  /** Reports the number of page frames drawn. */
-  onPageCountChange?: (count: number) => void;
+  /**
+   * Opens the Sections panel (the Add-section blocks' target). Without it the
+   * blocks fall back to the custom-section dialog, so a sheet rendered outside
+   * the editor page keeps a working affordance.
+   */
+  onOpenSections?: () => void;
 }
 
 export function DocSheet(props: DocSheetProps): JSX.Element {
   const mode = (): SheetMode => props.mode ?? "edit";
   const isEditable = (): boolean => mode() === "edit";
 
-  // The layout the drops address, and the drawn view of it. `editorPages()`
-  // never drops a page or column, so the two are aligned index-for-index.
+  // The layout the drops address, and the drawn view of it. In edit mode
+  // `editorPages()` never drops a page or column, so the two are aligned
+  // index-for-index.
   const layout = createMemo(() => layoutPages(props.resume, props.templateLayout));
-  const pages = createMemo<EditorSectionView[][][]>(() => {
-    // Done mode draws what the PDF draws: `renderPages` drops hidden sections,
-    // empty sections and empty pages, so the surface is the rendered document
-    // rather than the editing model with its chrome switched off.
+  const pages = createMemo<string[][][]>(() => {
     const rendered = isEditable()
       ? editorPages(props.resume, props.templateLayout)
-      : renderPages(props.resume, props.templateLayout).map((page) =>
-          page.map((column) => column.map((id) => ({ id, hidden: false }))),
-        );
-    // An empty resume still gets one frame, so the sheet reads as a blank page
-    // rather than as a failure to load.
+      : renderPages(props.resume, props.templateLayout);
+    // An empty resume still gets one sheet, so the surface reads as a blank
+    // page rather than as a failure to load.
     return rendered.length > 0 ? rendered : [[[]]];
   });
 
-  const links = createMemo(() => {
-    // `profiles` renders as a section wherever the layout places it; the header
-    // only carries the links when no page does.
-    const placed = pages().some((page) =>
-      page.some((column) => column.some((section) => section.id === "profiles")),
-    );
-    return placed ? [] : profileLinks(props.resume);
-  });
+  const theme = (): ResumeData["metadata"]["theme"] => props.resume.metadata.theme;
+  const layoutMode = (): TemplateLayout["layoutMode"] => props.templateLayout.layoutMode;
+  const headerStyle = (): TemplateLayout["headerStyle"] => props.templateLayout.headerStyle;
+  const contactIn = (): TemplateLayout["contactIn"] => props.templateLayout.contactIn;
 
-  const theme = () => props.resume.metadata.theme;
-
-  const [overflowing, setOverflowing] = createSignal<number[]>([]);
+  const [focusedSection, setFocusedSection] = createSignal<string | null>(null);
   const [isSectionDialogOpen, setIsSectionDialogOpen] = createSignal(false);
-  /** Section an add-block is adding an item to, or `null`. */
-  const [addTarget, setAddTarget] = createSignal<string | null>(null);
   const [activeDrag, setActiveDrag] = createSignal<SheetDragData | null>(null);
   const [announcement, setAnnouncement] = createSignal("");
+  const [measuredPages, setMeasuredPages] = createSignal(1);
+  const [sidebarOverride, setSidebarOverride] = createSignal<number | null>(storedSidebarWidth());
   let root: HTMLDivElement | undefined;
 
   function announce(message: string): void {
     announceLive(setAnnouncement, message);
   }
 
-  /**
-   * Flag every page holding a clipped column.
-   *
-   * The live DOM is the source of truth rather than a registry of refs: columns
-   * come and go with the layout, and a stale ref would keep reporting overflow
-   * for a page that no longer exists.
-   */
-  function measure(): void {
-    if (!root) return;
-    const clipped = new Set<number>();
-    for (const element of root.querySelectorAll<HTMLElement>(".doc-sheet__column")) {
-      // A sub-pixel difference is rounding, not overflow.
-      if (element.scrollHeight - element.clientHeight > 1) {
-        clipped.add(Number(element.dataset.pageIndex));
-      }
+  /** The sidebar width in sheet pixels: the user's override, else the template's. */
+  const sidebarWidth = createMemo<number>(() => {
+    const override = sidebarOverride();
+    if (override !== null) return clampSidebarWidth(override);
+    const declared = props.templateLayout.sidebarWidth;
+    if (declared === null || declared <= 0) return SIDEBAR_DEFAULT_PX;
+    return clampSidebarWidth(declared * SHEET_PX_PER_PT);
+  });
+
+  function setSidebarWidth(px: number): void {
+    const next = clampSidebarWidth(px);
+    setSidebarOverride(next);
+    try {
+      globalThis.localStorage?.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(next));
+    } catch {
+      // Persistence is best-effort; the in-session width still applies.
     }
-    const next = [...clipped].sort((a, b) => a - b);
-    setOverflowing((previous) =>
-      previous.length === next.length && previous.every((value, index) => value === next[index])
-        ? previous
-        : next,
-    );
   }
 
-  // A wider or narrower pane changes the page height, and with it what fits.
+  /**
+   * Measured page count (spec §3.5): per sheet, the taller of the two column
+   * stacks; totals divided by the A4 height; never fewer than the number of
+   * drawn sheets. No auto-fit and no orphan packing, deliberately.
+   */
+  function measurePages(): void {
+    if (!root) return;
+    const sheets = [...root.querySelectorAll<HTMLElement>(".doc-sheet__page")];
+    if (sheets.length === 0) {
+      setMeasuredPages(1);
+      return;
+    }
+    const columnHeight = (column: HTMLElement | null): number => {
+      if (!column) return 0;
+      let height = 0;
+      for (const child of column.children) {
+        if (child.classList.contains("doc-sheet__page-guide")) continue;
+        const box = child as HTMLElement;
+        height = Math.max(height, box.offsetTop + box.offsetHeight);
+      }
+      return height > 0 ? height : column.scrollHeight;
+    };
+    let mainTotal = 0;
+    let sideTotal = 0;
+    for (const sheet of sheets) {
+      mainTotal += columnHeight(
+        sheet.querySelector<HTMLElement>(".doc-sheet__main, .doc-sheet__single"),
+      );
+      sideTotal += columnHeight(sheet.querySelector<HTMLElement>(".doc-sheet__side"));
+    }
+    const byHeight = Math.max(1, Math.ceil(Math.max(mainTotal, sideTotal) / PAGE_HEIGHT_PX));
+    setMeasuredPages(Math.max(sheets.length, byHeight));
+  }
+
   const observer =
-    typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => measure());
+    typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => measurePages());
   onCleanup(() => observer?.disconnect());
 
   createEffect(() => {
-    // Re-measure whenever the drawn structure changes; the DOM for the new
-    // structure only exists once the current render pass has flushed.
-    pages();
-    queueMicrotask(() => measure());
+    // Re-measure whenever the drawn structure or geometry changes; the DOM for
+    // the new structure only exists once the current render pass has flushed.
+    void [pages(), mode(), sidebarWidth()];
+    queueMicrotask(() => measurePages());
   });
 
-  createEffect(() => props.onOverflowChange?.(overflowing()));
-  createEffect(() => props.onPageCountChange?.(pages().length));
-
-  // The cards the sheet draws. Drawn-ness depends on content and visibility,
-  // never on placement — so the set stays valid for a layout about to change.
+  // The cards the sheet draws. Drawn-ness depends on visibility, never on
+  // placement — so the set stays valid for a layout about to change.
   const drawnIds = createMemo(
-    () => new Set(pages().flatMap((page) => page.flatMap((column) => column.map((s) => s.id)))),
+    () => new Set(pages().flatMap((page) => page.flatMap((column) => column))),
   );
   const isDrawn = (id: string): boolean => drawnIds().has(id);
 
   /**
    * Announce where `sectionId` landed in `nextLayout`, in drawn-card terms:
-   * what is spoken must match what is seen, so positions count the cards the
-   * sheet draws, not the slots the layout stores.
+   * what is spoken must match what is seen.
    */
   function announceSectionMove(sectionId: string, nextLayout: string[][][]): void {
     const position = drawnSectionPosition(nextLayout, sectionId, isDrawn);
@@ -336,9 +321,6 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
       announce(`${title} section moved`);
       return;
     }
-    // Speak the visual column position, not the stored index: sidebar-left
-    // templates paint column 1 second, and what is spoken must match what
-    // is seen.
     const geometry = layoutColumns(nextLayout[position.page], props.templateLayout);
     const visualColumn =
       (geometry.find((column) => column.index === position.column)?.order ?? position.column) + 1;
@@ -348,10 +330,11 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
     );
   }
 
-  /** One-step section move, shared by the move controls (click and keyboard). */
+  const canMoveSection = (sectionId: string, step: MoveStep): boolean =>
+    moveSectionStep(layout(), sectionId, step, isDrawn) !== null;
+
+  /** One-step section move for the pencil menu (keyboard and pointer). */
   function moveSection(sectionId: string, step: MoveStep): void {
-    // Stepping is drawn-aware: slots the sheet does not draw are skipped, so
-    // a press never announces a move with zero visual change.
     const next = moveSectionStep(layout(), sectionId, step, isDrawn);
     if (!next) {
       announce(`${sectionTitle(props.resume, sectionId)} section did not move`);
@@ -359,50 +342,37 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
     }
     applyLayout(next);
     announceSectionMove(sectionId, next);
-    // Keep the user on the control they just used; it moved with the section.
-    requestAnimationFrame(() => {
-      root
-        ?.querySelector<HTMLButtonElement>(`[data-doc-move-section="${sectionId}:${step}"]`)
-        ?.focus();
-    });
   }
 
-  /** One-step entry move, shared by the move controls (click and keyboard). */
+  /** The pencil menu's cross-column move: to the end of the other column. */
+  function moveSectionToOtherColumn(sectionId: string): void {
+    const placement = findSectionPlacement(layout(), sectionId);
+    if (!placement) return;
+    const other = placement.column === 0 ? 1 : 0;
+    const next = resolveSectionDropOnColumn(layout(), sectionId, placement.page, other);
+    if (!next) return;
+    applyLayout(next);
+    announceSectionMove(sectionId, next);
+  }
+
+  /** One-step entry move for the action pill. */
   function moveEntry(sectionId: string, itemId: string, step: MoveStep): void {
+    if (step !== "up" && step !== "down") return;
     const label = entryLabel(props.resume, sectionId, itemId);
     const items = sectionItemList(props.resume, sectionId);
-
-    if (step === "up" || step === "down") {
-      const move = entryStep(items, itemId, step);
-      if (!move) {
-        announce(`${label} did not move`);
-        return;
-      }
-      reorderItem(sectionId, move.fromIndex, move.toIndex);
-      announce(reorderAnnouncement(label, move.toIndex, items.length));
-    } else {
-      const targetId = adjacentCustomSectionId(layout(), sectionId, step);
-      const fromIndex = items.findIndex((item) => item.id === itemId);
-      if (targetId === null || fromIndex === -1) {
-        announce(`${label} did not move`);
-        return;
-      }
-      const targetItems = sectionItemList(props.resume, targetId);
-      moveItemAcrossSections(sectionId, fromIndex, targetId, targetItems.length);
-      announce(`${label} moved to ${sectionTitle(props.resume, targetId)}`);
+    const move = entryStep(items, itemId, step);
+    if (!move) {
+      announce(`${label} did not move`);
+      return;
     }
-
-    requestAnimationFrame(() => {
-      root?.querySelector<HTMLButtonElement>(`[data-doc-move-entry="${itemId}:${step}"]`)?.focus();
-    });
+    reorderItem(sectionId, move.fromIndex, move.toIndex);
+    announce(reorderAnnouncement(label, move.toIndex, items.length));
   }
 
-  // Only droppables that mean something for the active drag may catch it —
-  // a section drag must never land on an entry, nor an entry on a column —
-  // and only droppables the dragged card actually overlaps count at all, so a
+  // Only droppables that mean something for the active drag may catch it, and
+  // only droppables the dragged card actually overlaps count at all, so a
   // sloppy release over dead space cancels instead of snapping to the nearest
-  // centre. Among the overlapping targets, closest-centre keeps the familiar
-  // card-versus-column selection.
+  // centre.
   const detectCollisions: CollisionDetector = (draggable, droppables, context) => {
     const dragged = draggable.transformed;
     const touching = droppables.filter(
@@ -434,12 +404,6 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
         next = resolveSectionDropOnSection(layout(), drag.sectionId, drop.sectionId);
       } else if (drop.type === "column") {
         next = resolveSectionDropOnColumn(layout(), drag.sectionId, drop.page, drop.column);
-      } else if (drop.type === "new-page") {
-        next = moveSectionInLayout(layout(), drag.sectionId, {
-          page: layout().length,
-          column: 0,
-          index: 0,
-        });
       }
       if (!next) return;
       applyLayout(next);
@@ -478,17 +442,6 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
     announce(`${label} moved to ${sectionTitle(props.resume, resolved.toSectionId)}`);
   }
 
-  /** The placed-but-empty item sections of one column — its add-block targets. */
-  function addTargets(pageIndex: number, columnIndex: number): AddTarget[] {
-    // The rendered document (Done mode) has no add affordances.
-    if (!isEditable()) return [];
-    const placed = layout()[pageIndex]?.[columnIndex] ?? [];
-    const drawn = new Set((pages()[pageIndex]?.[columnIndex] ?? []).map((section) => section.id));
-    return placed
-      .filter((id) => !drawn.has(id) && id !== "summary" && id !== "coverLetter")
-      .map((id) => ({ id, noun: itemNoun(sectionTitle(props.resume, id)) }));
-  }
-
   const dragLabel = (): string => {
     const drag = activeDrag();
     if (!drag) return "";
@@ -497,6 +450,340 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
     }
     return entryLabel(props.resume, drag.sectionId, drag.itemId);
   };
+
+  /** Merge a drawn page into the one before it (spec §3.4, simple variant). */
+  function removePageBreak(pageIndex: number): void {
+    const next = mergePageIntoPrevious(layout(), pageIndex);
+    if (!next) return;
+    applyLayout(next);
+    announce(`Page break removed; page ${pageIndex + 1} merged into page ${pageIndex}`);
+  }
+
+  function openSections(): void {
+    if (props.onOpenSections) {
+      props.onOpenSections();
+      return;
+    }
+    setIsSectionDialogOpen(true);
+  }
+
+  /** The sections of one column, then the end-of-column Add-section block. */
+  function SectionList(listProps: {
+    ids: string[];
+    /** The cross-column move's target name, or `null` on single-column pages. */
+    otherColumnLabel: string | null;
+  }): JSX.Element {
+    return (
+      <>
+        <For each={listProps.ids}>
+          {(sectionId) => (
+            <DocSection
+              resume={props.resume}
+              sectionId={sectionId}
+              focusedSection={focusedSection()}
+              onFocusSection={setFocusedSection}
+              canMoveSection={canMoveSection}
+              onMoveSection={moveSection}
+              otherColumnLabel={listProps.otherColumnLabel}
+              onMoveSectionToOtherColumn={moveSectionToOtherColumn}
+              onMoveEntry={moveEntry}
+              onAnnounce={announce}
+            />
+          )}
+        </For>
+        <Show when={isEditable()}>
+          <button
+            type="button"
+            class="doc-sheet__add-section-block"
+            data-testid="doc-sheet-add-section"
+            onClick={openSections}
+          >
+            <PlusIcon /> Add section
+          </button>
+        </Show>
+      </>
+    );
+  }
+
+  /** A column's droppable frame. */
+  function ColumnFrame(frameProps: {
+    pageIndex: number;
+    columnIndex: number;
+    class: string;
+    /** How the column reads to tests and tools: `main` or `sidebar`. */
+    role: "main" | "sidebar";
+    isAside?: boolean;
+    children: JSX.Element;
+  }): JSX.Element {
+    const droppable = createDroppable(
+      `drop:column:${frameProps.pageIndex}:${frameProps.columnIndex}`,
+      { type: "column", page: frameProps.pageIndex, column: frameProps.columnIndex },
+    );
+    const classes = (): Record<string, boolean> => ({
+      "doc-sheet__column": true,
+      [frameProps.class]: true,
+      "doc-sheet__column--drop": droppable.isActiveDroppable,
+    });
+    return (
+      <Show
+        when={frameProps.isAside === true}
+        fallback={
+          <div
+            ref={droppable.ref}
+            classList={classes()}
+            data-testid="doc-sheet-column"
+            data-column-role={frameProps.role}
+            data-column-index={frameProps.columnIndex}
+            data-page-index={frameProps.pageIndex}
+          >
+            {frameProps.children}
+          </div>
+        }
+      >
+        <aside
+          ref={droppable.ref}
+          classList={classes()}
+          data-testid="doc-sheet-column"
+          data-column-role={frameProps.role}
+          data-column-index={frameProps.columnIndex}
+          data-page-index={frameProps.pageIndex}
+        >
+          {frameProps.children}
+        </aside>
+      </Show>
+    );
+  }
+
+  /** The sidebar's edge-drag resize handle (spec §3.2). */
+  function SidebarResizeHandle(handleProps: { isRightSidebar: boolean }): JSX.Element {
+    let dragOrigin: { x: number; width: number } | null = null;
+
+    const widthFromPointer = (clientX: number): number => {
+      if (!dragOrigin) return sidebarWidth();
+      const delta = clientX - dragOrigin.x;
+      // A right sidebar grows leftwards: dragging left widens it.
+      return dragOrigin.width + (handleProps.isRightSidebar ? -delta : delta);
+    };
+
+    return (
+      <div
+        class="doc-sheet__side-resize"
+        classList={{ "doc-sheet__side-resize--right": handleProps.isRightSidebar }}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize sidebar"
+        aria-valuemin={SIDEBAR_MIN_PX}
+        aria-valuemax={SIDEBAR_MAX_PX}
+        aria-valuenow={sidebarWidth()}
+        tabindex="0"
+        onPointerDown={(event) => {
+          event.preventDefault();
+          dragOrigin = { x: event.clientX, width: sidebarWidth() };
+          event.currentTarget.setPointerCapture(event.pointerId);
+        }}
+        onPointerMove={(event) => {
+          if (!dragOrigin) return;
+          setSidebarWidth(widthFromPointer(event.clientX));
+        }}
+        onPointerUp={(event) => {
+          dragOrigin = null;
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }}
+        onKeyDown={(event) => {
+          const grow = handleProps.isRightSidebar ? "ArrowLeft" : "ArrowRight";
+          const shrink = handleProps.isRightSidebar ? "ArrowRight" : "ArrowLeft";
+          if (event.key === grow) {
+            event.preventDefault();
+            setSidebarWidth(sidebarWidth() + SIDEBAR_KEY_STEP_PX);
+          } else if (event.key === shrink) {
+            event.preventDefault();
+            setSidebarWidth(sidebarWidth() - SIDEBAR_KEY_STEP_PX);
+          }
+        }}
+      />
+    );
+  }
+
+  /** The sidebar column: page-0 identity chrome, sections, resize handle. */
+  function SideColumn(columnProps: {
+    pageIndex: number;
+    page: string[][];
+    isRightSidebar: boolean;
+  }): JSX.Element {
+    const isFirst = (): boolean => columnProps.pageIndex === 0;
+    return (
+      <ColumnFrame
+        pageIndex={columnProps.pageIndex}
+        columnIndex={1}
+        class="doc-sheet__side"
+        role="sidebar"
+        isAside
+      >
+        <Show when={isFirst() && headerStyle() === "sidebar"}>
+          <NameHeader basics={props.resume.basics} isInSidebar />
+        </Show>
+        <Show when={isFirst() && contactIn() === "sidebar"}>
+          <ContactBlock basics={props.resume.basics} withAvatar />
+        </Show>
+        <SectionList ids={columnProps.page[1] ?? []} otherColumnLabel="main column" />
+        <Show when={isEditable()}>
+          <SidebarResizeHandle isRightSidebar={columnProps.isRightSidebar} />
+        </Show>
+      </ColumnFrame>
+    );
+  }
+
+  /** The main column: page-0 name header (unless the sidebar owns it). */
+  function MainColumn(columnProps: {
+    pageIndex: number;
+    page: string[][];
+    withHeader: boolean;
+  }): JSX.Element {
+    const isFirst = (): boolean => columnProps.pageIndex === 0;
+    return (
+      <ColumnFrame
+        pageIndex={columnProps.pageIndex}
+        columnIndex={0}
+        class="doc-sheet__main"
+        role="main"
+      >
+        <Show when={isFirst() && columnProps.withHeader}>
+          <Show when={contactIn() !== "sidebar"}>
+            <SheetAvatar basics={props.resume.basics} />
+          </Show>
+          <NameHeader basics={props.resume.basics} />
+          <Show when={contactIn() === "header" && layoutMode() !== "single"}>
+            <ContactBlock basics={props.resume.basics} isCompact />
+          </Show>
+        </Show>
+        <SectionList ids={columnProps.page[0] ?? []} otherColumnLabel="sidebar" />
+      </ColumnFrame>
+    );
+  }
+
+  /** Single-column pages: banner identity, then one continuous section list. */
+  function SingleColumn(columnProps: { pageIndex: number; page: string[][] }): JSX.Element {
+    const isFirst = (): boolean => columnProps.pageIndex === 0;
+    const ids = (): string[] => columnProps.page.flat();
+    return (
+      <ColumnFrame
+        pageIndex={columnProps.pageIndex}
+        columnIndex={0}
+        class="doc-sheet__single"
+        role="main"
+      >
+        <Show when={isFirst()}>
+          <div class="doc-sheet__banner">
+            <SheetAvatar basics={props.resume.basics} />
+            <NameHeader basics={props.resume.basics} />
+            <ContactBlock basics={props.resume.basics} isCompact />
+          </div>
+        </Show>
+        <SectionList ids={ids()} otherColumnLabel={null} />
+      </ColumnFrame>
+    );
+  }
+
+  /** Legacy layouts with more than two columns: an even flex row. */
+  function MultiColumn(columnProps: { pageIndex: number; page: string[][] }): JSX.Element {
+    return (
+      <div class="doc-sheet__multi">
+        <For each={columnProps.page}>
+          {(ids, columnIndex) => (
+            <ColumnFrame
+              pageIndex={columnProps.pageIndex}
+              columnIndex={columnIndex()}
+              class="doc-sheet__multi-col"
+              role={columnIndex() === 0 ? "main" : "sidebar"}
+            >
+              <SectionList ids={ids} otherColumnLabel={null} />
+            </ColumnFrame>
+          )}
+        </For>
+      </div>
+    );
+  }
+
+  /** One page's body, composed per the template's layout mode (spec §3.6). */
+  function pageBody(pageIndex: number, page: string[][]): JSX.Element {
+    if (page.length > 2) return <MultiColumn pageIndex={pageIndex} page={page} />;
+    const isFirst = pageIndex === 0;
+
+    if (layoutMode() === "single") return <SingleColumn pageIndex={pageIndex} page={page} />;
+
+    if (layoutMode() === "header-split") {
+      return (
+        <div class="doc-sheet__split">
+          <Show when={isFirst}>
+            <div
+              class="doc-sheet__banner"
+              classList={{
+                "doc-sheet__banner--tint": headerStyle() === "banner",
+                "doc-sheet__banner--boxed": headerStyle() === "boxed",
+              }}
+            >
+              <SheetAvatar basics={props.resume.basics} />
+              <NameHeader basics={props.resume.basics} />
+              <Show when={contactIn() === "banner" || contactIn() === "header"}>
+                <ContactBlock basics={props.resume.basics} isCompact />
+              </Show>
+            </div>
+          </Show>
+          <div class="doc-sheet__grid doc-sheet__grid--split">
+            <MainColumn pageIndex={pageIndex} page={page} withHeader={false} />
+            <SideColumn pageIndex={pageIndex} page={page} isRightSidebar />
+          </div>
+        </div>
+      );
+    }
+
+    const isLeft = layoutMode() === "sidebar-left";
+    return (
+      <div
+        class="doc-sheet__grid"
+        classList={{
+          "doc-sheet__grid--side-left": isLeft,
+          "doc-sheet__grid--side-right": !isLeft,
+        }}
+      >
+        <Show
+          when={isLeft}
+          fallback={
+            <>
+              <MainColumn
+                pageIndex={pageIndex}
+                page={page}
+                withHeader={headerStyle() !== "sidebar"}
+              />
+              <SideColumn pageIndex={pageIndex} page={page} isRightSidebar />
+            </>
+          }
+        >
+          <SideColumn pageIndex={pageIndex} page={page} isRightSidebar={false} />
+          <MainColumn pageIndex={pageIndex} page={page} withHeader={headerStyle() !== "sidebar"} />
+        </Show>
+      </div>
+    );
+  }
+
+  /** One content-sized sheet: overflow guides over the composed page body. */
+  function SheetPage(pageProps: { pageIndex: number; page: string[][] }): JSX.Element {
+    const [element, setElement] = createSignal<HTMLElement>();
+    return (
+      <article
+        ref={setElement}
+        class="doc-sheet__page"
+        data-testid="doc-sheet-page"
+        data-page={pageProps.pageIndex + 1}
+        aria-label={`Page ${pageProps.pageIndex + 1} of ${pages().length}`}
+      >
+        <Show when={isEditable()}>
+          <SheetOverflowGuides sheet={element} />
+        </Show>
+        {pageBody(pageProps.pageIndex, pageProps.page)}
+      </article>
+    );
+  }
 
   return (
     <SheetModeContext.Provider value={mode}>
@@ -511,123 +798,47 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
             root = element;
             observer?.observe(element);
           }}
-          class="doc-sheet"
-          classList={{ "doc-sheet--done": !isEditable() }}
+          class={
+            `doc-sheet doc-sheet--tpl-${props.resume.metadata.template} ` +
+            `doc-sheet--layout-${layoutMode()} doc-sheet--head-${headerStyle()}`
+          }
+          classList={{
+            "doc-sheet--editing": isEditable(),
+            "doc-sheet--done": !isEditable(),
+          }}
           data-testid="doc-sheet"
           data-sheet-mode={mode()}
           style={{
             "--doc-sheet-bg": theme().background,
             "--doc-sheet-text": theme().text,
             "--doc-sheet-accent": theme().primary,
+            "--doc-sheet-side-w": `${sidebarWidth()}px`,
+            "--doc-sheet-page-h": `${PAGE_HEIGHT_PX}px`,
           }}
         >
           <For each={pages()}>
-            {(page, pageIndex) => {
-              const geometry = createMemo(() => layoutColumns(page, props.templateLayout));
-              const hasSidebar = () => geometry().some((column) => column.role === "sidebar");
-              const isFirst = () => pageIndex() === 0;
-              const identityIn = () => identityRegion(props.templateLayout, hasSidebar());
-              const contactIn = () => contactRegion(props.templateLayout, hasSidebar());
-
-              return (
-                <article
-                  class="doc-sheet__page"
-                  data-testid="doc-sheet-page"
-                  aria-label={`Page ${pageIndex() + 1} of ${pages().length}`}
-                  data-overflowing={overflowing().includes(pageIndex()) ? "true" : undefined}
-                >
-                  <Show when={isFirst() && identityIn() === "top"}>
-                    <DocHeader
-                      basics={props.resume.basics}
-                      headerStyle={props.templateLayout.headerStyle}
-                      showContact={contactIn() === "top"}
-                      profileLinks={links()}
-                    />
-                  </Show>
-                  <Show when={isFirst() && identityIn() !== "top" && contactIn() === "top"}>
-                    <DocHeader
-                      basics={props.resume.basics}
-                      headerStyle={props.templateLayout.headerStyle}
-                      showIdentity={false}
-                      showContact
-                      profileLinks={links()}
-                    />
-                  </Show>
-
-                  <div class="doc-sheet__columns">
-                    <For each={visualColumns(geometry())}>
-                      {(column) => (
-                        <SheetColumn
-                          pageIndex={pageIndex()}
-                          column={column}
-                          addTargets={addTargets(pageIndex(), column.index)}
-                          onAdd={setAddTarget}
-                        >
-                          <Show
-                            when={
-                              isFirst() && column.role === "sidebar" && identityIn() === "sidebar"
-                            }
-                          >
-                            <DocHeader
-                              basics={props.resume.basics}
-                              headerStyle="sidebar"
-                              showContact={contactIn() === "sidebar"}
-                              profileLinks={links()}
-                            />
-                          </Show>
-                          <Show
-                            when={
-                              isFirst() &&
-                              column.role === "sidebar" &&
-                              identityIn() !== "sidebar" &&
-                              contactIn() === "sidebar"
-                            }
-                          >
-                            <DocHeader
-                              basics={props.resume.basics}
-                              headerStyle="sidebar"
-                              showIdentity={false}
-                              showContact
-                              profileLinks={links()}
-                            />
-                          </Show>
-
-                          <For each={page[column.index] ?? []}>
-                            {(section) => (
-                              <DocSection
-                                resume={props.resume}
-                                sectionId={section.id}
-                                hidden={section.hidden}
-                                onMoveSection={moveSection}
-                                onMoveEntry={moveEntry}
-                                onAnnounce={announce}
-                              />
-                            )}
-                          </For>
-                        </SheetColumn>
-                      )}
-                    </For>
+            {(page, pageIndex) => (
+              <>
+                <Show when={pageIndex() > 0}>
+                  <div class="doc-sheet__page-break" data-testid="doc-sheet-page-break">
+                    <span class="doc-sheet__page-break-label">Page {pageIndex() + 1}</span>
+                    <Show when={isEditable()}>
+                      <button
+                        type="button"
+                        class="doc-sheet__page-break-remove"
+                        onClick={() => removePageBreak(pageIndex())}
+                      >
+                        Remove page break
+                      </button>
+                    </Show>
                   </div>
-                </article>
-              );
-            }}
+                </Show>
+                <SheetPage pageIndex={pageIndex()} page={page} />
+              </>
+            )}
           </For>
 
-          <NewPageZone active={activeDrag()?.type === "section"} />
-
-          {/* Sheet-level chrome: creating a section is not part of any one page. */}
-          <Show when={isEditable()}>
-            <div class="doc-sheet__actions">
-              <button
-                type="button"
-                class="doc-sheet__action"
-                data-testid="doc-sheet-add-section"
-                onClick={() => setIsSectionDialogOpen(true)}
-              >
-                Add section
-              </button>
-            </div>
-          </Show>
+          <PageCountPill count={measuredPages()} />
 
           {/* Dialogs are editing chrome: unmounted in Done mode even when an
               open flag was left set by a mid-dialog mode switch. */}
@@ -635,16 +846,6 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
             <CustomSectionDialog
               open={isSectionDialogOpen()}
               onOpenChange={setIsSectionDialogOpen}
-            />
-
-            {/* Add-block target: adds the first item of a placed-but-empty section. */}
-            <ItemDialog
-              open={addTarget() !== null}
-              sectionId={addTarget() ?? ""}
-              sectionTitle={sectionTitle(props.resume, addTarget() ?? "")}
-              onOpenChange={(open) => {
-                if (!open) setAddTarget(null);
-              }}
             />
           </Show>
 

--- a/apps/web/src/components/doc-editor/SectionChrome.tsx
+++ b/apps/web/src/components/doc-editor/SectionChrome.tsx
@@ -77,12 +77,25 @@ function pencilId(sectionId: string): string {
   return `doc-${sectionId}-section-pencil`;
 }
 
+/** Stable id for a section's pencil menu (`aria-controls` target). */
+function menuId(sectionId: string): string {
+  return `doc-${sectionId}-section-menu`;
+}
+
+/** The menu's operable items, in visual order. */
+function enabledMenuItems(menu: HTMLElement): HTMLButtonElement[] {
+  return [...menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')].filter(
+    (item) => !item.disabled,
+  );
+}
+
 export function SectionChrome(props: SectionChromeProps): JSX.Element {
   const isEditable = useSheetEditable();
   const [isMenuOpen, setIsMenuOpen] = createSignal(false);
   const hasChrome = (): boolean => isEditable() && props.menu !== undefined;
 
-  // The menu closes on outside press or Escape, like any popover.
+  // The menu closes on outside press or Escape, like any popover; Escape also
+  // hands focus back to the pencil so a keyboard user is not stranded.
   createEffect(() => {
     if (!isMenuOpen()) return;
     const onDown = (event: MouseEvent): void => {
@@ -90,7 +103,9 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
       if (!target?.closest(".doc-sheet__sec-menu, .doc-sheet__sec-pencil")) setIsMenuOpen(false);
     };
     const onKey = (event: KeyboardEvent): void => {
-      if (event.key === "Escape") setIsMenuOpen(false);
+      if (event.key !== "Escape") return;
+      setIsMenuOpen(false);
+      document.getElementById(pencilId(props.sectionId))?.focus();
     };
     document.addEventListener("mousedown", onDown);
     document.addEventListener("keydown", onKey);
@@ -99,6 +114,25 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
       document.removeEventListener("keydown", onKey);
     });
   });
+
+  /** Arrow-key roving focus over the menu's enabled items (menu pattern). */
+  function handleMenuKeyDown(event: KeyboardEvent): void {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+    const menu = event.currentTarget as HTMLElement;
+    const items = enabledMenuItems(menu);
+    if (items.length === 0) return;
+    event.preventDefault();
+    const active = document.activeElement as HTMLButtonElement | null;
+    const current = active === null ? -1 : items.indexOf(active);
+    const step = event.key === "ArrowDown" ? 1 : -1;
+    const next =
+      current === -1
+        ? step === 1
+          ? 0
+          : items.length - 1
+        : (current + step + items.length) % items.length;
+    items[next]?.focus();
+  }
 
   /**
    * Run a menu action; the menu always closes first.
@@ -170,6 +204,7 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
             aria-label={`${props.title} section options`}
             aria-haspopup="menu"
             aria-expanded={isMenuOpen()}
+            aria-controls={isMenuOpen() ? menuId(props.sectionId) : undefined}
             onClick={(event) => {
               event.stopPropagation();
               setIsMenuOpen(!isMenuOpen());
@@ -183,10 +218,16 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
       <Show when={hasChrome() && isMenuOpen() && props.menu}>
         {(menu) => (
           <div
+            ref={(element) => {
+              // Focus moves into the menu when it opens, per the menu pattern.
+              queueMicrotask(() => enabledMenuItems(element)[0]?.focus());
+            }}
+            id={menuId(props.sectionId)}
             class="doc-sheet__sec-menu"
             role="menu"
             aria-label={`${props.title} section options`}
             onClick={(event) => event.stopPropagation()}
+            onKeyDown={handleMenuKeyDown}
           >
             <Show when={menu().onAdd}>
               <button type="button" role="menuitem" onClick={menuAct(menu().onAdd)}>

--- a/apps/web/src/components/doc-editor/SectionChrome.tsx
+++ b/apps/web/src/components/doc-editor/SectionChrome.tsx
@@ -1,0 +1,262 @@
+/**
+ * The universal section card (#794, spec §1.5): every section body on the
+ * sheet renders inside this chrome.
+ *
+ * In edit mode the card is an HA-style dashed block: a header row holding the
+ * hidden-until-hover drag grip, the section title, and a pencil button whose
+ * popover menu consolidates the structural actions (add item, move up/down,
+ * move across columns, rename, hide). The dashed add-block (spec §1.10) draws
+ * under the body when the section can take a new item. In Done mode none of
+ * this chrome mounts — the card is just the section content.
+ *
+ * The chrome is presentational: every action arrives as a callback and every
+ * drag primitive (the grip's activators, the card's droppable ref) is owned by
+ * the caller, so the drag mechanism can be swapped (#796) without touching the
+ * card. The `basics` contact block reuses this card with no menu and no grip —
+ * template-owned chrome (spec §1.4).
+ */
+
+import { Show, createEffect, createSignal, onCleanup, type JSX } from "solid-js";
+import { DragGridIcon, PencilIcon, PlusIcon } from "./icons";
+import { InlineText } from "./InlineText";
+import { useSheetEditable } from "./sheetMode";
+
+/** The pencil menu's structural actions and their enablement. */
+export interface SectionMenuActions {
+  /** First menu entry, present when the section takes items. */
+  addLabel?: string;
+  onAdd?: () => void;
+  /** One-step column moves; disabled at the column's ends. */
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  /** Cross-column move, absent on single-column templates. */
+  otherColumnLabel?: string;
+  onMoveToOtherColumn?: () => void;
+  /** Arms the inline title editor. */
+  onRename: () => void;
+  onHide: () => void;
+}
+
+export interface SectionChromeProps {
+  sectionId: string;
+  /** Display title; inline-editable when `onRenameCommit` is provided. */
+  title: string;
+  /**
+   * Commit a new title typed into the inline editor. Absent for chrome whose
+   * title is fixed (the `basics` contact card).
+   */
+  onRenameCommit?: (value: string) => void;
+  /** Solid uses `focused` as the last-clicked card (solid accent border). */
+  isFocused: boolean;
+  onFocus: () => void;
+  /** Dashed add-block under the body; absent for rich-text sections. */
+  addLabel?: string;
+  onAdd?: () => void;
+  /** Pencil menu; absent for template-owned chrome (`basics`). */
+  menu?: SectionMenuActions;
+  /** Drag-grip activator props from the sheet's drag system. */
+  gripActivators?: Record<string, unknown>;
+  gripTitle?: string;
+  /** Ref for the card element (drop target registration). */
+  ref?: (element: HTMLElement) => void;
+  /** Drag-state classes driven by the sheet's drag system. */
+  isDropTarget?: boolean;
+  isDragging?: boolean;
+  children: JSX.Element;
+}
+
+/** Stable trigger id for a section's inline title editor. */
+export function sectionTitleTriggerId(sectionId: string): string {
+  return `doc-${sectionId}-section-title`;
+}
+
+/** Stable id for a section's pencil button, so menu actions can refocus it. */
+function pencilId(sectionId: string): string {
+  return `doc-${sectionId}-section-pencil`;
+}
+
+export function SectionChrome(props: SectionChromeProps): JSX.Element {
+  const isEditable = useSheetEditable();
+  const [isMenuOpen, setIsMenuOpen] = createSignal(false);
+  const hasChrome = (): boolean => isEditable() && props.menu !== undefined;
+
+  // The menu closes on outside press or Escape, like any popover.
+  createEffect(() => {
+    if (!isMenuOpen()) return;
+    const onDown = (event: MouseEvent): void => {
+      const target = event.target as HTMLElement | null;
+      if (!target?.closest(".doc-sheet__sec-menu, .doc-sheet__sec-pencil")) setIsMenuOpen(false);
+    };
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") setIsMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    onCleanup(() => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    });
+  });
+
+  /**
+   * Run a menu action; the menu always closes first.
+   *
+   * `refocus` hands focus back to the pencil once the sheet redraws, so a
+   * keyboard user's next Tab carries on from the card that was acted on. It is
+   * off for actions that place focus themselves (renaming arms the inline
+   * title editor; adding opens a dialog) and for hiding, which unmounts the
+   * card entirely.
+   */
+  const menuAct =
+    (action: (() => void) | undefined, refocus = false) =>
+    (): void => {
+      setIsMenuOpen(false);
+      action?.();
+      if (refocus) {
+        const id = pencilId(props.sectionId);
+        queueMicrotask(() => document.getElementById(id)?.focus());
+      }
+    };
+
+  return (
+    <section
+      ref={(element) => props.ref?.(element)}
+      class="doc-sheet__sec"
+      classList={{
+        "doc-sheet__sec--edit": hasChrome(),
+        "doc-sheet__sec--focused": hasChrome() && props.isFocused,
+        "doc-sheet__sec--menu-open": isMenuOpen(),
+        "doc-sheet__sec--drop": props.isDropTarget === true,
+        "doc-sheet__sec--dragging": props.isDragging === true,
+      }}
+      data-section-id={props.sectionId}
+      onClick={() => {
+        if (isEditable()) props.onFocus();
+      }}
+    >
+      <div class="doc-sheet__sec-bar">
+        <Show when={hasChrome() && props.gripActivators}>
+          <button
+            type="button"
+            class="doc-sheet__sec-grip"
+            aria-hidden="true"
+            tabindex="-1"
+            title={props.gripTitle}
+            {...(props.gripActivators ?? {})}
+          >
+            <DragGridIcon />
+          </button>
+        </Show>
+        <h3 class="doc-sheet__sec-title">
+          <Show when={props.onRenameCommit} fallback={props.title}>
+            {(commit) => (
+              <InlineText
+                value={props.title}
+                label="Section title"
+                triggerId={sectionTitleTriggerId(props.sectionId)}
+                onCommit={(value) => commit()(value)}
+              />
+            )}
+          </Show>
+        </h3>
+        <Show when={hasChrome()}>
+          <button
+            type="button"
+            id={pencilId(props.sectionId)}
+            class="doc-sheet__sec-pencil"
+            title="Section options"
+            aria-label={`${props.title} section options`}
+            aria-haspopup="menu"
+            aria-expanded={isMenuOpen()}
+            onClick={(event) => {
+              event.stopPropagation();
+              setIsMenuOpen(!isMenuOpen());
+            }}
+          >
+            <PencilIcon />
+          </button>
+        </Show>
+      </div>
+
+      <Show when={hasChrome() && isMenuOpen() && props.menu}>
+        {(menu) => (
+          <div
+            class="doc-sheet__sec-menu"
+            role="menu"
+            aria-label={`${props.title} section options`}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Show when={menu().onAdd}>
+              <button type="button" role="menuitem" onClick={menuAct(menu().onAdd)}>
+                {menu().addLabel ?? "Add item"}
+              </button>
+            </Show>
+            <button
+              type="button"
+              role="menuitem"
+              disabled={!menu().canMoveUp}
+              aria-label={`Move ${props.title} section up`}
+              onClick={menuAct(menu().onMoveUp, true)}
+            >
+              Move up
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              disabled={!menu().canMoveDown}
+              aria-label={`Move ${props.title} section down`}
+              onClick={menuAct(menu().onMoveDown, true)}
+            >
+              Move down
+            </button>
+            <Show when={menu().onMoveToOtherColumn}>
+              <button
+                type="button"
+                role="menuitem"
+                aria-label={`Move ${props.title} section to the ${menu().otherColumnLabel}`}
+                onClick={menuAct(menu().onMoveToOtherColumn, true)}
+              >
+                Move to {menu().otherColumnLabel}
+              </button>
+            </Show>
+            <div class="doc-sheet__sec-menu-sep" role="separator" />
+            <button
+              type="button"
+              role="menuitem"
+              aria-label={`Rename ${props.title} section`}
+              onClick={menuAct(menu().onRename)}
+            >
+              Rename title…
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              class="doc-sheet__sec-menu-danger"
+              aria-label={`Hide ${props.title} section`}
+              onClick={menuAct(menu().onHide)}
+            >
+              Hide section
+            </button>
+          </div>
+        )}
+      </Show>
+
+      <div class="doc-sheet__sec-body">{props.children}</div>
+
+      <Show when={isEditable() && props.onAdd}>
+        <button
+          type="button"
+          class="doc-sheet__add-block"
+          onClick={(event) => {
+            event.stopPropagation();
+            props.onAdd?.();
+          }}
+        >
+          <PlusIcon /> {props.addLabel ?? "Add"}
+        </button>
+      </Show>
+    </section>
+  );
+}

--- a/apps/web/src/components/doc-editor/SectionsPanel.tsx
+++ b/apps/web/src/components/doc-editor/SectionsPanel.tsx
@@ -21,11 +21,26 @@ import type { ResumeData } from "../../wasm/types";
 
 export interface SectionsPanelProps {
   resume: ResumeData;
+  /**
+   * Controlled open state, so the sheet's Add-section blocks can open the
+   * panel (#794). Leave both unset for the self-contained top-bar behaviour.
+   */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function SectionsPanel(props: SectionsPanelProps): JSX.Element {
-  const [open, setOpen] = createSignal(false);
+  const [internalOpen, setInternalOpen] = createSignal(false);
   const [adding, setAdding] = createSignal(false);
+
+  const open = (): boolean => props.open ?? internalOpen();
+  const setOpen = (next: boolean): void => {
+    if (props.onOpenChange) {
+      props.onOpenChange(next);
+      return;
+    }
+    setInternalOpen(next);
+  };
 
   const customIds = (): string[] => Object.keys(props.resume.sections.custom ?? {});
 

--- a/apps/web/src/components/doc-editor/SectionsPanel.tsx
+++ b/apps/web/src/components/doc-editor/SectionsPanel.tsx
@@ -33,10 +33,13 @@ export function SectionsPanel(props: SectionsPanelProps): JSX.Element {
   const [internalOpen, setInternalOpen] = createSignal(false);
   const [adding, setAdding] = createSignal(false);
 
-  const open = (): boolean => props.open ?? internalOpen();
+  // Controlled iff `open` is supplied — and then `onOpenChange` must drive it,
+  // so a one-sided pairing cannot leave the panel stuck open or closed.
+  const isControlled = (): boolean => props.open !== undefined;
+  const open = (): boolean => (isControlled() ? (props.open ?? false) : internalOpen());
   const setOpen = (next: boolean): void => {
-    if (props.onOpenChange) {
-      props.onOpenChange(next);
+    if (isControlled()) {
+      props.onOpenChange?.(next);
       return;
     }
     setInternalOpen(next);

--- a/apps/web/src/components/doc-editor/SortableEntry.tsx
+++ b/apps/web/src/components/doc-editor/SortableEntry.tsx
@@ -1,0 +1,199 @@
+/**
+ * Universal item-row chrome (#794, spec §1.8–§1.9).
+ *
+ * Every structured item on the sheet renders inside this row: a left-edge
+ * `⋮⋮` drag grip that fades in on hover, plus the hover action pill. Full
+ * rows get the floating top-right pill (edit / move / duplicate / visibility
+ * / remove, in the spec's fixed order); compact sidebar rows (profiles,
+ * languages, skills) get a single bare `✕` at the right edge and make the
+ * whole row the edit affordance — click anywhere opens the item dialog.
+ *
+ * Reveal is opacity, never `display`: every control stays focusable and
+ * announced, and `@media (hover: none)` keeps them visible for touch. The
+ * compact row's move buttons are visually hidden until keyboard focus — the
+ * spec draws no arrows there (drag covers pointer reorder), but a keyboard
+ * user still needs the path.
+ *
+ * Drag primitives are created here (grip = activator) but resolved by the
+ * sheet; #796 replaces the mechanism without touching this contract.
+ */
+
+import { Show, type JSX } from "solid-js";
+import { createDraggable, createDroppable } from "@thisbeyond/solid-dnd";
+import { EyeIcon } from "./icons";
+import { useSheetEditable } from "./sheetMode";
+
+/** The row's action callbacks; absent callbacks render no control. */
+export interface EntryActionsProps {
+  /** Short human name for the item, used in the buttons' accessible names. */
+  label: string;
+  isCompact: boolean;
+  isHidden: boolean;
+  onEdit: () => void;
+  onRemove: () => void;
+  onDuplicate: () => void;
+  onToggleVisibility: () => void;
+  /** Present only when a neighbour exists in that direction (spec §1.9). */
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+}
+
+/** One 26px circular ghost button of the pill. */
+function ActionButton(props: {
+  class?: string;
+  label: string;
+  isKeyboardOnly?: boolean;
+  onClick: () => void;
+  children: JSX.Element;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      class={`doc-sheet__entry-act ${props.class ?? ""}`}
+      classList={{ "doc-sheet__entry-act--kb-only": props.isKeyboardOnly === true }}
+      aria-label={props.label}
+      title={props.label}
+      onClick={(event) => {
+        event.stopPropagation();
+        props.onClick();
+      }}
+    >
+      {props.children}
+    </button>
+  );
+}
+
+/**
+ * The hover action pill (spec §1.9). Full rows float it at the top right;
+ * compact rows collapse it to a bare right-edge `✕` plus keyboard-only
+ * equivalents for the actions the spec draws no pointer control for.
+ */
+export function EntryActions(props: EntryActionsProps): JSX.Element {
+  return (
+    <div
+      class="doc-sheet__entry-actions"
+      classList={{ "doc-sheet__entry-actions--compact": props.isCompact }}
+      role="group"
+      aria-label={`${props.label} actions`}
+    >
+      <ActionButton
+        class="doc-sheet__entry-act--edit"
+        label={`Edit ${props.label}`}
+        isKeyboardOnly={props.isCompact}
+        onClick={props.onEdit}
+      >
+        ✎
+      </ActionButton>
+      <Show when={props.onMoveUp}>
+        {(onMoveUp) => (
+          <ActionButton
+            label={`Move ${props.label} up`}
+            isKeyboardOnly={props.isCompact}
+            onClick={() => onMoveUp()()}
+          >
+            ↑
+          </ActionButton>
+        )}
+      </Show>
+      <Show when={props.onMoveDown}>
+        {(onMoveDown) => (
+          <ActionButton
+            label={`Move ${props.label} down`}
+            isKeyboardOnly={props.isCompact}
+            onClick={() => onMoveDown()()}
+          >
+            ↓
+          </ActionButton>
+        )}
+      </Show>
+      <Show when={!props.isCompact}>
+        <ActionButton label={`Duplicate ${props.label}`} onClick={props.onDuplicate}>
+          ⧉
+        </ActionButton>
+        <ActionButton
+          label={`${props.isHidden ? "Show" : "Hide"} ${props.label}`}
+          onClick={props.onToggleVisibility}
+        >
+          <EyeIcon isOpen={!props.isHidden} />
+        </ActionButton>
+      </Show>
+      <ActionButton
+        class="doc-sheet__entry-act--remove"
+        label={`Remove ${props.label}`}
+        onClick={props.onRemove}
+      >
+        {props.isCompact ? "✕" : "−"}
+      </ActionButton>
+    </div>
+  );
+}
+
+export interface SortableEntryProps {
+  sectionId: string;
+  itemId: string;
+  /** Extra class naming the row's body layout (`entry`, `edu-entry`, …). */
+  class?: string;
+  isCompact?: boolean;
+  /** Switched off — drawn as chrome, but absent from the PDF. */
+  isHidden: boolean;
+  actions: Omit<EntryActionsProps, "isCompact">;
+  children: JSX.Element;
+}
+
+/** One item row: grip strip, action chrome, then the section's own body. */
+export function SortableEntry(props: SortableEntryProps): JSX.Element {
+  const isEditable = useSheetEditable();
+
+  const draggable = createDraggable(`drag:entry:${props.sectionId}:${props.itemId}`, {
+    type: "entry",
+    sectionId: props.sectionId,
+    itemId: props.itemId,
+  });
+  const droppable = createDroppable(`drop:entry:${props.sectionId}:${props.itemId}`, {
+    type: "entry",
+    sectionId: props.sectionId,
+    itemId: props.itemId,
+  });
+
+  return (
+    <article
+      ref={(element) => {
+        draggable.ref(element);
+        droppable.ref(element);
+      }}
+      class={`doc-sheet__entry-row ${props.class ?? ""}`}
+      classList={{
+        "doc-sheet__entry-row--compact": props.isCompact === true,
+        "doc-sheet__entry-row--edit": isEditable(),
+        "doc-sheet__entry-row--hidden": props.isHidden,
+        "doc-sheet__entry-row--drop": droppable.isActiveDroppable,
+        "doc-sheet__entry-row--dragging": draggable.isActiveDraggable,
+      }}
+      data-entry-id={props.itemId}
+      title={props.isCompact === true && isEditable() ? "Click to edit · hold to drag" : undefined}
+      onClick={(event) => {
+        // Compact rows: the whole row is the edit affordance. Presses on the
+        // grip or any button keep their own behaviour.
+        if (props.isCompact !== true || !isEditable()) return;
+        const target = event.target as HTMLElement;
+        if (target.closest("button, a")) return;
+        props.actions.onEdit();
+      }}
+    >
+      <Show when={isEditable()}>
+        <button
+          type="button"
+          class="doc-sheet__entry-handle"
+          aria-hidden="true"
+          tabindex="-1"
+          title={`Drag ${props.actions.label} to move it`}
+          {...draggable.dragActivators}
+        >
+          ⋮⋮
+        </button>
+        <EntryActions {...props.actions} isCompact={props.isCompact === true} />
+      </Show>
+      {props.children}
+    </article>
+  );
+}

--- a/apps/web/src/components/doc-editor/__tests__/inlineEdit.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/inlineEdit.test.tsx
@@ -48,9 +48,14 @@ describe("document sheet inline editing", () => {
     return region.getByRole("textbox", { name: fieldLabel }) as HTMLInputElement;
   }
 
-  /** The header region, where the basics are drawn. */
+  /** The header region, where the name and headline are drawn. */
   function header(): HTMLElement {
     return screen.getAllByTestId("doc-sheet-header")[0];
+  }
+
+  /** The contact block, where email, phone and location are drawn (#794). */
+  function contact(): HTMLElement {
+    return screen.getAllByTestId("doc-sheet-contact")[0];
   }
 
   it.each([
@@ -108,7 +113,7 @@ describe("document sheet inline editing", () => {
   it("restores the prior value on Escape without writing", () => {
     renderSheet();
 
-    const input = edit("mireille@okafor.design", "Email", header());
+    const input = edit("mireille@okafor.design", "Email", contact());
     fireEvent.input(input, { target: { value: "typo@example.com" } });
     fireEvent.keyDown(input, { key: "Escape" });
 
@@ -119,7 +124,7 @@ describe("document sheet inline editing", () => {
   it("writes nothing when the text is left unchanged", () => {
     renderSheet();
 
-    const input = edit("Lisbon, Portugal", "Location", header());
+    const input = edit("Lisbon, Portugal", "Location", contact());
     fireEvent.blur(input);
 
     expect(writeCount()).toBe(0);
@@ -138,16 +143,17 @@ describe("document sheet inline editing", () => {
     expect(writeCount()).toBe(1);
   });
 
-  it("commits a custom-section item through updateCustomSectionItem", () => {
+  it("draws custom-section items as chips with no inline editor (#794)", () => {
     renderSheet();
 
-    const input = edit("Design Tokens Beyond Colour", "Name");
-    fireEvent.input(input, { target: { value: "Design Tokens, Beyond Colour" } });
-    fireEvent.blur(input);
-
-    expect(store.updateCustomSectionItem).toHaveBeenCalledExactlyOnceWith("speaking", 0, {
-      name: "Design Tokens, Beyond Colour",
-    });
+    // Spec §1.7: custom sections are chip lists; items are managed through
+    // the add-block dialog and the chip's inline remove, never edited in
+    // place. The chip removal path is covered in `sectionCards.test.tsx`.
+    expect(screen.queryByRole("button", { name: "Design Tokens Beyond Colour" })).toBeNull();
+    const chips = [...document.querySelectorAll(".doc-sheet__skill-chip")].map(
+      (chip) => chip.textContent,
+    );
+    expect(chips.join(" ")).toContain("Design Tokens Beyond Colour");
   });
 
   it("renames a fixed section through updateSectionName", () => {
@@ -176,7 +182,7 @@ describe("document sheet inline editing", () => {
     resume.basics.phone = "";
     renderSheet();
 
-    const input = edit("Add phone", "Phone", header());
+    const input = edit("Add phone", "Phone", contact());
     fireEvent.input(input, { target: { value: "+351 000 000" } });
     fireEvent.blur(input);
 

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -1,6 +1,7 @@
 /**
- * The structural chrome of #729: section cards, entry action rows, add-blocks
- * and the single-pointer/keyboard move controls that mirror the drags.
+ * The structural chrome of #794: universal section cards with a grip and a
+ * pencil menu, entry rows with the hover action pill, dashed add-blocks, and
+ * the page-break rule.
  *
  * Pointer drags themselves are exercised against the pure resolvers in
  * `lib/__tests__/docDnd.test.ts`; here the assertions are that every control
@@ -54,6 +55,17 @@ function liveRegionText(): string {
     .join(" ");
 }
 
+/** Open a section's pencil menu, the home of its structural actions. */
+function openMenu(title: string): void {
+  fireEvent.click(screen.getByRole("button", { name: `${title} section options` }));
+}
+
+/**
+ * The fixture's first experience entry as the chrome names it — the position,
+ * per the headline-field preference order.
+ */
+const FIRST_EXPERIENCE = "Principal Design Systems Engineer";
+
 describe("document sheet structural chrome", () => {
   let resume: ResumeData;
 
@@ -63,15 +75,22 @@ describe("document sheet structural chrome", () => {
     store.store.resume = resume;
   });
 
-  function renderSheet() {
-    return render(() => <DocSheet resume={resume} templateLayout={SIDEBAR_TEMPLATE} />);
+  function renderSheet(options: { onOpenSections?: () => void } = {}) {
+    return render(() => (
+      <DocSheet
+        resume={resume}
+        templateLayout={SIDEBAR_TEMPLATE}
+        onOpenSections={options.onOpenSections}
+      />
+    ));
   }
 
   describe("section cards", () => {
     it("hides a fixed section through toggleSectionVisibility, and says so", async () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Hide Experience section" }));
+      openMenu("Experience");
+      fireEvent.click(screen.getByRole("menuitem", { name: "Hide Experience section" }));
 
       expect(store.toggleSectionVisibility).toHaveBeenCalledExactlyOnceWith("experience");
       expect(writeCount()).toBe(1);
@@ -83,69 +102,64 @@ describe("document sheet structural chrome", () => {
     it("hides a custom section through updateCustomSection", () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Hide Talks & Workshops section" }));
+      openMenu("Talks & Workshops");
+      fireEvent.click(screen.getByRole("menuitem", { name: "Hide Talks & Workshops section" }));
 
       expect(store.updateCustomSection).toHaveBeenCalledExactlyOnceWith("speaking", {
         visible: false,
       });
     });
 
-    it("keeps a hidden section on the surface, flagged, with a Show control", () => {
+    it("never draws a hidden section — the Sections panel is the recovery path", () => {
       resume.sections.experience.visible = false;
       renderSheet();
 
-      const section = document.querySelector('[data-section-id="experience"]');
-      expect(section).toBeTruthy();
-      expect(section?.classList.contains("doc-sheet__section--hidden")).toBe(true);
-
-      fireEvent.click(screen.getByRole("button", { name: "Show Experience section" }));
-
-      expect(store.toggleSectionVisibility).toHaveBeenCalledExactlyOnceWith("experience");
+      expect(document.querySelector('[data-section-id="experience"]')).toBeNull();
     });
 
-    it("keeps a hidden, empty summary on the surface with a Show control", () => {
-      // Regression: rich text has no add-block, so if hiding an empty summary
-      // dropped its card, nothing on the sheet could ever show it again.
-      resume.sections.summary.content = "";
-      resume.sections.summary.visible = false;
+    it("offers no destructive delete for any section, custom included", () => {
       renderSheet();
 
-      const summary = document.querySelector('[data-section-id="summary"]');
-      expect(summary).toBeTruthy();
-      expect(summary?.classList.contains("doc-sheet__section--hidden")).toBe(true);
-
-      fireEvent.click(screen.getByRole("button", { name: "Show Summary section" }));
-
-      expect(store.toggleSectionVisibility).toHaveBeenCalledExactlyOnceWith("summary");
+      openMenu("Talks & Workshops");
+      expect(
+        screen.queryByRole("menuitem", { name: "Delete Talks & Workshops section" }),
+      ).toBeNull();
+      expect(screen.queryByRole("menuitem", { name: "Delete Experience section" })).toBeNull();
     });
 
-    it("deletes a custom section through removeCustomSection", () => {
+    it("renames a section from the pencil menu through the inline title editor", () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Delete Talks & Workshops section" }));
-
-      expect(store.removeCustomSection).toHaveBeenCalledExactlyOnceWith("speaking");
-      expect(writeCount()).toBe(1);
-    });
-
-    it("offers no delete for fixed sections", () => {
-      renderSheet();
-
-      expect(screen.queryByRole("button", { name: "Delete Experience section" })).toBeNull();
-    });
-
-    it("renames a custom section through its dialog", () => {
-      renderSheet();
-
-      fireEvent.click(screen.getByRole("button", { name: "Rename Talks & Workshops section" }));
-      fireEvent.input(screen.getByRole("textbox", { name: "Section name" }), {
-        target: { value: "Talks" },
-      });
-      fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+      openMenu("Talks & Workshops");
+      fireEvent.click(screen.getByRole("menuitem", { name: "Rename Talks & Workshops section" }));
+      const input = screen.getByRole("textbox", { name: "Section title" });
+      fireEvent.input(input, { target: { value: "Talks" } });
+      fireEvent.blur(input);
 
       expect(store.updateCustomSection).toHaveBeenCalledExactlyOnceWith("speaking", {
         name: "Talks",
       });
+    });
+
+    it("closes the pencil menu on Escape without acting", () => {
+      renderSheet();
+
+      openMenu("Experience");
+      expect(screen.getByRole("menu", { name: "Experience section options" })).toBeInTheDocument();
+
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(screen.queryByRole("menu", { name: "Experience section options" })).toBeNull();
+      expect(writeCount()).toBe(0);
+    });
+
+    it("marks the last-clicked card focused", () => {
+      renderSheet();
+
+      const experience = document.querySelector('[data-section-id="experience"]') as HTMLElement;
+      fireEvent.click(experience);
+
+      expect(experience.classList.contains("doc-sheet__sec--focused")).toBe(true);
     });
   });
 
@@ -153,7 +167,8 @@ describe("document sheet structural chrome", () => {
     it("moves a section one step down through one updateLayout call", () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Move Experience section down" }));
+      openMenu("Experience");
+      fireEvent.click(screen.getByRole("menuitem", { name: "Move Experience section down" }));
 
       expect(store.updateLayout).toHaveBeenCalledExactlyOnceWith([
         [
@@ -168,22 +183,26 @@ describe("document sheet structural chrome", () => {
       expect(writeCount()).toBe(1);
     });
 
-    it("moves a section to the next column, across pages", () => {
+    it("moves a section to the other column's end", () => {
       renderSheet();
 
+      openMenu("Talks & Workshops");
       fireEvent.click(
-        screen.getByRole("button", { name: "Move Talks & Workshops section to the next column" }),
+        screen.getByRole("menuitem", {
+          name: "Move Talks & Workshops section to the main column",
+        }),
       );
 
       const [layout] = store.updateLayout.mock.calls[0] as [string[][][]];
       expect(layout[0][1]).toEqual(["profiles", "skills"]);
-      expect(layout[1][0]).toEqual(["publications", "volunteer", "awards", "speaking"]);
+      expect(layout[0][0]).toEqual(["summary", "experience", "education", "projects", "speaking"]);
     });
 
     it("announces the move in drawn-card terms", async () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Move Experience section down" }));
+      openMenu("Experience");
+      fireEvent.click(screen.getByRole("menuitem", { name: "Move Experience section down" }));
 
       await waitFor(() => {
         expect(liveRegionText()).toMatch(
@@ -192,25 +211,31 @@ describe("document sheet structural chrome", () => {
       });
     });
 
-    it("hands focus back to the control that was used", async () => {
+    it("hands focus back to the card's pencil after a menu move", async () => {
       renderSheet();
-      const control = screen.getByRole("button", { name: "Move Experience section down" });
 
-      fireEvent.click(control);
+      openMenu("Experience");
+      fireEvent.click(screen.getByRole("menuitem", { name: "Move Experience section down" }));
 
-      // The refocus rides requestAnimationFrame, after the sheet redraws.
-      await waitFor(() => expect(document.activeElement).toBe(control));
+      // The menu has closed; a keyboard user's next Tab must carry on from
+      // the card that was acted on, not restart at the top of the document.
+      await waitFor(() =>
+        expect(document.activeElement).toBe(
+          screen.getByRole("button", { name: "Experience section options" }),
+        ),
+      );
     });
 
     it("steps past a placed-but-undrawn section, and counts only drawn cards", async () => {
-      // `education` keeps its layout slot but has nothing to draw, so one
-      // press on Experience must clear it in a single visible step — and the
-      // announced position must match the three cards on screen, not the four
-      // slots in the layout.
-      resume.sections.education.items = [];
+      // `education` keeps its layout slot but is hidden, so one press on
+      // Experience must clear it in a single visible step — and the announced
+      // position must match the three cards on screen, not the four slots in
+      // the layout.
+      resume.sections.education.visible = false;
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Move Experience section down" }));
+      openMenu("Experience");
+      fireEvent.click(screen.getByRole("menuitem", { name: "Move Experience section down" }));
 
       const [layout] = store.updateLayout.mock.calls[0] as [string[][][]];
       expect(layout[0][0]).toEqual(["summary", "education", "projects", "experience"]);
@@ -221,16 +246,17 @@ describe("document sheet structural chrome", () => {
       });
     });
 
-    it("writes nothing at a boundary, and says so", async () => {
+    it("disables the move at a boundary, so nothing is written", () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Move Summary section up" }));
+      openMenu("Summary");
+      const control = screen.getByRole("menuitem", { name: "Move Summary section up" });
+      expect(control).toBeDisabled();
+
+      fireEvent.click(control);
 
       expect(store.updateLayout).not.toHaveBeenCalled();
       expect(writeCount()).toBe(0);
-      await waitFor(() => {
-        expect(liveRegionText()).toMatch(/Summary section did not move/i);
-      });
     });
   });
 
@@ -238,26 +264,26 @@ describe("document sheet structural chrome", () => {
     it("duplicates an entry through duplicateSectionItem", () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Duplicate Lumen Health" }));
+      fireEvent.click(screen.getByRole("button", { name: `Duplicate ${FIRST_EXPERIENCE}` }));
 
       expect(store.duplicateSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0);
       expect(writeCount()).toBe(1);
     });
 
-    it("deletes the right entry through removeSectionItem, and says so", async () => {
+    it("removes the right entry through removeSectionItem, and says so", async () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Delete Lumen Health" }));
+      fireEvent.click(screen.getByRole("button", { name: `Remove ${FIRST_EXPERIENCE}` }));
 
       expect(store.removeSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0);
       await waitFor(() => {
-        expect(liveRegionText()).toMatch(/Lumen Health deleted/i);
+        expect(liveRegionText()).toMatch(/Principal Design Systems Engineer removed/i);
       });
     });
 
     it("hides an entry, keeps it drawn, and can show it again", () => {
       const first = renderSheet();
-      fireEvent.click(screen.getByRole("button", { name: "Hide Lumen Health" }));
+      fireEvent.click(screen.getByRole("button", { name: `Hide ${FIRST_EXPERIENCE}` }));
       expect(store.updateSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, {
         visible: false,
       });
@@ -269,21 +295,19 @@ describe("document sheet structural chrome", () => {
       vi.clearAllMocks();
       renderSheet();
 
-      expect(screen.getByRole("button", { name: "Show Lumen Health" })).toBeInTheDocument();
-      fireEvent.click(screen.getByRole("button", { name: "Show Lumen Health" }));
+      fireEvent.click(screen.getByRole("button", { name: `Show ${FIRST_EXPERIENCE}` }));
       expect(store.updateSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, {
         visible: true,
       });
     });
 
-    it("routes a custom entry's actions to the custom store actions", () => {
+    it("removes a custom entry through its chip, with no dialog round-trip", () => {
       renderSheet();
 
-      fireEvent.click(
-        screen.getByRole("button", { name: "Duplicate Design Tokens Beyond Colour" }),
-      );
+      fireEvent.click(screen.getByRole("button", { name: "Remove Design Tokens Beyond Colour" }));
 
-      expect(store.duplicateCustomSectionItem).toHaveBeenCalledExactlyOnceWith("speaking", 0);
+      expect(store.removeCustomSectionItem).toHaveBeenCalledExactlyOnceWith("speaking", 0);
+      expect(writeCount()).toBe(1);
     });
   });
 
@@ -291,19 +315,21 @@ describe("document sheet structural chrome", () => {
     it("reorders within the section through one reorderSectionItem call", async () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Move Lumen Health down" }));
+      fireEvent.click(screen.getByRole("button", { name: `Move ${FIRST_EXPERIENCE} down` }));
 
       expect(store.reorderSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, 1);
       expect(writeCount()).toBe(1);
       await waitFor(() => {
-        expect(liveRegionText()).toMatch(/Lumen Health moved to position 2 of \d+/i);
+        expect(liveRegionText()).toMatch(
+          /Principal Design Systems Engineer moved to position 2 of \d+/i,
+        );
       });
     });
 
     it("performs the same mutation as the equivalent drag would", () => {
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Move Lumen Health down" }));
+      fireEvent.click(screen.getByRole("button", { name: `Move ${FIRST_EXPERIENCE} down` }));
 
       // The drag path resolves through `entryStep` to a (from, to) pair; the
       // control must hand the store the identical pair.
@@ -317,49 +343,12 @@ describe("document sheet structural chrome", () => {
       );
     });
 
-    it("offers lateral moves only where a cross-section drag exists", () => {
+    it("draws no move control at a boundary — the pill has no dead arrows", () => {
       renderSheet();
 
-      // Fixed sections share no item shape with anything: vertical moves only.
-      expect(
-        screen.queryByRole("button", { name: "Move Lumen Health to the next section" }),
-      ).toBeNull();
-      // Custom entries can drag to another custom section, so the keyboard
-      // and single-pointer path exists too.
-      expect(
-        screen.getByRole("button", {
-          name: "Move Design Tokens Beyond Colour to the next section",
-        }),
-      ).toBeInTheDocument();
-    });
-
-    it("moves a custom entry to the adjacent custom section in one action", async () => {
-      renderSheet();
-
-      fireEvent.click(
-        screen.getByRole("button", {
-          name: "Move Design Tokens Beyond Colour to the next section",
-        }),
-      );
-
-      const advisoryLength = resume.sections.custom.advisory.items.length;
-      expect(store.moveCustomSectionItem).toHaveBeenCalledExactlyOnceWith(
-        "speaking",
-        0,
-        "advisory",
-        advisoryLength,
-      );
-      expect(writeCount()).toBe(1);
-      await waitFor(() => {
-        expect(liveRegionText()).toMatch(/Design Tokens Beyond Colour moved to/i);
-      });
-    });
-
-    it("writes nothing at a boundary", () => {
-      renderSheet();
-
-      fireEvent.click(screen.getByRole("button", { name: "Move Lumen Health up" }));
-
+      // The first entry has no neighbour above; per spec §1.9 the arrow is
+      // rendered only when a neighbour exists in that direction.
+      expect(screen.queryByRole("button", { name: `Move ${FIRST_EXPERIENCE} up` })).toBeNull();
       expect(writeCount()).toBe(0);
     });
   });
@@ -369,7 +358,10 @@ describe("document sheet structural chrome", () => {
       resume.sections.projects.items = [];
       renderSheet();
 
-      fireEvent.click(screen.getByRole("button", { name: "Add project" }));
+      const projects = document.querySelector('[data-section-id="projects"]') as HTMLElement;
+      expect(within(projects).getByText("No items yet — use + to add one.")).toBeInTheDocument();
+
+      fireEvent.click(within(projects).getByRole("button", { name: "Add project" }));
       // Scoped to the dialog: the add-block trigger shares the same name.
       const dialog = screen.getByRole("dialog");
       fireEvent.input(within(dialog).getByRole("textbox", { name: "Name" }), {
@@ -387,10 +379,65 @@ describe("document sheet structural chrome", () => {
       expect(item.visible).toBe(true);
     });
 
-    it("draws no add-block when every placed section has content", () => {
+    it("draws a dashed add-block under every item section", () => {
       renderSheet();
 
-      expect(screen.queryByTestId("doc-sheet-add-block")).toBeNull();
+      const experience = document.querySelector('[data-section-id="experience"]') as HTMLElement;
+      expect(within(experience).getByRole("button", { name: "Add experience" })).toHaveClass(
+        "doc-sheet__add-block",
+      );
+      // Rich text takes no items, so it gets no add-block.
+      const summary = document.querySelector('[data-section-id="summary"]') as HTMLElement;
+      expect(within(summary).queryByRole("button", { name: /^Add / })).toBeNull();
+    });
+
+    it("routes the end-of-column Add-section block to the Sections panel", () => {
+      const onOpenSections = vi.fn();
+      renderSheet({ onOpenSections });
+
+      fireEvent.click(screen.getAllByTestId("doc-sheet-add-section")[0]);
+
+      expect(onOpenSections).toHaveBeenCalledOnce();
+      expect(writeCount()).toBe(0);
+    });
+
+    it("falls back to the custom-section dialog when no panel is wired", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getAllByTestId("doc-sheet-add-section")[0]);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  describe("page breaks", () => {
+    it("labels the rule between explicit pages", () => {
+      renderSheet();
+
+      const rule = screen.getByTestId("doc-sheet-page-break");
+      expect(rule).toHaveTextContent("Page 2");
+    });
+
+    it("merges the page into the one before it through one updateLayout call", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Remove page break" }));
+
+      expect(store.updateLayout).toHaveBeenCalledExactlyOnceWith([
+        [
+          ["summary", "experience", "education", "projects", "publications", "volunteer", "awards"],
+          [
+            "profiles",
+            "skills",
+            "speaking",
+            "languages",
+            "interests",
+            "certifications",
+            "advisory",
+          ],
+        ],
+      ]);
+      expect(writeCount()).toBe(1);
     });
   });
 
@@ -399,10 +446,10 @@ describe("document sheet structural chrome", () => {
       renderSheet();
 
       // Handles are pointer-only chrome: out of the tab order and hidden from
-      // assistive tech (the move buttons are the keyboard/SR path), so they
+      // assistive tech (the menu and pill are the keyboard/SR path), so they
       // are found by title rather than accessible name.
       const sectionHandle = screen.getByTitle("Drag Experience section to move it");
-      const entryHandle = screen.getByTitle("Drag Lumen Health to move it");
+      const entryHandle = screen.getByTitle(`Drag ${FIRST_EXPERIENCE} to move it`);
       expect(sectionHandle).toBeInTheDocument();
       expect(entryHandle).toBeInTheDocument();
       expect(sectionHandle.getAttribute("tabindex")).toBe("-1");
@@ -415,12 +462,25 @@ describe("document sheet structural chrome", () => {
       expect(section?.getAttribute("draggable")).toBeNull();
     });
 
-    it("keeps the new-page drop zone mounted but inert until a section drag", () => {
+    it("gives the basics contact block no grip, menu, or drag chrome", () => {
       renderSheet();
 
-      const zone = screen.getByTestId("doc-sheet-new-page");
-      expect(zone.getAttribute("aria-hidden")).toBe("true");
-      expect(zone.classList.contains("doc-sheet__new-page--active")).toBe(false);
+      const contact = document.querySelector('[data-section-id="basics"]');
+      expect(contact).not.toBeNull();
+      expect(contact?.querySelector(".doc-sheet__sec-grip")).toBeNull();
+      expect(contact?.querySelector(".doc-sheet__sec-pencil")).toBeNull();
+    });
+  });
+
+  describe("sidebar resize handle", () => {
+    it("exposes the handle as a separator with clamped bounds", () => {
+      renderSheet();
+
+      // One handle per drawn sheet; they share the same width signal.
+      const [handle] = screen.getAllByRole("separator", { name: "Resize sidebar" });
+      expect(handle.getAttribute("aria-valuemin")).toBe("160");
+      expect(handle.getAttribute("aria-valuemax")).toBe("360");
+      expect(Number(handle.getAttribute("aria-valuenow"))).toBeGreaterThanOrEqual(160);
     });
   });
 });

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -389,7 +389,7 @@
   color: inherit;
   text-decoration: underline;
   text-underline-offset: 2px;
-  word-break: break-word;
+  overflow-wrap: anywhere;
   font-size: 0.72rem;
   font-weight: 500;
 }

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -1,310 +1,1153 @@
 /*
- * Document-sheet styles.
+ * Document-sheet styles (#794): the prototype-normative sheet engine.
  *
  * Every rule in this file is nested under `.doc-sheet`. The sheet paints the
- * resume's own theme colours on a paper-proportioned frame, which means its
- * type scale, colours and spacing are deliberately unlike the surrounding app
+ * resume's own theme colours on paper-white sheets, which means its type
+ * scale, colours and spacing are deliberately unlike the surrounding app
  * chrome — so nothing here may escape the root class. Add rules only as
  * descendants of `.doc-sheet`.
  *
- * Sizes are expressed against `--doc-sheet-page-width` so the whole sheet
- * scales with the pane: one page is an A4 rectangle, and its contents are a
- * fixed fraction of its width rather than a fixed pixel size.
+ * Geometry is fixed CSS pixels (spec §3.1): sheets are `min(860px, 100%)`
+ * wide, sized to their content, with A4 boundaries drawn as guides at 1122px
+ * intervals rather than clipped frames. The base type is 12.5px/1.45 per the
+ * spec; the resume's theme arrives as custom properties set by `DocSheet`.
  */
 
 .doc-sheet {
-  --doc-sheet-page-width: 100%;
   --doc-sheet-bg: var(--color-sheet);
   --doc-sheet-text: var(--color-sheet-ink);
   --doc-sheet-accent: var(--color-sheet-ink);
-  --doc-sheet-muted: color-mix(in srgb, var(--doc-sheet-text) 65%, transparent);
+  --doc-sheet-muted: color-mix(in srgb, var(--doc-sheet-text) 60%, transparent);
   --doc-sheet-rule: color-mix(in srgb, var(--doc-sheet-accent) 35%, transparent);
   --doc-sheet-tint: color-mix(in srgb, var(--doc-sheet-accent) 10%, transparent);
-  --doc-sheet-gutter: 4.5%;
+  --doc-sheet-side-w: 287px;
+  --doc-sheet-page-h: 1122px;
 
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
-  padding: 1.5rem;
+  gap: 0;
+  padding: 1.5rem 0.5rem 4rem;
+  width: min(860px, 100%);
+  margin-inline: auto;
 }
 
+/* ── Sheets ─────────────────────────────────────────────────────────────── */
+
+/* Content-sized: no fixed height, no clipping. Overflow is signalled by the
+   guides and the pill, never absorbed. */
 .doc-sheet__page {
-  width: var(--doc-sheet-page-width);
-  max-width: 100%;
-  /* ISO 216 A4 — 210mm x 297mm. */
-  aspect-ratio: 210 / 297;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+  position: relative;
+  width: 100%;
   background: var(--doc-sheet-bg);
   color: var(--doc-sheet-text);
-  border: 1px solid var(--color-border);
-  box-shadow: 0 1px 12px var(--color-shadow);
-  container-type: inline-size;
-  /*
-   * One typographic point of the document, as a share of the page's width.
-   * A4 is 595.28pt wide, so 1pt is 100/595.28 container-query width units.
-   * Stored point sizes (the avatar, its border) render against this. Declared
-   * here but *used* by descendants, where cq units resolve against this page.
-   */
-  --doc-sheet-pt: 0.168cqw;
-  font-family: var(--font-body);
-  line-height: 1.5;
+  border-radius: 4px;
+  box-shadow: 0 24px 60px -20px var(--color-shadow, rgb(0 0 0 / 45%));
+  font-family: var(--font-body, "IBM Plex Sans", Inter, system-ui, sans-serif);
+  font-size: 12.5px;
+  line-height: 1.45;
+  overflow: visible;
 }
 
-/*
- * Page text is sized against the page's own width so a resized surface scales
- * the whole document rather than reflowing it — the same behaviour as the
- * Typst render, whose point sizes are fixed fractions of the A4 width.
- *
- * The size sits on the page's direct children, not the page: a container
- * cannot resolve container-query units against itself, and on `.doc-sheet__page`
- * the unit would silently fall back to the viewport and draw the document
- * out of proportion.
- */
-.doc-sheet__page > * {
-  font-size: 1.6cqw;
+/* Dotted A4 cut marks at page-height intervals (edit mode). */
+.doc-sheet__page-guide {
+  position: absolute;
+  left: 0.35rem;
+  right: 0.35rem;
+  height: 0;
+  border-top: 1px dashed color-mix(in srgb, var(--doc-sheet-accent) 40%, transparent);
+  pointer-events: none;
+  z-index: 4;
 }
 
-.doc-sheet__columns {
+/* ── Page-break rules ───────────────────────────────────────────────────── */
+
+.doc-sheet__page-break {
+  width: 100%;
   display: flex;
-  flex: 1;
-  min-height: 0;
-  align-items: stretch;
-}
-
-.doc-sheet__column {
-  min-width: 0;
-  /* Clipped, never scrolled: the sheet reports overflow, it does not absorb
-     it. Reflow is a section-level `metadata.layout` decision. */
-  overflow: hidden;
-  padding: var(--doc-sheet-gutter);
-  display: flex;
-  flex-direction: column;
-  gap: 1.1em;
-}
-
-.doc-sheet__column--sidebar {
-  background: var(--doc-sheet-tint);
-}
-
-/* ── Header region ─────────────────────────────────────────────────────── */
-
-.doc-sheet__header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5em;
-  padding: var(--doc-sheet-gutter);
-}
-
-/* The name block: photo plus name/headline, arranged per header style. */
-.doc-sheet__identity {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5em;
-}
-
-.doc-sheet__identity-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25em;
-  min-width: 0;
-}
-
-/*
- * `left` mirrors onyx/rhyhorn: the photo sits beside the name block, and the
- * contact details stack right-aligned on the far side of the same row.
- */
-.doc-sheet__header--left {
-  flex-direction: row;
   align-items: center;
-  justify-content: space-between;
-  gap: 1em;
-}
-
-.doc-sheet__header--left .doc-sheet__identity {
-  flex-direction: row;
-  align-items: center;
-  gap: 0.75em;
-  /* The name block owns the row's spare width; without this the contact
-     column's shrink-to-fit sizing squeezes the name into wrapping. */
-  flex: 1;
-  min-width: 0;
-}
-
-.doc-sheet__header--left .doc-sheet__contact {
-  flex-direction: column;
-  align-items: flex-end;
-  text-align: right;
-  gap: 0.25em;
-  margin-left: auto;
-  /* Shrinkable, not nowrap: typical entries stay on one line because the
-     column sizes to its widest entry, while a genuinely long URL or custom
-     field wraps (via the editable's overflow-wrap) instead of being clipped
-     by the page frame. */
-  min-width: 0;
-}
-
-.doc-sheet__header--center {
-  align-items: center;
-  text-align: center;
-}
-
-.doc-sheet__header--center .doc-sheet__identity,
-.doc-sheet__header--boxed .doc-sheet__identity {
-  align-items: center;
-}
-
-.doc-sheet__header--center .doc-sheet__identity-text,
-.doc-sheet__header--boxed .doc-sheet__identity-text {
-  align-items: center;
-}
-
-.doc-sheet__header--center .doc-sheet__contact,
-.doc-sheet__header--boxed .doc-sheet__contact {
   justify-content: center;
+  gap: 0.75rem;
+  margin: 1.1rem 0 0.85rem;
+  padding: 0.55rem 0 0.15rem;
+  border-top: 1.5px dashed var(--color-border, #57534e);
+  position: relative;
 }
 
-/* `boxed` (kakuna) centers its name block inside the stroked box. */
-.doc-sheet__header--boxed {
-  margin: var(--doc-sheet-gutter);
-  padding: calc(var(--doc-sheet-gutter) / 1.5);
-  border: 1px solid var(--doc-sheet-rule);
-  border-radius: 0.25em;
-  align-items: center;
-  text-align: center;
+.doc-sheet__page-break-label {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.65rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-stone, #a8a29e);
+  background: var(--color-surface, transparent);
+  padding: 0 0.55rem;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  top: -0.4rem;
 }
 
-.doc-sheet__header--banner {
-  background: var(--doc-sheet-accent);
-  color: var(--doc-sheet-bg);
+.doc-sheet__page-break-remove {
+  border: 1px solid var(--color-border, #57534e);
+  background: var(--color-paper, #292524);
+  color: var(--color-ink, #d6d3d1);
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.28rem 0.7rem;
+  cursor: pointer;
+  margin-top: 0.35rem;
 }
 
-.doc-sheet__header--sidebar {
-  padding: 0;
+.doc-sheet__page-break-remove:hover {
+  border-color: var(--doc-sheet-accent);
+}
+
+.doc-sheet__page-break-remove:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+}
+
+/* ── Page-count pill ────────────────────────────────────────────────────── */
+
+.doc-sheet__page-pill {
+  position: fixed;
+  bottom: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  background: var(--color-paper, #1c1917);
+  color: var(--color-ink, #e7e5e4);
+  border: 1px solid var(--color-border, #44403c);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  box-shadow: 0 10px 30px var(--color-shadow, rgb(0 0 0 / 35%));
+}
+
+.doc-sheet__page-pill strong {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.doc-sheet__page-pill span {
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-stone, #a8a29e);
+}
+
+/* ── Column compositors ─────────────────────────────────────────────────── */
+
+/* align-items: start — columns must NOT stretch to the taller sibling
+   (pinned bug: stretching invented voids). */
+.doc-sheet__grid {
+  display: grid;
+  grid-template-columns: var(--doc-sheet-side-w) 1fr;
+  min-height: 0;
+  align-items: start;
+}
+
+.doc-sheet__grid--side-right,
+.doc-sheet__grid--split {
+  grid-template-columns: 1fr var(--doc-sheet-side-w);
+}
+
+.doc-sheet__grid--side-right .doc-sheet__side,
+.doc-sheet__grid--split .doc-sheet__side {
+  border-left: 1px solid color-mix(in srgb, var(--doc-sheet-accent) 18%, transparent);
+}
+
+.doc-sheet__side {
+  position: relative;
+  background: color-mix(in srgb, var(--doc-sheet-accent) 15%, var(--doc-sheet-bg));
+  padding: 1.6rem 0.95rem 2rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.doc-sheet__main {
+  position: relative;
+  padding: 1.6rem 1.45rem 2rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.doc-sheet__single {
+  position: relative;
+  padding: 1.6rem 1.8rem 2rem;
+}
+
+.doc-sheet__split {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* Legacy layouts with more than two columns: an even flex row. */
+.doc-sheet__multi {
+  display: flex;
+  align-items: flex-start;
+}
+
+.doc-sheet__multi-col {
+  flex: 1;
+  min-width: 0;
+  padding: 1.6rem 0.95rem 2rem;
+}
+
+.doc-sheet__banner {
+  padding: 1.4rem 1.6rem 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--doc-sheet-accent) 20%, transparent);
+}
+
+.doc-sheet__banner--tint {
+  background: color-mix(in srgb, var(--doc-sheet-accent) 12%, var(--doc-sheet-bg));
+}
+
+.doc-sheet__banner--boxed {
+  border: 1.5px solid color-mix(in srgb, var(--doc-sheet-accent) 45%, transparent);
+  border-radius: 10px;
+  padding: 1.1rem 1.2rem;
+  margin: 1.1rem 1.2rem 1rem;
+}
+
+.doc-sheet__single .doc-sheet__banner {
+  padding: 0 0 1rem;
+  border-bottom: none;
+  margin-bottom: 0.4rem;
+}
+
+/* Column drop feedback while a section drag hovers it. */
+.doc-sheet__column--drop {
+  box-shadow: inset 0 0 0 2px var(--doc-sheet-accent);
+}
+
+/* ── Sidebar resize handle (spec §3.2) ──────────────────────────────────── */
+
+.doc-sheet__side-resize {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: -4px;
+  width: 8px;
+  cursor: col-resize;
+  z-index: 10;
+  touch-action: none;
+}
+
+.doc-sheet__side-resize--right {
+  right: auto;
+  left: -4px;
+}
+
+.doc-sheet__side-resize::after {
+  content: "";
+  position: absolute;
+  inset: 0 3px;
+  background: transparent;
+  transition: background 0.12s ease;
+}
+
+.doc-sheet__side-resize:hover::after,
+.doc-sheet__side-resize:focus-visible::after {
+  background: color-mix(in srgb, var(--doc-sheet-accent) 55%, transparent);
+}
+
+.doc-sheet__side-resize:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: -2px;
+}
+
+/* ── Identity chrome ────────────────────────────────────────────────────── */
+
+.doc-sheet__head {
+  margin-bottom: 1rem;
+}
+
+.doc-sheet__head--in-side {
+  margin-bottom: 1.1rem;
 }
 
 .doc-sheet__name {
-  font-family: var(--font-display);
-  font-size: 2.2em;
+  display: block;
+  font-family: var(--font-display, inherit);
+  font-size: 1.7rem;
   font-weight: 700;
-  line-height: 1.1;
+  line-height: 1.15;
   margin: 0;
 }
 
-.doc-sheet__header--sidebar .doc-sheet__name {
-  font-size: 1.7em;
+.doc-sheet__head--in-side .doc-sheet__name {
+  font-size: 1.35rem;
 }
 
 .doc-sheet__headline {
-  font-size: 1.1em;
-  color: var(--doc-sheet-muted);
-  margin: 0;
-}
-
-.doc-sheet__header--banner .doc-sheet__headline,
-.doc-sheet__header--banner .doc-sheet__contact {
-  color: color-mix(in srgb, var(--doc-sheet-bg) 85%, var(--doc-sheet-accent));
-}
-
-.doc-sheet__avatar {
   display: block;
-  object-fit: cover;
-  border: 0 solid var(--doc-sheet-accent);
+  color: var(--doc-sheet-accent);
+  font-size: 0.88rem;
+  font-weight: 500;
+  margin: 0.25rem 0 0;
 }
+
+.doc-sheet__head--in-side .doc-sheet__headline {
+  font-size: 0.78rem;
+}
+
+.doc-sheet__avatar-btn {
+  display: block;
+  margin: 0 auto 1rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: default;
+  line-height: 0;
+}
+
+.doc-sheet__avatar-btn:not(:disabled) {
+  cursor: pointer;
+}
+
+.doc-sheet__avatar-btn:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 2px;
+}
+
+.doc-sheet__avatar-initials {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: var(--doc-sheet-accent);
+  color: var(--doc-sheet-bg);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.45rem;
+  line-height: 1;
+}
+
+.doc-sheet__avatar-img {
+  display: block;
+  margin: 0 auto;
+  background: var(--doc-sheet-tint);
+  object-fit: cover;
+}
+
+/* ── Contact block ──────────────────────────────────────────────────────── */
 
 .doc-sheet__contact {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35em 1em;
   margin: 0;
   padding: 0;
   list-style: none;
-  font-size: 0.9em;
-  color: var(--doc-sheet-muted);
 }
 
-.doc-sheet__header--sidebar .doc-sheet__contact,
-.doc-sheet__contact--stacked {
+.doc-sheet__contact--list {
+  display: flex;
   flex-direction: column;
-  gap: 0.25em;
+  gap: 0.35rem;
+}
+
+.doc-sheet__contact--inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1.25rem;
+}
+
+.doc-sheet__icon-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.doc-sheet__row-ico {
+  width: 0.85rem;
+  height: 0.85rem;
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+  color: currentcolor;
+  opacity: 0.85;
 }
 
 .doc-sheet__contact-label {
   font-weight: 600;
 }
 
-/* ── Sections ──────────────────────────────────────────────────────────── */
-
-.doc-sheet__section {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6em;
+.doc-sheet__side-val {
+  font-size: 0.72rem;
+  font-weight: 500;
+  line-height: 1.35;
+  min-width: 0;
 }
 
-.doc-sheet__section-title {
-  font-family: var(--font-display);
-  font-size: 1em;
+.doc-sheet__side-link {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-word;
+  font-size: 0.72rem;
+  font-weight: 500;
+}
+
+/* ── Section cards (spec §1.5) ──────────────────────────────────────────── */
+
+.doc-sheet__sec {
+  margin-bottom: 0.7rem;
+  border-radius: 6px;
+  padding: 0.2rem 0.15rem;
+  position: relative;
+  max-width: 100%;
+}
+
+.doc-sheet__sec-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-bottom: 0.4rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.doc-sheet__sec-title {
+  margin: 0;
+  font-family: var(--font-display, inherit);
+  font-size: 0.64rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--doc-sheet-accent);
-  border-bottom: 1px solid var(--doc-sheet-rule);
-  padding-bottom: 0.2em;
-  margin: 0;
+  flex: 1;
+  min-width: 0;
 }
 
-.doc-sheet__items {
+.doc-sheet--layout-single .doc-sheet__sec-title {
+  border-bottom: 1.5px solid color-mix(in srgb, var(--doc-sheet-accent) 55%, transparent);
+  padding-bottom: 0.25rem;
+}
+
+/* The HA edit-mode card: a clearly outlined, grabbable block. */
+.doc-sheet--editing .doc-sheet__sec--edit {
+  border: 1.5px dashed color-mix(in srgb, var(--doc-sheet-accent) 30%, #c7c1b8);
+  border-radius: 12px;
+  padding: 0.5rem 0.6rem 0.6rem;
+  background: color-mix(in srgb, var(--doc-sheet-bg) 55%, transparent);
+  transition:
+    border-color 0.12s ease,
+    background 0.12s ease;
+}
+
+.doc-sheet--editing .doc-sheet__sec--edit:hover,
+.doc-sheet--editing .doc-sheet__sec--menu-open {
+  border-color: color-mix(in srgb, var(--doc-sheet-accent) 60%, #a8a29e);
+  background: var(--doc-sheet-bg);
+}
+
+.doc-sheet--editing .doc-sheet__sec--focused {
+  border-style: solid;
+  border-color: var(--doc-sheet-accent);
+  background: var(--doc-sheet-bg);
+}
+
+.doc-sheet__sec--dragging {
+  opacity: 0.45;
+}
+
+.doc-sheet__sec--drop {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 0.35em;
+}
+
+/* Grip and pencil: ghosts until the card is hovered or focused. */
+.doc-sheet__sec-grip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  margin-left: -3px;
+  border: none;
+  background: transparent;
+  color: var(--doc-sheet-muted);
+  cursor: grab;
+  border-radius: 6px;
+  padding: 0;
+  opacity: 0;
+  transition:
+    opacity 0.12s ease,
+    background 0.12s ease,
+    color 0.12s ease;
+  touch-action: none;
+}
+
+.doc-sheet__grip-ico {
+  width: 0.95rem;
+  height: 0.95rem;
+  display: block;
+}
+
+.doc-sheet__sec--edit:hover .doc-sheet__sec-grip,
+.doc-sheet__sec--edit:focus-within .doc-sheet__sec-grip,
+.doc-sheet__sec--dragging .doc-sheet__sec-grip {
+  opacity: 1;
+}
+
+.doc-sheet__sec-grip:hover {
+  color: var(--doc-sheet-text);
+  background: color-mix(in srgb, var(--doc-sheet-accent) 9%, transparent);
+}
+
+.doc-sheet__sec-grip:active {
+  cursor: grabbing;
+}
+
+.doc-sheet__sec-pencil {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--doc-sheet-muted);
+  cursor: pointer;
+  padding: 0;
+  opacity: 0;
+  transition:
+    opacity 0.12s ease,
+    background 0.12s ease,
+    color 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.doc-sheet__pencil-ico {
+  width: 0.9rem;
+  height: 0.9rem;
+  display: block;
+}
+
+.doc-sheet__sec--edit:hover .doc-sheet__sec-pencil,
+.doc-sheet__sec--edit:focus-within .doc-sheet__sec-pencil,
+.doc-sheet__sec--menu-open .doc-sheet__sec-pencil {
+  opacity: 1;
+}
+
+.doc-sheet__sec-pencil:hover,
+.doc-sheet__sec--menu-open .doc-sheet__sec-pencil {
+  color: var(--doc-sheet-accent);
+  background: color-mix(in srgb, var(--doc-sheet-accent) 9%, var(--doc-sheet-bg));
+  border-color: color-mix(in srgb, var(--doc-sheet-accent) 30%, #e7e5e4);
+}
+
+.doc-sheet__sec-pencil:focus-visible,
+.doc-sheet__sec-grip:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+  opacity: 1;
+}
+
+/* The pencil menu: a white popover anchored top-right of the card. */
+.doc-sheet__sec-menu {
+  position: absolute;
+  top: 1.7rem;
+  right: 0.35rem;
+  z-index: 30;
+  min-width: 9.5rem;
+  max-width: 100%;
+  background: #fff;
+  color: #44403c;
+  border: 1px solid #e7e5e4;
+  border-radius: 10px;
+  box-shadow: 0 14px 34px rgb(28 25 23 / 18%);
+  padding: 0.3rem;
+}
+
+.doc-sheet__sec-menu button {
   display: flex;
-  flex-direction: column;
-  gap: 0.9em;
+  align-items: center;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 7px;
+  padding: 0.42rem 0.55rem;
+  font-size: 0.76rem;
+  font-weight: 500;
+  line-height: 1.2;
+  color: #44403c;
+  cursor: pointer;
+  white-space: normal;
 }
 
-.doc-sheet__item {
+.doc-sheet__sec-menu button:hover:not(:disabled) {
+  background: #f5f5f4;
+}
+
+.doc-sheet__sec-menu button:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: -1px;
+}
+
+.doc-sheet__sec-menu button:disabled {
+  color: #c8c4bd;
+  cursor: default;
+}
+
+.doc-sheet__sec-menu .doc-sheet__sec-menu-danger {
+  color: #b91c1c;
+}
+
+.doc-sheet__sec-menu .doc-sheet__sec-menu-danger:hover {
+  background: #fef2f2;
+}
+
+.doc-sheet__sec-menu-sep {
+  height: 1px;
+  background: #f0eeeb;
+  margin: 0.25rem 0.4rem;
+}
+
+/* ── Add blocks (spec §1.6, §1.10) ──────────────────────────────────────── */
+
+.doc-sheet__add-block {
   display: flex;
-  flex-direction: column;
-  gap: 0.25em;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  width: 100%;
+  min-height: 2.9rem;
+  margin-top: 0.45rem;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--doc-sheet-accent) 75%, var(--doc-sheet-text));
+  background: transparent;
+  border: 2px dashed color-mix(in srgb, var(--doc-sheet-accent) 38%, #c7c1b8);
+  border-radius: 10px;
+  padding: 0.45rem 0.55rem;
+  cursor: pointer;
+  opacity: 0.55;
+  transition:
+    opacity 0.12s ease,
+    background 0.12s ease,
+    border-color 0.12s ease;
 }
 
-.doc-sheet__item-head {
+.doc-sheet__plus-ico {
+  width: 0.85rem;
+  height: 0.85rem;
+  flex-shrink: 0;
+}
+
+.doc-sheet__sec--edit:hover > .doc-sheet__add-block,
+.doc-sheet__sec--focused > .doc-sheet__add-block,
+.doc-sheet__add-block:focus-visible {
+  opacity: 1;
+}
+
+.doc-sheet__add-block:hover {
+  background: color-mix(in srgb, var(--doc-sheet-accent) 7%, var(--doc-sheet-bg));
+  border-color: var(--doc-sheet-accent);
+}
+
+.doc-sheet__add-block:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+}
+
+.doc-sheet__add-section-block {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  width: 100%;
+  min-height: 3.2rem;
+  margin: 0.2rem 0 1rem;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #8d8578;
+  background: transparent;
+  border: 2px dashed #cfc9bd;
+  border-radius: 12px;
+  cursor: pointer;
+  opacity: 0.6;
+  transition:
+    opacity 0.12s ease,
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.doc-sheet__add-section-block:hover,
+.doc-sheet__add-section-block:focus-visible {
+  opacity: 1;
+  color: var(--doc-sheet-accent);
+  border-color: color-mix(in srgb, var(--doc-sheet-accent) 55%, #cfc9bd);
+  background: color-mix(in srgb, var(--doc-sheet-accent) 6%, var(--doc-sheet-bg));
+}
+
+.doc-sheet__add-section-block:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+}
+
+.doc-sheet__empty-hint {
+  font-size: 0.7rem;
+  color: var(--doc-sheet-muted);
+  font-style: italic;
+  margin: 0.2rem 0;
+}
+
+/* ── Item rows (spec §1.8) ──────────────────────────────────────────────── */
+
+.doc-sheet__entry-row {
+  position: relative;
+  border-radius: 8px;
+  border: 1px solid transparent;
+}
+
+.doc-sheet__entry {
+  padding: 0.45rem 0.5rem 0.45rem 0.85rem;
+  margin-bottom: 0.35rem;
+}
+
+.doc-sheet__edu-entry {
+  padding: 0.4rem 0.45rem 0.5rem 0.85rem;
+  margin-bottom: 0.45rem;
+}
+
+.doc-sheet__profile-row {
+  margin-bottom: 0.35rem;
+  padding: 0.2rem 1.4rem 0.2rem 1.05rem;
+  border-radius: 6px;
+}
+
+.doc-sheet__lang-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem;
+  margin-bottom: 0.3rem;
+  padding: 0.35rem 1.4rem 0.35rem 1.05rem;
+  border-radius: 8px;
+  min-width: 0;
+}
+
+.doc-sheet__entry-row--edit.doc-sheet__entry:hover,
+.doc-sheet__entry-row--edit.doc-sheet__edu-entry:hover {
+  background: color-mix(in srgb, var(--doc-sheet-accent) 5%, transparent);
+}
+
+.doc-sheet__entry-row--edit.doc-sheet__profile-row:hover {
+  background: color-mix(in srgb, var(--doc-sheet-accent) 6%, transparent);
+}
+
+.doc-sheet__entry-row--edit.doc-sheet__lang-row:hover {
+  background: #faf8f4;
+  border-color: #ebe6dc;
+}
+
+.doc-sheet__entry-row--dragging {
+  opacity: 0.4;
+}
+
+.doc-sheet__entry-row--drop {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 2px;
+}
+
+/* Hidden means "not rendered to PDF" — still on the surface, dimmed. */
+.doc-sheet__entry-row--hidden > :not(.doc-sheet__entry-actions, .doc-sheet__entry-handle) {
+  opacity: 0.45;
+}
+
+/* The left-edge grip strip: a ghost until the row is hovered or focused. */
+.doc-sheet__entry-handle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  letter-spacing: -0.15em;
+  color: var(--doc-sheet-muted);
+  background: transparent;
+  border: none;
+  padding: 0;
+  opacity: 0;
+  cursor: grab;
+  z-index: 5;
+  transition: opacity 0.12s ease;
+  touch-action: none;
+}
+
+.doc-sheet__entry-handle:hover {
+  color: var(--doc-sheet-text);
+  background: color-mix(in srgb, var(--doc-sheet-accent) 7%, transparent);
+  border-radius: 6px 0 0 6px;
+}
+
+.doc-sheet__entry-handle:active {
+  cursor: grabbing;
+}
+
+.doc-sheet__entry-row--edit:hover > .doc-sheet__entry-handle,
+.doc-sheet__entry-row--edit:focus-within > .doc-sheet__entry-handle {
+  opacity: 1;
+}
+
+/* Compact rows: the whole row is the edit affordance. */
+.doc-sheet__entry-row--compact.doc-sheet__entry-row--edit {
+  cursor: pointer;
+}
+
+/* ── The hover action pill (spec §1.9) ──────────────────────────────────── */
+
+.doc-sheet__entry-actions {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  background: #fff;
+  border: 1px solid #e7e5e4;
+  border-radius: 999px;
+  padding: 2px;
+  box-shadow: 0 6px 18px rgb(28 25 23 / 14%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+
+.doc-sheet__entry-row--edit:hover > .doc-sheet__entry-actions,
+.doc-sheet__entry-row--edit:focus-within > .doc-sheet__entry-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Compact rows: no pill — a bare inline ✕ centred at the right edge. */
+.doc-sheet__entry-actions--compact {
+  top: 50%;
+  right: 0.25rem;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+
+.doc-sheet__entry-act {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: #57534e;
+  font-size: 0.8rem;
+  line-height: 1;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  padding: 0;
+}
+
+.doc-sheet__entry-act:hover {
+  color: var(--doc-sheet-accent);
+  background: color-mix(in srgb, var(--doc-sheet-accent) 12%, #fff);
+}
+
+.doc-sheet__entry-act:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+}
+
+.doc-sheet__entry-act--remove:hover {
+  color: #b91c1c;
+  background: #fef2f2;
+}
+
+.doc-sheet__entry-act .doc-sheet__eye-ico {
+  width: 0.85rem;
+  height: 0.85rem;
+}
+
+.doc-sheet__entry-actions--compact .doc-sheet__entry-act {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  font-size: 0.8rem;
+  color: #b3ada3;
+}
+
+.doc-sheet__entry-actions--compact .doc-sheet__entry-act--remove:hover {
+  color: #b91c1c;
+  background: color-mix(in srgb, #fef2f2 85%, transparent);
+}
+
+/* Spec §1.9 draws no arrows or edit glyph on compact rows — drag and row
+   click cover the pointer path — but the keyboard path must survive, so the
+   controls stay in the DOM and appear only when keyboard focus lands on them. */
+.doc-sheet__entry-act--kb-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.doc-sheet__entry-act--kb-only:focus-visible {
+  position: static;
+  width: 18px;
+  height: 18px;
+  overflow: visible;
+  clip-path: none;
+}
+
+/* ── Section body layouts (spec §1.7) ───────────────────────────────────── */
+
+.doc-sheet__summary {
+  display: block;
+  font-size: 0.84rem;
+}
+
+.doc-sheet__entry-top {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
-  gap: 0.75em;
+  align-items: flex-start;
+  gap: 0.75rem;
 }
 
-.doc-sheet__item-title {
-  font-size: 1em;
+.doc-sheet__entry-pos {
+  display: block;
   font-weight: 700;
-  margin: 0;
+  font-size: 0.88rem;
 }
 
-.doc-sheet__item-subtitle {
-  margin: 0;
-  font-size: 0.95em;
+.doc-sheet__entry-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.15rem 0.55rem;
+  margin: 0.1rem 0 0.15rem;
 }
 
-.doc-sheet__item-meta {
-  flex-shrink: 0;
-  text-align: right;
-  font-size: 0.85em;
+.doc-sheet__entry-co {
+  color: var(--doc-sheet-accent);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.doc-sheet__entry-date {
+  font-size: 0.68rem;
   color: var(--doc-sheet-muted);
+  white-space: nowrap;
+}
+
+.doc-sheet__entry-loc {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--doc-sheet-muted);
+  font-size: 0.68rem;
+  margin-bottom: 0.25rem;
+}
+
+.doc-sheet__entry-loc .doc-sheet__row-ico {
+  margin-top: 0;
+  width: 0.7rem;
+  height: 0.7rem;
+}
+
+.doc-sheet__entry-desc {
+  display: block;
+  color: var(--doc-sheet-muted);
+  font-size: 0.78rem;
+  margin: 0.15rem 0 0.25rem;
+}
+
+.doc-sheet__entry-sum {
+  display: block;
+  font-size: 0.8rem;
+}
+
+.doc-sheet__edu-degree {
+  display: block;
+  font-weight: 700;
+  font-size: 0.86rem;
+  line-height: 1.3;
+}
+
+.doc-sheet__edu-school {
+  display: block;
+  color: var(--doc-sheet-accent);
+  font-size: 0.76rem;
+  font-weight: 600;
+  margin: 0.2rem 0 0.15rem;
+  line-height: 1.35;
+}
+
+.doc-sheet__edu-date {
+  display: block;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.64rem;
+  color: var(--doc-sheet-muted);
+}
+
+.doc-sheet__lang-name {
+  font-size: 0.74rem;
+  font-weight: 600;
+  flex: 1 1 auto;
+  min-width: 0;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 0.25rem;
+}
+
+.doc-sheet__lang-dots {
+  display: inline-flex;
+  gap: 3px;
+  flex-shrink: 0;
+  transition: opacity 0.12s ease;
+}
+
+.doc-sheet__lang-dots i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #d6d3d1;
+}
+
+.doc-sheet__lang-dots i.doc-sheet__lang-dot--on {
+  background: var(--doc-sheet-accent);
+}
+
+/* Right-edge dots yield to the ✕ on hover (spec §2.2). */
+.doc-sheet__lang-row.doc-sheet__entry-row--edit:hover .doc-sheet__lang-dots {
+  opacity: 0;
+}
+
+.doc-sheet__lang-row .doc-sheet__tag-chips {
+  flex: 1 1 100%;
+  margin-top: 0.1rem;
+}
+
+.doc-sheet__custom-list {
+  margin: 0;
+  padding-left: 1rem;
+  font-size: 0.74rem;
+}
+
+.doc-sheet__chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.doc-sheet__skill-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 1.3;
+  background: color-mix(in srgb, var(--doc-sheet-accent) 8%, var(--doc-sheet-bg));
+  border: 1px solid color-mix(in srgb, var(--doc-sheet-accent) 24%, #e7e5e4);
+  border-radius: 999px;
+  padding: 0.28rem 0.55rem;
+}
+
+.doc-sheet__chip-x {
+  width: 1em;
+  border: none;
+  background: transparent;
+  color: var(--doc-sheet-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1;
+  padding: 0;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.doc-sheet__skill-chip:hover .doc-sheet__chip-x,
+.doc-sheet__skill-chip:focus-within .doc-sheet__chip-x {
+  opacity: 1;
+}
+
+.doc-sheet__chip-x:hover {
+  color: #b91c1c;
+}
+
+.doc-sheet__chip-x:focus-visible {
+  outline: 2px solid var(--doc-sheet-accent);
+  outline-offset: 1px;
+}
+
+.doc-sheet__tag-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.28rem;
+  margin: 0.35rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.doc-sheet__tag-chip {
+  display: inline-flex;
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.18rem 0.55rem;
+  background: color-mix(in srgb, var(--doc-sheet-accent) 10%, var(--doc-sheet-bg));
+  border: 1px solid color-mix(in srgb, var(--doc-sheet-accent) 28%, #e7e5e4);
+  border-radius: 999px;
+}
+
+.doc-sheet__extra-view {
+  margin-top: 0.35rem;
   display: flex;
   flex-direction: column;
+  gap: 0.2rem;
 }
 
-.doc-sheet__item-detail {
-  margin: 0;
-  font-size: 0.85em;
+.doc-sheet__extra-row {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.7rem;
+}
+
+.doc-sheet__extra-label {
   color: var(--doc-sheet-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  min-width: 4.5rem;
 }
 
-/*
- * Rich text renders formatted (`MarkdownView`): paragraphs, lists, bold,
- * italic — the sheet is the rendered document (#785). Line breaks are real
- * `<br>`s from the parser, so no `pre-wrap` is needed.
- */
+.doc-sheet__extra-val {
+  font-weight: 500;
+}
+
+/* ── Markdown view ──────────────────────────────────────────────────────── */
+
 .doc-sheet__rich-text {
   margin: 0;
   overflow-wrap: anywhere;
@@ -341,69 +1184,11 @@
   color: var(--doc-sheet-accent);
 }
 
-/* One profile as templates draw it: network label plus linked username. */
-.doc-sheet__item-inline {
-  margin: 0;
-  display: flex;
-  align-items: baseline;
-  gap: 0.5em;
-}
-
-.doc-sheet__item-inline-label {
-  font-weight: 700;
-}
-
-.doc-sheet__item-inline-value {
-  color: var(--doc-sheet-accent);
-}
-
-.doc-sheet__keywords {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.3em;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.doc-sheet__keyword {
-  font-size: 0.8em;
-  padding: 0.1em 0.45em;
-  border-radius: 0.2em;
-  background: var(--doc-sheet-tint);
-  color: var(--doc-sheet-accent);
-}
-
-.doc-sheet__level {
-  display: inline-flex;
-  gap: 0.25em;
-  align-items: center;
-}
-
-.doc-sheet__level-dot {
-  width: 0.5em;
-  height: 0.5em;
-  border-radius: 50%;
-  border: 1px solid var(--doc-sheet-accent);
-}
-
-.doc-sheet__level-dot--filled {
-  background: var(--doc-sheet-accent);
-}
-
-.doc-sheet__url {
-  font-size: 0.85em;
-  color: var(--doc-sheet-accent);
-  overflow-wrap: anywhere;
-}
-
-/* ── Editing affordances ───────────────────────────────────────────────────
+/* ── Editing affordances ────────────────────────────────────────────────────
  *
  * Editable values are real buttons so they are keyboard-reachable, but a
  * document must not look like a form: they inherit their surroundings entirely
- * and only declare themselves on hover and on focus. Focus is a visible ring
- * rather than a colour change, since the sheet paints the resume's own theme
- * and a colour cue could land on any background.
+ * and only declare themselves on hover and on focus.
  */
 
 .doc-sheet__editable {
@@ -427,9 +1212,11 @@
   overflow-wrap: anywhere;
 }
 
+/* Hover: a 40%-accent underline, not a fill (spec §2.2). */
 .doc-sheet__editable:hover {
-  background: var(--doc-sheet-tint);
-  box-shadow: inset 0 -1px 0 var(--doc-sheet-rule);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--doc-sheet-accent) 40%, transparent);
+  text-underline-offset: 3px;
 }
 
 .doc-sheet__editable:focus-visible {
@@ -442,14 +1229,6 @@
 .doc-sheet__editable--empty {
   color: var(--doc-sheet-muted);
   font-style: italic;
-}
-
-.doc-sheet__avatar-button {
-  cursor: pointer;
-  display: inline-block;
-  padding: 0;
-  margin: 0;
-  line-height: 0;
 }
 
 .doc-sheet__inline-input {
@@ -530,196 +1309,35 @@
   min-width: 8em;
 }
 
-/* ── Add / edit actions ────────────────────────────────────────────────── */
-
-.doc-sheet__actions,
-.doc-sheet__section-actions {
-  display: flex;
-  gap: 0.4em;
-}
-
-.doc-sheet__action {
-  font: inherit;
-  font-size: 0.8em;
-  color: var(--doc-sheet-accent);
-  background: none;
-  border: 1px dashed var(--doc-sheet-rule);
-  border-radius: 0.2em;
-  padding: 0.15em 0.5em;
-  cursor: pointer;
-}
-
-.doc-sheet__action:hover {
-  background: var(--doc-sheet-tint);
-}
-
-.doc-sheet__action:focus-visible {
-  outline: 2px solid var(--doc-sheet-accent);
-  outline-offset: 1px;
-}
-
-.doc-sheet__action--danger {
-  color: var(--turbo-state-error, #b3261e);
-  border-color: currentcolor;
-}
-
-/* Square icon control — arrows and drag handles. Sized in em so it scales
-   with the page, with a hard floor at the SC 2.5.8 24px target size. */
-.doc-sheet__action--icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.15em;
-  min-width: max(1.5em, 24px);
-  min-height: max(1.5em, 24px);
-}
-
-.doc-sheet__action--icon svg {
-  width: 1em;
-  height: 1em;
-}
-
-.doc-sheet__drag-handle {
-  cursor: grab;
-  touch-action: none;
-}
-
-.doc-sheet__drag-handle:active {
-  cursor: grabbing;
-}
-
-/* ── Structural chrome ─────────────────────────────────────────────────────
+/* ── Touch fallback ─────────────────────────────────────────────────────────
  *
- * Card and entry controls stay out of the document's way until their card is
- * hovered or something inside it takes focus. `opacity` rather than `display`,
- * so every control is always focusable and always announced.
- */
-
-.doc-sheet__section-chrome,
-.doc-sheet__item-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.3em;
-  opacity: 0;
-}
-
-.doc-sheet__section:hover > .doc-sheet__section-chrome,
-.doc-sheet__section:focus-within > .doc-sheet__section-chrome,
-.doc-sheet__item:hover .doc-sheet__item-actions,
-.doc-sheet__item:focus-within .doc-sheet__item-actions {
-  opacity: 1;
-}
-
-/*
- * Without hover there is nothing to reveal them, and this is the only route to
- * duplicating, hiding or deleting — so a touch user would be left with
- * invisible controls sitting on tappable rects.
+ * Without hover there is nothing to reveal the chrome, and it is the only
+ * route to duplicating, hiding or removing — so a touch user would be left
+ * with invisible controls sitting on tappable rects.
  */
 @media (hover: none) {
-  .doc-sheet__section-chrome,
-  .doc-sheet__item-actions {
+  .doc-sheet__sec-grip,
+  .doc-sheet__sec-pencil,
+  .doc-sheet__entry-handle,
+  .doc-sheet__chip-x,
+  .doc-sheet--editing .doc-sheet__entry-actions {
     opacity: 1;
+  }
+
+  .doc-sheet--editing .doc-sheet__entry-actions {
+    pointer-events: auto;
   }
 }
 
-/* Card affordances: a quiet outline that declares the card on hover/focus. */
-.doc-sheet__section {
-  border-radius: 0.25em;
-  outline: 1px dashed transparent;
-  outline-offset: 0.35em;
-}
-
-.doc-sheet__section:hover,
-.doc-sheet__section:focus-within {
-  outline-color: var(--doc-sheet-rule);
-}
-
-/* Done mode is the rendered document: no card affordances on hover. The
-   editing controls themselves are not mounted in this mode (see `sheetMode`);
-   this only silences the hover outline, which is pure CSS. */
-.doc-sheet--done .doc-sheet__section:hover,
-.doc-sheet--done .doc-sheet__section:focus-within {
-  outline-color: transparent;
-}
-
-/* Hidden means "not rendered to PDF" — still on the surface, dimmed. */
-.doc-sheet__section--hidden > :not(.doc-sheet__section-chrome),
-.doc-sheet__item--hidden > :not(.doc-sheet__item-actions) {
-  opacity: 0.45;
-}
-
-.doc-sheet__hidden-badge {
-  font-size: 0.7em;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--doc-sheet-muted);
-  border: 1px solid var(--doc-sheet-rule);
-  border-radius: 0.2em;
-  padding: 0.1em 0.4em;
-}
-
-/* Drop feedback: the card (or column) the drag would land on. Doubled class
-   so it outweighs the hover outline above while the pointer is over it. */
-.doc-sheet__section.doc-sheet__section--drop,
-.doc-sheet__item.doc-sheet__item--drop {
-  outline: 2px solid var(--doc-sheet-accent);
-  outline-offset: 0.35em;
-}
-
-.doc-sheet__section--dragging,
-.doc-sheet__item--dragging {
-  opacity: 0.35;
-}
-
-.doc-sheet__column--drop {
-  background: var(--doc-sheet-tint);
-  box-shadow: inset 0 0 0 2px var(--doc-sheet-accent);
-}
-
-/* ── Add-blocks ────────────────────────────────────────────────────────── */
-
-.doc-sheet__add-block {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4em;
-  margin-top: auto;
-  padding-top: 0.6em;
-}
-
-/* ── New-page drop zone ────────────────────────────────────────────────── */
-
-.doc-sheet__new-page {
-  width: var(--doc-sheet-page-width);
-  max-width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.85rem;
-  color: var(--color-ink, inherit);
-  border: 2px dashed var(--color-border);
-  border-radius: 0.375rem;
-  transition: opacity 150ms;
-  /* Mounted before any drag so the droppable is registered; shown only while
-     a section drag — the one thing it accepts — is under way. */
-  height: 0;
-  padding: 0;
-  margin: 0;
-  border-width: 0;
-  opacity: 0;
-  overflow: hidden;
-}
-
-.doc-sheet__new-page--active {
-  height: auto;
-  padding: 1.25rem;
-  border-width: 2px;
-  opacity: 1;
-}
-
-.doc-sheet__new-page--drop {
-  border-color: var(--doc-sheet-accent);
-  background: var(--doc-sheet-tint);
+/* ── Done mode ──────────────────────────────────────────────────────────────
+ *
+ * The rendered document: no card affordances on hover. The editing controls
+ * themselves are not mounted in this mode (see `sheetMode`); this only
+ * silences the pure-CSS hover cues.
+ */
+.doc-sheet--done .doc-sheet__entry-row:hover {
+  background: transparent;
+  border-color: transparent;
 }
 
 /* ── Drag overlay ──────────────────────────────────────────────────────── */

--- a/apps/web/src/components/doc-editor/icons.tsx
+++ b/apps/web/src/components/doc-editor/icons.tsx
@@ -1,0 +1,146 @@
+/**
+ * Inline SVG icons for the document sheet's chrome (#794, spec §1.17).
+ *
+ * The sheet paints the resume's own theme, so its icons are plain inline SVGs
+ * that inherit `currentColor` — no icon library, no app-chrome styling. Each
+ * maps 1:1 to the glyph the design spec names (mdi-plus, mdi-pencil, the 3×3
+ * drag grid, and the contact/profile glyphs).
+ */
+
+import { For, Show, type JSX } from "solid-js";
+
+/** mdi-plus — dashed "add" blocks. */
+export function PlusIcon(): JSX.Element {
+  return (
+    <svg class="doc-sheet__plus-ico" viewBox="0 0 24 24" aria-hidden="true">
+      <path fill="currentColor" d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+    </svg>
+  );
+}
+
+/** mdi-pencil — the section options affordance. */
+export function PencilIcon(): JSX.Element {
+  return (
+    <svg class="doc-sheet__pencil-ico" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9
+          16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+      />
+    </svg>
+  );
+}
+
+/** The section grip: mdi-drag's 3×3 dot grid. */
+export function DragGridIcon(): JSX.Element {
+  const dots = [5.5, 12, 18.5];
+  return (
+    <svg class="doc-sheet__grip-ico" viewBox="0 0 24 24" aria-hidden="true">
+      <For each={dots}>
+        {(cx) => (
+          <For each={dots}>{(cy) => <circle cx={cx} cy={cy} r="1.7" fill="currentColor" />}</For>
+        )}
+      </For>
+    </svg>
+  );
+}
+
+/** Which glyph a contact row shows. */
+export type ContactIconKind = "email" | "phone" | "location" | "link";
+
+const CONTACT_PATHS: Record<ContactIconKind, string> = {
+  email:
+    "M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 " +
+    "4l-8 5-8-5V6l8 5 8-5v2z",
+  phone:
+    "M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 " +
+    "3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 " +
+    ".45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z",
+  location:
+    "M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 " +
+    "1 1 0-5 2.5 2.5 0 0 1 0 5z",
+  link:
+    "M3.9 12a5 5 0 0 1 5-5h4v2h-4a3 3 0 1 0 0 6h4v2h-4a5 5 0 0 1-5-5zm7-1h6v2h-6v-2zm4.1-4h-4v2" +
+    "h4a3 3 0 1 1 0 6h-4v2h4a5 5 0 0 0 0-10z",
+};
+
+/** One contact row's leading glyph. */
+export function ContactIcon(props: { kind: ContactIconKind }): JSX.Element {
+  return (
+    <svg class="doc-sheet__row-ico" viewBox="0 0 24 24" aria-hidden="true">
+      <path fill="currentColor" d={CONTACT_PATHS[props.kind]} />
+    </svg>
+  );
+}
+
+const GITHUB_PATH =
+  "M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 " +
+  "0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 " +
+  "17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 " +
+  "1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 " +
+  "0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 " +
+  "1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 " +
+  "3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 " +
+  "5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 " +
+  ".315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12";
+
+const LINKEDIN_PATH =
+  "M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 " +
+  "2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 " +
+  "4.267 5.455v6.286zM5.337 7.433c-1.14 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 " +
+  "2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 " +
+  "13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 " +
+  "24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z";
+
+const GLOBE_PATH =
+  "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 " +
+  "17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c" +
+  "-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 " +
+  "2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z";
+
+/** Brand glyph for a profile row, keyed off the icon or network name. */
+export function ProfileIcon(props: { network?: string; icon?: string }): JSX.Element {
+  const key = (): string =>
+    (props.icon || props.network || "").toLowerCase().replaceAll(/\s+/g, "");
+  const path = (): string => {
+    if (key().includes("github")) return GITHUB_PATH;
+    if (key().includes("linkedin")) return LINKEDIN_PATH;
+    return GLOBE_PATH;
+  };
+  return (
+    <svg class="doc-sheet__row-ico" viewBox="0 0 24 24" aria-hidden="true">
+      <path fill="currentColor" d={path()} />
+    </svg>
+  );
+}
+
+/** Eye open/closed — visibility toggles. */
+export function EyeIcon(props: { isOpen: boolean }): JSX.Element {
+  return (
+    <Show
+      when={props.isOpen}
+      fallback={
+        <svg class="doc-sheet__eye-ico" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            fill="currentColor"
+            d="M2.1 3.51 3.5 2.1l18.4 18.4-1.4 1.4-2.53-2.53A12.3 12.3 0 0 1 12
+              20.5C6.48 20.5 1.9 16.9.3 12.25a13 13 0 0 1 4.55-5.7L2.1 3.5Zm6.2
+              6.2 1.55 1.55a2.75 2.75 0 0 0 3.39 3.39l1.55 1.55A4.75 4.75 0 0 1
+              8.3 9.71Zm3.9-5.96c5.52 0 10.1 3.6 11.7 8.25a12.9 12.9 0 0 1-3.48
+              5.05l-1.45-1.45A10.9 10.9 0 0 0 21.7 12a10.9 10.9 0 0
+              0-9.5-6.25c-1.03 0-2.02.14-2.96.4L7.7 4.6A12.4 12.4 0 0 1 12 3.75Z"
+          />
+        </svg>
+      }
+    >
+      <svg class="doc-sheet__eye-ico" viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          fill="currentColor"
+          d="M12 5c5.4 0 9.9 3.4 11.5 8-1.6 4.6-6.1 8-11.5 8S2.1 17.6.5 13C2.1
+            8.4 6.6 5 12 5Zm0 2.5A5.5 5.5 0 1 0 12 18a5.5 5.5 0 0 0 0-10.5Zm0
+            2.5a3 3 0 1 1 0 6 3 3 0 0 1 0-6Z"
+        />
+      </svg>
+    </Show>
+  );
+}

--- a/apps/web/src/components/doc-editor/index.ts
+++ b/apps/web/src/components/doc-editor/index.ts
@@ -1,5 +1,5 @@
 export { DocSheet, type DocSheetProps } from "./DocSheet";
-export { DocHeader, type DocHeaderProps } from "./DocHeader";
+export { ContactBlock, NameHeader, SheetAvatar, type ContactBlockProps } from "./DocHeader";
 export { DocSection, type DocSectionProps } from "./DocSection";
 export { InlineText, type InlineTextProps } from "./InlineText";
 export { InlineMarkdown, type InlineMarkdownProps } from "./InlineMarkdown";

--- a/apps/web/src/lib/__tests__/docDnd.test.ts
+++ b/apps/web/src/lib/__tests__/docDnd.test.ts
@@ -384,19 +384,16 @@ describe("editorPages", () => {
     });
   });
 
-  it("keeps a hidden section drawn, flagged as chrome", () => {
+  it("never draws a hidden section — the Sections panel is the recovery path", () => {
     const resume = loadDocEditorFixture();
     resume.sections.experience.visible = false;
 
     const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
 
-    expect(drawn.find((section) => section.id === "experience")).toEqual({
-      id: "experience",
-      hidden: true,
-    });
+    expect(drawn).not.toContain("experience");
   });
 
-  it("keeps a section whose items are all hidden — the items are chrome too", () => {
+  it("keeps a section whose items are all hidden — the items are chrome", () => {
     const resume = loadDocEditorFixture();
     for (const item of resume.sections.experience.items) {
       item.visible = false;
@@ -404,16 +401,16 @@ describe("editorPages", () => {
 
     const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
 
-    expect(drawn.some((section) => section.id === "experience")).toBe(true);
+    expect(drawn).toContain("experience");
   });
 
-  it("drops an item section with no items at all", () => {
+  it("keeps an empty item section drawn — its card carries the add affordance", () => {
     const resume = loadDocEditorFixture();
     resume.sections.experience.items = [];
 
     const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
 
-    expect(drawn.some((section) => section.id === "experience")).toBe(false);
+    expect(drawn).toContain("experience");
   });
 
   it("keeps an empty rich-text section reachable while it is visible", () => {
@@ -423,22 +420,6 @@ describe("editorPages", () => {
 
     const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
 
-    expect(drawn.some((section) => section.id === "summary")).toBe(true);
-  });
-
-  it("keeps a hidden, empty rich-text section drawn so hiding is reversible", () => {
-    // Regression: hiding an empty summary used to drop the card entirely —
-    // and rich text has no add-block, so nothing on the sheet could show it
-    // again. A placed rich-text section must always draw.
-    const resume = loadDocEditorFixture();
-    resume.sections.summary.content = "";
-    resume.sections.summary.visible = false;
-
-    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
-
-    expect(drawn.find((section) => section.id === "summary")).toEqual({
-      id: "summary",
-      hidden: true,
-    });
+    expect(drawn).toContain("summary");
   });
 });

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -302,6 +302,23 @@ describe("mergePageIntoPrevious", () => {
     ]);
   });
 
+  it("dedups across columns, not just within the same column index", () => {
+    const layout = [
+      [["summary"], ["skills"]],
+      [
+        ["skills", "projects"],
+        ["summary", "languages"],
+      ],
+    ];
+
+    expect(mergePageIntoPrevious(layout, 1)).toEqual([
+      [
+        ["summary", "projects"],
+        ["skills", "languages"],
+      ],
+    ]);
+  });
+
   it("merges ragged column counts without dropping a column", () => {
     const layout = [[["summary"]], [["experience"], ["languages"]]];
 

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -8,6 +8,7 @@ import {
   layoutColumns,
   layoutForTemplate,
   layoutPages,
+  mergePageIntoPrevious,
   nextId,
   renderPages,
   SECTION_LABELS,
@@ -272,6 +273,62 @@ describe("findSectionPlacement", () => {
     const resume = loadFixture();
 
     expect(findSectionPlacement(resume.metadata.layout, "references")).toBeNull();
+  });
+});
+
+describe("mergePageIntoPrevious", () => {
+  it("concatenates the page's columns onto the previous page, index-wise", () => {
+    const layout = [
+      [["summary"], ["skills"]],
+      [["experience"], ["languages"]],
+    ];
+
+    expect(mergePageIntoPrevious(layout, 1)).toEqual([
+      [
+        ["summary", "experience"],
+        ["skills", "languages"],
+      ],
+    ]);
+  });
+
+  it("keeps the first occurrence when the same id appears on both pages", () => {
+    const layout = [
+      [["summary", "experience"], ["skills"]],
+      [["experience", "projects"], []],
+    ];
+
+    expect(mergePageIntoPrevious(layout, 1)).toEqual([
+      [["summary", "experience", "projects"], ["skills"]],
+    ]);
+  });
+
+  it("merges ragged column counts without dropping a column", () => {
+    const layout = [[["summary"]], [["experience"], ["languages"]]];
+
+    expect(mergePageIntoPrevious(layout, 1)).toEqual([[["summary", "experience"], ["languages"]]]);
+  });
+
+  it("leaves later pages untouched", () => {
+    const layout = [[["a"]], [["b"]], [["c"]]];
+
+    expect(mergePageIntoPrevious(layout, 1)).toEqual([[["a", "b"]], [["c"]]]);
+  });
+
+  it("returns null when the merge is impossible", () => {
+    const layout = [[["summary"]], [["experience"]]];
+
+    expect(mergePageIntoPrevious(layout, 0)).toBeNull();
+    expect(mergePageIntoPrevious(layout, 2)).toBeNull();
+    expect(mergePageIntoPrevious(layout, -1)).toBeNull();
+  });
+
+  it("never mutates its input", () => {
+    const layout = [[["summary"]], [["experience"]]];
+    const snapshot = structuredClone(layout);
+
+    mergePageIntoPrevious(layout, 1);
+
+    expect(layout).toEqual(snapshot);
   });
 });
 

--- a/apps/web/src/lib/docDnd.ts
+++ b/apps/web/src/lib/docDnd.ts
@@ -335,6 +335,30 @@ export function adjacentCustomSectionId(
   return customIds[step === "previous" ? position - 1 : position + 1] ?? null;
 }
 
+/** Head-line fields an entry might carry, in display preference order. */
+const ENTRY_LABEL_KEYS = [
+  "name",
+  "position",
+  "company",
+  "institution",
+  "title",
+  "network",
+  "organization",
+] as const;
+
+/**
+ * A short human name for an entry — announcements, drag overlays and the
+ * accessible names of its row controls all speak the same label.
+ */
+export function entryDisplayLabel(item: unknown, fallback: string): string {
+  const record = item as Record<string, unknown> | undefined;
+  for (const key of ENTRY_LABEL_KEYS) {
+    const value = record?.[key];
+    if (typeof value === "string" && value.trim() !== "") return value;
+  }
+  return fallback;
+}
+
 /** The `items` list of any section, read through the shape they all share. */
 export function sectionItemList(resume: ResumeData, sectionId: string): EntryListItem[] {
   if (isCustomId(sectionId)) {

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -72,6 +72,23 @@ export const SECTION_LABELS: Readonly<Record<FixedSectionId, string>> = {
 const UNTITLED_CUSTOM_SECTION = "Untitled";
 
 /**
+ * CSS-pixel A4 geometry of the sheet (#794, spec §3.1).
+ *
+ * The on-screen sheet is `min(860px, 100%)` wide and sizes to its content;
+ * these constants are what the overflow guides, the measured page count and
+ * the PDF export agree on. 860×1122 is A4 at ~96 dpi.
+ */
+export const PAGE_WIDTH_PX = 860;
+export const PAGE_HEIGHT_PX = 1122;
+
+/**
+ * One typographic point in sheet CSS pixels: stored point sizes (the avatar,
+ * its border) render against the 860px sheet exactly as they do against the
+ * 595.28pt A4 render.
+ */
+export const SHEET_PX_PER_PT = PAGE_WIDTH_PX / 595.28;
+
+/**
  * Placeholder id that stands for "every custom section, in order".
  *
  * Templates emit it in their default columns (`main_with_custom()` in
@@ -337,61 +354,49 @@ export function renderPages(resume: ResumeData, templateLayout: TemplateLayout):
     .filter((page) => page.some((column) => column.length > 0));
 }
 
-/** A section as the editing surface draws it. */
-export interface EditorSectionView {
-  id: string;
-  /** Switched off — kept on the surface as chrome, but absent from the PDF. */
-  hidden: boolean;
-}
-
-/** Whether a section holds any items at all, hidden ones included. */
-function sectionHasItems(resume: ResumeData, sectionId: string): boolean {
-  return sectionItemCount(resume, sectionId) > 0;
-}
-
-/** How many items a section holds, hidden ones included. Zero for rich text. */
-function sectionItemCount(resume: ResumeData, sectionId: string): number {
-  if (isCustomId(sectionId)) {
-    return resume.sections.custom?.[sectionId]?.items?.length ?? 0;
-  }
-  if (!FIXED_SECTION_ID_SET.has(sectionId)) return 0;
-  const section = resume.sections[sectionId as FixedSectionId] as { items?: unknown[] } | undefined;
-  return section?.items?.length ?? 0;
-}
-
 /**
  * {@link layoutPages} as the *editing* surface draws it, aligned index-for-index
  * with the layout — no page or column is dropped, so a drop target's page and
  * column indices address `metadata.layout` directly, and no second layout model
  * exists for drag and drop.
  *
- * Unlike {@link renderPages}, hidden sections stay drawn (flagged, as chrome):
- * hidden means "not rendered to PDF", not "gone from the editing surface". Item
- * sections are drawn whenever they hold any item — hidden items are chrome too —
- * and a placed rich-text section always draws, whatever its content or
- * visibility, so a hidden or empty summary keeps its click-to-edit surface and
- * hiding it stays reversible.
+ * Hidden sections never draw (#794, spec §1.6) — the Sections panel is the
+ * recovery path, exactly as it is for the rendered document. Unlike
+ * {@link renderPages}, *empty* placed sections stay drawn in edit mode: their
+ * card carries the add affordance, so an empty section is a place to type
+ * rather than a gap in the layout.
  */
-export function editorPages(
-  resume: ResumeData,
-  templateLayout: TemplateLayout,
-): EditorSectionView[][][] {
+export function editorPages(resume: ResumeData, templateLayout: TemplateLayout): string[][][] {
   return layoutPages(resume, templateLayout).map((page) =>
-    page.map((column) =>
-      column
-        .filter((id) => {
-          if (id === "summary" || id === "coverLetter") {
-            // A placed rich-text section always draws: its editing surface is
-            // the card itself, and an add-block cannot resurface rich text —
-            // dropping a hidden, empty one would make hiding it irreversible
-            // from the sheet.
-            return true;
-          }
-          return sectionHasItems(resume, id);
-        })
-        .map((id) => ({ id, hidden: !sectionVisible(resume, id) })),
-    ),
+    page.map((column) => column.filter((id) => sectionVisible(resume, id))),
   );
+}
+
+/**
+ * `layout` with page `pageIndex` merged into the page before it — the simple
+ * "remove page break" of #794 (`metadata.itemBreaks`-aware merge semantics
+ * arrive with the drag-channel rework, #796). Columns concatenate index-wise;
+ * the first occurrence of a section id wins. Returns `null` when the merge is
+ * impossible (page 0, or an index past the last page), so callers write
+ * nothing rather than an unchanged layout.
+ */
+export function mergePageIntoPrevious(
+  layout: readonly (readonly (readonly string[])[])[],
+  pageIndex: number,
+): string[][][] | null {
+  if (pageIndex <= 0 || pageIndex >= layout.length) return null;
+  const pages = layout.map((page) => page.map((column) => [...column]));
+  const previous = pages[pageIndex - 1];
+  const current = pages[pageIndex];
+  const columns = Math.max(previous.length, current.length);
+  const merged: string[][] = [];
+  for (let column = 0; column < columns; column++) {
+    const head = previous[column] ?? [];
+    const tail = (current[column] ?? []).filter((id) => !head.includes(id));
+    merged.push([...head, ...tail]);
+  }
+  pages.splice(pageIndex - 1, 2, merged);
+  return pages;
 }
 
 /**

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -390,9 +390,16 @@ export function mergePageIntoPrevious(
   const current = pages[pageIndex];
   const columns = Math.max(previous.length, current.length);
   const merged: string[][] = [];
+  // Dedup across the whole merged page, not per column: a section sitting in
+  // a different column on the two pages must still collapse to one placement.
+  const seen = new Set(previous.flat());
   for (let column = 0; column < columns; column++) {
     const head = previous[column] ?? [];
-    const tail = (current[column] ?? []).filter((id) => !head.includes(id));
+    const tail = (current[column] ?? []).filter((id) => {
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
     merged.push([...head, ...tail]);
   }
   pages.splice(pageIndex - 1, 2, merged);

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -155,8 +155,8 @@ export default function DocEditor() {
     () => layouts()?.[store.resume?.metadata.template ?? ""] ?? FALLBACK_TEMPLATE_LAYOUT,
   );
 
-  const [pageCount, setPageCount] = createSignal(0);
-  const [overflowingPages, setOverflowingPages] = createSignal<number[]>([]);
+  // Lifted so the sheet's Add-section blocks can open the panel (#794).
+  const [isSectionsOpen, setIsSectionsOpen] = createSignal(false);
 
   // Edit or Done, per document. A brand-new empty resume opens ready to type;
   // an existing one opens as the clean rendered document.
@@ -190,23 +190,6 @@ export default function DocEditor() {
     }
   });
 
-  // A different document must not inherit the previous one's counts: drop all
-  // document-scoped display state until the new sheet reports in.
-  createEffect(() => {
-    void params.id;
-    setPageCount(0);
-    setOverflowingPages([]);
-  });
-
-  const overflowMessage = () => {
-    const pages = overflowingPages();
-    if (pages.length === 0) return "";
-    const labels = pages.map((page) => page + 1).join(", ");
-    return pages.length === 1
-      ? `Content overflows page ${labels}`
-      : `Content overflows pages ${labels}`;
-  };
-
   return (
     <div class="h-[calc(100vh-3.5rem)] flex flex-col">
       <CustomCssInjector />
@@ -224,28 +207,16 @@ export default function DocEditor() {
             {(resume) => (
               <>
                 <TemplatesDrawer resume={resume()} />
-                <SectionsPanel resume={resume()} />
+                <SectionsPanel
+                  resume={resume()}
+                  open={isSectionsOpen()}
+                  onOpenChange={setIsSectionsOpen}
+                />
               </>
             )}
           </Show>
         </div>
-        <p class="font-mono text-xs text-stone" data-testid="doc-editor-page-count">
-          {/* No count until a sheet exists — otherwise this reads "0 pages"
-              while loading and behind the load-error screen. Also hidden while
-              a same-document reload is in flight so a stale count never shows
-              over the loading state. */}
-          <Show when={!isLoading() && !loadError() && pageCount() > 0}>
-            {pageCount() === 1 ? "1 page" : `${pageCount()} pages`}
-          </Show>
-        </p>
         <div class="flex items-center gap-2">
-          <p
-            role="status"
-            class="font-mono text-xs text-[var(--turbo-state-warning)]"
-            data-testid="doc-editor-overflow"
-          >
-            {!isLoading() && !loadError() ? overflowMessage() : ""}
-          </p>
           <Button
             variant="ghost"
             size="sm"
@@ -400,8 +371,7 @@ export default function DocEditor() {
                     resume={resume()}
                     templateLayout={templateLayout()}
                     mode={mode()}
-                    onPageCountChange={setPageCount}
-                    onOverflowChange={setOverflowingPages}
+                    onOpenSections={() => setIsSectionsOpen(true)}
                   />
                 )}
               </Show>

--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -136,14 +136,16 @@ describe("DocEditor sheet", () => {
     return result;
   }
 
-  it("draws one A4 page frame per rendered page", async () => {
+  it("draws one content-sized sheet per rendered page, with the count pill", async () => {
     await renderSheet();
 
     const pages = screen.getAllByTestId("doc-sheet-page");
     expect(pages).toHaveLength(2);
     expect(pages[0]).toHaveAttribute("aria-label", "Page 1 of 2");
     expect(pages[1]).toHaveAttribute("aria-label", "Page 2 of 2");
-    expect(screen.getByTestId("doc-editor-page-count")).toHaveTextContent("2 pages");
+    // The measured page count lives in the sheet's floating pill now (#794);
+    // it can never report fewer pages than there are drawn sheets.
+    expect(screen.getByTestId("doc-sheet-page-count")).toHaveTextContent(/2\s*pages/);
   });
 
   it("renders a single document surface with no preview pane", async () => {
@@ -162,15 +164,16 @@ describe("DocEditor sheet", () => {
     const [first, second] = screen.getAllByTestId("doc-sheet-page");
 
     expect(pageColumns(first)).toEqual([
-      // `sidebar-left` paints the sidebar column first.
-      ["sidebar", ["profiles", "skills", "speaking"]],
-      // `coverLetter` and `references` are absent from the stored layout, so
-      // normalization back-fills them into the first main column (#770).
-      ["main", ["summary", "experience", "education", "projects", "coverLetter", "references"]],
+      // `sidebar-left` paints the sidebar column first. The contact block is
+      // template-owned chrome in the sidebar (`contactIn: "sidebar"`).
+      ["sidebar", ["basics", "profiles", "skills", "speaking"]],
+      // `coverLetter` and `references` are back-filled by normalization
+      // (#770) but hidden, and hidden sections never draw (#794).
+      ["main", ["summary", "experience", "education", "projects"]],
     ]);
     expect(pageColumns(second)).toEqual([
-      // `advisory` is switched off but stays drawn as chrome (see below).
-      ["sidebar", ["languages", "interests", "certifications", "advisory"]],
+      // `advisory` is switched off, so it is absent from the surface (#794).
+      ["sidebar", ["languages", "interests", "certifications"]],
       ["main", ["publications", "volunteer", "awards"]],
     ]);
   });
@@ -179,16 +182,17 @@ describe("DocEditor sheet", () => {
     await renderSheet();
 
     const [first] = screen.getAllByTestId("doc-sheet-page");
-    const sidebar = first.querySelector<HTMLElement>(".doc-sheet__column--sidebar");
+    const sidebar = first.querySelector<HTMLElement>('[data-column-role="sidebar"]');
     const header = within(sidebar as HTMLElement).getByTestId("doc-sheet-header");
 
     expect(within(header).getByRole("heading", { name: "Mireille Okafor" })).toBeInTheDocument();
     expect(header).toHaveTextContent("Principal Design Systems Engineer");
-    // `contactIn: "sidebar"` — contact details print alongside the name block.
-    expect(header).toHaveTextContent("mireille@okafor.design");
-    expect(header).toHaveTextContent("Lisbon, Portugal");
+    // `contactIn: "sidebar"` — the contact block prints in the sidebar too.
+    const contact = within(sidebar as HTMLElement).getByTestId("doc-sheet-contact");
+    expect(contact).toHaveTextContent("mireille@okafor.design");
+    expect(contact).toHaveTextContent("Lisbon, Portugal");
     // Custom fields keep their labels.
-    expect(header).toHaveTextContent("Pronouns:");
+    expect(contact).toHaveTextContent("Pronouns:");
   });
 
   it("renders item fields in the order the Typst templates present them", async () => {
@@ -197,8 +201,9 @@ describe("DocEditor sheet", () => {
     const experience = document.querySelector<HTMLElement>('[data-section-id="experience"]');
     const first = within(experience as HTMLElement).getAllByRole("article")[0];
 
+    // Spec §1.7: position over the company · date meta row, then location.
     expect(first.textContent).toMatch(
-      /Lumen Health.*Principal Design Systems Engineer.*March 2022 - Present.*Lisbon, Portugal \(Remote\)/s,
+      /Principal Design Systems Engineer.*Lumen Health.*March 2022 - Present.*Lisbon, Portugal \(Remote\)/s,
     );
   });
 
@@ -212,31 +217,31 @@ describe("DocEditor sheet", () => {
     expect(summary?.textContent).not.toContain("**");
   });
 
-  it("renders each profile as one entry, not stacked duplicates", async () => {
+  it("renders each profile as one compact icon row, not stacked duplicates", async () => {
     await renderSheet();
 
-    // #787: network label plus username on one line — no third text run
-    // repeating the URL.
+    // Spec §1.7: brand glyph plus username-or-network as a single link — no
+    // second text run repeating the network or the URL.
     const profiles = document.querySelector<HTMLElement>('[data-section-id="profiles"]');
     const entries = within(profiles as HTMLElement).getAllByRole("article");
+    expect(entries).toHaveLength(3);
     for (const entry of entries) {
-      expect(entry.querySelector(".doc-sheet__item-inline")).not.toBeNull();
-      expect(entry.querySelector(".doc-sheet__item-subtitle")).toBeNull();
-      expect(entry.querySelector(".doc-sheet__url")).toBeNull();
+      expect(entry.querySelectorAll(".doc-sheet__side-link")).toHaveLength(1);
+      expect(entry.querySelector(".doc-sheet__icon-row svg")).not.toBeNull();
     }
   });
 
-  it("keeps profile fields individually editable", async () => {
+  it("edits a profile through its dialog — the whole compact row is the affordance", async () => {
     await renderSheet();
 
     const profiles = document.querySelector<HTMLElement>('[data-section-id="profiles"]');
     const first = within(profiles as HTMLElement).getAllByRole("article")[0];
-    const buttons = [...first.querySelectorAll<HTMLButtonElement>(".doc-sheet__editable")];
+    expect(first).toHaveAttribute("title", "Click to edit · hold to drag");
 
-    // One editable slot for the network, one for the username.
-    expect(buttons.map((button) => button.title)).toEqual(
-      expect.arrayContaining(["Edit network", "Edit username"]),
-    );
+    fireEvent.click(first);
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByRole("textbox", { name: "Network" })).toHaveValue("GitHub");
+    expect(within(dialog).getByRole("textbox", { name: "Username" })).toHaveValue("mireilleokafor");
   });
 
   it("renders custom sections under their own names", async () => {
@@ -247,21 +252,15 @@ describe("DocEditor sheet", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps hidden sections on the surface as flagged chrome", async () => {
+  it("never draws hidden sections — the Sections panel is the recovery path", async () => {
     await renderSheet();
 
-    // `advisory` is placed and switched off: hidden means "not rendered to
-    // PDF", not "gone from the editing surface" — the section stays drawn,
-    // dimmed and flagged, so it can be shown again from the sheet.
-    const advisory = document.querySelector('[data-section-id="advisory"]');
-    expect(advisory).not.toBeNull();
-    expect(advisory?.classList.contains("doc-sheet__section--hidden")).toBe(true);
-    // A section the stored layout never placed is back-filled by
-    // normalization (#770), so it surfaces as hidden chrome too instead of
-    // being silently unreachable from the sheet.
-    const references = document.querySelector('[data-section-id="references"]');
-    expect(references).not.toBeNull();
-    expect(references?.classList.contains("doc-sheet__section--hidden")).toBe(true);
+    // `advisory` is placed and switched off; `references` is back-filled by
+    // normalization (#770) but hidden. Hidden sections never draw (#794) —
+    // they are toggled back on from the Sections panel, exactly as for the
+    // rendered document.
+    expect(document.querySelector('[data-section-id="advisory"]')).toBeNull();
+    expect(document.querySelector('[data-section-id="references"]')).toBeNull();
   });
 
   it("offers every drawn value as a keyboard-reachable editing affordance", async () => {
@@ -299,11 +298,13 @@ describe("DocEditor sheet", () => {
     );
   });
 
-  it("reports no overflow when nothing is clipped", async () => {
+  it("draws no A4 overflow guides while content fits a page", async () => {
     await renderSheet();
 
-    // jsdom reports zero-height layout, so nothing can be clipped.
-    expect(screen.getByTestId("doc-editor-overflow")).toHaveTextContent("");
+    // Sheets size to content and overflow is signalled by dashed guides at
+    // 1122px intervals (#794); jsdom reports zero-height layout, so no sheet
+    // can exceed a page.
+    expect(document.querySelectorAll(".doc-sheet__page-guide")).toHaveLength(0);
   });
 
   it("has no axe violations in Edit mode", async () => {
@@ -326,14 +327,11 @@ describe("DocEditor sheet", () => {
 
     await waitFor(() => {
       const [first] = screen.getAllByTestId("doc-sheet-page");
-      // The stored layout still supplies two columns; only the geometry and the
-      // header placement come from the template.
-      expect(first.querySelector(".doc-sheet__column")).toBeTruthy();
-      expect(first.querySelector(".doc-sheet__header")).toBeTruthy();
-      // FALLBACK_TEMPLATE_LAYOUT declares headerStyle "left" / contactIn
-      // "header", so the header must sit above the columns rather than inside
-      // the sidebar the way SIDEBAR_TEMPLATE places it.
-      expect(first.querySelector(".doc-sheet__column .doc-sheet__header")).toBeFalsy();
+      // FALLBACK_TEMPLATE_LAYOUT is single-column: one continuous section
+      // list with the identity banner at its top, and no sidebar at all.
+      expect(first.querySelector(".doc-sheet__single")).toBeTruthy();
+      expect(first.querySelector('[data-column-role="sidebar"]')).toBeFalsy();
+      expect(within(first).getByTestId("doc-sheet-header")).toBeInTheDocument();
     });
   });
 
@@ -345,8 +343,8 @@ describe("DocEditor sheet", () => {
 
     await waitFor(() => {
       const [first] = screen.getAllByTestId("doc-sheet-page");
-      expect(first.querySelector(".doc-sheet__column")).toBeTruthy();
-      expect(first.querySelector(".doc-sheet__column .doc-sheet__header")).toBeFalsy();
+      expect(first.querySelector(".doc-sheet__single")).toBeTruthy();
+      expect(first.querySelector('[data-column-role="sidebar"]')).toBeFalsy();
     });
   });
 });

--- a/apps/web/src/pages/__tests__/DocEditor.undo.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.undo.test.tsx
@@ -190,18 +190,14 @@ describe("DocEditor undo, autosave, and version history", () => {
   it("round-trips a section move as a single undo entry", async () => {
     await renderSheet();
     const before = mainColumnSections();
-    // `coverLetter` and `references` are back-filled by normalization (#770).
-    const moved = ["summary", "education", "experience", "projects", "coverLetter", "references"];
-    expect(before).toEqual([
-      "summary",
-      "experience",
-      "education",
-      "projects",
-      "coverLetter",
-      "references",
-    ]);
+    // `coverLetter` and `references` are back-filled by normalization (#770)
+    // but hidden, and hidden sections never draw (#794).
+    const moved = ["summary", "education", "experience", "projects"];
+    expect(before).toEqual(["summary", "experience", "education", "projects"]);
 
-    fireEvent.click(screen.getByRole("button", { name: "Move Experience section down" }));
+    // The structural actions live in the section's pencil menu (#794).
+    fireEvent.click(screen.getByRole("button", { name: "Experience section options" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Move Experience section down" }));
     await settleDebounce();
     expect(mainColumnSections()).toEqual(moved);
 

--- a/apps/web/src/stores/__tests__/resume.test.ts
+++ b/apps/web/src/stores/__tests__/resume.test.ts
@@ -1264,9 +1264,7 @@ describe("unplaced fixed sections (#770)", () => {
         [["summary", "experience", "coverLetter"], ["skills"]],
       ]);
       // The sheet draws only placed ids — the section must actually appear.
-      const drawnIds = editorPages(store.resume!, FALLBACK_TEMPLATE_LAYOUT)
-        .flat(2)
-        .map((section) => section.id);
+      const drawnIds = editorPages(store.resume!, FALLBACK_TEMPLATE_LAYOUT).flat(2);
       expect(drawnIds).toContain("coverLetter");
       dispose();
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `refactor(web): content-sized sheet engine with section and entry chrome (#794)`

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Replaces the doc sheet's fixed A4 frames and #788-era section internals with the
prototype's engine, per the normative spec in #794 (§1.1, §1.3–§1.10, §1.17, §2,
§3.1/§3.2/§3.6):

- **Content-sized sheets** — no more `aspect-ratio`/`overflow:hidden` page frames.
  Each sheet sizes to its content; A4 boundaries are dashed overflow guides at
  1122px intervals plus a floating measured page-count pill. The top-bar overflow
  status text and page count are gone. Page-break rules between explicit
  `metadata.layout` pages carry "Page N" labels and an edit-mode **Remove page
  break** that merges the page into the one before it (simple layout merge only —
  `itemBreaks`-aware semantics are #796's, per the owner's scope decision).
- **`SectionChrome`** — the universal dashed section card: hidden-until-hover grip,
  inline-editable title, and a pencil menu consolidating Add item / Move up / Move
  down / Move to sidebar|main column / Rename / Hide (with disabled bounds,
  cross-page aware). Menu moves hand focus back to the pencil. The `basics`
  contact block reuses the card as template-owned chrome: no grip, no pencil, not
  draggable.
- **`SortableEntry` + `EntryActions`** — universal item-row chrome: left-edge `⋮⋮`
  grip and the floating top-right hover pill (✎ ↑ ↓ ⧉ 👁 −, arrows only where a
  neighbour exists). Compact sidebar rows (profiles / languages / skills) follow
  the compact-row contract: whole row is the edit affordance, bare right-edge ✕,
  dots yield on hover, "Click to edit · hold to drag" tooltip. Custom sections are
  chip lists with an inline chip ✕ (no modal round-trip for removal).
- **Add flows** — per-section dashed add-blocks (spec labels per type) and the
  end-of-column dashed **Add section** block, which opens the Sections panel
  (lifted open-state; falls back to the custom-section dialog when unwired).
- **Section bodies per §1.7** — experience (position over company · date, location
  pin row), education (degree / `institution · area` / mono date), profile icon
  rows, language/skill proficiency dots, interests list, generic entries with
  right-aligned dates, `TagChips` and `ExtraFieldsView`.
- **Template compositors (§1.4/§3.6)** — `SingleColumn`, `MainColumn`,
  `SideColumn`, header-split banner; `NameHeader` / `SheetAvatar` / `ContactBlock`
  placed by `headerStyle` / `contactIn`. Sidebar is user-resizable via an 8px
  edge handle (`role="separator"`, 160–360px clamp, persisted to
  `rustume.studio.sidebarWidth`).
- **Surface semantics** — hidden sections never draw (the Sections panel is the
  recovery path); empty placed sections stay drawn in edit mode as add
  affordances. Done mode stays the clean rendered document.

Also carries the owner-requested one-line CI fix as its own commit
(`fix(ci): run the lintro quality gate when a draft PR is marked ready`):
`ready_for_review` added to the `pull_request` trigger types of
`ci-lintro-analysis.yml`. **This very PR validates the fix** — it opens as a
draft, and the `quality` context must appear when it is flipped to ready
(previously it never would, cf. #788/#798's close/reopen workaround).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` clean; web typecheck clean; vitest
      962/962; Playwright e2e 73 passed / 5 visual-skipped)

## Closes

- Closes #794
- Relates to #785
- Relates to #796

## Details

- Builds on the #788 base per the serial-wave instruction; prototype
  (`apps/web/src/prototypes/EditableSheet.tsx` on `local/prod-0.49.0`) read as
  design reference only, no code transcribed.
- Rename is the inline-editable title (owner decision: no `window.prompt`); the
  pencil menu's "Rename title…" arms it.
- Drag-and-drop keeps the #788 grip-activated solid-dnd mechanism; #796 replaces
  the drag channel wholesale, so `SectionChrome`/`SortableEntry` take drag
  primitives from the caller and stay mechanism-agnostic.
- `editorPages` contract change (hidden never drawn / empty drawn) is pinned in
  `docDnd`/`docLayout`/store tests; `mergePageIntoPrevious` has dedicated unit
  coverage (dedup, ragged columns, null at edges, input immutability).
- Local AI review: CodeRabbit CLI ran pre-push (10 findings; 9 addressed in a
  dedicated commit, 1 dismissed as spec-mandated — interests draw as a plain
  list per §1.7). Greptile CLI was rate-limited
  (`free_reviews_limit_reached`); `lintro review --transport cli` hung past its
  own `--timeout 540` twice on this diff and was abandoned (no API key for the
  api transport) — noting per the CLI-transport contract-signal instruction.
