### PR TITLE
feat(web): whole-surface drag and drop and explicit pagination

### DIFF
--- a/apps/web/e2e/doc-editor.spec.ts
+++ b/apps/web/e2e/doc-editor.spec.ts
@@ -132,7 +132,14 @@ test.describe("single-surface document editor", () => {
     const source = docEditorPage.sheet.locator(`[data-section-id="${second}"]`);
     const target = docEditorPage.sheet.locator(`[data-section-id="${first}"]`);
     await source.hover();
-    await source.locator(".doc-sheet__sec-grip").dragTo(target);
+    // Pin the drop above the target's midpoint: `dropIndexFromPointer` flips
+    // to insert-after past the midpoint, and dragTo's default center drop
+    // would sit exactly on that boundary.
+    const targetBox = await target.boundingBox();
+    if (!targetBox) throw new Error("target card has no bounding box");
+    await source
+      .locator(".doc-sheet__sec-grip")
+      .dragTo(target, { targetPosition: { x: targetBox.width / 2, y: 4 } });
     await expect
       .poll(async () =>
         cards.evaluateAll((elements) =>

--- a/apps/web/e2e/doc-editor.spec.ts
+++ b/apps/web/e2e/doc-editor.spec.ts
@@ -110,6 +110,52 @@ test.describe("single-surface document editor", () => {
     await expect(docEditorPage.sheet.getByRole("button", { name: "Ada Lovelace" })).toBeVisible();
   });
 
+  test("whole-surface drags reorder sections and explicit page breaks split the sheet", async ({
+    page,
+    homePage,
+    docEditorPage,
+  }) => {
+    await homePage.open();
+    await homePage.createResume();
+    await docEditorPage.assertDocEditorOpen();
+    await docEditorPage.assertMode("edit");
+
+    const cards = docEditorPage.sheet.locator('[data-section-id]:not([data-section-id="basics"])');
+    const idsBefore = (await cards.evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute("data-section-id")),
+    )) as string[];
+    expect(idsBefore.length).toBeGreaterThan(2);
+    const [first, second] = idsBefore;
+
+    // Whole-surface drag (#796): grab the second card by its grip and drop it
+    // on the first card — the two swap places through one layout write.
+    const source = docEditorPage.sheet.locator(`[data-section-id="${second}"]`);
+    const target = docEditorPage.sheet.locator(`[data-section-id="${first}"]`);
+    await source.hover();
+    await source.locator(".doc-sheet__sec-grip").dragTo(target);
+    await expect
+      .poll(async () =>
+        cards.evaluateAll((elements) =>
+          elements.map((element) => element.getAttribute("data-section-id")),
+        ),
+      )
+      .toEqual([second, first, ...idsBefore.slice(2)]);
+
+    // Explicit pagination: insert a page break before the now-second section
+    // from its pencil menu, then remove it from the rule between the sheets.
+    const sheets = docEditorPage.sheet.getByTestId("doc-sheet-page");
+    await expect(sheets).toHaveCount(1);
+    await target.getByRole("button", { name: / section options$/ }).click();
+    await page.getByRole("menuitem", { name: /^Insert page break before .* section$/ }).click();
+    await expect(sheets).toHaveCount(2);
+    await expect(docEditorPage.sheet.getByTestId("doc-sheet-page-break")).toBeVisible();
+    await expect(docEditorPage.sheet.getByTestId("doc-sheet-page-count")).toContainText("2");
+
+    await page.getByRole("button", { name: "Remove page break" }).click();
+    await expect(sheets).toHaveCount(1);
+    await expect(docEditorPage.sheet.getByTestId("doc-sheet-page-count")).toContainText("1");
+  });
+
   test("opening a legacy HTML resume shows formatted text, not raw tags", async ({
     page,
     homePage,

--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -22,14 +22,20 @@
  */
 
 import { For, Show, createSignal, type JSX } from "solid-js";
-import { createDraggable, createDroppable } from "@thisbeyond/solid-dnd";
 import { EditableField } from "./EditableField";
 import { ItemDialog } from "./ItemDialog";
 import { MarkdownView } from "./MarkdownView";
 import { SectionChrome, sectionTitleTriggerId, type SectionMenuActions } from "./SectionChrome";
-import { SortableEntry } from "./SortableEntry";
+import { SortableEntry, type InsertBreakAction } from "./SortableEntry";
 import { ContactIcon, ProfileIcon } from "./icons";
 import { useSheetEditable } from "./sheetMode";
+import {
+  SECTION_DRAG_MIME,
+  dragStartVetoed,
+  dropIndexFromPointer,
+  readDragPayload,
+  useSheetDnd,
+} from "./sheetDnd";
 import {
   duplicateItem,
   removeItem,
@@ -41,7 +47,8 @@ import {
 } from "./docEdits";
 import { itemNoun } from "./itemFields";
 import { entryDisplayLabel, entryStep, type MoveStep } from "../../lib/docDnd";
-import { isCustomId, sectionTitle } from "../../lib/docLayout";
+import { isCustomId, sectionTitle, type SectionPlacement } from "../../lib/docLayout";
+import type { SectionSlice } from "../../lib/docPagination";
 import type {
   Award,
   CustomField,
@@ -216,24 +223,51 @@ export interface DocSectionProps {
   onMoveEntry: (sectionId: string, itemId: string, step: MoveStep) => void;
   /** Announce a completed action to the sheet's live region. */
   onAnnounce: (message: string) => void;
+  /**
+   * The item slice this instance draws, or `null` for the whole section.
+   * Continuation instances (slice index > 0) render the "(cont.)" title and
+   * carry no add affordance unless they are the last slice (spec §2.6, §3.3).
+   */
+  slice: SectionSlice | null;
+  /** Whether splitting the layout before this section would change anything. */
+  canInsertPageBreak: boolean;
+  /** Split the layout so this section starts a fresh page (spec §3.4). */
+  onInsertPageBreak: (sectionId: string) => void;
+  /**
+   * The pill's "insert page break before this item" state, or `null` when the
+   * section cannot carry item breaks at all (non-main-flow, spec §3.4 guard).
+   */
+  itemBreakAction: (sectionId: string, itemId: string) => InsertBreakAction | null;
 }
 
 /** One section of the sheet: the universal card around a spec-§1.7 body. */
 export function DocSection(props: DocSectionProps): JSX.Element {
   const isEditable = useSheetEditable();
+  const dnd = useSheetDnd();
   const [editing, setEditing] = createSignal<ItemEntry | null>(null);
   const [isDialogOpen, setIsDialogOpen] = createSignal(false);
 
   const id = (): string => props.sectionId;
-  const title = (): string => sectionTitle(props.resume, id());
+  const baseTitle = (): string => sectionTitle(props.resume, id());
+  const isContinuation = (): boolean => (props.slice?.index ?? 0) > 0;
+  /** Continuation slices re-render the title as "<Title> (cont.)" (§3.3). */
+  const title = (): string => (isContinuation() ? `${baseTitle()} (cont.)` : baseTitle());
   const isRichText = (): boolean => id() === "summary" || id() === "coverLetter";
   const isChips = (): boolean => isCustomId(id());
-  const noun = (): string => itemNoun(title());
+  const noun = (): string => itemNoun(baseTitle());
   const addLabel = (): string => ADD_LABELS[id()] ?? `Add ${noun()}`;
+  /** Add affordances live only on the section's last slice (spec §2.6). */
+  const canAdd = (): boolean => props.slice === null || props.slice.isLast;
 
-  // Done mode mirrors the PDF: hidden items are dropped, not dimmed.
-  const entries = (): ItemEntry[] =>
-    itemEntries(props.resume, id()).filter((entry) => isEditable() || !entry.hidden);
+  // Done mode mirrors the PDF: hidden items are dropped, not dimmed. A sliced
+  // instance draws only its own slice of the drawn list.
+  const entries = (): ItemEntry[] => {
+    const drawn = itemEntries(props.resume, id()).filter((entry) => isEditable() || !entry.hidden);
+    const slice = props.slice;
+    if (slice === null) return drawn;
+    const included = new Set(slice.itemIds);
+    return drawn.filter((entry) => included.has(entry.id));
+  };
 
   const richText = (): string => {
     if (id() === "summary") return props.resume.sections.summary?.content ?? "";
@@ -241,13 +275,83 @@ export function DocSection(props: DocSectionProps): JSX.Element {
     return "";
   };
 
-  const draggable = createDraggable(`drag:section:${id()}`, {
-    type: "section",
-    sectionId: id(),
-  });
-  const droppable = createDroppable(`drop:section:${id()}`, {
-    type: "section",
-    sectionId: id(),
+  /** Where the press that may become a card drag started (spec §2.5 veto). */
+  let pressTarget: HTMLElement | null = null;
+
+  const isDragging = (): boolean => dnd !== null && dnd.sectionDrag() === id();
+  const placement = (): SectionPlacement | null => dnd?.sectionPlacement(id()) ?? null;
+
+  const slotState = (): { before: boolean; after: boolean } => {
+    const target = dnd?.sectionDropAt() ?? null;
+    const place = placement();
+    if (!target || !place || target.page !== place.page || target.column !== place.column) {
+      return { before: false, after: false };
+    }
+    return {
+      before: target.index === place.index,
+      after:
+        target.index === place.index + 1 &&
+        place.index === (dnd?.columnLength(place.page, place.column) ?? 0) - 1,
+    };
+  };
+
+  function endCardDrag(): void {
+    dnd?.setSectionDrag(null);
+    dnd?.setSectionDropAt(null);
+  }
+
+  /** dragenter *and* dragover both track — fast drags must register (§2.5). */
+  function trackCardDropTarget(event: DragEvent): void {
+    const dragging = dnd?.sectionDrag() ?? null;
+    if (dragging === null || dragging === id()) return;
+    const place = placement();
+    if (!place) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+    dnd?.setSectionDropAt({
+      page: place.page,
+      column: place.column,
+      index: dropIndexFromPointer(event, place.index),
+    });
+  }
+
+  /** Whole-surface card drag and drop-target wiring (spec §2.5). */
+  const cardDragProps = (): JSX.HTMLAttributes<HTMLElement> => ({
+    draggable: isEditable() && !isContinuation(),
+    onMouseDown: (event: MouseEvent) => {
+      // Record only — never preventDefault here (pinned Chromium bug).
+      pressTarget = event.target as HTMLElement;
+    },
+    onDragStart: (event: DragEvent) => {
+      const pressed = pressTarget;
+      pressTarget = null;
+      // Entry rows and the grip run their own drags (stopPropagation).
+      // Anything reaching here grabbed the card frame — veto presses that
+      // began on controls or on an entry row, so those keep their behaviour.
+      if (dragStartVetoed(pressed, ".doc-sheet__entry-row")) {
+        event.preventDefault();
+        return;
+      }
+      event.stopPropagation();
+      dnd?.setSectionDrag(id());
+      event.dataTransfer?.setData(SECTION_DRAG_MIME, JSON.stringify({ id: id() }));
+      if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+    },
+    onDragEnd: endCardDrag,
+    onDragEnter: trackCardDropTarget,
+    onDragOver: trackCardDropTarget,
+    onDrop: (event: DragEvent) => {
+      const dragging = dnd?.sectionDrag() ?? null;
+      if (dragging === null) return;
+      event.preventDefault();
+      const target = dnd?.sectionDropAt() ?? null;
+      const payload = readDragPayload<{ id?: string }>(event, SECTION_DRAG_MIME);
+      const draggedId = payload?.id ?? dragging;
+      if (target !== null) {
+        dnd?.onSectionDrop(draggedId, target);
+      }
+      endCardDrag();
+    },
   });
 
   function openAdd(): void {
@@ -270,6 +374,7 @@ export function DocSection(props: DocSectionProps): JSX.Element {
     onToggleVisibility: () => void;
     onMoveUp?: () => void;
     onMoveDown?: () => void;
+    insertBreak?: InsertBreakAction;
   } {
     const label = entryLabel(entry, noun());
     const steps = (step: "up" | "down"): (() => void) | undefined => {
@@ -298,12 +403,13 @@ export function DocSection(props: DocSectionProps): JSX.Element {
       },
       onMoveUp: steps("up"),
       onMoveDown: steps("down"),
+      insertBreak: props.itemBreakAction(id(), entry.id) ?? undefined,
     };
   }
 
   const menu = (): SectionMenuActions => ({
-    addLabel: isRichText() ? undefined : addLabel(),
-    onAdd: isRichText() ? undefined : openAdd,
+    addLabel: isRichText() || !canAdd() ? undefined : addLabel(),
+    onAdd: isRichText() || !canAdd() ? undefined : openAdd,
     canMoveUp: props.canMoveSection(id(), "up"),
     canMoveDown: props.canMoveSection(id(), "down"),
     onMoveUp: () => props.onMoveSection(id(), "up"),
@@ -311,10 +417,12 @@ export function DocSection(props: DocSectionProps): JSX.Element {
     otherColumnLabel: props.otherColumnLabel ?? undefined,
     onMoveToOtherColumn:
       props.otherColumnLabel === null ? undefined : () => props.onMoveSectionToOtherColumn(id()),
+    canInsertPageBreak: props.canInsertPageBreak,
+    onInsertPageBreak: () => props.onInsertPageBreak(id()),
     onRename: () => document.getElementById(sectionTitleTriggerId(id()))?.click(),
     onHide: () => {
       toggleSection(id());
-      props.onAnnounce(`${title()} section hidden`);
+      props.onAnnounce(`${baseTitle()} section hidden`);
     },
   });
 
@@ -452,21 +560,30 @@ export function DocSection(props: DocSectionProps): JSX.Element {
     <>
       <SectionChrome
         sectionId={id()}
+        idKey={props.slice === null ? id() : `${id()}-slice-${props.slice.index}`}
         title={title()}
-        onRenameCommit={(value) => renameSection(id(), value)}
+        onRenameCommit={isContinuation() ? undefined : (value) => renameSection(id(), value)}
         isFocused={props.focusedSection === id()}
         onFocus={() => props.onFocusSection(id())}
-        addLabel={isRichText() ? undefined : addLabel()}
-        onAdd={isRichText() ? undefined : openAdd}
+        addLabel={isRichText() || !canAdd() ? undefined : addLabel()}
+        onAdd={isRichText() || !canAdd() ? undefined : openAdd}
         menu={menu()}
-        gripActivators={draggable.dragActivators}
-        gripTitle={`Drag ${title()} section to move it`}
-        ref={(element) => {
-          draggable.ref(element);
-          droppable.ref(element);
+        gripActivators={{
+          draggable: "true",
+          onDragStart: (event: DragEvent) => {
+            // Grip drags stopPropagation so the card doesn't double-fire.
+            event.stopPropagation();
+            dnd?.setSectionDrag(id());
+            event.dataTransfer?.setData(SECTION_DRAG_MIME, JSON.stringify({ id: id() }));
+            if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+          },
+          onDragEnd: endCardDrag,
         }}
-        isDropTarget={droppable.isActiveDroppable}
-        isDragging={draggable.isActiveDraggable}
+        gripTitle={`Drag ${baseTitle()} section to move it`}
+        dragProps={cardDragProps()}
+        isDragging={isDragging()}
+        showSlotBefore={slotState().before}
+        showSlotAfter={slotState().after}
       >
         <Show when={isRichText()}>
           <div class="doc-sheet__summary">
@@ -550,10 +667,12 @@ export function DocSection(props: DocSectionProps): JSX.Element {
 
         <Show when={!isRichText() && !isChips() && id() !== "interests"}>
           <For each={entries()}>
-            {(entry) => (
+            {(entry, drawnIndex) => (
               <SortableEntry
                 sectionId={id()}
                 itemId={entry.id}
+                index={entry.index}
+                isLast={drawnIndex() === entries().length - 1}
                 class={rowClass()}
                 isCompact={isCompact()}
                 isHidden={entry.hidden}
@@ -565,7 +684,7 @@ export function DocSection(props: DocSectionProps): JSX.Element {
           </For>
         </Show>
 
-        <Show when={!isRichText() && isEditable() && entries().length === 0}>
+        <Show when={!isRichText() && isEditable() && canAdd() && entries().length === 0}>
           <p class="doc-sheet__empty-hint">No items yet — use + to add one.</p>
         </Show>
       </SectionChrome>

--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -568,17 +568,24 @@ export function DocSection(props: DocSectionProps): JSX.Element {
         addLabel={isRichText() || !canAdd() ? undefined : addLabel()}
         onAdd={isRichText() || !canAdd() ? undefined : openAdd}
         menu={menu()}
-        gripActivators={{
-          draggable: "true",
-          onDragStart: (event: DragEvent) => {
-            // Grip drags stopPropagation so the card doesn't double-fire.
-            event.stopPropagation();
-            dnd?.setSectionDrag(id());
-            event.dataTransfer?.setData(SECTION_DRAG_MIME, JSON.stringify({ id: id() }));
-            if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
-          },
-          onDragEnd: endCardDrag,
-        }}
+        gripActivators={
+          // Continuation slices carry no drag chrome: the slice-0 card is the
+          // one drag surface for the whole section, matching its raw
+          // placement (the only thing a drop can address).
+          isContinuation()
+            ? undefined
+            : {
+                draggable: "true",
+                onDragStart: (event: DragEvent) => {
+                  // Grip drags stopPropagation so the card doesn't double-fire.
+                  event.stopPropagation();
+                  dnd?.setSectionDrag(id());
+                  event.dataTransfer?.setData(SECTION_DRAG_MIME, JSON.stringify({ id: id() }));
+                  if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+                },
+                onDragEnd: endCardDrag,
+              }
+        }
         gripTitle={`Drag ${baseTitle()} section to move it`}
         dragProps={cardDragProps()}
         isDragging={isDragging()}

--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -417,8 +417,11 @@ export function DocSection(props: DocSectionProps): JSX.Element {
     otherColumnLabel: props.otherColumnLabel ?? undefined,
     onMoveToOtherColumn:
       props.otherColumnLabel === null ? undefined : () => props.onMoveSectionToOtherColumn(id()),
-    canInsertPageBreak: props.canInsertPageBreak,
-    onInsertPageBreak: () => props.onInsertPageBreak(id()),
+    // Continuation slices have no raw placement of their own — the action
+    // would split before the whole section, not the "(cont.)" card it names —
+    // so, like rename and the grip, it lives on the slice-0 card only.
+    canInsertPageBreak: isContinuation() ? false : props.canInsertPageBreak,
+    onInsertPageBreak: isContinuation() ? undefined : () => props.onInsertPageBreak(id()),
     onRename: () => document.getElementById(sectionTitleTriggerId(id()))?.click(),
     onHide: () => {
       toggleSection(id());

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -70,6 +70,7 @@ import {
 import {
   ITEM_BREAK_TEMPLATE_DISABLED_REASON,
   editorSheetPages,
+  expandItemBreakPages,
   itemBreaksWithBreakBefore,
   itemBreaksWithoutSection,
   renderSheetPages,
@@ -189,6 +190,10 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
     // page rather than as a failure to load.
     return rendered.length > 0 ? rendered : [[[]]];
   });
+  // One expansion per render for every card's slice lookup to share.
+  const expandedPages = createMemo(() =>
+    expandItemBreakPages(props.resume, props.templateLayout, isEditable()),
+  );
 
   const theme = (): ResumeData["metadata"]["theme"] => props.resume.metadata.theme;
   const layoutMode = (): TemplateLayout["layoutMode"] => props.templateLayout.layoutMode;
@@ -530,6 +535,7 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
                 listProps.pageIndex,
                 listProps.columnIndex,
                 isEditable(),
+                expandedPages(),
               )}
               canInsertPageBreak={canInsertPageBreakBefore(sectionId)}
               onInsertPageBreak={insertPageBreakBeforeSection}

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -5,48 +5,55 @@
  * Sheets no longer clip to fixed A4 frames — each `.doc-sheet__page` sizes to
  * its content, and A4 boundaries are communicated by dashed overflow guides at
  * 1122px intervals plus the floating page-count pill (spec §3.1, §3.5).
- * Explicit `metadata.layout` pages draw as separate sheets divided by
- * page-break rules with "Page N" labels and (edit mode) a "Remove page break"
- * action that merges the page into the one before it — the simple layout
- * merge; `itemBreaks`-aware semantics arrive with #796.
+ * Explicit `metadata.layout` pages — and `metadata.itemBreaks` continuation
+ * slices (#796, spec §3.3) — draw as separate sheets divided by page-break
+ * rules with "Page N" labels and (edit mode) a "Remove page break" action
+ * that prefers clearing the item-break shared across the boundary and falls
+ * back to merging the raw pages (spec §3.4). Explicit "insert page break"
+ * affordances live in the section pencil menu and the entry action pill
+ * (owner decision, umbrella Q6).
  *
  * The page body is composed per the template's `layoutMode` (spec §1.4,
  * §3.6): `SingleColumn`, `MainColumn` + `SideColumn` grids, or the
  * header-split banner over two columns. The template layer only picks the
  * compositor and the palette; all behaviour lives in the shared components.
  *
- * Editing chrome — the drag-drop context, drop resolution, announcements, and
+ * Editing chrome — the whole-surface HTML5 drag channels (spec §2.4–§2.5,
+ * provided through `SheetDndContext`), drop resolution, announcements, and
  * the end-of-column Add-section blocks — is owned here; every mutation writes
- * through a `resumeStore` action (see `docEdits.ts`). Drags start from grips
- * only, never from the surface, so text selection and inline editing keep
- * working; #796 replaces the drag mechanism wholesale.
+ * through a `resumeStore` action (see `docEdits.ts`).
  */
 
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
-import {
-  DragDropProvider,
-  DragDropSensors,
-  DragOverlay,
-  closestCenter,
-  createDroppable,
-  type CollisionDetector,
-  type DragEvent,
-} from "@thisbeyond/solid-dnd";
 import { CustomSectionDialog } from "./CustomSectionDialog";
 import { ContactBlock, NameHeader, SheetAvatar } from "./DocHeader";
 import { DocSection } from "./DocSection";
-import { applyLayout, moveItemAcrossSections, reorderItem, updateSidebarRatio } from "./docEdits";
+import {
+  applyItemBreaks,
+  applyLayout,
+  applyPagination,
+  reorderItem,
+  updateSidebarRatio,
+} from "./docEdits";
 import { PlusIcon } from "./icons";
 import { SheetModeContext, type SheetMode } from "./sheetMode";
+import type { InsertBreakAction } from "./SortableEntry";
 import {
-  canMoveEntryAcross,
+  SECTION_DRAG_MIME,
+  SheetDndContext,
+  readDragPayload,
+  type EntryDragPayload,
+  type SectionDropTarget,
+  type SheetDndValue,
+} from "./sheetDnd";
+import {
   drawnSectionPosition,
   entryDisplayLabel,
   entryStep,
+  moveSectionInLayout,
   moveSectionStep,
-  resolveEntryDrop,
+  resolveEntryDropIndex,
   resolveSectionDropOnColumn,
-  resolveSectionDropOnSection,
   sectionItemList,
   type MoveStep,
 } from "../../lib/docDnd";
@@ -54,15 +61,24 @@ import {
   PAGE_HEIGHT_PX,
   SHEET_CONTENT_WIDTH_PX,
   SHEET_PX_PER_PT,
-  editorPages,
   findSectionPlacement,
   layoutColumns,
   layoutPages,
-  mergePageIntoPrevious,
-  renderPages,
   sectionTitle,
   type TemplateLayout,
 } from "../../lib/docLayout";
+import {
+  ITEM_BREAK_TEMPLATE_DISABLED_REASON,
+  editorSheetPages,
+  itemBreaksWithBreakBefore,
+  itemBreaksWithoutSection,
+  renderSheetPages,
+  resolvePageBreakRemoval,
+  sectionSliceAt,
+  sectionSupportsItemBreaks,
+  splitLayoutBeforeSection,
+  templateSupportsItemBreaks,
+} from "../../lib/docPagination";
 import { reorderAnnouncement } from "../../lib/reorderAnnounce";
 import { LiveRegion, announceLive } from "../ui/LiveRegion";
 import type { ResumeData } from "../../wasm/types";
@@ -76,29 +92,7 @@ const SIDEBAR_DEFAULT_PX = 287;
 /** Keyboard resize step for the handle. */
 const SIDEBAR_KEY_STEP_PX = 8;
 
-/** What a drag carries: the thing being moved. */
-type SheetDragData =
-  | { type: "section"; sectionId: string }
-  | { type: "entry"; sectionId: string; itemId: string };
-
-/** What a droppable is: where the dragged thing may land. */
-type SheetDropData =
-  | { type: "section"; sectionId: string; itemId?: undefined }
-  | { type: "entry"; sectionId: string; itemId: string }
-  | { type: "column"; page: number; column: number };
-
-/** Whether `drop` is a meaningful target for `drag`. */
-function acceptsDrop(drag: SheetDragData, drop: SheetDropData): boolean {
-  if (drag.type === "section") {
-    return drop.type === "section" || drop.type === "column";
-  }
-  if (drop.type === "entry" || drop.type === "section") {
-    return drop.sectionId === drag.sectionId || canMoveEntryAcross(drag.sectionId, drop.sectionId);
-  }
-  return false;
-}
-
-/** A short human name for an entry, for announcements and the drag overlay. */
+/** A short human name for an entry, for announcements. */
 function entryLabel(resume: ResumeData, sectionId: string, itemId: string): string {
   const item = sectionItemList(resume, sectionId).find((entry) => entry.id === itemId);
   return entryDisplayLabel(item, "Item");
@@ -181,14 +175,16 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
   const mode = (): SheetMode => props.mode ?? "edit";
   const isEditable = (): boolean => mode() === "edit";
 
-  // The layout the drops address, and the drawn view of it. In edit mode
-  // `editorPages()` never drops a page or column, so the two are aligned
-  // index-for-index.
+  // The raw layout the drops address, and the drawn view of it: expanded so
+  // item-break continuations occupy their own sheets (spec §3.3). Drawn page
+  // indices can exceed the raw page count; drop targets therefore address a
+  // card's *raw* placement, and end-of-column drops auto-create the missing
+  // raw pages.
   const layout = createMemo(() => layoutPages(props.resume, props.templateLayout));
   const pages = createMemo<string[][][]>(() => {
     const rendered = isEditable()
-      ? editorPages(props.resume, props.templateLayout)
-      : renderPages(props.resume, props.templateLayout);
+      ? editorSheetPages(props.resume, props.templateLayout)
+      : renderSheetPages(props.resume, props.templateLayout);
     // An empty resume still gets one sheet, so the surface reads as a blank
     // page rather than as a failure to load.
     return rendered.length > 0 ? rendered : [[[]]];
@@ -201,7 +197,12 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
 
   const [focusedSection, setFocusedSection] = createSignal<string | null>(null);
   const [isSectionDialogOpen, setIsSectionDialogOpen] = createSignal(false);
-  const [activeDrag, setActiveDrag] = createSignal<SheetDragData | null>(null);
+  const [entryDrag, setEntryDrag] = createSignal<EntryDragPayload | null>(null);
+  const [entryDropAt, setEntryDropAt] = createSignal<{ sectionId: string; index: number } | null>(
+    null,
+  );
+  const [sectionDrag, setSectionDrag] = createSignal<string | null>(null);
+  const [sectionDropAt, setSectionDropAt] = createSignal<SectionDropTarget | null>(null);
   const [announcement, setAnnouncement] = createSignal("");
   const [measuredPages, setMeasuredPages] = createSignal(1);
   // Live width while a resize drag is in flight; `null` between gestures.
@@ -357,94 +358,113 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
     announce(reorderAnnouncement(label, move.toIndex, items.length));
   }
 
-  // Only droppables that mean something for the active drag may catch it, and
-  // only droppables the dragged card actually overlaps count at all, so a
-  // sloppy release over dead space cancels instead of snapping to the nearest
-  // centre.
-  const detectCollisions: CollisionDetector = (draggable, droppables, context) => {
-    const dragged = draggable.transformed;
-    const touching = droppables.filter(
-      (droppable) =>
-        acceptsDrop(draggable.data as SheetDragData, droppable.data as SheetDropData) &&
-        dragged.left < droppable.layout.right &&
-        dragged.right > droppable.layout.left &&
-        dragged.top < droppable.layout.bottom &&
-        dragged.bottom > droppable.layout.top,
-    );
-    return touching.length > 0 ? closestCenter(draggable, touching, context) : null;
-  };
-
-  function onDragStart({ draggable }: DragEvent): void {
-    setActiveDrag(draggable.data as SheetDragData);
-  }
-
-  /** Resolve a finished drag to at most one store action. */
-  function onDragEnd({ draggable, droppable }: DragEvent): void {
-    setActiveDrag(null);
-    if (!droppable) return;
-    const drag = draggable.data as SheetDragData;
-    const drop = droppable.data as SheetDropData;
-    if (!acceptsDrop(drag, drop)) return;
-
-    if (drag.type === "section") {
-      let next: string[][][] | null = null;
-      if (drop.type === "section") {
-        next = resolveSectionDropOnSection(layout(), drag.sectionId, drop.sectionId);
-      } else if (drop.type === "column") {
-        next = resolveSectionDropOnColumn(layout(), drag.sectionId, drop.page, drop.column);
-      }
-      if (!next) return;
-      applyLayout(next);
-      announceSectionMove(drag.sectionId, next);
-      return;
-    }
-
-    if (drop.type !== "entry" && drop.type !== "section") return;
-    const resolved = resolveEntryDrop({
-      fromSectionId: drag.sectionId,
-      fromItems: sectionItemList(props.resume, drag.sectionId),
-      itemId: drag.itemId,
-      toSectionId: drop.sectionId,
-      toItems: sectionItemList(props.resume, drop.sectionId),
-      targetItemId: drop.type === "entry" ? drop.itemId : null,
-    });
+  /**
+   * Resolve a finished item drop (spec §2.4): a reorder within the section's
+   * own `items` array, one store action, no-op drops write nothing.
+   */
+  function onEntryDrop(payload: EntryDragPayload, dropIndex: number): void {
+    const items = sectionItemList(props.resume, payload.sectionId);
+    const resolved = resolveEntryDropIndex(items, payload.id, dropIndex);
     if (!resolved) return;
-    const label = entryLabel(props.resume, drag.sectionId, drag.itemId);
-    if (resolved.kind === "reorder") {
-      reorderItem(resolved.sectionId, resolved.fromIndex, resolved.toIndex);
-      announce(
-        reorderAnnouncement(
-          label,
-          resolved.toIndex,
-          sectionItemList(props.resume, resolved.sectionId).length,
-        ),
-      );
-      return;
-    }
-    moveItemAcrossSections(
-      resolved.fromSectionId,
-      resolved.fromIndex,
-      resolved.toSectionId,
-      resolved.toIndex,
+    reorderItem(payload.sectionId, resolved.fromIndex, resolved.toIndex);
+    announce(
+      reorderAnnouncement(
+        entryLabel(props.resume, payload.sectionId, payload.id),
+        resolved.toIndex,
+        items.length,
+      ),
     );
-    announce(`${label} moved to ${sectionTitle(props.resume, resolved.toSectionId)}`);
   }
 
-  const dragLabel = (): string => {
-    const drag = activeDrag();
-    if (!drag) return "";
-    if (drag.type === "section") {
-      return `${sectionTitle(props.resume, drag.sectionId)} section`;
+  /**
+   * Resolve a finished section drop (spec §2.5): exact insert at the target,
+   * auto-created pages/columns, and the moved section's now-meaningless
+   * mid-section breaks dropped in the same write.
+   */
+  function onSectionDrop(sectionId: string, target: SectionDropTarget): void {
+    const next = moveSectionInLayout(layout(), sectionId, target);
+    if (!next) return;
+    const nextBreaks = itemBreaksWithoutSection(props.resume.metadata.itemBreaks, sectionId);
+    if (nextBreaks === null) {
+      applyLayout(next);
+    } else {
+      applyPagination(next, nextBreaks);
     }
-    return entryLabel(props.resume, drag.sectionId, drag.itemId);
+    announceSectionMove(sectionId, next);
+  }
+
+  const dnd: SheetDndValue = {
+    entryDrag,
+    setEntryDrag,
+    entryDropAt,
+    setEntryDropAt,
+    sectionDrag,
+    setSectionDrag,
+    sectionDropAt,
+    setSectionDropAt,
+    sectionPlacement: (sectionId) => findSectionPlacement(layout(), sectionId),
+    columnLength: (page, column) => layout()[page]?.[column]?.length ?? 0,
+    onEntryDrop,
+    onSectionDrop,
   };
 
-  /** Merge a drawn page into the one before it (spec §3.4, simple variant). */
+  /**
+   * Remove the rule between two drawn sheets (spec §3.4): prefer clearing the
+   * item-break continuation shared across the boundary, else merge the raw
+   * pages — either way one store write and one undo entry.
+   */
   function removePageBreak(pageIndex: number): void {
-    const next = mergePageIntoPrevious(layout(), pageIndex);
+    const removal = resolvePageBreakRemoval(props.resume, props.templateLayout, pageIndex);
+    if (!removal) return;
+    if (removal.kind === "itemBreaks") {
+      applyItemBreaks(removal.itemBreaks);
+    } else {
+      applyLayout(removal.layout);
+    }
+    announce(`Page break removed; page ${pageIndex + 1} merged into page ${pageIndex}`);
+  }
+
+  /** Split the layout so `sectionId` starts a fresh page (spec §3.4). */
+  function insertPageBreakBeforeSection(sectionId: string): void {
+    const next = splitLayoutBeforeSection(layout(), sectionId);
     if (!next) return;
     applyLayout(next);
-    announce(`Page break removed; page ${pageIndex + 1} merged into page ${pageIndex}`);
+    announce(`Page break inserted before ${sectionTitle(props.resume, sectionId)}`);
+  }
+
+  const canInsertPageBreakBefore = (sectionId: string): boolean =>
+    splitLayoutBeforeSection(layout(), sectionId) !== null;
+
+  /**
+   * The pill's "insert page break before this item" state (owner decisions):
+   * `null` on sections that cannot carry breaks; greyed out with the
+   * explanatory tooltip on templates whose layout cannot honor them; greyed
+   * out with a short reason when the marker would be inert.
+   */
+  function itemBreakAction(sectionId: string, itemId: string): InsertBreakAction | null {
+    if (!sectionSupportsItemBreaks(sectionId)) return null;
+    if (!templateSupportsItemBreaks(props.templateLayout)) {
+      return { onInsert: () => {}, disabledReason: ITEM_BREAK_TEMPLATE_DISABLED_REASON };
+    }
+    const nextBreaks = itemBreaksWithBreakBefore(
+      props.resume,
+      props.templateLayout,
+      sectionId,
+      itemId,
+    );
+    if (nextBreaks === null) {
+      return { onInsert: () => {}, disabledReason: "This item already starts a page." };
+    }
+    return {
+      onInsert: () => {
+        applyItemBreaks(nextBreaks);
+        announce(
+          `Page break inserted before ${entryLabel(props.resume, sectionId, itemId)} ` +
+            `in ${sectionTitle(props.resume, sectionId)}`,
+        );
+      },
+      disabledReason: null,
+    };
   }
 
   function openSections(): void {
@@ -458,9 +478,36 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
   /** The sections of one column, then the end-of-column Add-section block. */
   function SectionList(listProps: {
     ids: string[];
+    pageIndex: number;
+    columnIndex: number;
     /** The cross-column move's target name, or `null` on single-column pages. */
     otherColumnLabel: string | null;
   }): JSX.Element {
+    /**
+     * The Add-section block is every column's end-of-column drop target
+     * (spec §2.5): `MAX_SAFE_INTEGER` clamps to "after everything".
+     */
+    const endOfColumn = (): SectionDropTarget => ({
+      page: listProps.pageIndex,
+      column: listProps.columnIndex,
+      index: Number.MAX_SAFE_INTEGER,
+    });
+    const isEndDropTarget = (): boolean => {
+      const target = sectionDropAt();
+      const end = endOfColumn();
+      return (
+        target !== null &&
+        target.page === end.page &&
+        target.column === end.column &&
+        target.index === end.index
+      );
+    };
+    const trackEndDrop = (event: DragEvent): void => {
+      if (sectionDrag() === null) return;
+      event.preventDefault();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+      setSectionDropAt(endOfColumn());
+    };
     return (
       <>
         <For each={listProps.ids}>
@@ -476,6 +523,17 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
               onMoveSectionToOtherColumn={moveSectionToOtherColumn}
               onMoveEntry={moveEntry}
               onAnnounce={announce}
+              slice={sectionSliceAt(
+                props.resume,
+                props.templateLayout,
+                sectionId,
+                listProps.pageIndex,
+                listProps.columnIndex,
+                isEditable(),
+              )}
+              canInsertPageBreak={canInsertPageBreakBefore(sectionId)}
+              onInsertPageBreak={insertPageBreakBeforeSection}
+              itemBreakAction={itemBreakAction}
             />
           )}
         </For>
@@ -483,8 +541,20 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
           <button
             type="button"
             class="doc-sheet__add-section-block"
+            classList={{ "doc-sheet__add-section-block--drop-hint": isEndDropTarget() }}
             data-testid="doc-sheet-add-section"
             onClick={openSections}
+            onDragEnter={trackEndDrop}
+            onDragOver={trackEndDrop}
+            onDrop={(event) => {
+              const dragging = sectionDrag();
+              if (dragging === null) return;
+              event.preventDefault();
+              const payload = readDragPayload<{ id?: string }>(event, SECTION_DRAG_MIME);
+              onSectionDrop(payload?.id ?? dragging, endOfColumn());
+              setSectionDrag(null);
+              setSectionDropAt(null);
+            }}
           >
             <PlusIcon /> Add section
           </button>
@@ -493,7 +563,11 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
     );
   }
 
-  /** A column's droppable frame. */
+  /**
+   * A column's frame. The column itself is not a drop target — the drag
+   * catalog's targets are section cards and each column's Add-section block
+   * (spec §2.5).
+   */
   function ColumnFrame(frameProps: {
     pageIndex: number;
     columnIndex: number;
@@ -503,25 +577,15 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
     isAside?: boolean;
     children: JSX.Element;
   }): JSX.Element {
-    const droppable = createDroppable(
-      `drop:column:${frameProps.pageIndex}:${frameProps.columnIndex}`,
-      {
-        type: "column",
-        page: frameProps.pageIndex,
-        column: frameProps.columnIndex,
-      },
-    );
     const classes = (): Record<string, boolean> => ({
       "doc-sheet__column": true,
       [frameProps.class]: true,
-      "doc-sheet__column--drop": droppable.isActiveDroppable,
     });
     return (
       <Show
         when={frameProps.isAside === true}
         fallback={
           <div
-            ref={droppable.ref}
             classList={classes()}
             data-testid="doc-sheet-column"
             data-column-role={frameProps.role}
@@ -533,7 +597,6 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
         }
       >
         <aside
-          ref={droppable.ref}
           classList={classes()}
           data-testid="doc-sheet-column"
           data-column-role={frameProps.role}
@@ -627,7 +690,12 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
         <Show when={isFirst() && contactIn() === "sidebar"}>
           <ContactBlock basics={props.resume.basics} withAvatar />
         </Show>
-        <SectionList ids={columnProps.page[1] ?? []} otherColumnLabel="main column" />
+        <SectionList
+          ids={columnProps.page[1] ?? []}
+          pageIndex={columnProps.pageIndex}
+          columnIndex={1}
+          otherColumnLabel="main column"
+        />
         <Show when={isEditable()}>
           <SidebarResizeHandle isRightSidebar={columnProps.isRightSidebar} />
         </Show>
@@ -658,7 +726,12 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
             <ContactBlock basics={props.resume.basics} isCompact />
           </Show>
         </Show>
-        <SectionList ids={columnProps.page[0] ?? []} otherColumnLabel="sidebar" />
+        <SectionList
+          ids={columnProps.page[0] ?? []}
+          pageIndex={columnProps.pageIndex}
+          columnIndex={0}
+          otherColumnLabel="sidebar"
+        />
       </ColumnFrame>
     );
   }
@@ -681,7 +754,12 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
             <ContactBlock basics={props.resume.basics} isCompact />
           </div>
         </Show>
-        <SectionList ids={ids()} otherColumnLabel={null} />
+        <SectionList
+          ids={ids()}
+          pageIndex={columnProps.pageIndex}
+          columnIndex={0}
+          otherColumnLabel={null}
+        />
       </ColumnFrame>
     );
   }
@@ -698,7 +776,12 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
               class="doc-sheet__multi-col"
               role={columnIndex() === 0 ? "main" : "sidebar"}
             >
-              <SectionList ids={ids} otherColumnLabel={null} />
+              <SectionList
+                ids={ids}
+                pageIndex={columnProps.pageIndex}
+                columnIndex={columnIndex()}
+                otherColumnLabel={null}
+              />
             </ColumnFrame>
           )}
         </For>
@@ -789,12 +872,7 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
 
   return (
     <SheetModeContext.Provider value={mode}>
-      <DragDropProvider
-        onDragStart={onDragStart}
-        onDragEnd={onDragEnd}
-        collisionDetector={detectCollisions}
-      >
-        <DragDropSensors />
+      <SheetDndContext.Provider value={dnd}>
         <div
           ref={(element) => {
             root = element;
@@ -853,13 +931,7 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
 
           <LiveRegion message={announcement()} politeness="polite" />
         </div>
-
-        <DragOverlay>
-          <Show when={activeDrag()}>
-            <div class="doc-sheet__drag-overlay">{dragLabel()}</div>
-          </Show>
-        </DragOverlay>
-      </DragDropProvider>
+      </SheetDndContext.Provider>
     </SheetModeContext.Provider>
   );
 }

--- a/apps/web/src/components/doc-editor/SectionChrome.tsx
+++ b/apps/web/src/components/doc-editor/SectionChrome.tsx
@@ -10,9 +10,9 @@
  * this chrome mounts — the card is just the section content.
  *
  * The chrome is presentational: every action arrives as a callback and every
- * drag primitive (the grip's activators, the card's droppable ref) is owned by
- * the caller, so the drag mechanism can be swapped (#796) without touching the
- * card. The `basics` contact block reuses this card with no menu and no grip —
+ * drag primitive (the grip's activators, the card's whole-surface `dragProps`)
+ * is owned by the caller, so the card never knows the drag mechanism. The
+ * `basics` contact block reuses this card with no menu and no grip —
  * template-owned chrome (spec §1.4).
  */
 
@@ -34,6 +34,12 @@ export interface SectionMenuActions {
   /** Cross-column move, absent on single-column templates. */
   otherColumnLabel?: string;
   onMoveToOtherColumn?: () => void;
+  /**
+   * Explicit "insert page break before this section" (spec §3.4, owner
+   * decision Q6); disabled when the split would change nothing.
+   */
+  canInsertPageBreak?: boolean;
+  onInsertPageBreak?: () => void;
   /** Arms the inline title editor. */
   onRename: () => void;
   onHide: () => void;
@@ -41,6 +47,12 @@ export interface SectionMenuActions {
 
 export interface SectionChromeProps {
   sectionId: string;
+  /**
+   * Discriminator for this card's DOM ids when a section renders more than
+   * one instance (item-break continuation slices, spec §3.3). Defaults to
+   * `sectionId`; duplicate ids would break the pencil/menu ARIA wiring.
+   */
+  idKey?: string;
   /** Display title; inline-editable when `onRenameCommit` is provided. */
   title: string;
   /**
@@ -59,11 +71,17 @@ export interface SectionChromeProps {
   /** Drag-grip activator props from the sheet's drag system. */
   gripActivators?: Record<string, unknown>;
   gripTitle?: string;
-  /** Ref for the card element (drop target registration). */
-  ref?: (element: HTMLElement) => void;
-  /** Drag-state classes driven by the sheet's drag system. */
-  isDropTarget?: boolean;
+  /**
+   * Whole-surface drag and drop-target props (`draggable`, the drag and drop
+   * handlers), spread onto the card element. Owned by the caller so the card
+   * stays presentational (spec §2.5); absent for chrome that never drags.
+   */
+  dragProps?: JSX.HTMLAttributes<HTMLElement>;
+  /** Drag-state chrome driven by the sheet's drag signals. */
   isDragging?: boolean;
+  /** 3px accent slot indicators around the card (spec §2.5). */
+  showSlotBefore?: boolean;
+  showSlotAfter?: boolean;
   children: JSX.Element;
 }
 
@@ -105,7 +123,7 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
     const onKey = (event: KeyboardEvent): void => {
       if (event.key !== "Escape") return;
       setIsMenuOpen(false);
-      document.getElementById(pencilId(props.sectionId))?.focus();
+      document.getElementById(pencilId(props.idKey ?? props.sectionId))?.focus();
     };
     document.addEventListener("mousedown", onDown);
     document.addEventListener("keydown", onKey);
@@ -149,20 +167,19 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
       setIsMenuOpen(false);
       action?.();
       if (refocus) {
-        const id = pencilId(props.sectionId);
+        const id = pencilId(props.idKey ?? props.sectionId);
         queueMicrotask(() => document.getElementById(id)?.focus());
       }
     };
 
   return (
     <section
-      ref={(element) => props.ref?.(element)}
+      {...(props.dragProps ?? {})}
       class="doc-sheet__sec"
       classList={{
         "doc-sheet__sec--edit": hasChrome(),
         "doc-sheet__sec--focused": hasChrome() && props.isFocused,
         "doc-sheet__sec--menu-open": isMenuOpen(),
-        "doc-sheet__sec--drop": props.isDropTarget === true,
         "doc-sheet__sec--dragging": props.isDragging === true,
       }}
       data-section-id={props.sectionId}
@@ -170,6 +187,9 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
         if (isEditable()) props.onFocus();
       }}
     >
+      <Show when={props.showSlotBefore === true}>
+        <span class="doc-sheet__sec-slot doc-sheet__sec-slot--before" aria-hidden="true" />
+      </Show>
       <div class="doc-sheet__sec-bar">
         <Show when={hasChrome() && props.gripActivators}>
           <button
@@ -204,13 +224,13 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
         <Show when={hasChrome()}>
           <button
             type="button"
-            id={pencilId(props.sectionId)}
+            id={pencilId(props.idKey ?? props.sectionId)}
             class="doc-sheet__sec-pencil"
             title="Section options"
             aria-label={`${props.title} section options`}
             aria-haspopup="menu"
             aria-expanded={isMenuOpen()}
-            aria-controls={isMenuOpen() ? menuId(props.sectionId) : undefined}
+            aria-controls={isMenuOpen() ? menuId(props.idKey ?? props.sectionId) : undefined}
             onClick={(event) => {
               event.stopPropagation();
               setIsMenuOpen(!isMenuOpen());
@@ -228,7 +248,7 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
               // Focus moves into the menu when it opens, per the menu pattern.
               queueMicrotask(() => enabledMenuItems(element)[0]?.focus());
             }}
-            id={menuId(props.sectionId)}
+            id={menuId(props.idKey ?? props.sectionId)}
             class="doc-sheet__sec-menu"
             role="menu"
             aria-label={`${props.title} section options`}
@@ -268,6 +288,19 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
                 Move to {menu().otherColumnLabel}
               </button>
             </Show>
+            <Show when={menu().onInsertPageBreak}>
+              {(onInsertPageBreak) => (
+                <button
+                  type="button"
+                  role="menuitem"
+                  disabled={menu().canInsertPageBreak !== true}
+                  aria-label={`Insert page break before ${props.title} section`}
+                  onClick={menuAct(() => onInsertPageBreak()(), true)}
+                >
+                  Insert page break before
+                </button>
+              )}
+            </Show>
             <div class="doc-sheet__sec-menu-sep" role="separator" />
             <button
               type="button"
@@ -303,6 +336,9 @@ export function SectionChrome(props: SectionChromeProps): JSX.Element {
         >
           <PlusIcon /> {props.addLabel ?? "Add"}
         </button>
+      </Show>
+      <Show when={props.showSlotAfter === true}>
+        <span class="doc-sheet__sec-slot doc-sheet__sec-slot--after" aria-hidden="true" />
       </Show>
     </section>
   );

--- a/apps/web/src/components/doc-editor/SortableEntry.tsx
+++ b/apps/web/src/components/doc-editor/SortableEntry.tsx
@@ -1,27 +1,49 @@
 /**
- * Universal item-row chrome (#794, spec §1.8–§1.9).
+ * Universal item-row chrome (#794 §1.8–§1.9, drag channels reworked in #796).
  *
  * Every structured item on the sheet renders inside this row: a left-edge
  * `⋮⋮` drag grip that fades in on hover, plus the hover action pill. Full
  * rows get the floating top-right pill (edit / move / duplicate / visibility
- * / remove, in the spec's fixed order); compact sidebar rows (profiles,
- * languages, skills) get a single bare `✕` at the right edge and make the
- * whole row the edit affordance — click anywhere opens the item dialog.
+ * / page break / remove); compact sidebar rows (profiles, languages, skills)
+ * get a single bare `✕` at the right edge and make the whole row the edit
+ * affordance — click anywhere opens the item dialog.
+ *
+ * Dragging is whole-surface HTML5 DnD (spec §2.4): the grip *and* the row are
+ * drag surfaces, presses that began on controls are vetoed in `dragstart`
+ * (never on `mousedown` — the pinned Chromium bug), the payload rides
+ * `application/x-entry` mirrored in the sheet's drag signals, and targets are
+ * rows of the same section only. The 3px `.doc-sheet__entry-slot` bars mark
+ * the insert position; the sheet resolves the drop.
  *
  * Reveal is opacity, never `display`: every control stays focusable and
  * announced, and `@media (hover: none)` keeps them visible for touch. The
  * compact row's move buttons are visually hidden until keyboard focus — the
  * spec draws no arrows there (drag covers pointer reorder), but a keyboard
  * user still needs the path.
- *
- * Drag primitives are created here (grip = activator) but resolved by the
- * sheet; #796 replaces the mechanism without touching this contract.
  */
 
 import { Show, type JSX } from "solid-js";
-import { createDraggable, createDroppable } from "@thisbeyond/solid-dnd";
-import { EyeIcon } from "./icons";
+import { EyeIcon, PageBreakIcon } from "./icons";
 import { useSheetEditable } from "./sheetMode";
+import {
+  ENTRY_DRAG_MIME,
+  dragStartVetoed,
+  dropIndexFromPointer,
+  readDragPayload,
+  useSheetDnd,
+  type EntryDragPayload,
+} from "./sheetDnd";
+
+/** The insert-page-break pill control's state (owner decision, umbrella Q6). */
+export interface InsertBreakAction {
+  onInsert: () => void;
+  /**
+   * Why the action is unavailable, or `null` when it is live. A disabled
+   * control stays focusable (`aria-disabled`) with the reason as its
+   * tooltip, reachable on hover *and* focus (owner decision 2026-08-03).
+   */
+  disabledReason: string | null;
+}
 
 /** The row's action callbacks; absent callbacks render no control. */
 export interface EntryActionsProps {
@@ -36,6 +58,8 @@ export interface EntryActionsProps {
   /** Present only when a neighbour exists in that direction (spec §1.9). */
   onMoveUp?: () => void;
   onMoveDown?: () => void;
+  /** Explicit "insert page break before" (spec §3.4); main-flow rows only. */
+  insertBreak?: InsertBreakAction;
 }
 
 /** One 26px circular ghost button of the pill. */
@@ -60,6 +84,46 @@ function ActionButton(props: {
     >
       {props.children}
     </button>
+  );
+}
+
+let breakTooltipCounter = 0;
+
+/**
+ * The pill's "insert page break before" control. When the action is
+ * unavailable the button stays in the tab order (`aria-disabled`, not
+ * `disabled`) and the reason renders as a `role="tooltip"` element wired via
+ * `aria-describedby`, shown on hover and on keyboard focus alike — a
+ * pointer-only tooltip would strand keyboard and AT users.
+ */
+function InsertBreakButton(props: { label: string; action: InsertBreakAction }): JSX.Element {
+  breakTooltipCounter += 1;
+  const tooltipId = `doc-entry-break-tip-${breakTooltipCounter}`;
+  const isDisabled = (): boolean => props.action.disabledReason !== null;
+  return (
+    <span class="doc-sheet__entry-act-slot">
+      <button
+        type="button"
+        class="doc-sheet__entry-act doc-sheet__entry-act--break"
+        aria-label={`Insert page break before ${props.label}`}
+        title={isDisabled() ? undefined : `Insert page break before ${props.label}`}
+        aria-disabled={isDisabled() ? "true" : undefined}
+        aria-describedby={isDisabled() ? tooltipId : undefined}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (!isDisabled()) props.action.onInsert();
+        }}
+      >
+        <PageBreakIcon />
+      </button>
+      <Show when={props.action.disabledReason}>
+        {(reason) => (
+          <span role="tooltip" id={tooltipId} class="doc-sheet__act-tooltip">
+            {reason()}
+          </span>
+        )}
+      </Show>
+    </span>
   );
 }
 
@@ -116,6 +180,9 @@ export function EntryActions(props: EntryActionsProps): JSX.Element {
         >
           <EyeIcon isOpen={!props.isHidden} />
         </ActionButton>
+        <Show when={props.insertBreak}>
+          {(insertBreak) => <InsertBreakButton label={props.label} action={insertBreak()} />}
+        </Show>
       </Show>
       <ActionButton
         class="doc-sheet__entry-act--remove"
@@ -131,6 +198,10 @@ export function EntryActions(props: EntryActionsProps): JSX.Element {
 export interface SortableEntryProps {
   sectionId: string;
   itemId: string;
+  /** Index into the section's own unfiltered `items` array. */
+  index: number;
+  /** Whether this row is the last one its section instance draws. */
+  isLast: boolean;
   /** Extra class naming the row's body layout (`entry`, `edu-entry`, …). */
   class?: string;
   isCompact?: boolean;
@@ -143,31 +214,61 @@ export interface SortableEntryProps {
 /** One item row: grip strip, action chrome, then the section's own body. */
 export function SortableEntry(props: SortableEntryProps): JSX.Element {
   const isEditable = useSheetEditable();
+  const dnd = useSheetDnd();
 
-  const draggable = createDraggable(`drag:entry:${props.sectionId}:${props.itemId}`, {
-    type: "entry",
-    sectionId: props.sectionId,
-    itemId: props.itemId,
-  });
-  const droppable = createDroppable(`drop:entry:${props.sectionId}:${props.itemId}`, {
-    type: "entry",
-    sectionId: props.sectionId,
-    itemId: props.itemId,
-  });
+  /** Where the press that may become a drag started (spec §2.4 veto rule). */
+  let pressTarget: HTMLElement | null = null;
+
+  const isDragging = (): boolean => {
+    const drag = dnd?.entryDrag() ?? null;
+    return drag !== null && drag.sectionId === props.sectionId && drag.id === props.itemId;
+  };
+  const showSlotBefore = (): boolean => {
+    const target = dnd?.entryDropAt() ?? null;
+    return target !== null && target.sectionId === props.sectionId && target.index === props.index;
+  };
+  const showSlotAfter = (): boolean => {
+    if (!props.isLast) return false;
+    const target = dnd?.entryDropAt() ?? null;
+    return (
+      target !== null && target.sectionId === props.sectionId && target.index === props.index + 1
+    );
+  };
+
+  function beginDrag(event: DragEvent): void {
+    dnd?.setEntryDrag({ sectionId: props.sectionId, id: props.itemId });
+    event.dataTransfer?.setData(
+      ENTRY_DRAG_MIME,
+      JSON.stringify({ sectionId: props.sectionId, id: props.itemId }),
+    );
+    if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+  }
+
+  function endDrag(): void {
+    dnd?.setEntryDrag(null);
+    dnd?.setEntryDropAt(null);
+  }
+
+  /** Targets are rows of the same section only (spec §2.4, owner decision). */
+  function trackDropTarget(event: DragEvent): void {
+    const drag = dnd?.entryDrag() ?? null;
+    if (drag === null || drag.sectionId !== props.sectionId) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+    dnd?.setEntryDropAt({
+      sectionId: props.sectionId,
+      index: dropIndexFromPointer(event, props.index),
+    });
+  }
 
   return (
     <article
-      ref={(element) => {
-        draggable.ref(element);
-        droppable.ref(element);
-      }}
       class={`doc-sheet__entry-row ${props.class ?? ""}`}
       classList={{
         "doc-sheet__entry-row--compact": props.isCompact === true,
         "doc-sheet__entry-row--edit": isEditable(),
         "doc-sheet__entry-row--hidden": props.isHidden,
-        "doc-sheet__entry-row--drop": droppable.isActiveDroppable,
-        "doc-sheet__entry-row--dragging": draggable.isActiveDraggable,
+        "doc-sheet__entry-row--dragging": isDragging(),
       }}
       data-entry-id={props.itemId}
       title={
@@ -177,6 +278,7 @@ export function SortableEntry(props: SortableEntryProps): JSX.Element {
             : "Double-click to edit"
           : undefined
       }
+      draggable={isEditable()}
       onClick={(event) => {
         // Compact rows: the whole row is the edit affordance. Presses on the
         // grip or any button keep their own behaviour.
@@ -193,7 +295,42 @@ export function SortableEntry(props: SortableEntryProps): JSX.Element {
         if (target.closest("button, a")) return;
         props.actions.onEdit();
       }}
+      onMouseDown={(event) => {
+        // Record only — never preventDefault here (pinned Chromium bug).
+        pressTarget = event.target as HTMLElement;
+      }}
+      onDragStart={(event) => {
+        const pressed = pressTarget;
+        pressTarget = null;
+        // The grip runs its own drag (stopPropagation); anything reaching
+        // here grabbed the row surface. Veto presses that began on controls
+        // so they keep their native behaviour.
+        if (dragStartVetoed(pressed)) {
+          event.preventDefault();
+          return;
+        }
+        // Nested rows drag independently of their section card.
+        event.stopPropagation();
+        beginDrag(event);
+      }}
+      onDragEnd={endDrag}
+      onDragEnter={trackDropTarget}
+      onDragOver={trackDropTarget}
+      onDrop={(event) => {
+        const drag = dnd?.entryDrag() ?? null;
+        if (drag === null || drag.sectionId !== props.sectionId) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const payload = readDragPayload<EntryDragPayload>(event, ENTRY_DRAG_MIME) ?? drag;
+        if (payload.sectionId === props.sectionId) {
+          dnd?.onEntryDrop(payload, dropIndexFromPointer(event, props.index));
+        }
+        endDrag();
+      }}
     >
+      <Show when={showSlotBefore()}>
+        <span class="doc-sheet__entry-slot doc-sheet__entry-slot--before" aria-hidden="true" />
+      </Show>
       <Show when={isEditable()}>
         <button
           type="button"
@@ -201,13 +338,22 @@ export function SortableEntry(props: SortableEntryProps): JSX.Element {
           aria-hidden="true"
           tabindex="-1"
           title={`Drag ${props.actions.label} to move it`}
-          {...draggable.dragActivators}
+          draggable="true"
+          onDragStart={(event) => {
+            // Grip drags stopPropagation so the row doesn't double-fire.
+            event.stopPropagation();
+            beginDrag(event);
+          }}
+          onDragEnd={endDrag}
         >
           ⋮⋮
         </button>
         <EntryActions {...props.actions} isCompact={props.isCompact === true} />
       </Show>
       {props.children}
+      <Show when={showSlotAfter()}>
+        <span class="doc-sheet__entry-slot doc-sheet__entry-slot--after" aria-hidden="true" />
+      </Show>
     </article>
   );
 }

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -41,7 +41,6 @@ const store = vi.hoisted(() => ({
   removeCustomSectionItem: vi.fn(),
   reorderCustomSectionItem: vi.fn(),
   duplicateCustomSectionItem: vi.fn(),
-  moveCustomSectionItem: vi.fn(),
   updateLayout: vi.fn(),
   updatePagination: vi.fn(),
   updateMetadata: vi.fn(),
@@ -566,6 +565,35 @@ describe("document sheet structural chrome", () => {
       expect(document.querySelector(".doc-sheet__entry-slot--before")).toBeNull();
     });
 
+    it("inserts after the target when dropped in its bottom half", () => {
+      renderSheet();
+      const source = entryRow("exp-1");
+      const target = entryRow("exp-3");
+      // jsdom rects are all zero, and jsdom has no DragEvent, so fireEvent's
+      // drag events fall back to plain Event and cannot carry clientY. Give
+      // the target a real box and dispatch MouseEvent-based drag events so a
+      // pointer below the midpoint exercises the +1 branch of
+      // dropIndexFromPointer.
+      target.getBoundingClientRect = () =>
+        ({ top: 100, bottom: 140, height: 40, left: 0, right: 400, width: 400 }) as DOMRect;
+      const dataTransfer = mockDataTransfer();
+      const dragEventAt = (type: string, clientY: number): MouseEvent => {
+        const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientY });
+        Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+        return event;
+      };
+
+      fireEvent.mouseDown(source);
+      fireEvent.dragStart(source, { dataTransfer });
+      target.dispatchEvent(dragEventAt("dragover", 135));
+      // Bottom half of the last row -> the after-slot marks "insert last".
+      expect(target.querySelector(".doc-sheet__entry-slot--after")).not.toBeNull();
+      target.dispatchEvent(dragEventAt("drop", 135));
+
+      expect(store.reorderSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 0, 2);
+      expect(writeCount()).toBe(1);
+    });
+
     it("rejects cross-section item drops — same-section-only by decision", () => {
       renderSheet();
       const source = entryRow("exp-1");
@@ -674,6 +702,16 @@ describe("document sheet structural chrome", () => {
       // The add affordance lives only on the last slice (spec 2.6).
       expect(cards[0].querySelector(".doc-sheet__add-block")).toBeNull();
       expect(cards[1].querySelector(".doc-sheet__add-block")).not.toBeNull();
+    });
+
+    it("offers no insert-break menu action on a continuation slice", () => {
+      resume.metadata.itemBreaks = { experience: ["exp-2"] };
+      renderSheet({ template: SINGLE_TEMPLATE });
+
+      // A continuation has no raw placement of its own — the action would
+      // split before the whole section, not the "(cont.)" card it names.
+      fireEvent.click(screen.getByRole("button", { name: "Experience (cont.) section options" }));
+      expect(screen.queryByRole("menuitem", { name: /Insert page break before/ })).toBeNull();
     });
 
     it("leaves markers inert on templates whose layout cannot honor them", () => {

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -12,7 +12,12 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import { entryStep } from "../../../lib/docDnd";
-import { loadDocEditorFixture, SIDEBAR_TEMPLATE } from "../../../test/docEditorFixture";
+import {
+  loadDocEditorFixture,
+  SIDEBAR_TEMPLATE,
+  SINGLE_TEMPLATE,
+} from "../../../test/docEditorFixture";
+import type { TemplateLayout } from "../../../lib/docLayout";
 import { DocSheet } from "../DocSheet";
 import type { ResumeData } from "../../../wasm/types";
 
@@ -38,6 +43,7 @@ const store = vi.hoisted(() => ({
   duplicateCustomSectionItem: vi.fn(),
   moveCustomSectionItem: vi.fn(),
   updateLayout: vi.fn(),
+  updatePagination: vi.fn(),
   updateMetadata: vi.fn(),
 }));
 
@@ -76,11 +82,11 @@ describe("document sheet structural chrome", () => {
     store.store.resume = resume;
   });
 
-  function renderSheet(options: { onOpenSections?: () => void } = {}) {
+  function renderSheet(options: { onOpenSections?: () => void; template?: TemplateLayout } = {}) {
     return render(() => (
       <DocSheet
         resume={resume}
-        templateLayout={SIDEBAR_TEMPLATE}
+        templateLayout={options.template ?? SIDEBAR_TEMPLATE}
         onOpenSections={options.onOpenSections}
       />
     ));
@@ -466,25 +472,177 @@ describe("document sheet structural chrome", () => {
     });
   });
 
-  describe("drag chrome", () => {
-    it("gives cards and entries drag handles rather than surface capture", () => {
+  describe("whole-surface drag and drop", () => {
+    interface MockDataTransfer {
+      data: Record<string, string>;
+      setData: (mime: string, value: string) => void;
+      getData: (mime: string) => string;
+      effectAllowed: string;
+      dropEffect: string;
+    }
+
+    function mockDataTransfer(): MockDataTransfer {
+      const data: Record<string, string> = {};
+      return {
+        data,
+        setData: (mime, value) => {
+          data[mime] = value;
+        },
+        getData: (mime) => data[mime] ?? "",
+        effectAllowed: "",
+        dropEffect: "",
+      };
+    }
+
+    function sectionCard(sectionId: string): HTMLElement {
+      const card = document.querySelector(`[data-section-id="${sectionId}"]`);
+      expect(card).not.toBeNull();
+      return card as HTMLElement;
+    }
+
+    function entryRow(itemId: string): HTMLElement {
+      const row = document.querySelector(`[data-entry-id="${itemId}"]`);
+      expect(row).not.toBeNull();
+      return row as HTMLElement;
+    }
+
+    it("makes the whole row and the whole card drag surfaces, grips included", () => {
       renderSheet();
 
-      // Handles are pointer-only chrome: out of the tab order and hidden from
-      // assistive tech (the menu and pill are the keyboard/SR path), so they
-      // are found by title rather than accessible name.
-      const sectionHandle = screen.getByTitle("Drag Experience section to move it");
-      const entryHandle = screen.getByTitle(`Drag ${FIRST_EXPERIENCE} to move it`);
-      expect(sectionHandle).toBeInTheDocument();
-      expect(entryHandle).toBeInTheDocument();
-      expect(sectionHandle.getAttribute("tabindex")).toBe("-1");
-      expect(sectionHandle.getAttribute("aria-hidden")).toBe("true");
-      expect(entryHandle.getAttribute("tabindex")).toBe("-1");
-      expect(entryHandle.getAttribute("aria-hidden")).toBe("true");
-      // The section surface itself must not be a drag activator, or text
-      // selection and inline editing would fight the drag sensor.
-      const section = document.querySelector('[data-section-id="experience"]');
-      expect(section?.getAttribute("draggable")).toBeNull();
+      expect(sectionCard("experience").getAttribute("draggable")).toBe("true");
+      expect(entryRow("exp-1").getAttribute("draggable")).toBe("true");
+      // The grips remain as visible affordances with their own drag wiring.
+      expect(screen.getByTitle("Drag Experience section to move it")).toBeInTheDocument();
+      expect(screen.getByTitle(`Drag ${FIRST_EXPERIENCE} to move it`)).toBeInTheDocument();
+    });
+
+    it("carries the spec MIME payload and mirrors the drag in row styling", () => {
+      renderSheet();
+      const row = entryRow("exp-1");
+      const dataTransfer = mockDataTransfer();
+
+      fireEvent.mouseDown(row);
+      fireEvent.dragStart(row, { dataTransfer });
+
+      expect(JSON.parse(dataTransfer.data["application/x-entry"])).toEqual({
+        sectionId: "experience",
+        id: "exp-1",
+      });
+      expect(dataTransfer.effectAllowed).toBe("move");
+      expect(row.classList.contains("doc-sheet__entry-row--dragging")).toBe(true);
+    });
+
+    it("vetoes a row drag that began on a control, in dragstart not mousedown", () => {
+      renderSheet();
+      const row = entryRow("exp-1");
+      const control = within(row).getByRole("button", { name: `Edit ${FIRST_EXPERIENCE}` });
+      const dataTransfer = mockDataTransfer();
+
+      fireEvent.mouseDown(control);
+      const proceeded = fireEvent.dragStart(row, { dataTransfer });
+
+      // fireEvent returns false when the handler called preventDefault.
+      expect(proceeded).toBe(false);
+      expect(dataTransfer.data["application/x-entry"]).toBeUndefined();
+    });
+
+    it("reorders an entry within its section from a whole-row drag", () => {
+      renderSheet();
+      const source = entryRow("exp-2");
+      const target = entryRow("exp-1");
+      const dataTransfer = mockDataTransfer();
+
+      fireEvent.mouseDown(source);
+      fireEvent.dragStart(source, { dataTransfer });
+      fireEvent.dragEnter(target, { dataTransfer, clientY: 0 });
+      fireEvent.dragOver(target, { dataTransfer, clientY: 0 });
+      // A 3px slot bar marks the insert position on the target row.
+      expect(target.querySelector(".doc-sheet__entry-slot--before")).not.toBeNull();
+      fireEvent.drop(target, { dataTransfer, clientY: 0 });
+
+      expect(store.reorderSectionItem).toHaveBeenCalledExactlyOnceWith("experience", 1, 0);
+      expect(writeCount()).toBe(1);
+      // Drag state is cleared on drop.
+      expect(document.querySelector(".doc-sheet__entry-slot--before")).toBeNull();
+    });
+
+    it("rejects cross-section item drops — same-section-only by decision", () => {
+      renderSheet();
+      const source = entryRow("exp-1");
+      const target = entryRow("edu-1");
+      const dataTransfer = mockDataTransfer();
+
+      fireEvent.mouseDown(source);
+      fireEvent.dragStart(source, { dataTransfer });
+      fireEvent.dragEnter(target, { dataTransfer, clientY: 0 });
+      fireEvent.dragOver(target, { dataTransfer, clientY: 0 });
+      fireEvent.drop(target, { dataTransfer, clientY: 0 });
+
+      expect(target.querySelector(".doc-sheet__entry-slot--before")).toBeNull();
+      expect(writeCount()).toBe(0);
+    });
+
+    it("moves a section dropped on another card, with a slot indicator", () => {
+      renderSheet();
+      const source = sectionCard("education");
+      const target = sectionCard("experience");
+      const dataTransfer = mockDataTransfer();
+
+      fireEvent.mouseDown(source);
+      fireEvent.dragStart(source, { dataTransfer });
+      expect(JSON.parse(dataTransfer.data["application/x-section"])).toEqual({
+        id: "education",
+      });
+      expect(source.classList.contains("doc-sheet__sec--dragging")).toBe(true);
+
+      fireEvent.dragEnter(target, { dataTransfer, clientY: 0 });
+      fireEvent.dragOver(target, { dataTransfer, clientY: 0 });
+      expect(target.querySelector(".doc-sheet__sec-slot--before")).not.toBeNull();
+      fireEvent.drop(target, { dataTransfer, clientY: 0 });
+
+      expect(store.updateLayout).toHaveBeenCalledExactlyOnceWith([
+        [
+          ["summary", "education", "experience", "projects"],
+          ["profiles", "skills", "speaking"],
+        ],
+        [
+          ["publications", "volunteer", "awards"],
+          ["languages", "interests", "certifications", "advisory"],
+        ],
+      ]);
+      expect(writeCount()).toBe(1);
+    });
+
+    it("vetoes a card drag that began on an entry row — the row owns it", () => {
+      renderSheet();
+      const card = sectionCard("experience");
+      const dataTransfer = mockDataTransfer();
+
+      fireEvent.mouseDown(entryRow("exp-1"));
+      const proceeded = fireEvent.dragStart(card, { dataTransfer });
+
+      expect(proceeded).toBe(false);
+      expect(dataTransfer.data["application/x-section"]).toBeUndefined();
+    });
+
+    it("accepts the Add-section block as the end-of-column drop target", () => {
+      renderSheet();
+      const source = sectionCard("experience");
+      // Sidebar-left template: the sidebar column renders first on the page.
+      const [sidebarBlock] = screen.getAllByTestId("doc-sheet-add-section");
+      const dataTransfer = mockDataTransfer();
+
+      fireEvent.mouseDown(source);
+      fireEvent.dragStart(source, { dataTransfer });
+      fireEvent.dragEnter(sidebarBlock, { dataTransfer });
+      fireEvent.dragOver(sidebarBlock, { dataTransfer });
+      expect(sidebarBlock.classList.contains("doc-sheet__add-section-block--drop-hint")).toBe(true);
+      fireEvent.drop(sidebarBlock, { dataTransfer });
+
+      const [layout] = store.updateLayout.mock.calls[0] as [string[][][]];
+      expect(layout[0][0]).toEqual(["summary", "education", "projects"]);
+      expect(layout[0][1]).toEqual(["profiles", "skills", "speaking", "experience"]);
+      expect(writeCount()).toBe(1);
     });
 
     it("gives the basics contact block no grip, menu, or drag chrome", () => {
@@ -494,6 +652,192 @@ describe("document sheet structural chrome", () => {
       expect(contact).not.toBeNull();
       expect(contact?.querySelector(".doc-sheet__sec-grip")).toBeNull();
       expect(contact?.querySelector(".doc-sheet__sec-pencil")).toBeNull();
+    });
+  });
+
+  describe("explicit pagination (#796)", () => {
+    it("draws item-break continuation slices with a (cont.) title", () => {
+      resume.metadata.itemBreaks = { experience: ["exp-2"] };
+      renderSheet({ template: SINGLE_TEMPLATE });
+
+      const cards = [...document.querySelectorAll('[data-section-id="experience"]')];
+      expect(cards).toHaveLength(2);
+      expect(cards[0].querySelector(".doc-sheet__sec-title")?.textContent).toBe("Experience");
+      expect(cards[1].querySelector(".doc-sheet__sec-title")?.textContent).toBe(
+        "Experience (cont.)",
+      );
+      // Slice 0 holds the item before the marker; the continuation the rest.
+      expect(cards[0].querySelector('[data-entry-id="exp-1"]')).not.toBeNull();
+      expect(cards[0].querySelector('[data-entry-id="exp-2"]')).toBeNull();
+      expect(cards[1].querySelector('[data-entry-id="exp-2"]')).not.toBeNull();
+      expect(cards[1].querySelector('[data-entry-id="exp-3"]')).not.toBeNull();
+      // The add affordance lives only on the last slice (spec 2.6).
+      expect(cards[0].querySelector(".doc-sheet__add-block")).toBeNull();
+      expect(cards[1].querySelector(".doc-sheet__add-block")).not.toBeNull();
+    });
+
+    it("leaves markers inert on templates whose layout cannot honor them", () => {
+      resume.metadata.itemBreaks = { experience: ["exp-2"] };
+      renderSheet({ template: SIDEBAR_TEMPLATE });
+
+      expect(document.querySelectorAll('[data-section-id="experience"]')).toHaveLength(1);
+    });
+
+    it("prefers clearing the item break when removing the page break rule", () => {
+      resume.metadata.itemBreaks = { experience: ["exp-2"] };
+      renderSheet({ template: SINGLE_TEMPLATE });
+
+      const [removeButton] = screen.getAllByRole("button", { name: "Remove page break" });
+      fireEvent.click(removeButton);
+
+      expect(store.updateMetadata).toHaveBeenCalledExactlyOnceWith("itemBreaks", {});
+      expect(store.updateLayout).not.toHaveBeenCalled();
+      expect(writeCount()).toBe(1);
+    });
+
+    it("falls back to merging the raw pages when no item break spans the rule", () => {
+      renderSheet();
+
+      fireEvent.click(screen.getByRole("button", { name: "Remove page break" }));
+
+      expect(store.updateLayout).toHaveBeenCalledExactlyOnceWith([
+        [
+          ["summary", "experience", "education", "projects", "publications", "volunteer", "awards"],
+          [
+            "profiles",
+            "skills",
+            "speaking",
+            "languages",
+            "interests",
+            "certifications",
+            "advisory",
+          ],
+        ],
+      ]);
+      expect(writeCount()).toBe(1);
+    });
+
+    it("inserts an item break from the entry pill on a single-flow template", () => {
+      renderSheet({ template: SINGLE_TEMPLATE });
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Insert page break before Senior Frontend Engineer",
+        }),
+      );
+
+      expect(store.updateMetadata).toHaveBeenCalledExactlyOnceWith("itemBreaks", {
+        experience: ["exp-2"],
+      });
+      expect(writeCount()).toBe(1);
+    });
+
+    it("greys the pill action out with a reason on the section's first item", () => {
+      renderSheet({ template: SINGLE_TEMPLATE });
+
+      const button = screen.getByRole("button", {
+        name: `Insert page break before ${FIRST_EXPERIENCE}`,
+      });
+      fireEvent.click(button);
+
+      expect(button.getAttribute("aria-disabled")).toBe("true");
+      expect(writeCount()).toBe(0);
+    });
+
+    it("greys the pill action out with the template tooltip on column layouts", () => {
+      renderSheet({ template: SIDEBAR_TEMPLATE });
+
+      const button = screen.getByRole("button", {
+        name: "Insert page break before Senior Frontend Engineer",
+      });
+      expect(button.getAttribute("aria-disabled")).toBe("true");
+      // The reason is a tooltip wired through aria-describedby, reachable on
+      // keyboard focus as well as hover (owner decision 2026-08-03).
+      const tooltipId = button.getAttribute("aria-describedby");
+      expect(tooltipId).not.toBeNull();
+      const tooltip = document.getElementById(tooltipId as string);
+      expect(tooltip?.getAttribute("role")).toBe("tooltip");
+      expect(tooltip?.textContent).toMatch(/single-flow templates/i);
+
+      fireEvent.click(button);
+      expect(writeCount()).toBe(0);
+    });
+
+    it("splits the layout from the pencil menu's insert-break action", () => {
+      renderSheet();
+
+      openMenu("Education");
+      fireEvent.click(
+        screen.getByRole("menuitem", { name: "Insert page break before Education section" }),
+      );
+
+      expect(store.updateLayout).toHaveBeenCalledExactlyOnceWith([
+        [
+          ["summary", "experience"],
+          ["profiles", "skills", "speaking"],
+        ],
+        [["education", "projects"], []],
+        [
+          ["publications", "volunteer", "awards"],
+          ["languages", "interests", "certifications", "advisory"],
+        ],
+      ]);
+      expect(writeCount()).toBe(1);
+    });
+
+    it("disables the pencil insert-break action when the split changes nothing", () => {
+      // A section already at the very top of a page with nothing beside it:
+      // splitting before it reproduces the same page stack.
+      resume.metadata.layout = [[["summary", "experience", "education"]]];
+      renderSheet({ template: SINGLE_TEMPLATE });
+
+      openMenu("Summary");
+      const item = screen.getByRole("menuitem", {
+        name: "Insert page break before Summary section",
+      });
+      expect((item as HTMLButtonElement).disabled).toBe(true);
+
+      // The same action is live for a section with content above it.
+      fireEvent.keyDown(document, { key: "Escape" });
+      openMenu("Experience");
+      const enabled = screen.getByRole("menuitem", {
+        name: "Insert page break before Experience section",
+      });
+      expect((enabled as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it("drops a moved section's item breaks in the same pagination write", () => {
+      resume.metadata.itemBreaks = { experience: ["exp-2"] };
+      renderSheet({ template: SINGLE_TEMPLATE });
+
+      const source = document.querySelector('[data-section-id="experience"]') as HTMLElement;
+      const target = document.querySelector('[data-section-id="projects"]') as HTMLElement;
+      const data: Record<string, string> = {};
+      const dataTransfer = {
+        data,
+        setData: (mime: string, value: string) => {
+          data[mime] = value;
+        },
+        getData: (mime: string) => data[mime] ?? "",
+        effectAllowed: "",
+        dropEffect: "",
+      };
+      fireEvent.mouseDown(source);
+      fireEvent.dragStart(source, { dataTransfer });
+      fireEvent.dragEnter(target, { dataTransfer, clientY: 0 });
+      fireEvent.drop(target, { dataTransfer, clientY: 0 });
+
+      // One combined write: the new layout and the cleared breaks together
+      // (spec 2.5 - a whole-section move invalidates its mid-section breaks).
+      expect(store.updateLayout).not.toHaveBeenCalled();
+      expect(store.updatePagination).toHaveBeenCalledOnce();
+      const [layout, breaks] = store.updatePagination.mock.calls[0] as [
+        string[][][],
+        Record<string, string[]>,
+      ];
+      expect(layout[0][0]).toEqual(["summary", "education", "experience", "projects"]);
+      expect(breaks).toEqual({});
+      expect(writeCount()).toBe(1);
     });
   });
 

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -73,6 +73,39 @@ function openMenu(title: string): void {
  */
 const FIRST_EXPERIENCE = "Principal Design Systems Engineer";
 
+interface MockDataTransfer {
+  data: Record<string, string>;
+  setData: (mime: string, value: string) => void;
+  getData: (mime: string) => string;
+  effectAllowed: string;
+  dropEffect: string;
+}
+
+function mockDataTransfer(): MockDataTransfer {
+  const data: Record<string, string> = {};
+  return {
+    data,
+    setData: (mime, value) => {
+      data[mime] = value;
+    },
+    getData: (mime) => data[mime] ?? "",
+    effectAllowed: "",
+    dropEffect: "",
+  };
+}
+
+function sectionCard(sectionId: string): HTMLElement {
+  const card = document.querySelector(`[data-section-id="${sectionId}"]`);
+  expect(card).not.toBeNull();
+  return card as HTMLElement;
+}
+
+function entryRow(itemId: string): HTMLElement {
+  const row = document.querySelector(`[data-entry-id="${itemId}"]`);
+  expect(row).not.toBeNull();
+  return row as HTMLElement;
+}
+
 describe("document sheet structural chrome", () => {
   let resume: ResumeData;
 
@@ -473,39 +506,6 @@ describe("document sheet structural chrome", () => {
   });
 
   describe("whole-surface drag and drop", () => {
-    interface MockDataTransfer {
-      data: Record<string, string>;
-      setData: (mime: string, value: string) => void;
-      getData: (mime: string) => string;
-      effectAllowed: string;
-      dropEffect: string;
-    }
-
-    function mockDataTransfer(): MockDataTransfer {
-      const data: Record<string, string> = {};
-      return {
-        data,
-        setData: (mime, value) => {
-          data[mime] = value;
-        },
-        getData: (mime) => data[mime] ?? "",
-        effectAllowed: "",
-        dropEffect: "",
-      };
-    }
-
-    function sectionCard(sectionId: string): HTMLElement {
-      const card = document.querySelector(`[data-section-id="${sectionId}"]`);
-      expect(card).not.toBeNull();
-      return card as HTMLElement;
-    }
-
-    function entryRow(itemId: string): HTMLElement {
-      const row = document.querySelector(`[data-entry-id="${itemId}"]`);
-      expect(row).not.toBeNull();
-      return row as HTMLElement;
-    }
-
     it("makes the whole row and the whole card drag surfaces, grips included", () => {
       renderSheet();
 
@@ -810,18 +810,9 @@ describe("document sheet structural chrome", () => {
       resume.metadata.itemBreaks = { experience: ["exp-2"] };
       renderSheet({ template: SINGLE_TEMPLATE });
 
-      const source = document.querySelector('[data-section-id="experience"]') as HTMLElement;
-      const target = document.querySelector('[data-section-id="projects"]') as HTMLElement;
-      const data: Record<string, string> = {};
-      const dataTransfer = {
-        data,
-        setData: (mime: string, value: string) => {
-          data[mime] = value;
-        },
-        getData: (mime: string) => data[mime] ?? "",
-        effectAllowed: "",
-        dropEffect: "",
-      };
+      const source = sectionCard("experience");
+      const target = sectionCard("projects");
+      const dataTransfer = mockDataTransfer();
       fireEvent.mouseDown(source);
       fireEvent.dragStart(source, { dataTransfer });
       fireEvent.dragEnter(target, { dataTransfer, clientY: 0 });

--- a/apps/web/src/components/doc-editor/docEdits.ts
+++ b/apps/web/src/components/doc-editor/docEdits.ts
@@ -144,23 +144,23 @@ export function reorderItem(sectionId: string, fromIndex: number, toIndex: numbe
   resumeStore.reorderSectionItem(sectionId as SectionKey, fromIndex, toIndex);
 }
 
-/**
- * Move an item between two custom sections — one store action, one undo entry.
- * The only cross-section pair with a shared item shape (see `docDnd.ts`).
- */
-export function moveItemAcrossSections(
-  fromSectionId: string,
-  fromIndex: number,
-  toSectionId: string,
-  toIndex: number,
-): void {
-  if (!isCustomId(fromSectionId) || !isCustomId(toSectionId)) return;
-  resumeStore.moveCustomSectionItem(fromSectionId, fromIndex, toSectionId, toIndex);
-}
-
 /** Replace `metadata.layout` wholesale — one drop, one layout write. */
 export function applyLayout(layout: string[][][]): void {
   resumeStore.updateLayout(layout);
+}
+
+/** Replace `metadata.itemBreaks` wholesale — one break edit, one write. */
+export function applyItemBreaks(itemBreaks: Record<string, string[]>): void {
+  resumeStore.updateMetadata("itemBreaks", itemBreaks);
+}
+
+/**
+ * Replace `metadata.layout` and `metadata.itemBreaks` in a single store
+ * action — the whole-section drop that also invalidates the section's
+ * mid-section breaks must stay one undo entry (spec §2.5).
+ */
+export function applyPagination(layout: string[][][], itemBreaks: Record<string, string[]>): void {
+  resumeStore.updatePagination(layout, itemBreaks);
 }
 
 /**

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -223,10 +223,6 @@
   margin-bottom: 0.4rem;
 }
 
-/* Column drop feedback while a section drag hovers it. */
-.doc-sheet__column--drop {
-  box-shadow: inset 0 0 0 2px var(--doc-sheet-accent);
-}
 
 /* ── Sidebar resize handle (spec §3.2) ──────────────────────────────────── */
 
@@ -457,9 +453,32 @@
   opacity: 0.45;
 }
 
-.doc-sheet__sec--drop {
-  outline: 2px solid var(--doc-sheet-accent);
-  outline-offset: 0.35em;
+/* Whole-surface drags (spec §2.4–§2.5): selection is suppressed instead of
+   preventDefault on mousedown — the pinned Chromium dragstart bug. */
+.doc-sheet__sec--edit {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* 3px accent slot indicators, absolutely positioned so they never shift
+   layout under a stationary pointer (spec §2.5, pinned bug). */
+.doc-sheet__sec-slot {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--doc-sheet-accent);
+  pointer-events: none;
+  z-index: 4;
+}
+
+.doc-sheet__sec-slot--before {
+  top: -5px;
+}
+
+.doc-sheet__sec-slot--after {
+  bottom: -5px;
 }
 
 /* Grip and pencil: ghosts until the card is hovered or focused. */
@@ -689,7 +708,8 @@
 }
 
 .doc-sheet__add-section-block:hover,
-.doc-sheet__add-section-block:focus-visible {
+.doc-sheet__add-section-block:focus-visible,
+.doc-sheet__add-section-block--drop-hint {
   opacity: 1;
   color: var(--doc-sheet-accent);
   border-color: color-mix(in srgb, var(--doc-sheet-accent) 55%, #cfc9bd);
@@ -762,9 +782,39 @@
   opacity: 0.4;
 }
 
-.doc-sheet__entry-row--drop {
-  outline: 2px solid var(--doc-sheet-accent);
-  outline-offset: 2px;
+.doc-sheet__entry-row--edit {
+  user-select: none;
+  -webkit-user-select: none;
+  cursor: grab;
+}
+
+.doc-sheet__entry-row--edit.doc-sheet__entry-row--dragging {
+  cursor: grabbing;
+}
+
+.doc-sheet__entry-row--edit.doc-sheet__entry-row--compact {
+  cursor: pointer;
+}
+
+/* 3px accent slot bars marking the item drop position (spec §2.4); absolute
+   so indicators never shift layout under a stationary pointer. */
+.doc-sheet__entry-slot {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--doc-sheet-accent);
+  pointer-events: none;
+  z-index: 4;
+}
+
+.doc-sheet__entry-slot--before {
+  top: -3px;
+}
+
+.doc-sheet__entry-slot--after {
+  bottom: -3px;
 }
 
 /* Hidden means "not rendered to PDF" — still on the surface, dimmed. */
@@ -1281,16 +1331,46 @@
   border-color: transparent;
 }
 
-/* ── Drag overlay ──────────────────────────────────────────────────────── */
+/* ── Insert-page-break pill control (#796) ─────────────────────────────── */
 
-.doc-sheet__drag-overlay {
-  pointer-events: none;
-  display: inline-block;
-  padding: 0.35rem 0.75rem;
-  font-size: 0.85rem;
-  color: var(--color-ink, inherit);
-  background: var(--color-paper, #fff);
-  border: 1px solid var(--doc-sheet-accent);
+.doc-sheet__entry-act-slot {
+  position: relative;
+  display: inline-flex;
+}
+
+.doc-sheet__break-ico {
+  width: 0.8rem;
+  height: 0.8rem;
+  display: block;
+}
+
+.doc-sheet__entry-act--break[aria-disabled="true"] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* The disabled reason: a tooltip reachable on hover AND keyboard focus
+   (owner decision 2026-08-03 — never hover-only). */
+.doc-sheet__act-tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  right: 0;
+  width: 15rem;
+  padding: 0.4rem 0.55rem;
+  font-size: 0.7rem;
+  line-height: 1.35;
+  text-align: left;
+  color: var(--color-paper, #fff);
+  background: var(--color-ink, #1c1917);
   border-radius: 0.375rem;
   box-shadow: 0 4px 16px var(--color-shadow);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+  z-index: 30;
+}
+
+.doc-sheet__entry-act--break:hover + .doc-sheet__act-tooltip,
+.doc-sheet__entry-act--break:focus-visible + .doc-sheet__act-tooltip {
+  opacity: 1;
 }

--- a/apps/web/src/components/doc-editor/icons.tsx
+++ b/apps/web/src/components/doc-editor/icons.tsx
@@ -31,6 +31,19 @@ export function PencilIcon(): JSX.Element {
   );
 }
 
+/** mdi-format-page-break — the explicit "insert page break" affordances. */
+export function PageBreakIcon(): JSX.Element {
+  return (
+    <svg class="doc-sheet__break-ico" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M9,13H7V11H9V13M13,13H11V11H13V13M17,13H15V11H17V13M21,3H3V10H5V5H19V10H21V3M21,
+          21V14H19V19H5V14H3V21H21Z"
+      />
+    </svg>
+  );
+}
+
 /** The section grip: mdi-drag's 3×3 dot grid. */
 export function DragGridIcon(): JSX.Element {
   const dots = [5.5, 12, 18.5];

--- a/apps/web/src/components/doc-editor/sheetDnd.ts
+++ b/apps/web/src/components/doc-editor/sheetDnd.ts
@@ -1,0 +1,108 @@
+/**
+ * The sheet's whole-surface drag channels (#796, spec §2.4–§2.5).
+ *
+ * Native HTML5 drag and drop, exactly as the spec pins it: two channels with
+ * their own MIME types (`application/x-section` cards across columns and
+ * pages, `application/x-entry` rows within one section), mirrored in reactive
+ * signals so slot indicators and opacity styling follow the drag. `DocSheet`
+ * provides the context and owns drop resolution; rows and cards register the
+ * events and read the signals.
+ *
+ * Pinned constraints (spec §2.4):
+ * - never `preventDefault` on `mousedown` of a drag surface — it kills the
+ *   Chromium dragstart. Selection is suppressed via `user-select: none`.
+ * - a drag that *started* on a control is vetoed in `dragstart` instead, so
+ *   controls keep their native behavior ({@link dragStartVetoed}).
+ * - grip drags `stopPropagation` so the surface doesn't double-fire; entry
+ *   rows claim their presses before the section card sees them.
+ */
+
+import { createContext, useContext, type Accessor } from "solid-js";
+import type { SectionPlacement } from "../../lib/docLayout";
+
+/** MIME type of an item-row drag (spec §2.4). */
+export const ENTRY_DRAG_MIME = "application/x-entry";
+/** MIME type of a section-card drag (spec §2.5). */
+export const SECTION_DRAG_MIME = "application/x-section";
+
+/** What an item drag carries. */
+export interface EntryDragPayload {
+  sectionId: string;
+  id: string;
+}
+
+/** Where an item drop would land: an insert-before index into `items`. */
+export interface EntryDropTarget {
+  sectionId: string;
+  index: number;
+}
+
+/** Where a section drop would land, in pre-removal raw-layout coordinates. */
+export interface SectionDropTarget {
+  page: number;
+  column: number;
+  index: number;
+}
+
+/** The drag state and drop resolution the sheet shares with rows and cards. */
+export interface SheetDndValue {
+  /** The item in flight, or `null`. */
+  entryDrag: Accessor<EntryDragPayload | null>;
+  setEntryDrag: (drag: EntryDragPayload | null) => void;
+  /** Where the item drag would drop, for the slot indicators. */
+  entryDropAt: Accessor<EntryDropTarget | null>;
+  setEntryDropAt: (target: EntryDropTarget | null) => void;
+  /** The section card in flight, or `null`. */
+  sectionDrag: Accessor<string | null>;
+  setSectionDrag: (sectionId: string | null) => void;
+  /** Where the section drag would drop, for the slot indicators. */
+  sectionDropAt: Accessor<SectionDropTarget | null>;
+  setSectionDropAt: (target: SectionDropTarget | null) => void;
+  /** Raw-layout placement of a drawn card — what its drop target addresses. */
+  sectionPlacement: (sectionId: string) => SectionPlacement | null;
+  /** How many sections the raw layout stores in a column (after-slot check). */
+  columnLength: (page: number, column: number) => number;
+  /** Resolve a finished item drop to at most one store action. */
+  onEntryDrop: (payload: EntryDragPayload, dropIndex: number) => void;
+  /** Resolve a finished section drop to at most one store action. */
+  onSectionDrop: (sectionId: string, target: SectionDropTarget) => void;
+}
+
+export const SheetDndContext = createContext<SheetDndValue>();
+
+/** The surrounding sheet's drag channels; `null` outside a `DocSheet`. */
+export function useSheetDnd(): SheetDndValue | null {
+  return useContext(SheetDndContext) ?? null;
+}
+
+/**
+ * Whether a drag that began on `pressTarget` must be vetoed so the control
+ * keeps its native behavior (spec §2.4). `extraVeto` extends the list — the
+ * section card adds the entry-row class, because presses on rows belong to
+ * the entry drag.
+ */
+export function dragStartVetoed(pressTarget: Element | null, extraVeto = ""): boolean {
+  if (!pressTarget) return false;
+  const selectors = 'button, input, textarea, select, [contenteditable="true"]';
+  return pressTarget.closest(extraVeto === "" ? selectors : `${selectors}, ${extraVeto}`) !== null;
+}
+
+/**
+ * The insert-before drop index a pointer position means: the row or card's
+ * own index, `+1` when the pointer is in its bottom half (spec §2.4).
+ */
+export function dropIndexFromPointer(event: DragEvent, index: number): number {
+  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+  return index + (event.clientY > rect.top + rect.height / 2 ? 1 : 0);
+}
+
+/** Parse a drag payload of `mime` from the event, or `null`. */
+export function readDragPayload<T>(event: DragEvent, mime: string): T | null {
+  const raw = event.dataTransfer?.getData(mime) ?? "";
+  if (raw === "") return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/__tests__/docDnd.test.ts
+++ b/apps/web/src/lib/__tests__/docDnd.test.ts
@@ -1,18 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
-  adjacentCustomSectionId,
-  canMoveEntryAcross,
   drawnSectionPosition,
   entryStep,
   moveSectionInLayout,
   moveSectionStep,
-  resolveEntryDrop,
+  resolveEntryDropIndex,
   resolveSectionDropOnColumn,
   resolveSectionDropOnSection,
   sectionItemList,
   type EntryListItem,
 } from "../docDnd";
-import { editorPages, layoutPages } from "../docLayout";
+import { layoutPages } from "../docLayout";
+import { editorSheetPages } from "../docPagination";
 import { loadDocEditorFixture, SIDEBAR_TEMPLATE } from "../../test/docEditorFixture";
 
 /** The fixture's stored layout: two pages of two columns each. */
@@ -80,10 +79,20 @@ describe("moveSectionInLayout", () => {
     expect(moveSectionInLayout(LAYOUT, "missing", { page: 0, column: 0, index: 0 })).toBeNull();
   });
 
-  it("returns null for out-of-range targets", () => {
+  it("returns null for negative targets", () => {
     expect(moveSectionInLayout(LAYOUT, "summary", { page: -1, column: 0, index: 0 })).toBeNull();
     expect(moveSectionInLayout(LAYOUT, "summary", { page: 0, column: -1, index: 0 })).toBeNull();
-    expect(moveSectionInLayout(LAYOUT, "summary", { page: 5, column: 0, index: 0 })).toBeNull();
+  });
+
+  it("auto-creates missing pages for a target past the end, pruning empties", () => {
+    // Item-break continuations draw more sheets than the raw layout stores
+    // (spec §3.3); a drop on such a sheet targets a raw page that does not
+    // exist yet. Pages created only as scaffolding are pruned, so the section
+    // lands on the first fresh page after the existing content.
+    const next = moveSectionInLayout(LAYOUT, "summary", { page: 5, column: 0, index: 0 });
+
+    expect(next).toHaveLength(3);
+    expect(next?.[2]).toEqual([["summary"], []]);
   });
 
   it("never mutates its input", () => {
@@ -229,107 +238,29 @@ describe("drawnSectionPosition", () => {
   });
 });
 
-describe("canMoveEntryAcross", () => {
-  it("permits custom-to-custom only — the one pair with a shared item shape", () => {
-    expect(canMoveEntryAcross("speaking", "advisory")).toBe(true);
-    expect(canMoveEntryAcross("speaking", "speaking")).toBe(false);
-    expect(canMoveEntryAcross("experience", "education")).toBe(false);
-    expect(canMoveEntryAcross("speaking", "experience")).toBe(false);
-    expect(canMoveEntryAcross("experience", "speaking")).toBe(false);
-  });
-});
-
-describe("resolveEntryDrop", () => {
+describe("resolveEntryDropIndex", () => {
   const list = items("a", "b", "c");
 
-  it("reorders within a section, landing on the target's index", () => {
-    expect(
-      resolveEntryDrop({
-        fromSectionId: "experience",
-        fromItems: list,
-        itemId: "a",
-        toSectionId: "experience",
-        toItems: list,
-        targetItemId: "c",
-      }),
-    ).toEqual({ kind: "reorder", sectionId: "experience", fromIndex: 0, toIndex: 2 });
+  it("maps an insert-before drop index to the store's reorder pair", () => {
+    // Dropping "a" below "c" (pointer in the bottom half -> index 3).
+    expect(resolveEntryDropIndex(list, "a", 3)).toEqual({ fromIndex: 0, toIndex: 2 });
+    // Dropping "c" above "a" (top half -> index 0).
+    expect(resolveEntryDropIndex(list, "c", 0)).toEqual({ fromIndex: 2, toIndex: 0 });
   });
 
-  it("reorders to the end when dropped on the section itself", () => {
-    expect(
-      resolveEntryDrop({
-        fromSectionId: "experience",
-        fromItems: list,
-        itemId: "a",
-        toSectionId: "experience",
-        toItems: list,
-        targetItemId: null,
-      }),
-    ).toEqual({ kind: "reorder", sectionId: "experience", fromIndex: 0, toIndex: 2 });
-  });
-
-  it("moves across custom sections", () => {
-    expect(
-      resolveEntryDrop({
-        fromSectionId: "speaking",
-        fromItems: list,
-        itemId: "b",
-        toSectionId: "advisory",
-        toItems: items("x"),
-        targetItemId: "x",
-      }),
-    ).toEqual({
-      kind: "move",
-      fromSectionId: "speaking",
-      fromIndex: 1,
-      toSectionId: "advisory",
-      toIndex: 0,
-    });
-  });
-
-  it("appends when dropped on the target section itself", () => {
-    expect(
-      resolveEntryDrop({
-        fromSectionId: "speaking",
-        fromItems: list,
-        itemId: "b",
-        toSectionId: "advisory",
-        toItems: items("x"),
-        targetItemId: null,
-      }),
-    ).toEqual({
-      kind: "move",
-      fromSectionId: "speaking",
-      fromIndex: 1,
-      toSectionId: "advisory",
-      toIndex: 1,
-    });
+  it("accounts for the removal shifting later positions down", () => {
+    // Dropping "a" above "c" means landing at index 1 once "a" is removed.
+    expect(resolveEntryDropIndex(list, "a", 2)).toEqual({ fromIndex: 0, toIndex: 1 });
   });
 
   it("returns null for a drop that changes nothing", () => {
-    expect(
-      resolveEntryDrop({
-        fromSectionId: "experience",
-        fromItems: list,
-        itemId: "b",
-        toSectionId: "experience",
-        toItems: list,
-        targetItemId: "b",
-      }),
-    ).toBeNull();
+    expect(resolveEntryDropIndex(list, "b", 1)).toBeNull();
+    expect(resolveEntryDropIndex(list, "b", 2)).toBeNull();
   });
 
-  it("returns null for an incompatible cross-section drop", () => {
-    expect(
-      resolveEntryDrop({
-        fromSectionId: "experience",
-        fromItems: list,
-        itemId: "a",
-        toSectionId: "education",
-        toItems: items("x"),
-        targetItemId: "x",
-      }),
-    ).toBeNull();
+  it("returns null for an unknown item and clamps out-of-range indices", () => {
+    expect(resolveEntryDropIndex(list, "missing", 0)).toBeNull();
+    expect(resolveEntryDropIndex(list, "a", 99)).toEqual({ fromIndex: 0, toIndex: 2 });
   });
 });
 
@@ -348,19 +279,6 @@ describe("entryStep", () => {
   });
 });
 
-describe("adjacentCustomSectionId", () => {
-  it("walks custom sections in flattened layout order", () => {
-    expect(adjacentCustomSectionId(LAYOUT, "speaking", "next")).toBe("advisory");
-    expect(adjacentCustomSectionId(LAYOUT, "advisory", "previous")).toBe("speaking");
-  });
-
-  it("returns null at the ends and for unknown sections", () => {
-    expect(adjacentCustomSectionId(LAYOUT, "speaking", "previous")).toBeNull();
-    expect(adjacentCustomSectionId(LAYOUT, "advisory", "next")).toBeNull();
-    expect(adjacentCustomSectionId(LAYOUT, "experience", "next")).toBeNull();
-  });
-});
-
 describe("sectionItemList", () => {
   it("reads fixed and custom sections through the shared item shape", () => {
     const resume = loadDocEditorFixture();
@@ -371,12 +289,12 @@ describe("sectionItemList", () => {
   });
 });
 
-describe("editorPages", () => {
+describe("editorSheetPages", () => {
   it("stays aligned index-for-index with layoutPages", () => {
     const resume = loadDocEditorFixture();
 
     const layout = layoutPages(resume, SIDEBAR_TEMPLATE);
-    const drawn = editorPages(resume, SIDEBAR_TEMPLATE);
+    const drawn = editorSheetPages(resume, SIDEBAR_TEMPLATE);
 
     expect(drawn).toHaveLength(layout.length);
     drawn.forEach((page, pageIndex) => {
@@ -388,7 +306,7 @@ describe("editorPages", () => {
     const resume = loadDocEditorFixture();
     resume.sections.experience.visible = false;
 
-    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
+    const drawn = editorSheetPages(resume, SIDEBAR_TEMPLATE).flat(2);
 
     expect(drawn).not.toContain("experience");
   });
@@ -399,7 +317,7 @@ describe("editorPages", () => {
       item.visible = false;
     }
 
-    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
+    const drawn = editorSheetPages(resume, SIDEBAR_TEMPLATE).flat(2);
 
     expect(drawn).toContain("experience");
   });
@@ -408,7 +326,7 @@ describe("editorPages", () => {
     const resume = loadDocEditorFixture();
     resume.sections.experience.items = [];
 
-    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
+    const drawn = editorSheetPages(resume, SIDEBAR_TEMPLATE).flat(2);
 
     expect(drawn).toContain("experience");
   });
@@ -418,7 +336,7 @@ describe("editorPages", () => {
     resume.sections.summary.content = "";
     resume.sections.summary.visible = true;
 
-    const drawn = editorPages(resume, SIDEBAR_TEMPLATE).flat(2);
+    const drawn = editorSheetPages(resume, SIDEBAR_TEMPLATE).flat(2);
 
     expect(drawn).toContain("summary");
   });

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -10,12 +10,12 @@ import {
   layoutPages,
   mergePageIntoPrevious,
   nextId,
-  renderPages,
   SECTION_LABELS,
   sectionTitle,
   sectionVisible,
   type TemplateLayout,
 } from "../docLayout";
+import { renderSheetPages } from "../docPagination";
 import {
   HEADER_SPLIT_TEMPLATE,
   loadDocEditorFixture as loadFixture,
@@ -123,11 +123,11 @@ describe("layoutPages", () => {
   });
 });
 
-describe("renderPages", () => {
+describe("renderSheetPages (no item breaks)", () => {
   it("drops hidden sections", () => {
     const resume = loadFixture();
 
-    const pages = renderPages(resume, SIDEBAR_TEMPLATE);
+    const pages = renderSheetPages(resume, SIDEBAR_TEMPLATE);
 
     // `advisory` is a custom section with `visible: false`.
     expect(pages[1][1]).toEqual(["languages", "interests", "certifications"]);
@@ -138,7 +138,7 @@ describe("renderPages", () => {
     resume.sections.awards.items = [];
     resume.metadata.layout = [[["awards", "experience"]]];
 
-    expect(renderPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
+    expect(renderSheetPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
   });
 
   it("drops a section whose items are all hidden", () => {
@@ -149,27 +149,27 @@ describe("renderPages", () => {
     }));
     resume.metadata.layout = [[["publications", "experience"]]];
 
-    expect(renderPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
+    expect(renderSheetPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
   });
 
   it("keeps a column emptied by filtering so column indices stay stable", () => {
     const resume = loadFixture();
     resume.metadata.layout = [[["experience"], ["advisory"]]];
 
-    expect(renderPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"], []]]);
+    expect(renderSheetPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"], []]]);
   });
 
   it("removes a page left empty by filtering", () => {
     const resume = loadFixture();
     resume.metadata.layout = [[["experience"]], [["references", "advisory"]]];
 
-    expect(renderPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
+    expect(renderSheetPages(resume, SIDEBAR_TEMPLATE)).toEqual([[["experience"]]]);
   });
 
   it("keeps a page that still has content", () => {
     const resume = loadFixture();
 
-    const pages = renderPages(resume, SIDEBAR_TEMPLATE);
+    const pages = renderSheetPages(resume, SIDEBAR_TEMPLATE);
 
     expect(pages).toHaveLength(2);
     expect(pages[0][0]).toEqual(["summary", "experience", "education", "projects"]);

--- a/apps/web/src/lib/__tests__/docPagination.test.ts
+++ b/apps/web/src/lib/__tests__/docPagination.test.ts
@@ -21,8 +21,8 @@ import {
 } from "../../test/docEditorFixture";
 import type { ResumeData } from "../../wasm/types";
 
-/** The fixture on a single-flow template, the only layout that honors breaks. */
-function loadSingleFlowFixture(breaks?: Record<string, string[]>): ResumeData {
+/** The shared doc-editor fixture, optionally seeded with break markers. */
+function loadBreakFixture(breaks?: Record<string, string[]>): ResumeData {
   const resume = loadDocEditorFixture();
   if (breaks !== undefined) {
     resume.metadata.itemBreaks = breaks;
@@ -69,19 +69,19 @@ describe("itemSlices", () => {
 
 describe("orderedItemBreaks", () => {
   it("orders markers by item position and drops unknown ids", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-3", "exp-2", "ghost"] });
+    const resume = loadBreakFixture({ experience: ["exp-3", "exp-2", "ghost"] });
 
     expect(orderedItemBreaks(resume, "experience", true)).toEqual(["exp-2", "exp-3"]);
   });
 
   it("ignores markers on sections that cannot carry them", () => {
-    const resume = loadSingleFlowFixture({ skills: ["skill-1"] });
+    const resume = loadBreakFixture({ skills: ["skill-1"] });
 
     expect(orderedItemBreaks(resume, "skills", true)).toEqual([]);
   });
 
   it("drops a hidden item's marker when hidden items are not drawn", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+    const resume = loadBreakFixture({ experience: ["exp-2"] });
     resume.sections.experience.items[1].visible = false;
 
     expect(orderedItemBreaks(resume, "experience", false)).toEqual([]);
@@ -91,7 +91,7 @@ describe("orderedItemBreaks", () => {
 
 describe("expandItemBreakPages", () => {
   it("places a broken section on consecutive pages in the same column", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+    const resume = loadBreakFixture({ experience: ["exp-2"] });
 
     const pages = expandItemBreakPages(resume, SINGLE_TEMPLATE, true);
 
@@ -101,7 +101,7 @@ describe("expandItemBreakPages", () => {
   });
 
   it("creates missing pages for trailing continuations", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2", "exp-3"] });
+    const resume = loadBreakFixture({ experience: ["exp-2", "exp-3"] });
     resume.metadata.layout = [[["summary", "experience"]]];
 
     const pages = expandItemBreakPages(resume, SINGLE_TEMPLATE, true);
@@ -112,7 +112,7 @@ describe("expandItemBreakPages", () => {
   });
 
   it("expands nothing on templates whose layout cannot honor breaks", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+    const resume = loadBreakFixture({ experience: ["exp-2"] });
 
     const pages = expandItemBreakPages(resume, SIDEBAR_TEMPLATE, true);
 
@@ -122,7 +122,7 @@ describe("expandItemBreakPages", () => {
 
 describe("sectionSliceAt", () => {
   it("names each instance's items, index and last-ness", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+    const resume = loadBreakFixture({ experience: ["exp-2"] });
 
     const first = sectionSliceAt(resume, SINGLE_TEMPLATE, "experience", 0, 0, true);
     const second = sectionSliceAt(resume, SINGLE_TEMPLATE, "experience", 1, 0, true);
@@ -132,7 +132,7 @@ describe("sectionSliceAt", () => {
   });
 
   it("returns null for unbroken sections and unsupported templates", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+    const resume = loadBreakFixture({ experience: ["exp-2"] });
 
     expect(sectionSliceAt(resume, SINGLE_TEMPLATE, "education", 0, 0, true)).toBeNull();
     expect(sectionSliceAt(resume, SIDEBAR_TEMPLATE, "experience", 0, 0, true)).toBeNull();
@@ -141,7 +141,7 @@ describe("sectionSliceAt", () => {
 
 describe("renderSheetPages / editorSheetPages with breaks", () => {
   it("draws the continuation in both modes", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+    const resume = loadBreakFixture({ experience: ["exp-2"] });
 
     for (const pages of [
       renderSheetPages(resume, SINGLE_TEMPLATE),
@@ -153,7 +153,7 @@ describe("renderSheetPages / editorSheetPages with breaks", () => {
   });
 
   it("drops only trailing empty pages so drawn indices stay aligned", () => {
-    const resume = loadSingleFlowFixture();
+    const resume = loadBreakFixture();
     resume.metadata.layout = [[["experience"]], [["references"]], [["education"]]];
     // References holds items in the fixture; hide the section so page 1
     // renders empty mid-stack.
@@ -168,7 +168,7 @@ describe("renderSheetPages / editorSheetPages with breaks", () => {
 
 describe("itemBreaksWithBreakBefore", () => {
   it("appends a marker for a breakable item", () => {
-    const resume = loadSingleFlowFixture();
+    const resume = loadBreakFixture();
 
     expect(itemBreaksWithBreakBefore(resume, SINGLE_TEMPLATE, "experience", "exp-2")).toEqual({
       experience: ["exp-2"],
@@ -176,7 +176,7 @@ describe("itemBreaksWithBreakBefore", () => {
   });
 
   it("returns null for inert markers: first item, duplicates, guards", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+    const resume = loadBreakFixture({ experience: ["exp-2"] });
 
     expect(itemBreaksWithBreakBefore(resume, SINGLE_TEMPLATE, "experience", "exp-1")).toBeNull();
     expect(itemBreaksWithBreakBefore(resume, SINGLE_TEMPLATE, "experience", "exp-2")).toBeNull();
@@ -226,7 +226,7 @@ describe("splitLayoutBeforeSection", () => {
 
 describe("resolvePageBreakRemoval", () => {
   it("prefers clearing the item break shared across the boundary", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+    const resume = loadBreakFixture({ experience: ["exp-2"] });
 
     const removal = resolvePageBreakRemoval(resume, SINGLE_TEMPLATE, 1);
 
@@ -234,7 +234,7 @@ describe("resolvePageBreakRemoval", () => {
   });
 
   it("clears only the responsible marker of a multi-break section", () => {
-    const resume = loadSingleFlowFixture({ experience: ["exp-2", "exp-3"] });
+    const resume = loadBreakFixture({ experience: ["exp-2", "exp-3"] });
     resume.metadata.layout = [[["summary", "experience"]]];
 
     const removal = resolvePageBreakRemoval(resume, SINGLE_TEMPLATE, 1);
@@ -246,7 +246,7 @@ describe("resolvePageBreakRemoval", () => {
   });
 
   it("falls back to merging the raw pages column-wise", () => {
-    const resume = loadSingleFlowFixture();
+    const resume = loadBreakFixture();
 
     const removal = resolvePageBreakRemoval(resume, SIDEBAR_TEMPLATE, 1);
 
@@ -270,7 +270,7 @@ describe("resolvePageBreakRemoval", () => {
   });
 
   it("returns null for page 0 and out-of-range pages", () => {
-    const resume = loadSingleFlowFixture();
+    const resume = loadBreakFixture();
 
     expect(resolvePageBreakRemoval(resume, SIDEBAR_TEMPLATE, 0)).toBeNull();
     expect(resolvePageBreakRemoval(resume, SIDEBAR_TEMPLATE, 9)).toBeNull();

--- a/apps/web/src/lib/__tests__/docPagination.test.ts
+++ b/apps/web/src/lib/__tests__/docPagination.test.ts
@@ -292,4 +292,14 @@ describe("sanitizedItemBreaks", () => {
     expect(sanitizedItemBreaks(undefined)).toBeNull();
     expect(sanitizedItemBreaks({ experience: ["exp-2"] })).toBeNull();
   });
+
+  it("repairs a malformed field to no breaks", () => {
+    // Loaded documents can carry any shape here (imports, old clients).
+    expect(sanitizedItemBreaks(null)).toEqual({});
+    expect(sanitizedItemBreaks(["experience"])).toEqual({});
+    expect(sanitizedItemBreaks("experience")).toEqual({});
+    expect(sanitizedItemBreaks({ experience: "exp-2" })).toEqual({});
+    // Non-string markers drop the whole entry rather than half a list.
+    expect(sanitizedItemBreaks({ experience: [1, "exp-2"] })).toEqual({});
+  });
 });

--- a/apps/web/src/lib/__tests__/docPagination.test.ts
+++ b/apps/web/src/lib/__tests__/docPagination.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest";
+import {
+  editorSheetPages,
+  expandItemBreakPages,
+  itemBreaksWithBreakBefore,
+  itemBreaksWithoutSection,
+  itemSlices,
+  orderedItemBreaks,
+  renderSheetPages,
+  resolvePageBreakRemoval,
+  sanitizedItemBreaks,
+  sectionSliceAt,
+  sectionSupportsItemBreaks,
+  splitLayoutBeforeSection,
+  templateSupportsItemBreaks,
+} from "../docPagination";
+import {
+  loadDocEditorFixture,
+  SIDEBAR_TEMPLATE,
+  SINGLE_TEMPLATE,
+} from "../../test/docEditorFixture";
+import type { ResumeData } from "../../wasm/types";
+
+/** The fixture on a single-flow template, the only layout that honors breaks. */
+function loadSingleFlowFixture(breaks?: Record<string, string[]>): ResumeData {
+  const resume = loadDocEditorFixture();
+  if (breaks !== undefined) {
+    resume.metadata.itemBreaks = breaks;
+  }
+  return resume;
+}
+
+describe("sectionSupportsItemBreaks", () => {
+  it("allows main-flow sections only (spec §3.4 guard)", () => {
+    expect(sectionSupportsItemBreaks("experience")).toBe(true);
+    expect(sectionSupportsItemBreaks("references")).toBe(true);
+    expect(sectionSupportsItemBreaks("skills")).toBe(false);
+    expect(sectionSupportsItemBreaks("profiles")).toBe(false);
+    expect(sectionSupportsItemBreaks("summary")).toBe(false);
+    expect(sectionSupportsItemBreaks("speaking")).toBe(false);
+  });
+});
+
+describe("templateSupportsItemBreaks", () => {
+  it("is true for single-flow templates only — Typst cannot break a grid", () => {
+    expect(templateSupportsItemBreaks(SINGLE_TEMPLATE)).toBe(true);
+    expect(templateSupportsItemBreaks(SIDEBAR_TEMPLATE)).toBe(false);
+  });
+});
+
+describe("itemSlices", () => {
+  it("starts a new slice at every marker", () => {
+    expect(itemSlices(["a", "b", "c", "d"], ["c"])).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+    expect(itemSlices(["a", "b", "c"], ["b", "c"])).toEqual([["a"], ["b"], ["c"]]);
+  });
+
+  it("treats a marker on the first item as inert — slices are never empty", () => {
+    expect(itemSlices(["a", "b"], ["a"])).toEqual([["a", "b"]]);
+  });
+
+  it("passes empty inputs through", () => {
+    expect(itemSlices([], ["a"])).toEqual([[]]);
+    expect(itemSlices(["a"], [])).toEqual([["a"]]);
+  });
+});
+
+describe("orderedItemBreaks", () => {
+  it("orders markers by item position and drops unknown ids", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-3", "exp-2", "ghost"] });
+
+    expect(orderedItemBreaks(resume, "experience", true)).toEqual(["exp-2", "exp-3"]);
+  });
+
+  it("ignores markers on sections that cannot carry them", () => {
+    const resume = loadSingleFlowFixture({ skills: ["skill-1"] });
+
+    expect(orderedItemBreaks(resume, "skills", true)).toEqual([]);
+  });
+
+  it("drops a hidden item's marker when hidden items are not drawn", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+    resume.sections.experience.items[1].visible = false;
+
+    expect(orderedItemBreaks(resume, "experience", false)).toEqual([]);
+    expect(orderedItemBreaks(resume, "experience", true)).toEqual(["exp-2"]);
+  });
+});
+
+describe("expandItemBreakPages", () => {
+  it("places a broken section on consecutive pages in the same column", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+
+    const pages = expandItemBreakPages(resume, SINGLE_TEMPLATE, true);
+
+    expect(pages[0][0]).toContain("experience");
+    // The continuation is prepended to the next page's same column.
+    expect(pages[1][0][0]).toBe("experience");
+  });
+
+  it("creates missing pages for trailing continuations", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2", "exp-3"] });
+    resume.metadata.layout = [[["summary", "experience"]]];
+
+    const pages = expandItemBreakPages(resume, SINGLE_TEMPLATE, true);
+
+    expect(pages).toHaveLength(3);
+    expect(pages[1][0]).toEqual(["experience"]);
+    expect(pages[2][0]).toEqual(["experience"]);
+  });
+
+  it("expands nothing on templates whose layout cannot honor breaks", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+
+    const pages = expandItemBreakPages(resume, SIDEBAR_TEMPLATE, true);
+
+    expect(pages.flat(2).filter((id) => id === "experience")).toHaveLength(1);
+  });
+});
+
+describe("sectionSliceAt", () => {
+  it("names each instance's items, index and last-ness", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+
+    const first = sectionSliceAt(resume, SINGLE_TEMPLATE, "experience", 0, 0, true);
+    const second = sectionSliceAt(resume, SINGLE_TEMPLATE, "experience", 1, 0, true);
+
+    expect(first).toEqual({ index: 0, itemIds: ["exp-1"], isLast: false });
+    expect(second).toEqual({ index: 1, itemIds: ["exp-2", "exp-3"], isLast: true });
+  });
+
+  it("returns null for unbroken sections and unsupported templates", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+
+    expect(sectionSliceAt(resume, SINGLE_TEMPLATE, "education", 0, 0, true)).toBeNull();
+    expect(sectionSliceAt(resume, SIDEBAR_TEMPLATE, "experience", 0, 0, true)).toBeNull();
+  });
+});
+
+describe("renderSheetPages / editorSheetPages with breaks", () => {
+  it("draws the continuation in both modes", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+
+    for (const pages of [
+      renderSheetPages(resume, SINGLE_TEMPLATE),
+      editorSheetPages(resume, SINGLE_TEMPLATE),
+    ]) {
+      expect(pages[0][0]).toContain("experience");
+      expect(pages[1][0][0]).toBe("experience");
+    }
+  });
+
+  it("drops only trailing empty pages so drawn indices stay aligned", () => {
+    const resume = loadSingleFlowFixture();
+    resume.metadata.layout = [[["experience"]], [["references"]], [["education"]]];
+    // References holds items in the fixture; hide the section so page 1
+    // renders empty mid-stack.
+    resume.sections.references.visible = false;
+
+    const pages = renderSheetPages(resume, SINGLE_TEMPLATE);
+
+    expect(pages).toHaveLength(3);
+    expect(pages[1]).toEqual([[]]);
+  });
+});
+
+describe("itemBreaksWithBreakBefore", () => {
+  it("appends a marker for a breakable item", () => {
+    const resume = loadSingleFlowFixture();
+
+    expect(itemBreaksWithBreakBefore(resume, SINGLE_TEMPLATE, "experience", "exp-2")).toEqual({
+      experience: ["exp-2"],
+    });
+  });
+
+  it("returns null for inert markers: first item, duplicates, guards", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+
+    expect(itemBreaksWithBreakBefore(resume, SINGLE_TEMPLATE, "experience", "exp-1")).toBeNull();
+    expect(itemBreaksWithBreakBefore(resume, SINGLE_TEMPLATE, "experience", "exp-2")).toBeNull();
+    expect(itemBreaksWithBreakBefore(resume, SINGLE_TEMPLATE, "experience", "ghost")).toBeNull();
+    expect(itemBreaksWithBreakBefore(resume, SINGLE_TEMPLATE, "skills", "skill-1")).toBeNull();
+    expect(itemBreaksWithBreakBefore(resume, SIDEBAR_TEMPLATE, "experience", "exp-3")).toBeNull();
+  });
+});
+
+describe("itemBreaksWithoutSection", () => {
+  it("removes the section's markers and reports no-ops as null", () => {
+    expect(
+      itemBreaksWithoutSection({ experience: ["exp-2"], education: ["edu-2"] }, "experience"),
+    ).toEqual({ education: ["edu-2"] });
+    expect(itemBreaksWithoutSection({ education: ["edu-2"] }, "experience")).toBeNull();
+    expect(itemBreaksWithoutSection(undefined, "experience")).toBeNull();
+  });
+});
+
+describe("splitLayoutBeforeSection", () => {
+  const layout = [
+    [
+      ["summary", "experience", "education"],
+      ["profiles", "skills"],
+    ],
+  ];
+
+  it("moves the section and its column tail to a fresh page", () => {
+    expect(splitLayoutBeforeSection(layout, "experience")).toEqual([
+      [["summary"], ["profiles", "skills"]],
+      [["experience", "education"], []],
+    ]);
+  });
+
+  it("splits a whole column away when the page keeps other content", () => {
+    expect(splitLayoutBeforeSection(layout, "summary")).toEqual([
+      [[], ["profiles", "skills"]],
+      [["summary", "experience", "education"], []],
+    ]);
+  });
+
+  it("returns null when the split reproduces the same stack", () => {
+    expect(splitLayoutBeforeSection([[["summary", "experience"]]], "summary")).toBeNull();
+    expect(splitLayoutBeforeSection(layout, "missing")).toBeNull();
+  });
+});
+
+describe("resolvePageBreakRemoval", () => {
+  it("prefers clearing the item break shared across the boundary", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2"] });
+
+    const removal = resolvePageBreakRemoval(resume, SINGLE_TEMPLATE, 1);
+
+    expect(removal).toEqual({ kind: "itemBreaks", itemBreaks: {} });
+  });
+
+  it("clears only the responsible marker of a multi-break section", () => {
+    const resume = loadSingleFlowFixture({ experience: ["exp-2", "exp-3"] });
+    resume.metadata.layout = [[["summary", "experience"]]];
+
+    const removal = resolvePageBreakRemoval(resume, SINGLE_TEMPLATE, 1);
+
+    expect(removal).toEqual({
+      kind: "itemBreaks",
+      itemBreaks: { experience: ["exp-3"] },
+    });
+  });
+
+  it("falls back to merging the raw pages column-wise", () => {
+    const resume = loadSingleFlowFixture();
+
+    const removal = resolvePageBreakRemoval(resume, SIDEBAR_TEMPLATE, 1);
+
+    expect(removal).toEqual({
+      kind: "layout",
+      layout: [
+        [
+          ["summary", "experience", "education", "projects", "publications", "volunteer", "awards"],
+          [
+            "profiles",
+            "skills",
+            "speaking",
+            "languages",
+            "interests",
+            "certifications",
+            "advisory",
+          ],
+        ],
+      ],
+    });
+  });
+
+  it("returns null for page 0 and out-of-range pages", () => {
+    const resume = loadSingleFlowFixture();
+
+    expect(resolvePageBreakRemoval(resume, SIDEBAR_TEMPLATE, 0)).toBeNull();
+    expect(resolvePageBreakRemoval(resume, SIDEBAR_TEMPLATE, 9)).toBeNull();
+  });
+});
+
+describe("sanitizedItemBreaks", () => {
+  it("strips non-main-flow sections and empty marker lists", () => {
+    expect(
+      sanitizedItemBreaks({
+        experience: ["exp-2"],
+        skills: ["skill-1"],
+        education: [],
+      }),
+    ).toEqual({ experience: ["exp-2"] });
+  });
+
+  it("returns null when nothing needed stripping", () => {
+    expect(sanitizedItemBreaks(undefined)).toBeNull();
+    expect(sanitizedItemBreaks({ experience: ["exp-2"] })).toBeNull();
+  });
+});

--- a/apps/web/src/lib/docDnd.ts
+++ b/apps/web/src/lib/docDnd.ts
@@ -83,13 +83,18 @@ export function moveSectionInLayout(
 
   // Auto-create missing pages (spec §2.5): item-break continuations can draw
   // more sheets than the raw layout stores, and a drop on one of those sheets
-  // targets a raw page that does not exist yet.
-  while (target.page >= next.length) {
+  // targets a raw page that does not exist yet. The target is clamped to one
+  // page past the current count — the only reachable new page, and empty
+  // scaffolding pages would be pruned anyway — so a sentinel-sized page value
+  // (the shape's `index` already uses `MAX_SAFE_INTEGER`) cannot allocate
+  // unboundedly.
+  const targetPage = Math.min(target.page, next.length);
+  while (targetPage >= next.length) {
     const columnCount = Math.max(1, next[next.length - 1]?.length ?? 1);
     next.push(Array.from({ length: columnCount }, () => []));
   }
 
-  const page = next[target.page];
+  const page = next[targetPage];
   // A template can draw more columns than the stored layout carries (a sidebar
   // page stored as one column, say); dropping on such a column materializes it.
   while (page.length <= target.column) {
@@ -99,7 +104,7 @@ export function moveSectionInLayout(
 
   let index = target.index;
   if (
-    target.page === placement.page &&
+    targetPage === placement.page &&
     target.column === placement.column &&
     placement.index < index
   ) {

--- a/apps/web/src/lib/docDnd.ts
+++ b/apps/web/src/lib/docDnd.ts
@@ -36,17 +36,6 @@ export interface EntryListItem {
   visible: boolean;
 }
 
-/** A resolved entry drop: a reorder within one section, or a move across two. */
-export type EntryDrop =
-  | { kind: "reorder"; sectionId: string; fromIndex: number; toIndex: number }
-  | {
-      kind: "move";
-      fromSectionId: string;
-      fromIndex: number;
-      toSectionId: string;
-      toIndex: number;
-    };
-
 function cloneLayout(layout: readonly (readonly (readonly string[])[])[]): string[][][] {
   return layout.map((page) => page.map((column) => [...column]));
 }
@@ -74,8 +63,10 @@ function pruneEmptyPages(layout: string[][][]): string[][][] {
  * section is not placed or the move changes nothing.
  *
  * `target` is expressed in pre-removal coordinates: "insert before whatever is
- * at this position now". A target page of `layout.length` appends a fresh page
- * with the same column count as the last existing page.
+ * at this position now". A target page at or past `layout.length` creates the
+ * missing pages with the same column count as the last existing page; pages
+ * left empty are pruned afterwards, so the section lands on the first fresh
+ * page after the existing content.
  */
 export function moveSectionInLayout(
   layout: readonly (readonly (readonly string[])[])[],
@@ -83,14 +74,17 @@ export function moveSectionInLayout(
   target: SectionDropTarget,
 ): string[][][] | null {
   const placement = findSectionPlacement(layout, sectionId);
-  if (!placement || target.page < 0 || target.page > layout.length || target.column < 0) {
+  if (!placement || target.page < 0 || target.column < 0) {
     return null;
   }
 
   const next = cloneLayout(layout);
   next[placement.page][placement.column].splice(placement.index, 1);
 
-  if (target.page === next.length) {
+  // Auto-create missing pages (spec §2.5): item-break continuations can draw
+  // more sheets than the raw layout stores, and a drop on one of those sheets
+  // targets a raw page that does not exist yet.
+  while (target.page >= next.length) {
     const columnCount = Math.max(1, next[next.length - 1]?.length ?? 1);
     next.push(Array.from({ length: columnCount }, () => []));
   }
@@ -252,58 +246,27 @@ export function drawnSectionPosition(
 }
 
 /**
- * Whether an entry may leave `fromSectionId` for `toSectionId`.
+ * Resolve an entry drop at `dropIndex` — an insert-before position in the
+ * section's own `items` array, `+1` when the pointer was in the target row's
+ * bottom half — as the `(fromIndex, toIndex)` pair the store's splice-based
+ * reorder expects. `null` for an unknown item or a drop that changes nothing
+ * (one drop is one store action, and a no-op drop is no action at all).
  *
- * Only custom sections share an item shape, so they are the only pair a move
- * is defined for; a fixed section's items would be structurally wrong anywhere
- * else, and no store action exists to put them there.
+ * Item drags are same-section-only (spec §2.4, owner decision): callers
+ * never route a drop here across sections.
  */
-export function canMoveEntryAcross(fromSectionId: string, toSectionId: string): boolean {
-  return fromSectionId !== toSectionId && isCustomId(fromSectionId) && isCustomId(toSectionId);
-}
-
-/**
- * Resolve an entry drop onto another entry (or a section's tail) as index
- * pairs into the sections' unfiltered `items` arrays.
- *
- * `targetItemId: null` addresses the end of the target section. Within one
- * section the usual reorder rule applies — dropping onto the entry below lands
- * after it, onto the entry above lands before it (which is what the store's
- * splice-based reorder computes from a plain target index).
- */
-export function resolveEntryDrop(args: {
-  fromSectionId: string;
-  fromItems: readonly EntryListItem[];
-  itemId: string;
-  toSectionId: string;
-  toItems: readonly EntryListItem[];
-  targetItemId: string | null;
-}): EntryDrop | null {
-  const fromIndex = args.fromItems.findIndex((item) => item.id === args.itemId);
+export function resolveEntryDropIndex(
+  items: readonly EntryListItem[],
+  itemId: string,
+  dropIndex: number,
+): { fromIndex: number; toIndex: number } | null {
+  const fromIndex = items.findIndex((item) => item.id === itemId);
   if (fromIndex === -1) return null;
-
-  if (args.fromSectionId === args.toSectionId) {
-    const toIndex =
-      args.targetItemId === null
-        ? args.toItems.length - 1
-        : args.toItems.findIndex((item) => item.id === args.targetItemId);
-    if (toIndex === -1 || toIndex === fromIndex) return null;
-    return { kind: "reorder", sectionId: args.fromSectionId, fromIndex, toIndex };
-  }
-
-  if (!canMoveEntryAcross(args.fromSectionId, args.toSectionId)) return null;
-  const toIndex =
-    args.targetItemId === null
-      ? args.toItems.length
-      : args.toItems.findIndex((item) => item.id === args.targetItemId);
-  if (toIndex === -1) return null;
-  return {
-    kind: "move",
-    fromSectionId: args.fromSectionId,
-    fromIndex,
-    toSectionId: args.toSectionId,
-    toIndex,
-  };
+  const clamped = Math.max(0, Math.min(dropIndex, items.length));
+  // Removing the dragged item first shifts every later position down by one.
+  const toIndex = clamped > fromIndex ? clamped - 1 : clamped;
+  if (toIndex === fromIndex) return null;
+  return { fromIndex, toIndex: Math.min(toIndex, items.length - 1) };
 }
 
 /** One-step reorder of an entry within its section, or `null` at a boundary. */
@@ -317,22 +280,6 @@ export function entryStep(
   const toIndex = step === "up" ? fromIndex - 1 : fromIndex + 1;
   if (toIndex < 0 || toIndex >= items.length) return null;
   return { fromIndex, toIndex };
-}
-
-/**
- * The custom section an entry moves to for a lateral keyboard step: the
- * previous or next custom section in flattened layout order, or `null` when
- * there is none — the keyboard mirror of a cross-section drag.
- */
-export function adjacentCustomSectionId(
-  layout: readonly (readonly (readonly string[])[])[],
-  fromSectionId: string,
-  step: "previous" | "next",
-): string | null {
-  const customIds = layout.flat(2).filter((id) => isCustomId(id));
-  const position = customIds.indexOf(fromSectionId);
-  if (position === -1) return null;
-  return customIds[step === "previous" ? position - 1 : position + 1] ?? null;
 }
 
 /** Head-line fields an entry might carry, in display preference order. */

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -8,9 +8,9 @@
  * only computes what the next `metadata.layout` *should* be — the write goes
  * through `resumeStore.updateLayout`).
  *
- * `metadata.layout` is `string[][][]`: pages -> columns -> section ids. Section
- * placement is the only pagination mechanism; there are no item-level page
- * breaks.
+ * `metadata.layout` is `string[][][]`: pages -> columns -> section ids.
+ * Mid-section pagination (`metadata.itemBreaks`) layers on top of this raw
+ * structure — see `docPagination.ts` for the expansion pipeline.
  */
 
 import { FIXED_LAYOUT_SECTION_KEYS, isHtmlEmpty } from "./resumeSections";
@@ -263,7 +263,7 @@ export function sectionTitle(resume: ResumeData, sectionId: string): string {
 }
 
 /** Whether a section holds anything worth drawing chrome for. */
-function sectionHasContent(resume: ResumeData, sectionId: string): boolean {
+export function sectionHasContent(resume: ResumeData, sectionId: string): boolean {
   if (isCustomId(sectionId)) {
     const section = resume.sections.custom?.[sectionId];
     return section !== undefined && section.items.some((item) => item.visible);
@@ -348,42 +348,9 @@ export function layoutPages(resume: ResumeData, templateLayout: TemplateLayout):
 }
 
 /**
- * {@link layoutPages} reduced to what actually renders: hidden sections and
- * sections with no content are dropped, and any page left entirely empty is
- * removed. Empty columns are kept so column indices stay meaningful.
- */
-export function renderPages(resume: ResumeData, templateLayout: TemplateLayout): string[][][] {
-  return layoutPages(resume, templateLayout)
-    .map((page) =>
-      page.map((column) =>
-        column.filter((id) => sectionVisible(resume, id) && sectionHasContent(resume, id)),
-      ),
-    )
-    .filter((page) => page.some((column) => column.length > 0));
-}
-
-/**
- * {@link layoutPages} as the *editing* surface draws it, aligned index-for-index
- * with the layout — no page or column is dropped, so a drop target's page and
- * column indices address `metadata.layout` directly, and no second layout model
- * exists for drag and drop.
- *
- * Hidden sections never draw (#794, spec §1.6) — the Sections panel is the
- * recovery path, exactly as it is for the rendered document. Unlike
- * {@link renderPages}, *empty* placed sections stay drawn in edit mode: their
- * card carries the add affordance, so an empty section is a place to type
- * rather than a gap in the layout.
- */
-export function editorPages(resume: ResumeData, templateLayout: TemplateLayout): string[][][] {
-  return layoutPages(resume, templateLayout).map((page) =>
-    page.map((column) => column.filter((id) => sectionVisible(resume, id))),
-  );
-}
-
-/**
- * `layout` with page `pageIndex` merged into the page before it — the simple
- * "remove page break" of #794 (`metadata.itemBreaks`-aware merge semantics
- * arrive with the drag-channel rework, #796). Columns concatenate index-wise;
+ * `layout` with page `pageIndex` merged into the page before it — the layout
+ * half of "remove page break" (`metadata.itemBreaks`-aware semantics live in
+ * `docPagination.resolvePageBreakRemoval`). Columns concatenate index-wise;
  * the first occurrence of a section id wins. Returns `null` when the merge is
  * impossible (page 0, or an index past the last page), so callers write
  * nothing rather than an unchanged layout.

--- a/apps/web/src/lib/docPagination.ts
+++ b/apps/web/src/lib/docPagination.ts
@@ -1,0 +1,442 @@
+/**
+ * Mid-section pagination model (#796, spec §3.3–§3.5).
+ *
+ * Pure helpers around `metadata.itemBreaks` — the item ids that start a new
+ * page within a section. A section with N honored break markers occupies N+1
+ * consecutive pages in the same column; continuation slices render the title
+ * with a "(cont.)" suffix. Nothing here reads a store or touches the DOM:
+ * callers pass the resume and the template layout in, and every mutation
+ * helper returns the *next* value for the caller to write (`null` for a
+ * change that would change nothing, so callers write nothing).
+ *
+ * The rules mirror the renderer (`_common.typ`): breaks are honored only on
+ * main-flow sections, only on single-flow templates (Typst cannot page-break
+ * inside a grid), and a marker on a slice's first item is inert — slices are
+ * never empty.
+ */
+
+import {
+  findSectionPlacement,
+  isCustomId,
+  layoutPages,
+  mergePageIntoPrevious,
+  sectionHasContent,
+  sectionVisible,
+  type TemplateLayout,
+} from "./docLayout";
+import type { ResumeData } from "../wasm/types";
+
+/**
+ * Main-flow section ids allowed to carry mid-section page breaks (spec §3.4).
+ * Break markers on any other section are ignored and stripped by repairs —
+ * chip and sidebar sections over-fragment into empty sheets. Mirrors
+ * `item-break-sections` in `crates/render/.../_common.typ`; keep in step.
+ */
+export const ITEM_BREAK_SECTION_IDS: readonly string[] = [
+  "experience",
+  "education",
+  "projects",
+  "volunteer",
+  "awards",
+  "certifications",
+  "publications",
+  "references",
+];
+
+const ITEM_BREAK_SECTION_ID_SET: ReadonlySet<string> = new Set(ITEM_BREAK_SECTION_IDS);
+
+/** Why the insert-break action is unavailable, shown as the tooltip text. */
+export const ITEM_BREAK_TEMPLATE_DISABLED_REASON =
+  "This template's column layout paginates automatically; " +
+  "manual item breaks apply only to single-flow templates.";
+
+/** Whether `sectionId` may carry mid-section page breaks at all. */
+export function sectionSupportsItemBreaks(sectionId: string): boolean {
+  return ITEM_BREAK_SECTION_ID_SET.has(sectionId);
+}
+
+/**
+ * Whether the template's layout can honor mid-section breaks. Only
+ * single-flow templates can — Typst cannot page-break inside a grid, so
+ * markers on sidebar/two-column templates are inert (owner decision
+ * 2026-08-03: the editor greys the insert action out there, with a tooltip).
+ */
+export function templateSupportsItemBreaks(templateLayout: TemplateLayout): boolean {
+  return templateLayout.layoutMode === "single";
+}
+
+/** The `id`/`visible` shape every section item shares. */
+interface BreakableItem {
+  id: string;
+  visible: boolean;
+}
+
+function sectionItems(resume: ResumeData, sectionId: string): BreakableItem[] {
+  if (isCustomId(sectionId)) {
+    return resume.sections.custom?.[sectionId]?.items ?? [];
+  }
+  const section = resume.sections[sectionId as keyof typeof resume.sections] as
+    | { items?: BreakableItem[] }
+    | undefined;
+  return section?.items ?? [];
+}
+
+/**
+ * The item ids a sheet draws for `sectionId`, in stored order. Edit mode
+ * draws hidden items as chrome (`includeHidden`); Done mode, like the PDF,
+ * draws only visible ones — slicing and page expansion must follow the same
+ * list the sheet actually draws.
+ */
+export function drawnItemIds(
+  resume: ResumeData,
+  sectionId: string,
+  includeHidden: boolean,
+): string[] {
+  return sectionItems(resume, sectionId)
+    .filter((item) => includeHidden || item.visible)
+    .map((item) => item.id);
+}
+
+/**
+ * The section's honored break markers, in item order: markers on sections or
+ * templates that cannot carry them, and markers whose item is not drawn, are
+ * dropped.
+ */
+export function orderedItemBreaks(
+  resume: ResumeData,
+  sectionId: string,
+  includeHidden: boolean,
+): string[] {
+  if (!sectionSupportsItemBreaks(sectionId)) return [];
+  const raw = resume.metadata.itemBreaks?.[sectionId] ?? [];
+  if (raw.length === 0) return [];
+  const markers = new Set(raw);
+  return drawnItemIds(resume, sectionId, includeHidden).filter((id) => markers.has(id));
+}
+
+/**
+ * Split `itemIds` into page slices: each break marker starts a new slice.
+ * Never yields an empty slice — a marker on the first drawn item is inert,
+ * matching the renderer (`split-items-by-breaks` in `_common.typ`).
+ */
+export function itemSlices(itemIds: readonly string[], breakIds: readonly string[]): string[][] {
+  if (itemIds.length === 0) return [[]];
+  if (breakIds.length === 0) return [[...itemIds]];
+  const markers = new Set(breakIds);
+  const slices: string[][] = [[]];
+  for (const id of itemIds) {
+    if (markers.has(id) && slices[slices.length - 1].length > 0) {
+      slices.push([]);
+    }
+    slices[slices.length - 1].push(id);
+  }
+  return slices;
+}
+
+function cloneLayout(layout: readonly (readonly (readonly string[])[])[]): string[][][] {
+  return layout.map((page) => page.map((column) => [...column]));
+}
+
+/**
+ * {@link layoutPages} expanded so a section with N honored breaks appears on
+ * N+1 consecutive pages in the same column (spec §3.3 step 2). Missing pages
+ * and columns are created; nothing is stripped — feed the result through the
+ * mode filters below for the drawn page stack.
+ */
+export function expandItemBreakPages(
+  resume: ResumeData,
+  templateLayout: TemplateLayout,
+  includeHidden: boolean,
+): string[][][] {
+  const pages = cloneLayout(layoutPages(resume, templateLayout));
+  if (!templateSupportsItemBreaks(templateLayout)) return pages;
+
+  const placements: { id: string; page: number; column: number }[] = [];
+  for (let page = 0; page < pages.length; page++) {
+    for (let column = 0; column < pages[page].length; column++) {
+      for (const id of pages[page][column]) {
+        const breaks = orderedItemBreaks(resume, id, includeHidden);
+        if (breaks.length === 0) continue;
+        const sliceCount = itemSlices(drawnItemIds(resume, id, includeHidden), breaks).length;
+        if (sliceCount > 1) placements.push({ id, page, column });
+      }
+    }
+  }
+
+  for (const { id, page, column } of placements) {
+    const breaks = orderedItemBreaks(resume, id, includeHidden);
+    const sliceCount = itemSlices(drawnItemIds(resume, id, includeHidden), breaks).length;
+    for (let slice = 1; slice < sliceCount; slice++) {
+      const target = page + slice;
+      while (pages.length <= target) {
+        const columns = Math.max(1, pages[page]?.length ?? 1);
+        pages.push(Array.from({ length: columns }, () => []));
+      }
+      while (pages[target].length <= column) {
+        pages[target].push([]);
+      }
+      if (!pages[target][column].includes(id)) {
+        pages[target][column] = [id, ...pages[target][column]];
+      }
+    }
+  }
+  return pages;
+}
+
+/** Slice position of a section instance within an expanded page list. */
+function sliceIndexInPages(
+  pages: readonly (readonly (readonly string[])[])[],
+  sectionId: string,
+  pageIndex: number,
+  columnIndex: number,
+): number {
+  let slice = 0;
+  for (let page = 0; page < pageIndex; page++) {
+    if (pages[page]?.[columnIndex]?.includes(sectionId)) slice += 1;
+  }
+  return slice;
+}
+
+/**
+ * Which item slice the section instance at `pageIndex`/`columnIndex` shows.
+ * Counted on the **pre-strip** expanded pages, so indices stay aligned with
+ * `itemBreaks` even when empty continuation chrome was stripped (spec §3.3
+ * step 4). Instances with slice > 0 render the title as "<Title> (cont.)".
+ */
+export function sectionSliceIndex(
+  resume: ResumeData,
+  templateLayout: TemplateLayout,
+  sectionId: string,
+  pageIndex: number,
+  columnIndex: number,
+  includeHidden: boolean,
+): number {
+  return sliceIndexInPages(
+    expandItemBreakPages(resume, templateLayout, includeHidden),
+    sectionId,
+    pageIndex,
+    columnIndex,
+  );
+}
+
+/** One drawn instance of a sliced section: which items, and where it sits. */
+export interface SectionSlice {
+  /** 0-based slice position; slices > 0 render the "(cont.)" title. */
+  index: number;
+  /** The item ids this instance draws. */
+  itemIds: string[];
+  /** Only the last slice carries the add affordances (spec §2.6). */
+  isLast: boolean;
+}
+
+/**
+ * The slice a section instance draws, or `null` when the section is not
+ * sliced at all (no honored breaks) — callers draw the whole section then.
+ */
+export function sectionSliceAt(
+  resume: ResumeData,
+  templateLayout: TemplateLayout,
+  sectionId: string,
+  pageIndex: number,
+  columnIndex: number,
+  includeHidden: boolean,
+): SectionSlice | null {
+  if (!templateSupportsItemBreaks(templateLayout)) return null;
+  const breaks = orderedItemBreaks(resume, sectionId, includeHidden);
+  if (breaks.length === 0) return null;
+  const slices = itemSlices(drawnItemIds(resume, sectionId, includeHidden), breaks);
+  if (slices.length <= 1) return null;
+  const index = Math.min(
+    sectionSliceIndex(resume, templateLayout, sectionId, pageIndex, columnIndex, includeHidden),
+    slices.length - 1,
+  );
+  return { index, itemIds: slices[index], isLast: index === slices.length - 1 };
+}
+
+/** Whether a section instance has anything to draw on its slice (spec §3.3). */
+function sectionHasSliceContent(
+  resume: ResumeData,
+  pages: readonly (readonly (readonly string[])[])[],
+  sectionId: string,
+  pageIndex: number,
+  columnIndex: number,
+): boolean {
+  const slice = sliceIndexInPages(pages, sectionId, pageIndex, columnIndex);
+  if (sectionId === "summary" || sectionId === "coverLetter") {
+    return slice === 0 && sectionHasContent(resume, sectionId);
+  }
+  const breaks = orderedItemBreaks(resume, sectionId, false);
+  if (breaks.length === 0) {
+    return slice === 0 && sectionHasContent(resume, sectionId);
+  }
+  const slices = itemSlices(drawnItemIds(resume, sectionId, false), breaks);
+  return (slices[slice]?.length ?? 0) > 0;
+}
+
+/**
+ * The page stack Done mode (and the PDF) draws: expanded pages with hidden
+ * sections, contentless slices and trailing empty pages stripped. Only
+ * *trailing* empty pages are dropped (spec §3.3) — dropping one mid-stack
+ * would misalign the drawn page indices the slice lookup and the page-break
+ * rules address.
+ */
+export function renderSheetPages(resume: ResumeData, templateLayout: TemplateLayout): string[][][] {
+  const expanded = expandItemBreakPages(resume, templateLayout, false);
+  const stripped = expanded.map((page, pageIndex) =>
+    page.map((column, columnIndex) =>
+      column.filter(
+        (id) =>
+          sectionVisible(resume, id) &&
+          sectionHasSliceContent(resume, expanded, id, pageIndex, columnIndex),
+      ),
+    ),
+  );
+  while (stripped.length > 1) {
+    const last = stripped[stripped.length - 1];
+    if (last.some((column) => column.length > 0)) break;
+    stripped.pop();
+  }
+  return stripped;
+}
+
+/**
+ * The page stack Edit mode draws: expanded pages with only hidden sections
+ * dropped. Placed-but-empty sections stay drawn — their card carries the add
+ * affordance — and no page is dropped, so drawn page indices match the
+ * expanded pages that drop targets and slice lookups address.
+ */
+export function editorSheetPages(resume: ResumeData, templateLayout: TemplateLayout): string[][][] {
+  return expandItemBreakPages(resume, templateLayout, true).map((page) =>
+    page.map((column) => column.filter((id) => sectionVisible(resume, id))),
+  );
+}
+
+/**
+ * `itemBreaks` with a marker added before `itemId` in `sectionId`, or `null`
+ * when the marker would change nothing: unsupported section or template,
+ * unknown item, already marked, or the section's first drawn item (a marker
+ * there is inert — slices are never empty).
+ */
+export function itemBreaksWithBreakBefore(
+  resume: ResumeData,
+  templateLayout: TemplateLayout,
+  sectionId: string,
+  itemId: string,
+): Record<string, string[]> | null {
+  if (!sectionSupportsItemBreaks(sectionId)) return null;
+  if (!templateSupportsItemBreaks(templateLayout)) return null;
+  const drawn = drawnItemIds(resume, sectionId, true);
+  const position = drawn.indexOf(itemId);
+  if (position <= 0) return null;
+  const existing = resume.metadata.itemBreaks?.[sectionId] ?? [];
+  if (existing.includes(itemId)) return null;
+  return {
+    ...(resume.metadata.itemBreaks ?? {}),
+    [sectionId]: [...existing, itemId],
+  };
+}
+
+/** `breaks` without `sectionId`'s markers, or `null` when it carries none. */
+export function itemBreaksWithoutSection(
+  breaks: Record<string, string[]> | undefined,
+  sectionId: string,
+): Record<string, string[]> | null {
+  if (!breaks?.[sectionId]?.length) return null;
+  const next = { ...breaks };
+  delete next[sectionId];
+  return next;
+}
+
+/**
+ * `layout` split so `sectionId` starts a fresh page: the section and
+ * everything after it in its column move to a new page inserted right after
+ * its current one. `null` when the split would change nothing (section not
+ * placed, or the resulting stack renders identically).
+ */
+export function splitLayoutBeforeSection(
+  layout: readonly (readonly (readonly string[])[])[],
+  sectionId: string,
+): string[][][] | null {
+  const placement = findSectionPlacement(layout, sectionId);
+  if (!placement) return null;
+  const next = cloneLayout(layout);
+  const column = next[placement.page][placement.column];
+  const tail = column.splice(placement.index);
+  if (tail.length === 0) return null;
+  const columnCount = next[placement.page].length;
+  next.splice(
+    placement.page + 1,
+    0,
+    Array.from({ length: columnCount }, (_, index) => (index === placement.column ? tail : [])),
+  );
+  const pruned = next.filter((page) => page.some((column_) => column_.length > 0));
+  const result = pruned.length > 0 ? pruned : next.slice(0, 1);
+  return JSON.stringify(result) === JSON.stringify(layout) ? null : result;
+}
+
+/** What removing the rule between two drawn pages should write (spec §3.4). */
+export type PageBreakRemoval =
+  | { kind: "itemBreaks"; itemBreaks: Record<string, string[]> }
+  | { kind: "layout"; layout: string[][][] };
+
+/**
+ * Resolve "Remove page break" between drawn pages `pageIndex - 1` and
+ * `pageIndex`: prefer clearing an item-break continuation shared across the
+ * boundary (the responsible marker of every such section is deleted);
+ * otherwise merge raw page `pageIndex` into the one before it. `null` when
+ * neither applies.
+ */
+export function resolvePageBreakRemoval(
+  resume: ResumeData,
+  templateLayout: TemplateLayout,
+  pageIndex: number,
+): PageBreakRemoval | null {
+  if (pageIndex <= 0) return null;
+  const drawn = editorSheetPages(resume, templateLayout);
+  if (pageIndex >= drawn.length) return null;
+
+  const previous = drawn[pageIndex - 1];
+  const current = drawn[pageIndex];
+  const columns = Math.max(previous.length, current.length);
+  let cleared = false;
+  const nextBreaks = { ...(resume.metadata.itemBreaks ?? {}) };
+  for (let column = 0; column < columns; column++) {
+    for (const sectionId of current[column] ?? []) {
+      if (!(previous[column] ?? []).includes(sectionId)) continue;
+      const slice = sectionSliceIndex(resume, templateLayout, sectionId, pageIndex, column, true);
+      if (slice <= 0) continue;
+      const ordered = orderedItemBreaks(resume, sectionId, true);
+      const marker = ordered[slice - 1];
+      if (marker === undefined) continue;
+      const filtered = (nextBreaks[sectionId] ?? []).filter((id) => id !== marker);
+      if (filtered.length > 0) nextBreaks[sectionId] = filtered;
+      else delete nextBreaks[sectionId];
+      cleared = true;
+    }
+  }
+  if (cleared) return { kind: "itemBreaks", itemBreaks: nextBreaks };
+
+  const merged = mergePageIntoPrevious(layoutPages(resume, templateLayout), pageIndex);
+  return merged === null ? null : { kind: "layout", layout: merged };
+}
+
+/**
+ * `breaks` with every unhonorable entry stripped: non-main-flow sections
+ * (spec §3.4 guard) and empty marker lists. Returns `null` when nothing
+ * needed stripping, so load-time repairs write nothing for a clean document.
+ */
+export function sanitizedItemBreaks(
+  breaks: Record<string, string[]> | undefined,
+): Record<string, string[]> | null {
+  if (breaks === undefined) return null;
+  let changed = false;
+  const next: Record<string, string[]> = {};
+  for (const [sectionId, markers] of Object.entries(breaks)) {
+    if (!sectionSupportsItemBreaks(sectionId) || markers.length === 0) {
+      changed = true;
+      continue;
+    }
+    next[sectionId] = markers;
+  }
+  return changed ? next : null;
+}

--- a/apps/web/src/lib/docPagination.ts
+++ b/apps/web/src/lib/docPagination.ts
@@ -151,21 +151,19 @@ export function expandItemBreakPages(
   const pages = cloneLayout(layoutPages(resume, templateLayout));
   if (!templateSupportsItemBreaks(templateLayout)) return pages;
 
-  const placements: { id: string; page: number; column: number }[] = [];
+  const placements: { id: string; page: number; column: number; sliceCount: number }[] = [];
   for (let page = 0; page < pages.length; page++) {
     for (let column = 0; column < pages[page].length; column++) {
       for (const id of pages[page][column]) {
         const breaks = orderedItemBreaks(resume, id, includeHidden);
         if (breaks.length === 0) continue;
         const sliceCount = itemSlices(drawnItemIds(resume, id, includeHidden), breaks).length;
-        if (sliceCount > 1) placements.push({ id, page, column });
+        if (sliceCount > 1) placements.push({ id, page, column, sliceCount });
       }
     }
   }
 
-  for (const { id, page, column } of placements) {
-    const breaks = orderedItemBreaks(resume, id, includeHidden);
-    const sliceCount = itemSlices(drawnItemIds(resume, id, includeHidden), breaks).length;
+  for (const { id, page, column, sliceCount } of placements) {
     for (let slice = 1; slice < sliceCount; slice++) {
       const target = page + slice;
       while (pages.length <= target) {
@@ -210,9 +208,10 @@ export function sectionSliceIndex(
   pageIndex: number,
   columnIndex: number,
   includeHidden: boolean,
+  expandedPages?: readonly (readonly (readonly string[])[])[],
 ): number {
   return sliceIndexInPages(
-    expandItemBreakPages(resume, templateLayout, includeHidden),
+    expandedPages ?? expandItemBreakPages(resume, templateLayout, includeHidden),
     sectionId,
     pageIndex,
     columnIndex,
@@ -232,6 +231,9 @@ export interface SectionSlice {
 /**
  * The slice a section instance draws, or `null` when the section is not
  * sliced at all (no honored breaks) — callers draw the whole section then.
+ *
+ * `expandedPages` lets a caller drawing many instances reuse one
+ * {@link expandItemBreakPages} result instead of re-deriving it per card.
  */
 export function sectionSliceAt(
   resume: ResumeData,
@@ -240,6 +242,7 @@ export function sectionSliceAt(
   pageIndex: number,
   columnIndex: number,
   includeHidden: boolean,
+  expandedPages?: readonly (readonly (readonly string[])[])[],
 ): SectionSlice | null {
   if (!templateSupportsItemBreaks(templateLayout)) return null;
   const breaks = orderedItemBreaks(resume, sectionId, includeHidden);
@@ -247,7 +250,15 @@ export function sectionSliceAt(
   const slices = itemSlices(drawnItemIds(resume, sectionId, includeHidden), breaks);
   if (slices.length <= 1) return null;
   const index = Math.min(
-    sectionSliceIndex(resume, templateLayout, sectionId, pageIndex, columnIndex, includeHidden),
+    sectionSliceIndex(
+      resume,
+      templateLayout,
+      sectionId,
+      pageIndex,
+      columnIndex,
+      includeHidden,
+      expandedPages,
+    ),
     slices.length - 1,
   );
   return { index, itemIds: slices[index], isLast: index === slices.length - 1 };
@@ -361,8 +372,8 @@ export function splitLayoutBeforeSection(
   if (!placement) return null;
   const next = cloneLayout(layout);
   const column = next[placement.page][placement.column];
+  // The tail always holds at least the section itself — the placement is real.
   const tail = column.splice(placement.index);
-  if (tail.length === 0) return null;
   const columnCount = next[placement.page].length;
   next.splice(
     placement.page + 1,
@@ -422,21 +433,32 @@ export function resolvePageBreakRemoval(
 
 /**
  * `breaks` with every unhonorable entry stripped: non-main-flow sections
- * (spec §3.4 guard) and empty marker lists. Returns `null` when nothing
- * needed stripping, so load-time repairs write nothing for a clean document.
+ * (spec §3.4 guard), empty or non-array marker lists, and non-string
+ * markers. Loaded documents can carry any shape here (imports, old
+ * clients), so the value is guarded at runtime like `sections.custom` and
+ * `metadata.layout` are. Returns `null` when nothing needed stripping, so
+ * load-time repairs write nothing for a clean document.
  */
-export function sanitizedItemBreaks(
-  breaks: Record<string, string[]> | undefined,
-): Record<string, string[]> | null {
+export function sanitizedItemBreaks(breaks: unknown): Record<string, string[]> | null {
   if (breaks === undefined) return null;
+  if (typeof breaks !== "object" || breaks === null || Array.isArray(breaks)) {
+    // A malformed field is repaired to "no breaks" rather than left to trip
+    // every Object.entries reader downstream.
+    return {};
+  }
   let changed = false;
   const next: Record<string, string[]> = {};
   for (const [sectionId, markers] of Object.entries(breaks)) {
-    if (!sectionSupportsItemBreaks(sectionId) || markers.length === 0) {
+    const valid =
+      sectionSupportsItemBreaks(sectionId) &&
+      Array.isArray(markers) &&
+      markers.length > 0 &&
+      markers.every((marker) => typeof marker === "string");
+    if (!valid) {
       changed = true;
       continue;
     }
-    next[sectionId] = markers;
+    next[sectionId] = markers as string[];
   }
   return changed ? next : null;
 }

--- a/apps/web/src/stores/__tests__/resume.test.ts
+++ b/apps/web/src/stores/__tests__/resume.test.ts
@@ -2,7 +2,8 @@ import { createRoot } from "solid-js";
 import { createDefaultResume } from "../../wasm/defaults";
 import type { ResumeData } from "../../wasm/types";
 import { FIXED_LAYOUT_SECTION_KEYS } from "../../lib/resumeSections";
-import { editorPages, FALLBACK_TEMPLATE_LAYOUT } from "../../lib/docLayout";
+import { FALLBACK_TEMPLATE_LAYOUT } from "../../lib/docLayout";
+import { editorSheetPages } from "../../lib/docPagination";
 import {
   isResumeEmpty,
   useResumeStore,
@@ -1264,7 +1265,7 @@ describe("unplaced fixed sections (#770)", () => {
         [["summary", "experience", "coverLetter"], ["skills"]],
       ]);
       // The sheet draws only placed ids — the section must actually appear.
-      const drawnIds = editorPages(store.resume!, FALLBACK_TEMPLATE_LAYOUT).flat(2);
+      const drawnIds = editorSheetPages(store.resume!, FALLBACK_TEMPLATE_LAYOUT).flat(2);
       expect(drawnIds).toContain("coverLetter");
       dispose();
     });

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -1,7 +1,7 @@
 /**
- * The structural item actions the document editor's cards call: duplicate,
- * and the single-action cross-section move — each one store action, so each
- * one undo entry.
+ * The structural store actions the document editor's cards call — duplicate,
+ * remove with page-break marker cleanup, template application, and combined
+ * pagination writes. Each is one store action, so each is one undo entry.
  */
 
 import { createRoot } from "solid-js";
@@ -138,105 +138,6 @@ describe("duplicateCustomSectionItem", () => {
       duplicateCustomSectionItem(sectionId, 99);
 
       expect(store.resume!.sections.custom[sectionId].items.length).toBe(0);
-      dispose();
-    });
-  });
-});
-
-describe("moveCustomSectionItem", () => {
-  it("moves an item between custom sections in one action", () => {
-    createRoot((dispose) => {
-      const {
-        store,
-        createNewResume,
-        addCustomSection,
-        addCustomSectionItem,
-        moveCustomSectionItem,
-      } = useResumeStore();
-      createNewResume("move-1");
-      const talks = addCustomSection("Talks");
-      const advisory = addCustomSection("Advisory");
-      addCustomSectionItem(talks, customItem("t1", "First"));
-      addCustomSectionItem(talks, customItem("t2", "Second"));
-      addCustomSectionItem(advisory, customItem("a1", "Board"));
-
-      moveCustomSectionItem(talks, 0, advisory, 1);
-
-      expect(store.resume!.sections.custom[talks].items.map((item) => item.id)).toEqual(["t2"]);
-      expect(store.resume!.sections.custom[advisory].items.map((item) => item.id)).toEqual([
-        "a1",
-        "t1",
-      ]);
-      dispose();
-    });
-  });
-
-  it("clamps an out-of-range destination index to the section's end", () => {
-    createRoot((dispose) => {
-      const {
-        store,
-        createNewResume,
-        addCustomSection,
-        addCustomSectionItem,
-        moveCustomSectionItem,
-      } = useResumeStore();
-      createNewResume("move-4");
-      const talks = addCustomSection("Talks");
-      const advisory = addCustomSection("Advisory");
-      addCustomSectionItem(talks, customItem("t1", "First"));
-      addCustomSectionItem(advisory, customItem("a1", "Board"));
-
-      moveCustomSectionItem(talks, 0, advisory, 99);
-
-      expect(store.resume!.sections.custom[advisory].items.map((item) => item.id)).toEqual([
-        "a1",
-        "t1",
-      ]);
-      dispose();
-    });
-  });
-
-  it("refuses a move onto the same section", () => {
-    createRoot((dispose) => {
-      const {
-        store,
-        createNewResume,
-        addCustomSection,
-        addCustomSectionItem,
-        moveCustomSectionItem,
-      } = useResumeStore();
-      createNewResume("move-2");
-      const talks = addCustomSection("Talks");
-      addCustomSectionItem(talks, customItem("t1", "First"));
-      addCustomSectionItem(talks, customItem("t2", "Second"));
-
-      moveCustomSectionItem(talks, 0, talks, 1);
-
-      expect(store.resume!.sections.custom[talks].items.map((item) => item.id)).toEqual([
-        "t1",
-        "t2",
-      ]);
-      dispose();
-    });
-  });
-
-  it("does nothing when either section or the item is missing", () => {
-    createRoot((dispose) => {
-      const {
-        store,
-        createNewResume,
-        addCustomSection,
-        addCustomSectionItem,
-        moveCustomSectionItem,
-      } = useResumeStore();
-      createNewResume("move-3");
-      const talks = addCustomSection("Talks");
-      addCustomSectionItem(talks, customItem("t1", "First"));
-
-      moveCustomSectionItem(talks, 5, "nope", 0);
-      moveCustomSectionItem("nope", 0, talks, 0);
-
-      expect(store.resume!.sections.custom[talks].items.map((item) => item.id)).toEqual(["t1"]);
       dispose();
     });
   });

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -270,3 +270,69 @@ describe("applyTemplate", () => {
     }
   });
 });
+
+describe("removeSectionItem", () => {
+  it("cleans the removed item's page-break marker in the same write (#796)", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, addSectionItem, updateMetadata, removeSectionItem } =
+        useResumeStore();
+      createNewResume("break-1");
+      addSectionItem("skills", skill("skill-a", "Alpha"));
+      addSectionItem("skills", skill("skill-b", "Beta"));
+      const base = store.resume!.sections.skills.items.length - 2;
+      updateMetadata("itemBreaks", { skills: ["skill-b"], experience: ["exp-x"] });
+
+      removeSectionItem("skills", base + 1);
+
+      // Only the removed item's marker goes; other sections keep theirs.
+      expect(store.resume!.metadata.itemBreaks).toEqual({ experience: ["exp-x"] });
+      dispose();
+    });
+  });
+
+  it("leaves itemBreaks untouched when the removed item carried no marker", () => {
+    createRoot((dispose) => {
+      const { store, createNewResume, addSectionItem, updateMetadata, removeSectionItem } =
+        useResumeStore();
+      createNewResume("break-2");
+      addSectionItem("skills", skill("skill-a", "Alpha"));
+      updateMetadata("itemBreaks", { experience: ["exp-x"] });
+
+      removeSectionItem("skills", store.resume!.sections.skills.items.length - 1);
+
+      expect(store.resume!.metadata.itemBreaks).toEqual({ experience: ["exp-x"] });
+      dispose();
+    });
+  });
+});
+
+describe("updatePagination", () => {
+  it("writes layout and itemBreaks together as one undo entry", () => {
+    vi.useFakeTimers();
+    try {
+      createRoot((dispose) => {
+        const { store, createNewResume, updateMetadata, updatePagination, undo } = useResumeStore();
+        createNewResume("pagination-1");
+        updateMetadata("itemBreaks", { experience: ["exp-x"] });
+        vi.advanceTimersByTime(600);
+        const layoutBefore = JSON.parse(
+          JSON.stringify(store.resume!.metadata.layout),
+        ) as string[][][];
+
+        updatePagination([[["summary"], []]], {});
+        vi.advanceTimersByTime(600);
+
+        expect(store.resume!.metadata.layout).toEqual([[["summary"], []]]);
+        expect(store.resume!.metadata.itemBreaks).toEqual({});
+
+        // One undo restores both halves at once.
+        expect(undo()).toBe(true);
+        expect(store.resume!.metadata.layout).toEqual(layoutBefore);
+        expect(store.resume!.metadata.itemBreaks).toEqual({ experience: ["exp-x"] });
+        dispose();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/stores/__tests__/structuralActions.test.ts
+++ b/apps/web/src/stores/__tests__/structuralActions.test.ts
@@ -8,7 +8,7 @@ import { createRoot } from "solid-js";
 import { describe, expect, it, vi, type Mock } from "vitest";
 import { createDefaultResume } from "../../wasm/defaults";
 import { useResumeStore } from "../resume";
-import type { CustomItem, Skill } from "../../wasm/types";
+import type { CustomItem, Experience, Skill } from "../../wasm/types";
 
 vi.mock("../../wasm", () => ({
   createEmptyResume: () => createDefaultResume(),
@@ -17,6 +17,21 @@ vi.mock("../../wasm", () => ({
   isWasmReady: () => false,
   ensureWasmReady: async () => false,
 }));
+
+function experienceItem(id: string, company: string): Experience {
+  return {
+    id,
+    visible: true,
+    company,
+    position: "Engineer",
+    location: "",
+    date: "",
+    summary: "",
+    url: { label: "", href: "" },
+    keywords: [],
+    customFields: [],
+  };
+}
 
 function skill(id: string, name: string): Skill {
   return { id, visible: true, name, description: "", level: 3, keywords: ["k"] };
@@ -277,15 +292,15 @@ describe("removeSectionItem", () => {
       const { store, createNewResume, addSectionItem, updateMetadata, removeSectionItem } =
         useResumeStore();
       createNewResume("break-1");
-      addSectionItem("skills", skill("skill-a", "Alpha"));
-      addSectionItem("skills", skill("skill-b", "Beta"));
-      const base = store.resume!.sections.skills.items.length - 2;
-      updateMetadata("itemBreaks", { skills: ["skill-b"], experience: ["exp-x"] });
+      addSectionItem("experience", experienceItem("exp-a", "Alpha Corp"));
+      addSectionItem("experience", experienceItem("exp-b", "Beta Corp"));
+      const base = store.resume!.sections.experience.items.length - 2;
+      updateMetadata("itemBreaks", { experience: ["exp-b"], education: ["edu-x"] });
 
-      removeSectionItem("skills", base + 1);
+      removeSectionItem("experience", base + 1);
 
       // Only the removed item's marker goes; other sections keep theirs.
-      expect(store.resume!.metadata.itemBreaks).toEqual({ experience: ["exp-x"] });
+      expect(store.resume!.metadata.itemBreaks).toEqual({ education: ["edu-x"] });
       dispose();
     });
   });

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -29,6 +29,7 @@ import {
   showResumeVersionConflictToast,
 } from "./cloudStorage";
 import { FIXED_LAYOUT_SECTION_KEYS, isHtmlEmpty } from "../lib/resumeSections";
+import { sanitizedItemBreaks } from "../lib/docPagination";
 import { setUndoRecorder, recordUndo } from "./editorUndo";
 import { saveSnapshot } from "./versionHistory";
 import {
@@ -248,6 +249,12 @@ function normalizeResumeForStore(resume: ResumeData): ResumeData {
   }
   if (!Array.isArray(resume.metadata.layout)) {
     resume.metadata.layout = [];
+  }
+  // Strip break markers the renderer would ignore (spec §3.4 guard): markers
+  // on chip/side sections over-fragment the sheet into empty continuations.
+  const repairedBreaks = sanitizedItemBreaks(resume.metadata.itemBreaks);
+  if (repairedBreaks !== null) {
+    resume.metadata.itemBreaks = repairedBreaks;
   }
   ensureCoverLetterSection(resume);
 
@@ -648,8 +655,24 @@ export function useResumeStore() {
     removeSectionItem<K extends SectionKey>(sectionKey: K, index: number) {
       setStore(
         produce((s) => {
-          if (s.resume) {
-            (s.resume.sections[sectionKey] as Section<unknown>).items.splice(index, 1);
+          if (!s.resume) return;
+          const items = (s.resume.sections[sectionKey] as Section<{ id: string }>).items;
+          const [removed] = items.splice(index, 1);
+          // Removing an item also cleans its page-break marker (spec §2.7),
+          // in the same write so the removal stays one undo entry.
+          const markers = s.resume.metadata.itemBreaks?.[sectionKey];
+          if (removed !== undefined && markers?.includes(removed.id) === true) {
+            const filtered = markers.filter((id) => id !== removed.id);
+            if (filtered.length > 0) {
+              s.resume.metadata.itemBreaks = {
+                ...s.resume.metadata.itemBreaks,
+                [sectionKey]: filtered,
+              };
+            } else {
+              const next = { ...s.resume.metadata.itemBreaks };
+              delete next[sectionKey];
+              s.resume.metadata.itemBreaks = next;
+            }
           }
         }),
       );
@@ -892,6 +915,24 @@ export function useResumeStore() {
         produce((s) => {
           if (s.resume) {
             s.resume.metadata.layout = layout;
+          }
+        }),
+      );
+      markDirty();
+    },
+
+    /**
+     * Write `metadata.layout` and `metadata.itemBreaks` together as **one**
+     * action and one undo entry — a whole-section move both re-places the
+     * section and drops its now-meaningless mid-section breaks (spec §2.5),
+     * and undoing it must restore both halves at once.
+     */
+    updatePagination(layout: string[][][], itemBreaks: Record<string, string[]>) {
+      setStore(
+        produce((s) => {
+          if (s.resume) {
+            s.resume.metadata.layout = layout;
+            s.resume.metadata.itemBreaks = itemBreaks;
           }
         }),
       );

--- a/apps/web/src/stores/resume.ts
+++ b/apps/web/src/stores/resume.ts
@@ -827,36 +827,6 @@ export function useResumeStore() {
       markDirty();
     },
 
-    /**
-     * Move an item between two custom sections as **one** action — removal and
-     * insertion together, so a cross-section drag is a single undo entry.
-     * Custom sections only: they are the only sections sharing an item shape.
-     */
-    moveCustomSectionItem(
-      fromSectionId: string,
-      fromIndex: number,
-      toSectionId: string,
-      toIndex: number,
-    ) {
-      if (fromSectionId === toSectionId) return;
-      const fromItems = store.resume?.sections.custom[fromSectionId]?.items;
-      const toItems = store.resume?.sections.custom[toSectionId]?.items;
-      const item = fromItems?.[fromIndex];
-      if (!fromItems || !toItems || !item) return;
-      setStore(
-        produce((s) => {
-          if (!s.resume) return;
-          const source = s.resume.sections.custom[fromSectionId];
-          const target = s.resume.sections.custom[toSectionId];
-          if (!source || !target) return;
-          const [moved] = source.items.splice(fromIndex, 1);
-          if (!moved) return;
-          target.items.splice(Math.max(0, Math.min(toIndex, target.items.length)), 0, moved);
-        }),
-      );
-      markDirty();
-    },
-
     // Metadata updates
     updateMetadata<K extends keyof Metadata>(field: K, value: Metadata[K]) {
       setStore(

--- a/docs/design/doc-editor.md
+++ b/docs/design/doc-editor.md
@@ -549,9 +549,11 @@ splits). Derivation pipeline (production: `apps/web/src/lib/docLayout.ts` +
 3. `renderSheetPages` — strips section ids whose slice has no content on that page/column
    (`sectionHasSliceContent`: summary only on slice 0; item sections need a non-empty slice from
    `itemSlices`), then drops trailing empty pages. Result feeds the sheet stack.
-4. Per-instance: `sectionSliceIndex(doc, id, page, col)` (counted on **pre-strip** expanded pages so
-   indices stay aligned with `itemBreaks`) selects which item slice a given rendered section shows;
-   slices > 0 render the title as **`"<Title> (cont.)"`**.
+4. Per-instance: `sectionSliceIndex(resume, templateLayout, id, page, col, includeHidden)` (counted
+   on **pre-strip** expanded pages so indices stay aligned with `itemBreaks`; `includeHidden`
+   selects the Edit-mode item list — Edit draws hidden items as chrome, Done drops them like the
+   PDF, so the two modes can slice differently) selects which item slice a given rendered section
+   shows; slices > 0 render the title as **`"<Title> (cont.)"`**.
 
 ### 3.4 Page breaks
 

--- a/docs/design/doc-editor.md
+++ b/docs/design/doc-editor.md
@@ -539,15 +539,16 @@ invented voids). The sidebar is user-resizable in edit mode via an 8px edge hand
 
 `metadata.layout: string[][][]` = **pages → columns → section ids**, plus
 `metadata.itemBreaks: Record<sectionId, itemId[]>` = items that start a new page (mid-section
-splits). Derivation pipeline (all in `docModel.ts`, all pure):
+splits). Derivation pipeline (production: `apps/web/src/lib/docLayout.ts` +
+`apps/web/src/lib/docPagination.ts`, all pure):
 
 1. `layoutPages` — raw pages with cross-page dedup (first occurrence of a section id wins;
    duplicates cause re-render bugs).
 2. `expandItemBreakPages` — a section with N break markers occupies N+1 consecutive pages **in the
    same column**; missing pages/columns are created.
-3. `renderPages` — strips section ids whose slice has no content on that page/column
+3. `renderSheetPages` — strips section ids whose slice has no content on that page/column
    (`sectionHasSliceContent`: summary only on slice 0; item sections need a non-empty slice from
-   `itemSlicesForSection`), then drops trailing empty pages. Result feeds the sheet stack.
+   `itemSlices`), then drops trailing empty pages. Result feeds the sheet stack.
 4. Per-instance: `sectionSliceIndex(doc, id, page, col)` (counted on **pre-strip** expanded pages so
    indices stay aligned with `itemBreaks`) selects which item slice a given rendered section shows;
    slices > 0 render the title as **`"<Title> (cont.)"`**.

--- a/docs/design/doc-editor.md
+++ b/docs/design/doc-editor.md
@@ -455,8 +455,8 @@ ghosts have no animation (instant).
 ### 2.5 Section drag & drop (blocks across columns/pages)
 
 - **Drag surfaces**: the header grip _and the whole card_ (same veto rules; presses on entry rows
-  are claimed by the entry drag first — entries carry `.edit-ready`, which the card's veto list
-  includes).
+  are claimed by the entry drag first — the card's veto list includes the entry-row class,
+  `.doc-sheet__entry-row` in production).
 - **Payload**: MIME `application/x-section`, `{id}`; mirrored in `secDragging`.
 - **Targets**: any other section card in any column of any page (drop index = that card's
   `{page, col, index}`, +1 for bottom half) and every column's **Add-section block** as the
@@ -554,10 +554,14 @@ splits). Derivation pipeline (all in `docModel.ts`, all pure):
 
 ### 3.4 Page breaks
 
-- **Creating**: the prototype UI never creates breaks explicitly; extra pages come from
-  `metadata.layout` having multiple pages (via drags to later pages) or from pre-existing
-  `itemBreaks` data. (Deliberate gap — see Open questions for an explicit "insert page break"
-  affordance.)
+- **Creating** (owner decision, §6 Q6 — implemented in #796): explicit "insert page break before"
+  actions. The section pencil menu splits `metadata.layout` so the section starts a fresh page
+  (disabled when the split would change nothing); the entry action pill adds an `itemBreaks`
+  marker before the item. On templates whose layout cannot honor mid-section breaks
+  (sidebar/two-column — Typst cannot page-break inside a grid) the item-level action is greyed
+  out with an explanatory tooltip reachable on hover _and_ keyboard focus (owner decision
+  2026-08-03); existing markers stay inert there. Extra pages also still come from drags to later
+  pages.
 - **Removing** (`removePageBreakAt(pageIndex)`): prefer clearing an **item-break** continuation
   shared across the boundary (find sections present in the same column of both rendered pages with
   slice > 0; delete the responsible break id); otherwise **merge** raw page `pageIndex` into


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): whole-surface drag and drop and explicit pagination
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The doc-editor wave for #796: spec §2's drag catalog and §3's pagination model on the modal-editing base (#794/#795).

**Whole-surface drag channels (spec §2.4–§2.5).** The grip-only solid-dnd mechanism is replaced with the spec's native HTML5 DnD:

- The whole item row and the whole section card are drag surfaces; grips remain and `stopPropagation` so surfaces don't double-fire.
- Presses that began on controls (and, for cards, on entry rows) are vetoed **in `dragstart`** — never `preventDefault` on `mousedown` (spec-pinned Chromium bug); selection is suppressed via `user-select: none`.
- Payloads ride `application/x-entry` / `application/x-section` MIME types, mirrored in the sheet's reactive signals (`sheetDnd.ts` context).
- Item drops are **same-section-only** (owner decision); section drops target any card's raw `{page, column, index}` (+1 for bottom half, `dragenter` *and* `dragover` both track) plus every column's Add-section block as the end-of-column target (`MAX_SAFE_INTEGER`, `drop-hint` styling).
- Indicators are 3px absolutely positioned accent slot bars (`.doc-sheet__entry-slot`, `.doc-sheet__sec-slot`) that never shift layout under a stationary pointer; dragged surfaces dim (0.4/0.45).
- A whole-section drop clears that section's item breaks in **one** combined store write (`updatePagination`), and drops auto-create missing raw pages.

**Explicit pagination (spec §1.16, §3.3–§3.4).** `metadata.itemBreaks` (schema wave) is now honored end to end in the editor:

- New pure module `lib/docPagination.ts`: expansion of broken sections onto consecutive same-column pages, item slicing (a marker on a slice's first item is inert, matching the Typst renderer), pre-strip slice indices, break-aware render/editor page stacks, and all mutation resolvers.
- Continuation cards render "<Title> (cont.)" and carry the add affordance only on the last slice.
- "Remove page break" prefers clearing the item break shared across the boundary, then falls back to the column-wise raw-page merge — one write, one undo entry either way.
- Explicit "insert page break before": section pencil menu (layout split, disabled when it would change nothing) and the entry action pill (item marker). On sidebar/two-column templates the pill action is greyed out with an explanatory tooltip reachable on hover **and** keyboard focus (owner decision 2026-08-03); existing markers stay inert there, matching #798's render behavior.
- Guards: item removal cleans its marker in the same write; load-time repairs strip markers on non-main-flow sections and malformed `itemBreaks` shapes.

Docs: spec §2.5/§3.3/§3.4 updated to the shipped behavior and production module names.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, vitest, Playwright e2e, `tsc --noEmit`)

## Related Issues

Closes #796

## Details

- **Gates**: `uv run lintro chk` clean (the only red is `pip_audit` aborting while bootstrapping its venv — a machine-level `ensurepip` SIGABRT, unrelated to this diff, which touches no Python); vitest 1047 passed (82 files, +50 new); Playwright e2e 77 passed / 5 skipped (visual project) including a new doc-editor test driving a real Chromium HTML5 drag; `tsc --noEmit` clean on both configs.
- **Review**: CodeRabbit CLI (10 findings: 4 major, 1 minor, 5 trivial) — all addressed in the follow-up commit except the suggestion to memoize the per-section enablement checks (`canInsertPageBreakBefore`) into a render-scoped set: those checks match the existing `canMoveUp`/`canMoveDown` enablement pattern from #794 and operate on document-scale data behind Solid's lazy prop access; the sibling perf findings (shared `expandItemBreakPages` memo, single slice-count computation) were applied. Greptile CLI was rate-limited (`free_reviews_limit_reached`).
- **Testing strategy**: pure resolvers pinned in `docPagination.test.ts` (27 tests) and `docDnd.test.ts`; drag semantics (MIME payloads, veto rules, slot indicators, same-section rejection, end-of-column target, combined pagination write) exercised at the component level in `sectionCards.test.tsx`; store-level marker cleanup and one-undo-entry pagination writes in `structuralActions.test.ts`; a real-browser drag + insert/remove page break flow in `e2e/doc-editor.spec.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorder document sections and entries with drag-and-drop across the editing surface.
  * Insert or remove page breaks before sections and between supported section items.
  * Automatically update pagination, page counts, and continuation sections as content moves.
  * Preserve page-break changes with undo support.
* **Bug Fixes**
  * Improved drag-and-drop placement indicators and prevented accidental drags from controls.
  * Cleaned up obsolete page breaks when content is removed or rearranged.
  * Page-break controls are appropriately disabled for unsupported layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->