### PR TITLE
feat(web): sections, templates, and theme panels for the document editor

### DIFF
--- a/apps/web/e2e/accessibility.spec.ts
+++ b/apps/web/e2e/accessibility.spec.ts
@@ -165,4 +165,57 @@ test.describe("accessibility", () => {
     await accountPage.assertLocalMode();
     expect(await scanForViolations(page)).toEqual([]);
   });
+
+  /**
+   * The document editor (#785–#797). A brand-new resume opens in Edit mode,
+   * which is the denser tree: section chrome, entry actions, the edge drawer
+   * buttons and the whole top bar are all present.
+   */
+  test.describe("document editor", () => {
+    test.use({ formBuilderOverride: false });
+
+    test("edit surface has no WCAG 2.2 AA violations", async ({
+      page,
+      homePage,
+      docEditorPage,
+    }) => {
+      await homePage.open();
+      await homePage.createResume();
+      await docEditorPage.assertDocEditorOpen();
+      await docEditorPage.assertMode("edit");
+      await expect(page.getByText("New resume created")).toBeHidden({ timeout: 15_000 });
+      expect(await scanForViolations(page)).toEqual([]);
+    });
+
+    test("drawers and theme dialog have no WCAG 2.2 AA violations", async ({
+      page,
+      homePage,
+      docEditorPage,
+    }) => {
+      await homePage.open();
+      await homePage.createResume();
+      await docEditorPage.assertDocEditorOpen();
+      await expect(page.getByText("New resume created")).toBeHidden({ timeout: 15_000 });
+
+      // Sections drawer, from its edge button.
+      await page.getByTestId("doc-editor-sections-tab").click();
+      await expect(page.getByRole("dialog", { name: "Sections" })).toBeVisible();
+      expect(await scanForViolations(page, '[role="dialog"]')).toEqual([]);
+      await page.keyboard.press("Escape");
+      await expect(page.getByRole("dialog", { name: "Sections" })).toBeHidden();
+
+      // Templates drawer, from its edge button.
+      await page.getByTestId("doc-editor-templates-tab").click();
+      const templates = page.getByRole("dialog", { name: "Templates" });
+      await expect(templates.getByTestId("templates-drawer-list")).toBeVisible();
+      expect(await scanForViolations(page, '[role="dialog"]')).toEqual([]);
+      await page.keyboard.press("Escape");
+      await expect(templates).toBeHidden();
+
+      // Theme dialog, from the top bar.
+      await page.getByTestId("doc-editor-theme-button").click();
+      await expect(page.getByRole("dialog", { name: "Theme" })).toBeVisible();
+      expect(await scanForViolations(page, '[role="dialog"]')).toEqual([]);
+    });
+  });
 });

--- a/apps/web/e2e/custom-sections.spec.ts
+++ b/apps/web/e2e/custom-sections.spec.ts
@@ -71,8 +71,17 @@ test.describe("custom sections from the panel", () => {
     await expect(row).toBeChecked();
     await expect(sheetCard(page, "Field Notes")).toHaveCount(1);
 
-    // Delete: gone from panel list and sheet immediately.
+    // Delete goes through the confirm dialog (#797): cancelling keeps the
+    // section, confirming removes it from panel list and sheet immediately.
     await panel.getByRole("button", { name: "Delete Field Notes section" }).click();
+    const confirm = page.getByRole("dialog", { name: "Delete section?" });
+    await expect(confirm).toBeVisible();
+    await confirm.getByRole("button", { name: "Cancel" }).click();
+    await expect(confirm).toBeHidden();
+    await expect(panel.getByRole("switch", { name: "Field Notes" })).toHaveCount(1);
+
+    await panel.getByRole("button", { name: "Delete Field Notes section" }).click();
+    await confirm.getByRole("button", { name: "Delete section" }).click();
     await expect(panel.getByRole("switch", { name: "Field Notes" })).toHaveCount(0);
     await expect(sheetCard(page, "Field Notes")).toHaveCount(0);
   });

--- a/apps/web/e2e/doc-editor.spec.ts
+++ b/apps/web/e2e/doc-editor.spec.ts
@@ -163,6 +163,57 @@ test.describe("single-surface document editor", () => {
     await expect(docEditorPage.sheet.getByTestId("doc-sheet-page-count")).toContainText("1");
   });
 
+  test("edge tabs drive the panels and the top bar drives theme selection", async ({
+    page,
+    homePage,
+    docEditorPage,
+  }) => {
+    await homePage.open();
+    await homePage.createResume();
+    await docEditorPage.assertDocEditorOpen();
+
+    // The panels are not top-bar items (owner decision 2026-08-04): their
+    // buttons ride the edges of the resume surface.
+    const topBar = page.getByTestId("doc-editor-topbar");
+    await expect(topBar.getByRole("button", { name: "Templates" })).toHaveCount(0);
+    await expect(topBar.getByRole("button", { name: "Sections" })).toHaveCount(0);
+
+    const templatesTab = page.getByTestId("doc-editor-templates-tab");
+    const sectionsTab = page.getByTestId("doc-editor-sections-tab");
+    await expect(templatesTab).toBeVisible();
+    await expect(sectionsTab).toBeVisible();
+
+    // Templates: expand from the left edge, collapse with Escape.
+    await templatesTab.click();
+    const templatesDrawer = page.getByRole("dialog", { name: "Templates" });
+    await expect(templatesDrawer).toBeVisible();
+    await expect(templatesDrawer.getByTestId("templates-drawer-list")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(templatesDrawer).toBeHidden();
+
+    // Sections: expand from the right edge, collapse with Escape.
+    await sectionsTab.click();
+    const sectionsDrawer = page.getByRole("dialog", { name: "Sections" });
+    await expect(sectionsDrawer).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(sectionsDrawer).toBeHidden();
+
+    // Theme selection stays in the top bar (spec §1.2, owner addition):
+    // picking a preset recolors the sheet through the store.
+    await topBar.getByRole("button", { name: "Theme" }).click();
+    const themeDialog = page.getByRole("dialog", { name: "Theme" });
+    await expect(themeDialog).toBeVisible();
+    await themeDialog.getByRole("button", { name: "Use Emerald theme" }).click();
+
+    await expect(docEditorPage.sheet).toHaveCSS("--doc-sheet-accent", "#65a30d");
+    await expect(themeDialog.getByRole("button", { name: "Use Emerald theme" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await page.keyboard.press("Escape");
+    await expect(themeDialog).toBeHidden();
+  });
+
   test("opening a legacy HTML resume shows formatted text, not raw tags", async ({
     page,
     homePage,

--- a/apps/web/src/components/doc-editor/SectionsPanel.tsx
+++ b/apps/web/src/components/doc-editor/SectionsPanel.tsx
@@ -5,9 +5,11 @@
  * Visibility toggles cover every fixed and custom section — including sections
  * currently hidden and therefore absent from the sheet, which is what makes a
  * hidden section recoverable. Custom sections can be added (through the same
- * dialog the sheet uses, so placement stays one undo entry) and removed. Notes
- * are private scratch text that never renders to the PDF, so they are a plain
- * text field — no rich editor, no markdown toolbar.
+ * dialog the sheet uses, so placement stays one undo entry) and deleted —
+ * deletion is destructive (owner decision, spec §6 Q5), so it always goes
+ * through a confirm dialog. Notes are private scratch text that never renders
+ * to the PDF, so they are a plain text field — no rich editor, no markdown
+ * toolbar.
  *
  * The panel is controlled: it renders no trigger of its own. The document
  * editor drives it from the Sections edge tab on the resume surface (owner
@@ -17,7 +19,7 @@
  */
 
 import { For, Show, createSignal, type JSX } from "solid-js";
-import { Button, Drawer, Switch, TextArea } from "../ui";
+import { Button, Drawer, Modal, Switch, TextArea } from "../ui";
 import { FIXED_SECTION_IDS, sectionTitle, sectionVisible } from "../../lib/docLayout";
 import { CustomSectionDialog } from "./CustomSectionDialog";
 import { removeSection, toggleSection, updateNotes } from "./docEdits";
@@ -31,8 +33,14 @@ export interface SectionsPanelProps {
 
 export function SectionsPanel(props: SectionsPanelProps): JSX.Element {
   const [adding, setAdding] = createSignal(false);
+  // The custom section id awaiting delete confirmation, if any.
+  const [confirmingDelete, setConfirmingDelete] = createSignal<string | null>(null);
 
   const customIds = (): string[] => Object.keys(props.resume.sections.custom ?? {});
+  const confirmingTitle = (): string => {
+    const sectionId = confirmingDelete();
+    return sectionId === null ? "" : sectionTitle(props.resume, sectionId);
+  };
 
   return (
     <>
@@ -84,7 +92,7 @@ export function SectionsPanel(props: SectionsPanelProps): JSX.Element {
                         class="focus-ring rounded-lg p-1.5 text-stone transition-colors
                           hover:bg-surface hover:text-red-600"
                         aria-label={`Delete ${sectionTitle(props.resume, sectionId)} section`}
-                        onClick={() => removeSection(sectionId)}
+                        onClick={() => setConfirmingDelete(sectionId)}
                       >
                         <svg
                           class="h-4 w-4"
@@ -127,6 +135,35 @@ export function SectionsPanel(props: SectionsPanelProps): JSX.Element {
       </Drawer>
 
       <CustomSectionDialog open={adding()} onOpenChange={setAdding} />
+
+      {/* Destructive delete always confirms (owner decision, spec §6 Q5):
+          unlike hiding, deleting discards the section's content for good —
+          undo is the only way back. */}
+      <Modal
+        open={confirmingDelete() !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmingDelete(null);
+        }}
+        title="Delete section?"
+        description={`"${confirmingTitle()}" and everything in it will be deleted.`}
+        size="sm"
+      >
+        <div class="flex justify-end gap-3">
+          <Button variant="secondary" onClick={() => setConfirmingDelete(null)}>
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            onClick={() => {
+              const sectionId = confirmingDelete();
+              setConfirmingDelete(null);
+              if (sectionId !== null) removeSection(sectionId);
+            }}
+          >
+            Delete section
+          </Button>
+        </div>
+      </Modal>
     </>
   );
 }

--- a/apps/web/src/components/doc-editor/SectionsPanel.tsx
+++ b/apps/web/src/components/doc-editor/SectionsPanel.tsx
@@ -9,6 +9,10 @@
  * are private scratch text that never renders to the PDF, so they are a plain
  * text field — no rich editor, no markdown toolbar.
  *
+ * The panel is controlled: it renders no trigger of its own. The document
+ * editor drives it from the Sections edge tab on the resume surface (owner
+ * decision 2026-08-04: the panels are not top-bar items).
+ *
  * Every mutation routes through `docEdits` (decision 4).
  */
 
@@ -21,41 +25,20 @@ import type { ResumeData } from "../../wasm/types";
 
 export interface SectionsPanelProps {
   resume: ResumeData;
-  /**
-   * Controlled open state, so the sheet's Add-section blocks can open the
-   * panel (#794). Leave both unset for the self-contained top-bar behaviour.
-   */
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
 export function SectionsPanel(props: SectionsPanelProps): JSX.Element {
-  const [internalOpen, setInternalOpen] = createSignal(false);
   const [adding, setAdding] = createSignal(false);
-
-  // Controlled iff `open` is supplied — and then `onOpenChange` must drive it,
-  // so a one-sided pairing cannot leave the panel stuck open or closed.
-  const isControlled = (): boolean => props.open !== undefined;
-  const open = (): boolean => (isControlled() ? (props.open ?? false) : internalOpen());
-  const setOpen = (next: boolean): void => {
-    if (isControlled()) {
-      props.onOpenChange?.(next);
-      return;
-    }
-    setInternalOpen(next);
-  };
 
   const customIds = (): string[] => Object.keys(props.resume.sections.custom ?? {});
 
   return (
     <>
-      <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
-        Sections
-      </Button>
-
       <Drawer
-        open={open()}
-        onOpenChange={setOpen}
+        open={props.open}
+        onOpenChange={props.onOpenChange}
         title="Sections"
         description="Show, hide and manage the document's sections."
         side="right"

--- a/apps/web/src/components/doc-editor/TemplatesDrawer.tsx
+++ b/apps/web/src/components/doc-editor/TemplatesDrawer.tsx
@@ -10,9 +10,21 @@
  * action — a single undo entry — re-placing custom sections the new template's
  * defaults do not mention. The sheet re-renders from the new layout reactively;
  * nothing here touches the page frames or their drop zones.
+ *
+ * The drawer is controlled: it renders no trigger of its own. The document
+ * editor drives it from the Templates edge tab on the resume surface (owner
+ * decision 2026-08-04: the panels are not top-bar items).
  */
 
-import { For, Show, Suspense, createResource, createSignal, type JSX } from "solid-js";
+import {
+  For,
+  Show,
+  Suspense,
+  createEffect,
+  createResource,
+  createSignal,
+  type JSX,
+} from "solid-js";
 import { Button, Drawer, Spinner } from "../ui";
 import { fetchTemplates, getTemplateThumbnailUrl } from "../../api/render";
 import { FALLBACK_TEMPLATE_LAYOUT, type TemplateLayoutMode } from "../../lib/docLayout";
@@ -36,12 +48,16 @@ function layoutSummary(template: TemplateInfo): string {
 
 export interface TemplatesDrawerProps {
   resume: ResumeData;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
 export function TemplatesDrawer(props: TemplatesDrawerProps): JSX.Element {
-  const [open, setOpen] = createSignal(false);
   // Latches true on first open so the registry is fetched once, lazily.
   const [requested, setRequested] = createSignal(false);
+  createEffect(() => {
+    if (props.open) setRequested(true);
+  });
   const [templates, { refetch }] = createResource(
     () => requested() || undefined,
     () => fetchTemplates(),
@@ -54,71 +70,58 @@ export function TemplatesDrawer(props: TemplatesDrawerProps): JSX.Element {
     if (template.id !== props.resume.metadata.template) {
       applyTemplate(template.id, template.layout ?? FALLBACK_TEMPLATE_LAYOUT);
     }
-    setOpen(false);
+    props.onOpenChange(false);
   }
 
   return (
-    <>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => {
-          setRequested(true);
-          setOpen(true);
-        }}
+    <Drawer
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      title="Templates"
+      description="Pick a design from the registry; your sections come along."
+      side="left"
+    >
+      <Suspense
+        fallback={
+          <div class="flex items-center justify-center py-12">
+            <Spinner />
+          </div>
+        }
       >
-        Templates
-      </Button>
-
-      <Drawer
-        open={open()}
-        onOpenChange={setOpen}
-        title="Templates"
-        description="Pick a design from the registry; your sections come along."
-        side="left"
-      >
-        <Suspense
+        <Show
+          when={!templates.error}
           fallback={
-            <div class="flex items-center justify-center py-12">
-              <Spinner />
+            <div class="flex flex-col items-center gap-3 py-8">
+              <p class="text-center text-sm text-red-600" role="alert">
+                Failed to load templates. Check that the server is running and try again.
+              </p>
+              <Button variant="secondary" size="sm" onClick={() => void refetch()}>
+                Retry
+              </Button>
             </div>
           }
         >
           <Show
-            when={!templates.error}
-            fallback={
-              <div class="flex flex-col items-center gap-3 py-8">
-                <p class="text-center text-sm text-red-600" role="alert">
-                  Failed to load templates. Check that the server is running and try again.
-                </p>
-                <Button variant="secondary" size="sm" onClick={() => void refetch()}>
-                  Retry
-                </Button>
-              </div>
-            }
+            when={templates()?.length}
+            fallback={<p class="py-8 text-center text-sm text-stone">No templates available.</p>}
           >
-            <Show
-              when={templates()?.length}
-              fallback={<p class="py-8 text-center text-sm text-stone">No templates available.</p>}
-            >
-              <ul class="grid grid-cols-2 gap-3" data-testid="templates-drawer-list">
-                <For each={templates()}>
-                  {(template) => (
-                    <li>
-                      <TemplateCard
-                        template={template}
-                        isCurrent={props.resume.metadata.template === template.id}
-                        onSelect={select}
-                      />
-                    </li>
-                  )}
-                </For>
-              </ul>
-            </Show>
+            <ul class="grid grid-cols-2 gap-3" data-testid="templates-drawer-list">
+              <For each={templates()}>
+                {(template) => (
+                  <li>
+                    <TemplateCard
+                      template={template}
+                      isCurrent={props.resume.metadata.template === template.id}
+                      onSelect={select}
+                    />
+                  </li>
+                )}
+              </For>
+            </ul>
           </Show>
-        </Suspense>
-      </Drawer>
-    </>
+        </Show>
+      </Suspense>
+    </Drawer>
   );
 }
 

--- a/apps/web/src/components/doc-editor/ThemeDialog.tsx
+++ b/apps/web/src/components/doc-editor/ThemeDialog.tsx
@@ -1,0 +1,183 @@
+/**
+ * Theme selection for the document editor's top bar (spec §1.2, owner
+ * addition: "version history and theme selection controls in this bar").
+ *
+ * A modal — matching the editor's modal-editing model (owner decision
+ * 2026-08-04) — over the embedded client-side presets (`stores/themePresets`,
+ * offline-first, no server dependency) plus the three custom color fields.
+ * Picking a preset lands its id and all three colors as one store action;
+ * hand-editing a color detaches the theme from its preset. Every write routes
+ * through `docEdits` (decision 4), so the sheet recolors reactively and each
+ * change is one undo entry.
+ */
+
+import { For, Show, createSignal, type JSX } from "solid-js";
+import { Modal } from "../ui";
+import { getThemePresets } from "../../stores/themePresets";
+import { applyThemePreset, updateThemeColor } from "./docEdits";
+import type { ResumeData, Theme, ThemePresetInfo } from "../../wasm/types";
+
+export interface ThemeDialogProps {
+  resume: ResumeData;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const COLOR_FIELDS: readonly { field: keyof Omit<Theme, "preset">; label: string }[] = [
+  { field: "background", label: "Background" },
+  { field: "text", label: "Text" },
+  { field: "primary", label: "Primary" },
+];
+
+const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
+
+export function ThemeDialog(props: ThemeDialogProps): JSX.Element {
+  const presets = getThemePresets();
+  const lightPresets = presets.filter((preset) => !preset.isDark);
+  const darkPresets = presets.filter((preset) => preset.isDark);
+
+  const theme = (): Theme => props.resume.metadata.theme;
+
+  return (
+    <Modal
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      title="Theme"
+      description="Colors for the rendered document — the PDF uses them too."
+      size="lg"
+    >
+      <div class="flex flex-col gap-6" data-testid="theme-dialog">
+        <section aria-label="Light themes">
+          <h3 class="mb-2 font-mono text-xs uppercase tracking-wider text-stone">Light themes</h3>
+          <PresetGrid presets={lightPresets} currentPresetId={theme().preset} />
+        </section>
+
+        <section aria-label="Dark themes">
+          <h3 class="mb-2 font-mono text-xs uppercase tracking-wider text-stone">Dark themes</h3>
+          <PresetGrid presets={darkPresets} currentPresetId={theme().preset} />
+        </section>
+
+        <section aria-label="Custom colors">
+          <h3 class="mb-2 font-mono text-xs uppercase tracking-wider text-stone">Custom colors</h3>
+          <div class="grid grid-cols-3 gap-4">
+            <For each={COLOR_FIELDS}>
+              {({ field, label }) => (
+                <ColorField label={label} value={theme()[field] ?? ""} field={field} />
+              )}
+            </For>
+          </div>
+        </section>
+      </div>
+    </Modal>
+  );
+}
+
+function PresetGrid(props: {
+  presets: ThemePresetInfo[];
+  currentPresetId: string | undefined;
+}): JSX.Element {
+  return (
+    <ul class="grid grid-cols-6 gap-2">
+      <For each={props.presets}>
+        {(preset) => (
+          <li>
+            <button
+              type="button"
+              class={`focus-ring w-full rounded-lg border-2 p-1.5 transition-colors
+                hover:border-accent
+                ${
+                  props.currentPresetId === preset.id
+                    ? "border-accent ring-2 ring-accent/20"
+                    : "border-border"
+                }`}
+              aria-label={`Use ${preset.name} theme`}
+              aria-pressed={props.currentPresetId === preset.id}
+              title={preset.name}
+              onClick={() => applyThemePreset(preset)}
+            >
+              <span
+                class="flex aspect-square w-full flex-col justify-end gap-0.5 overflow-hidden
+                  rounded-md border border-border/50 p-1"
+                style={{ background: preset.colors.background }}
+              >
+                <span
+                  class="h-1 w-3/4 rounded-full opacity-60"
+                  style={{ background: preset.colors.text }}
+                />
+                <span
+                  class="h-1.5 w-1/2 rounded-full"
+                  style={{ background: preset.colors.primary }}
+                />
+              </span>
+              <span class="mt-1 block truncate text-center text-[10px] text-stone">
+                {preset.name}
+              </span>
+            </button>
+          </li>
+        )}
+      </For>
+    </ul>
+  );
+}
+
+/**
+ * One theme color: a native picker behind a swatch, plus an editable hex
+ * field. Only a complete `#rrggbb` value commits — partial typing must not
+ * write garbage into the document.
+ */
+function ColorField(props: {
+  label: string;
+  value: string;
+  field: keyof Omit<Theme, "preset">;
+}): JSX.Element {
+  const [draft, setDraft] = createSignal<string | null>(null);
+  const inputId = (): string => `theme-color-${props.field}`;
+
+  function commitHex(value: string): void {
+    if (HEX_COLOR_REGEX.test(value)) {
+      setDraft(null);
+      updateThemeColor(props.field, value);
+      return;
+    }
+    setDraft(value);
+  }
+
+  return (
+    <div class="space-y-1.5">
+      <label for={inputId()} class="block font-mono text-xs uppercase tracking-wider text-stone">
+        {props.label}
+      </label>
+      <div class="flex items-center gap-2">
+        <span
+          class="relative h-8 w-8 shrink-0 overflow-hidden rounded-lg border border-border"
+          style={{ background: props.value }}
+        >
+          <input
+            type="color"
+            value={props.value}
+            aria-label={`Pick ${props.label.toLowerCase()} color`}
+            class="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            onInput={(event) => {
+              setDraft(null);
+              updateThemeColor(props.field, event.currentTarget.value);
+            }}
+          />
+        </span>
+        <input
+          id={inputId()}
+          type="text"
+          value={draft() ?? props.value}
+          maxLength={7}
+          placeholder="#000000"
+          class="focus-ring w-full rounded-lg border border-border bg-surface px-2 py-1.5
+            font-mono text-xs uppercase"
+          onInput={(event) => commitHex(event.currentTarget.value)}
+          onBlur={() => setDraft(null)}
+        />
+      </div>
+      <Show when={draft() !== null}>
+        <p class="text-[10px] text-stone">Use a full #rrggbb value.</p>
+      </Show>
+    </div>
+  );
+}

--- a/apps/web/src/components/doc-editor/ThemeDialog.tsx
+++ b/apps/web/src/components/doc-editor/ThemeDialog.tsx
@@ -157,7 +157,10 @@ function ColorField(props: {
             value={props.value}
             aria-label={`Pick ${props.label.toLowerCase()} color`}
             class="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-            onInput={(event) => {
+            // `change`, not `input`: the native picker fires `input` on every
+            // drag tick, which would burn one store write (and undo entry)
+            // per tick — `change` commits once per completed selection.
+            onChange={(event) => {
               setDraft(null);
               updateThemeColor(props.field, event.currentTarget.value);
             }}

--- a/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
@@ -221,15 +221,39 @@ describe("document editor panels", () => {
       expect(writeCount()).toBe(1);
     });
 
-    it("removes a custom section through removeCustomSection", () => {
+    it("deletes a custom section only after the confirm step", async () => {
+      // Destructive delete (owner decision, spec §6 Q5): the trash button
+      // alone must write nothing — the confirm dialog's Delete does.
       const panel = openPanel();
 
       fireEvent.click(
         within(panel).getByRole("button", { name: "Delete Talks & Workshops section" }),
       );
 
+      const dialog = await screen.findByRole("dialog", { name: "Delete section?" });
+      expect(dialog).toHaveTextContent("Talks & Workshops");
+      expect(writeCount()).toBe(0);
+
+      fireEvent.click(within(dialog).getByRole("button", { name: "Delete section" }));
+
       expect(store.removeCustomSection).toHaveBeenCalledExactlyOnceWith("speaking");
       expect(writeCount()).toBe(1);
+    });
+
+    it("cancelling the delete confirm keeps the section", async () => {
+      const panel = openPanel();
+
+      fireEvent.click(
+        within(panel).getByRole("button", { name: "Delete Talks & Workshops section" }),
+      );
+      const dialog = await screen.findByRole("dialog", { name: "Delete section?" });
+      fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog", { name: "Delete section?" })).toBeNull(),
+      );
+      expect(store.removeCustomSection).not.toHaveBeenCalled();
+      expect(writeCount()).toBe(0);
     });
 
     it("commits notes as plain text, with no rich-text controls", () => {

--- a/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
@@ -76,9 +76,12 @@ describe("document editor panels", () => {
   });
 
   describe("templates drawer", () => {
+    const onOpenChange = vi.fn();
+
+    // The drawer is controlled (owner decision 2026-08-04): the editor's edge
+    // tab drives `open`; the drawer itself renders no trigger.
     async function openDrawer() {
-      render(() => <TemplatesDrawer resume={resume} />);
-      fireEvent.click(screen.getByRole("button", { name: "Templates" }));
+      render(() => <TemplatesDrawer resume={resume} open onOpenChange={onOpenChange} />);
       await waitFor(() => expect(screen.getByTestId("templates-drawer-list")).toBeInTheDocument());
     }
 
@@ -108,11 +111,12 @@ describe("document editor panels", () => {
       );
     });
 
-    it("switches template and layout through one combined store action", async () => {
+    it("switches template and layout through one combined store action, then closes", async () => {
       await openDrawer();
 
       fireEvent.click(screen.getByRole("button", { name: "Use Aurora template" }));
 
+      expect(onOpenChange).toHaveBeenCalledWith(false);
       expect(store.applyTemplate).toHaveBeenCalledOnce();
       expect(writeCount()).toBe(1);
       const [templateId, layout] = store.applyTemplate.mock.calls[0] as [string, string[][][]];
@@ -156,9 +160,7 @@ describe("document editor panels", () => {
 
     it("reports a registry failure, and retries without reopening", async () => {
       api.fetchTemplates.mockRejectedValue(new Error("down"));
-      render(() => <TemplatesDrawer resume={resume} />);
-
-      fireEvent.click(screen.getByRole("button", { name: "Templates" }));
+      render(() => <TemplatesDrawer resume={resume} open onOpenChange={onOpenChange} />);
 
       await waitFor(() => {
         expect(screen.getByRole("alert")).toHaveTextContent(/failed to load templates/i);
@@ -174,9 +176,10 @@ describe("document editor panels", () => {
   });
 
   describe("sections panel", () => {
+    // Controlled just like the templates drawer: the editor's edge tab owns
+    // `open` (it is also what the sheet's Add-section blocks drive, #794).
     function openPanel() {
-      render(() => <SectionsPanel resume={resume} />);
-      fireEvent.click(screen.getByRole("button", { name: "Sections" }));
+      render(() => <SectionsPanel resume={resume} open onOpenChange={vi.fn()} />);
       return screen.getByTestId("sections-panel");
     }
 

--- a/apps/web/src/components/doc-editor/__tests__/themeDialog.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/themeDialog.test.tsx
@@ -105,10 +105,12 @@ describe("theme dialog", () => {
     expect(within(dialog).getByText("Use a full #rrggbb value.")).toBeInTheDocument();
   });
 
-  it("commits from the native color picker as one action", () => {
+  it("commits a completed native color selection as one action", () => {
     const dialog = openDialog();
 
-    fireEvent.input(within(dialog).getByLabelText("Pick text color"), {
+    // `change`, not `input`: the picker's per-drag-tick `input` events must
+    // not write — only the completed selection commits.
+    fireEvent.change(within(dialog).getByLabelText("Pick text color"), {
       target: { value: "#222222" },
     });
 

--- a/apps/web/src/components/doc-editor/__tests__/themeDialog.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/themeDialog.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Theme selection (#797, spec §1.2 owner addition): the top-bar theme dialog
+ * over the embedded presets plus custom colors. Every control must route to
+ * `resumeStore.updateTheme`, one store action per user gesture — a preset
+ * click lands its id and all three colors together; a hand-picked color
+ * detaches the preset.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@solidjs/testing-library";
+import { loadDocEditorFixture } from "../../../test/docEditorFixture";
+import { THEME_PRESETS } from "../../../stores/themePresets";
+import { ThemeDialog } from "../ThemeDialog";
+import type { ResumeData } from "../../../wasm/types";
+
+const store = vi.hoisted(() => ({
+  store: { resume: null as unknown },
+  updateTheme: vi.fn(),
+}));
+
+vi.mock("../../../stores/resume", () => ({ resumeStore: store }));
+
+describe("theme dialog", () => {
+  let resume: ResumeData;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resume = loadDocEditorFixture();
+    resume.metadata.theme = {
+      preset: undefined,
+      background: "#ffffff",
+      text: "#000000",
+      primary: "#dc2626",
+    };
+    store.store.resume = resume;
+  });
+
+  function openDialog() {
+    render(() => <ThemeDialog resume={resume} open onOpenChange={vi.fn()} />);
+    return screen.getByTestId("theme-dialog");
+  }
+
+  it("lists every embedded preset, grouped by light and dark", () => {
+    const dialog = openDialog();
+
+    const light = within(dialog).getByRole("region", { name: "Light themes" });
+    const dark = within(dialog).getByRole("region", { name: "Dark themes" });
+    const lightCount = THEME_PRESETS.filter((preset) => !preset.isDark).length;
+    const darkCount = THEME_PRESETS.filter((preset) => preset.isDark).length;
+    expect(within(light).getAllByRole("button")).toHaveLength(lightCount);
+    expect(within(dark).getAllByRole("button")).toHaveLength(darkCount);
+  });
+
+  it("applies a preset as one store action carrying id and all three colors", () => {
+    const dialog = openDialog();
+    const preset = THEME_PRESETS.find((candidate) => candidate.id === "light-emerald");
+    if (!preset) throw new Error("light-emerald preset missing");
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Use Emerald theme" }));
+
+    expect(store.updateTheme).toHaveBeenCalledExactlyOnceWith({
+      preset: "light-emerald",
+      background: preset.colors.background,
+      text: preset.colors.text,
+      primary: preset.colors.primary,
+    });
+  });
+
+  it("marks the resume's current preset", () => {
+    resume.metadata.theme.preset = "light-emerald";
+    const dialog = openDialog();
+
+    expect(within(dialog).getByRole("button", { name: "Use Emerald theme" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(within(dialog).getByRole("button", { name: "Use Default theme" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("commits a complete hex value and detaches the preset", () => {
+    resume.metadata.theme.preset = "light-default";
+    const dialog = openDialog();
+
+    fireEvent.input(within(dialog).getByRole("textbox", { name: "Primary" }), {
+      target: { value: "#123abc" },
+    });
+
+    expect(store.updateTheme).toHaveBeenCalledExactlyOnceWith({
+      primary: "#123abc",
+      preset: undefined,
+    });
+  });
+
+  it("never writes a partial hex value", () => {
+    const dialog = openDialog();
+
+    fireEvent.input(within(dialog).getByRole("textbox", { name: "Background" }), {
+      target: { value: "#12" },
+    });
+
+    expect(store.updateTheme).not.toHaveBeenCalled();
+    expect(within(dialog).getByText("Use a full #rrggbb value.")).toBeInTheDocument();
+  });
+
+  it("commits from the native color picker as one action", () => {
+    const dialog = openDialog();
+
+    fireEvent.input(within(dialog).getByLabelText("Pick text color"), {
+      target: { value: "#222222" },
+    });
+
+    expect(store.updateTheme).toHaveBeenCalledExactlyOnceWith({
+      text: "#222222",
+      preset: undefined,
+    });
+  });
+});

--- a/apps/web/src/components/doc-editor/docEdits.ts
+++ b/apps/web/src/components/doc-editor/docEdits.ts
@@ -19,7 +19,7 @@ import {
   type TemplateLayout,
 } from "../../lib/docLayout";
 import { resumeStore, type LayoutSectionKey, type SectionKey } from "../../stores/resume";
-import type { Basics, CustomItem, Picture } from "../../wasm/types";
+import type { Basics, CustomItem, Picture, Theme, ThemePresetInfo } from "../../wasm/types";
 
 /** A partial item, keyed by the field names in `itemFields.ts`. */
 export type ItemUpdates = Record<string, unknown>;
@@ -174,6 +174,24 @@ export function applyTemplate(templateId: string, templateLayout: TemplateLayout
   const resume = resumeStore.store.resume;
   if (!resume) return;
   resumeStore.applyTemplate(templateId, layoutForTemplate(resume, templateLayout));
+}
+
+/** Apply a theme preset — its id and all three colors as one store action. */
+export function applyThemePreset(preset: ThemePresetInfo): void {
+  resumeStore.updateTheme({
+    preset: preset.id,
+    background: preset.colors.background,
+    text: preset.colors.text,
+    primary: preset.colors.primary,
+  });
+}
+
+/**
+ * Set one custom theme color, detaching the theme from any preset — a palette
+ * with a hand-picked color is no longer the preset it started from.
+ */
+export function updateThemeColor(field: keyof Omit<Theme, "preset">, value: string): void {
+  resumeStore.updateTheme({ [field]: value, preset: undefined });
 }
 
 /** Replace the private notes scratch text. Plain text; never rendered to PDF. */

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -647,15 +647,17 @@
   font-weight: 700;
   letter-spacing: 0.09em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--doc-sheet-accent) 75%, var(--doc-sheet-text));
+  /* Muted through color, never element opacity: a semi-transparent label
+     over the paper fails WCAG 1.4.3 (#797 axe sweep). Mixing toward the
+     document text keeps the resting label readable on any theme. */
+  color: color-mix(in srgb, var(--doc-sheet-accent) 45%, var(--doc-sheet-text));
   background: transparent;
-  border: 2px dashed color-mix(in srgb, var(--doc-sheet-accent) 38%, #c7c1b8);
+  border: 2px dashed color-mix(in srgb, var(--doc-sheet-accent) 24%, #c7c1b8);
   border-radius: 10px;
   padding: 0.45rem 0.55rem;
   cursor: pointer;
-  opacity: 0.55;
   transition:
-    opacity 0.12s ease,
+    color 0.12s ease,
     background 0.12s ease,
     border-color 0.12s ease;
 }
@@ -669,7 +671,8 @@
 .doc-sheet__sec--edit:hover > .doc-sheet__add-block,
 .doc-sheet__sec--focused > .doc-sheet__add-block,
 .doc-sheet__add-block:focus-visible {
-  opacity: 1;
+  color: color-mix(in srgb, var(--doc-sheet-accent) 75%, var(--doc-sheet-text));
+  border-color: color-mix(in srgb, var(--doc-sheet-accent) 38%, #c7c1b8);
 }
 
 .doc-sheet__add-block:hover {
@@ -694,14 +697,14 @@
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #8d8578;
+  /* Same 1.4.3 rule as the add-block: muted through a theme-tracking color
+     at full opacity, never element opacity (#797 axe sweep). */
+  color: var(--doc-sheet-muted);
   background: transparent;
   border: 2px dashed #cfc9bd;
   border-radius: 12px;
   cursor: pointer;
-  opacity: 0.6;
   transition:
-    opacity 0.12s ease,
     background 0.12s ease,
     border-color 0.12s ease,
     color 0.12s ease;
@@ -710,7 +713,6 @@
 .doc-sheet__add-section-block:hover,
 .doc-sheet__add-section-block:focus-visible,
 .doc-sheet__add-section-block--drop-hint {
-  opacity: 1;
   color: var(--doc-sheet-accent);
   border-color: color-mix(in srgb, var(--doc-sheet-accent) 55%, #cfc9bd);
   background: color-mix(in srgb, var(--doc-sheet-accent) 6%, var(--doc-sheet-bg));

--- a/apps/web/src/components/doc-editor/index.ts
+++ b/apps/web/src/components/doc-editor/index.ts
@@ -10,5 +10,6 @@ export { CustomSectionDialog, type CustomSectionDialogProps } from "./CustomSect
 export { PhotoDialog, type PhotoDialogProps } from "./PhotoDialog";
 export { TemplatesDrawer, type TemplatesDrawerProps } from "./TemplatesDrawer";
 export { SectionsPanel, type SectionsPanelProps } from "./SectionsPanel";
+export { ThemeDialog, type ThemeDialogProps } from "./ThemeDialog";
 export { MarkdownView } from "./MarkdownView";
 export { SheetModeContext, useSheetEditable, type SheetMode } from "./sheetMode";

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -155,8 +155,11 @@ export default function DocEditor() {
     () => layouts()?.[store.resume?.metadata.template ?? ""] ?? FALLBACK_TEMPLATE_LAYOUT,
   );
 
-  // Lifted so the sheet's Add-section blocks can open the panel (#794).
+  // Lifted so the sheet's Add-section blocks can open the panel (#794). Both
+  // drawers hang off the edge tabs on the resume surface, never the top bar
+  // (owner decision 2026-08-04).
   const [isSectionsOpen, setIsSectionsOpen] = createSignal(false);
+  const [isTemplatesOpen, setIsTemplatesOpen] = createSignal(false);
 
   // Edit or Done, per document. A brand-new empty resume opens ready to type;
   // an existing one opens as the clean rendered document.
@@ -199,23 +202,10 @@ export default function DocEditor() {
         reflows anything. Pagination is a section-level `metadata.layout`
         decision made elsewhere.
       */}
-      <div class="h-12 flex items-center justify-between gap-4 border-b border-border bg-paper px-4">
-        {/* Panel chrome around the sheet: the drawers overlay the surface and
-            never disturb the page frames or their drop zones. */}
-        <div class="flex items-center gap-2">
-          <Show when={store.resume}>
-            {(resume) => (
-              <>
-                <TemplatesDrawer resume={resume()} />
-                <SectionsPanel
-                  resume={resume()}
-                  open={isSectionsOpen()}
-                  onOpenChange={setIsSectionsOpen}
-                />
-              </>
-            )}
-          </Show>
-        </div>
+      <div
+        class="h-12 flex items-center justify-end gap-4 border-b border-border bg-paper px-4"
+        data-testid="doc-editor-topbar"
+      >
         <div class="flex items-center gap-2">
           <Button
             variant="ghost"
@@ -328,7 +318,7 @@ export default function DocEditor() {
         </div>
       </div>
 
-      <div class="flex-1 overflow-hidden">
+      <div class="relative flex-1 overflow-hidden">
         <Show
           when={!isLoading() && !loadError() && store.resume != null}
           fallback={
@@ -377,6 +367,42 @@ export default function DocEditor() {
               </Show>
             </div>
           </div>
+
+          {/* Drawer chrome around the sheet (owner decision 2026-08-04: not
+              top-bar items): edge tabs on the resume surface expand/collapse
+              the Templates and Sections drawers in place. The drawers overlay
+              the surface and never disturb the page frames or their drop
+              zones. */}
+          <Show when={store.resume}>
+            {(resume) => (
+              <>
+                <SurfaceEdgeTab
+                  side="left"
+                  label="Templates"
+                  testId="doc-editor-templates-tab"
+                  expanded={isTemplatesOpen()}
+                  onToggle={() => setIsTemplatesOpen(!isTemplatesOpen())}
+                />
+                <SurfaceEdgeTab
+                  side="right"
+                  label="Sections"
+                  testId="doc-editor-sections-tab"
+                  expanded={isSectionsOpen()}
+                  onToggle={() => setIsSectionsOpen(!isSectionsOpen())}
+                />
+                <TemplatesDrawer
+                  resume={resume()}
+                  open={isTemplatesOpen()}
+                  onOpenChange={setIsTemplatesOpen}
+                />
+                <SectionsPanel
+                  resume={resume()}
+                  open={isSectionsOpen()}
+                  onOpenChange={setIsSectionsOpen}
+                />
+              </>
+            )}
+          </Show>
         </Show>
       </div>
 
@@ -397,5 +423,42 @@ export default function DocEditor() {
         </Suspense>
       </Show>
     </div>
+  );
+}
+
+interface SurfaceEdgeTabProps {
+  side: "left" | "right";
+  label: string;
+  testId: string;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * A vertical drawer button riding one edge of the resume surface (owner
+ * decision 2026-08-04): clicking it expands its drawer in place; clicking
+ * again — or the drawer's own backdrop/Escape — collapses it. Vertical
+ * writing keeps the tab narrow, so it never crowds the sheet; the left tab
+ * is flipped so both read away from the page.
+ */
+function SurfaceEdgeTab(props: SurfaceEdgeTabProps) {
+  return (
+    <button
+      type="button"
+      data-testid={props.testId}
+      aria-haspopup="dialog"
+      aria-expanded={props.expanded}
+      onClick={() => props.onToggle()}
+      class={`focus-ring absolute top-1/2 z-10 -translate-y-1/2 border border-border bg-paper
+        px-1.5 py-4 font-mono text-xs uppercase tracking-wider text-stone shadow-sm
+        transition-colors hover:bg-surface hover:text-ink [writing-mode:vertical-rl]
+        ${
+          props.side === "left"
+            ? "left-0 rotate-180 rounded-l-lg border-r-0"
+            : "right-0 rounded-l-lg border-r-0"
+        }`}
+    >
+      {props.label}
+    </button>
   );
 }

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -25,7 +25,7 @@ import {
 } from "solid-js";
 import { useNavigate, useParams } from "@solidjs/router";
 import { Button, Spinner, toast } from "../components/ui";
-import { DocSheet, SectionsPanel, TemplatesDrawer } from "../components/doc-editor";
+import { DocSheet, SectionsPanel, TemplatesDrawer, ThemeDialog } from "../components/doc-editor";
 import type { SheetMode } from "../components/doc-editor/sheetMode";
 import { CustomCssInjector } from "../components/templates/CustomCssInjector";
 import { useHotkeys, type Shortcut } from "../hooks/useHotkeys";
@@ -161,6 +161,9 @@ export default function DocEditor() {
   const [isSectionsOpen, setIsSectionsOpen] = createSignal(false);
   const [isTemplatesOpen, setIsTemplatesOpen] = createSignal(false);
 
+  // Theme selection lives in the top bar (spec §1.2, owner addition).
+  const [isThemeOpen, setIsThemeOpen] = createSignal(false);
+
   // Edit or Done, per document. A brand-new empty resume opens ready to type;
   // an existing one opens as the clean rendered document.
   const [mode, setMode] = createSignal<SheetMode>("edit");
@@ -287,6 +290,31 @@ export default function DocEditor() {
             </svg>
             Export
           </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="doc-editor-theme-button"
+            onClick={() => setIsThemeOpen(true)}
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0
+                  01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11
+                  7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010
+                  2.828l-8.486 8.485M7 17h.01"
+              />
+            </svg>
+            Theme
+          </Button>
           <Button variant="ghost" size="sm" onClick={() => openModal("versionHistory")}>
             <svg
               class="w-4 h-4"
@@ -400,6 +428,7 @@ export default function DocEditor() {
                   open={isSectionsOpen()}
                   onOpenChange={setIsSectionsOpen}
                 />
+                <ThemeDialog resume={resume()} open={isThemeOpen()} onOpenChange={setIsThemeOpen} />
               </>
             )}
           </Show>

--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -342,6 +342,17 @@ describe("DocEditor sheet", () => {
     expect(tab).toHaveAttribute("aria-expanded", "true");
   });
 
+  it("opens theme selection from the top bar", async () => {
+    await renderSheet();
+
+    // Spec §1.2 (owner addition): theme selection is a top-bar control.
+    const topBar = screen.getByTestId("doc-editor-topbar");
+    fireEvent.click(within(topBar).getByRole("button", { name: "Theme" }));
+
+    expect(await screen.findByRole("dialog", { name: /Theme/ })).toBeInTheDocument();
+    expect(screen.getByTestId("theme-dialog")).toBeInTheDocument();
+  });
+
   it("has no axe violations in Edit mode", async () => {
     const { container } = await renderSheet();
 

--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -311,6 +311,37 @@ describe("DocEditor sheet", () => {
     expect(document.querySelectorAll(".doc-sheet__page-guide")).toHaveLength(0);
   });
 
+  it("drives the Templates drawer from its surface edge tab, not the top bar", async () => {
+    await renderSheet();
+
+    // Owner decision 2026-08-04: the panels are not top-bar items.
+    const topBar = screen.getByTestId("doc-editor-topbar");
+    expect(within(topBar).queryByRole("button", { name: "Templates" })).toBeNull();
+    expect(within(topBar).queryByRole("button", { name: "Sections" })).toBeNull();
+
+    const tab = screen.getByTestId("doc-editor-templates-tab");
+    expect(tab).toHaveTextContent("Templates");
+    expect(tab).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(tab);
+
+    expect(await screen.findByRole("dialog", { name: /Templates/ })).toBeInTheDocument();
+    expect(tab).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("drives the Sections panel from its surface edge tab", async () => {
+    await renderSheet();
+
+    const tab = screen.getByTestId("doc-editor-sections-tab");
+    expect(tab).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(tab);
+
+    expect(await screen.findByRole("dialog", { name: /Sections/ })).toBeInTheDocument();
+    expect(screen.getByTestId("sections-panel")).toBeInTheDocument();
+    expect(tab).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("has no axe violations in Edit mode", async () => {
     const { container } = await renderSheet();
 

--- a/docs/design/doc-editor.md
+++ b/docs/design/doc-editor.md
@@ -102,6 +102,12 @@ when the Sections panel is docked open, the canvas gets `padding-left:16.5rem` s
 overlaps the sheet. Production adds (per owner): version history and theme selection controls in
 this bar.
 
+> **Superseded in part (owner decision, 2026-08-04, from PR #805 verification):** the **Templates**
+> and **Sections** controls are _not_ top-bar items in production. They are vertical drawer buttons
+> riding the left/right edges of the resume surface that expand/collapse their drawers in place
+> (see §1.14–§1.15). The top bar keeps undo/redo, import/export, version history, theme selection
+> and the Edit/Done toggle.
+
 ### 1.3 `EditableSheet` — the sheet engine
 
 Props: `ctx`, `variant` (chrome flavor; production uses one), `focusedSection`, `onFocusSection`.
@@ -361,6 +367,11 @@ on `#292524`; **off** = muted with `line-through` label. Click = `toggleSection`
 _visibility + creation only_ — all editing happens on the sheet (owner: no sidebar-based section
 editing).
 
+> **Production (owner decision, 2026-08-04):** the panel is a right-edge drawer expanded and
+> collapsed in place by a vertical **Sections** edge button on the resume surface — not a docked
+> panel, and not driven from the top bar. Custom sections are additionally _deletable_ (destructive,
+> behind a confirm step — §6 Q5).
+
 ### 1.15 `TemplatesPanel` — template drawer
 
 Right-edge drawer (`min(300px, 92vw)`, dark, slides in `.22s ease` with a dimmed blurred backdrop;
@@ -371,6 +382,10 @@ template's own colors — over the template name. Active card: accent border + g
 applies the template (`setTemplate`: palette + default layout) and closes. A vertical "Templates"
 edge tab (`.tpl-tab`) exists for standalone use; the Studio top bar hides it and drives the drawer
 from its own button.
+
+> **Production (owner decision, 2026-08-04):** the prototype's edge-tab variant is the shipped one —
+> the drawer hangs on the left edge of the resume surface, expanded and collapsed in place by a
+> vertical **Templates** edge button. There is no top-bar Templates control.
 
 ### 1.16 `PageCountPill` + `SheetOverflowGuides` + `.page-break-rule`
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(web): sections, templates, and theme panels for the document editor
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The wave-closing panels slice for #797 on the drag/pagination base (#794/#795/#796).

**Edge drawer buttons (owner scope addition, 2026-08-04, from PR #805 verification).** The Sections and Templates panels are no longer top-bar items. Vertical drawer buttons ride the left/right edges of the resume surface and expand/collapse their drawers in place:

- `TemplatesDrawer` (left edge) and `SectionsPanel` (right edge) become controlled, trigger-less components; `DocEditor` owns both open states and renders the `SurfaceEdgeTab`s (vertical writing mode, `aria-haspopup="dialog"` + `aria-expanded`, stable accessible names so existing e2e selectors keep meaning what they said).
- The sheet's Add-section blocks still open the Sections panel through the same lifted state (#794 behavior preserved).

**Theme selection in the top bar (spec §1.2, owner addition).** A Theme control joins undo/redo, import/export, history and Edit/Done:

- New `ThemeDialog` over the embedded client-side presets (`stores/themePresets`, offline-first) grouped light/dark, plus the three custom color fields (native picker + hex text; only a complete `#rrggbb` commits).
- A preset click lands its id and all three colors as **one** store action; a hand-picked color detaches the preset. All writes route through `docEdits` (`applyThemePreset`, `updateThemeColor`), so the undo/autosave invariant holds and the sheet recolors reactively via its CSS variables.

**Destructive custom-section delete confirms (owner decision, spec §6 Q5).** The Sections panel's trash button now opens a confirm dialog naming the section; only its Delete action calls `removeSection` — cancel writes nothing. No `window.confirm`/`window.prompt` anywhere.

**Polish/a11y sweep.** New axe (WCAG 2.2 AA, `target-size` force-enabled) e2e coverage over the doc editor's edit surface, both drawers, and the theme dialog. The sweep caught a real 1.4.3 failure: the sheet's dashed add-block/add-section affordances were muted via element `opacity`, blending their labels below AA contrast. They are now muted through full-opacity theme-tracking colors (`color-mix` toward the document text / `--doc-sheet-muted`) with the same resting subtlety and hover emphasis.

**Docs.** `docs/design/doc-editor.md` §1.2/§1.14/§1.15 annotated with the 2026-08-04 owner decision (edge drawer buttons, no top-bar panel toggles, confirmed custom-section delete).

**Explicitly out of UI scope** (owner decisions): `separateLinks`/`columns` stay schema-only — they were already unexposed in the doc editor, verified, nothing to remove; photo aspect ratio out of v1; cover letter deferred to #782. No new visual-regression screenshots were added: baselines are CI-generated from the workflow artifact, and the existing `visual.spec.ts` surfaces (form-builder pages) are untouched by this diff.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, vitest, Playwright e2e, `tsc --noEmit`)

## Related Issues

Closes #797

## Details

- **Gates** (run before every commit): `uv run lintro chk` — 0 issues; vitest 1057 passed (83 files, +8 new tests); Playwright e2e 80 passed / 5 skipped (the `visual` project, CI-baseline-only as designed); `tsc --noEmit` clean on both configs. Rebased onto v0.64.0's main; unit + typecheck re-verified post-rebase. (One full-suite run mid-lane showed mass 15-minute `toBeVisible` timeouts across untouched form-builder specs — overlapping preview servers from a concurrent run; a clean re-run passed everything.)
- **Review**: CodeRabbit CLI on the branch diff — 1 finding (minor): the native color picker committed on `input`, i.e. one store write and undo entry per drag tick; fixed to `change` (one completed selection, one undo entry — the docEdits invariant) in the follow-up commit. Greptile CLI was rate-limited (`free_reviews_limit_reached`), as in the previous waves.
- **Testing strategy**: controlled-panel wiring and one-write-per-gesture contracts in `panels.test.tsx` (12 tests, incl. confirm/cancel paths); `themeDialog.test.tsx` (6 tests) pins preset grouping, single-action preset application, preset detachment, and partial-hex rejection; `DocEditor.test.tsx` covers the edge tabs, top-bar theme entry point, and asserts the top bar carries no panel buttons; e2e: a real-browser edge-tab/theme flow in `doc-editor.spec.ts` (asserts the sheet's `--doc-sheet-accent` recolors), the confirm-then-delete flow in `custom-sections.spec.ts`, and the two new axe scans in `accessibility.spec.ts`.
