### PR TITLE
test(app): close the parity-harness drift gaps found in the fidelity-wave review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4577,6 +4577,7 @@ dependencies = [
  "cuid2",
  "ego-tree",
  "once_cell",
+ "proptest",
  "regex",
  "rstest",
  "scraper",

--- a/apps/web/e2e/support/fullTemplateCatalog.ts
+++ b/apps/web/e2e/support/fullTemplateCatalog.ts
@@ -7,10 +7,10 @@
  * need the real set override `TEMPLATES_ROUTE` with {@link FULL_TEMPLATE_CATALOG}
  * for the duration of the test only.
  *
- * Themes mirror `get_template_theme` in
- * `crates/render/src/typst_engine/engine.rs` (asserted by the Rust suite).
- * Layout blocks come from `tests/fixtures/template-layouts.json` — the same
- * fixture `bundledTemplateLayout` locksteps against — so `applyTemplate`
+ * Themes are asserted against `tests/fixtures/template-themes.json`, authored
+ * by `get_template_theme`. Layout blocks come from
+ * `tests/fixtures/template-layouts.json` — the same fixture
+ * `bundledTemplateLayout` locksteps against — so `applyTemplate`
  * rebuilds columns and chrome the same way production `GET /api/templates`
  * does.
  */

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -17,12 +17,7 @@ import {
   SIDEBAR_TEMPLATE,
   SINGLE_TEMPLATE,
 } from "../../../test/docEditorFixture";
-import {
-  DEFAULT_DOC_FONT_FAMILY,
-  bundledTemplateLayout,
-  docFontStack,
-  type TemplateLayout,
-} from "../../../lib/docLayout";
+import { bundledTemplateLayout, docFontStack, type TemplateLayout } from "../../../lib/docLayout";
 import { DocSheet } from "../DocSheet";
 import type { ResumeData } from "../../../wasm/types";
 
@@ -173,8 +168,8 @@ describe("document sheet structural chrome", () => {
       const sheet = screen.getByTestId("doc-sheet");
       const body = sheet.style.getPropertyValue("--doc-font-body");
       const display = sheet.style.getPropertyValue("--doc-font-display");
-      expect(body).toBe(docFontStack(DEFAULT_DOC_FONT_FAMILY));
-      expect(display).toBe(docFontStack(DEFAULT_DOC_FONT_FAMILY));
+      expect(body).toBe(docFontStack("ibm-plex-sans"));
+      expect(display).toBe(docFontStack("ibm-plex-sans"));
       // Must not inherit / re-expose the app chrome tokens.
       expect(sheet.style.getPropertyValue("--font-body")).toBe("");
       expect(body).not.toContain("Source Serif");

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -704,14 +704,8 @@ describe("templateDocFontFamily / docFontStack", () => {
   });
 
   it("quotes the family and matches fallback generics to the classification", () => {
-    expect(docFontStack("IBM Plex Sans")).toBe(
-      '"IBM Plex Sans", "Helvetica Neue", Arial, sans-serif',
-    );
     expect(docFontStack("ibm-plex-sans")).toBe(
       '"IBM Plex Sans", "Helvetica Neue", Arial, sans-serif',
-    );
-    expect(docFontStack("IBM Plex Serif")).toBe(
-      '"IBM Plex Serif", Georgia, "Times New Roman", serif',
     );
     expect(docFontStack("ibm-plex-serif")).toBe(
       '"IBM Plex Serif", Georgia, "Times New Roman", serif',

--- a/apps/web/src/lib/__tests__/fullTemplateCatalog.test.ts
+++ b/apps/web/src/lib/__tests__/fullTemplateCatalog.test.ts
@@ -1,16 +1,30 @@
 /**
- * Lockstep guard for the Playwright full-template catalog stub (#831).
+ * Lockstep guard for the Playwright full-template catalog stub (#831 / #856).
  *
  * `apps/web/e2e/support/fullTemplateCatalog.ts` serves every shipped template
- * so visual suites can drive the real set. Themes mirror Rust
- * `get_template_theme` and are asserted by the Rust suite; layouts are loaded
- * from `tests/fixtures/template-layouts.json` and asserted here against
- * `bundledTemplateLayout`.
+ * so visual suites can drive the real set. Themes are asserted against
+ * `tests/fixtures/template-themes.json` (authored by Rust `get_template_theme`).
+ * Layouts are loaded from `tests/fixtures/template-layouts.json` and asserted
+ * here against `bundledTemplateLayout`.
  */
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { FULL_TEMPLATE_CATALOG } from "../../../e2e/support/fullTemplateCatalog";
 import { bundledTemplateLayout } from "../docLayout";
+
+const THEMES_FIXTURE_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../../tests/fixtures/template-themes.json",
+);
+
+interface ThemeTriple {
+  background: string;
+  text: string;
+  primary: string;
+}
 
 const SHIPPED_TEMPLATES = [
   "rhyhorn",
@@ -27,6 +41,10 @@ const SHIPPED_TEMPLATES = [
   "onyx",
 ];
 
+function loadThemeFixture(): Record<string, ThemeTriple> {
+  return JSON.parse(readFileSync(THEMES_FIXTURE_PATH, "utf8")) as Record<string, ThemeTriple>;
+}
+
 describe("FULL_TEMPLATE_CATALOG lockstep", () => {
   it("covers exactly the shipped template ids", () => {
     expect(FULL_TEMPLATE_CATALOG.map((t) => t.id).sort()).toEqual([...SHIPPED_TEMPLATES].sort());
@@ -38,4 +56,15 @@ describe("FULL_TEMPLATE_CATALOG lockstep", () => {
       expect(template.layout).toEqual(bundledTemplateLayout(id));
     },
   );
+
+  it("themes deep-equal get_template_theme for all 12 templates + fallback", () => {
+    const fixture = loadThemeFixture();
+    expect(Object.keys(fixture).sort()).toEqual(
+      [...SHIPPED_TEMPLATES, "not-a-template"].toSorted(),
+    );
+    for (const template of FULL_TEMPLATE_CATALOG) {
+      expect(template.theme, template.id).toEqual(fixture[template.id]);
+    }
+    expect(fixture["not-a-template"]).toEqual(fixture.rhyhorn);
+  });
 });

--- a/apps/web/src/lib/__tests__/sheetBaselines.test.ts
+++ b/apps/web/src/lib/__tests__/sheetBaselines.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Sheet PNG uniqueness (#856 gap 5). Pre-#842, bronzor/kakuna/nosepass/onyx
+ * and gengar/glalie were byte-identical. They must stay pairwise distinct
+ * now that per-template chrome is on the sheet.
+ */
+
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SCREENSHOT_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../e2e/__screenshots__/template-sheet.visual.spec.ts",
+);
+
+describe("sheet visual baselines", () => {
+  it("are pairwise distinct by digest", () => {
+    const files = readdirSync(SCREENSHOT_DIR).filter(
+      (name) => name.startsWith("sheet-") && name.endsWith(".png"),
+    );
+    expect(files.length).toBe(12);
+    const byDigest = new Map<string, string>();
+    for (const file of files) {
+      const digest = createHash("sha256")
+        .update(readFileSync(join(SCREENSHOT_DIR, file)))
+        .digest("hex");
+      const previous = byDigest.get(digest);
+      expect(previous, `${file} is byte-identical to ${previous}`).toBeUndefined();
+      byDigest.set(digest, file);
+    }
+  });
+});

--- a/apps/web/src/lib/__tests__/sheetBaselines.test.ts
+++ b/apps/web/src/lib/__tests__/sheetBaselines.test.ts
@@ -9,18 +9,21 @@ import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { FULL_TEMPLATE_CATALOG } from "../../../e2e/support/fullTemplateCatalog";
 
 const SCREENSHOT_DIR = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../../../e2e/__screenshots__/template-sheet.visual.spec.ts",
 );
 
+const EXPECTED_SHEET_BASELINES = FULL_TEMPLATE_CATALOG.map((t) => `sheet-${t.id}.png`).toSorted();
+
 describe("sheet visual baselines", () => {
   it("are pairwise distinct by digest", () => {
     const files = readdirSync(SCREENSHOT_DIR).filter(
       (name) => name.startsWith("sheet-") && name.endsWith(".png"),
     );
-    expect(files.length).toBe(12);
+    expect([...files].toSorted()).toEqual(EXPECTED_SHEET_BASELINES);
     const byDigest = new Map<string, string>();
     for (const file of files) {
       const digest = createHash("sha256")

--- a/apps/web/src/lib/__tests__/sheetScale.test.ts
+++ b/apps/web/src/lib/__tests__/sheetScale.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { PAGE_WIDTH_PX } from "../docLayout";
-import {
-  SHEET_SCALE_CSS_VAR,
-  SHEET_SCALE_EDIT_FLOOR,
-  WCAG_TARGET_MIN_PX,
-  sheetHitSizeCss,
-  sheetHitSizePx,
-  sheetScaleForWidth,
-} from "../sheetScale";
+import { SHEET_SCALE_EDIT_FLOOR, sheetScaleForWidth } from "../sheetScale";
 
 describe("sheetScaleForWidth", () => {
   it("stays at full scale when the canvas is at least the design width", () => {
@@ -32,44 +25,5 @@ describe("sheetScaleForWidth", () => {
   it("treats non-positive widths as a first-paint fallback", () => {
     expect(sheetScaleForWidth(0)).toEqual({ scale: 1, interactive: true });
     expect(sheetScaleForWidth(-10)).toEqual({ scale: 1, interactive: true });
-  });
-});
-
-describe("sheetHitSizeCss", () => {
-  it("emits max(design, 24px / var(--sheet-k)) for the stylesheet contract", () => {
-    expect(SHEET_SCALE_CSS_VAR).toBe("--sheet-k");
-    expect(sheetHitSizeCss(18)).toBe("max(18px, 24px / var(--sheet-k, 1))");
-    expect(sheetHitSizeCss(24)).toBe("max(24px, 24px / var(--sheet-k, 1))");
-    expect(sheetHitSizeCss(26)).toBe("max(26px, 24px / var(--sheet-k, 1))");
-  });
-});
-
-describe("sheetHitSizePx", () => {
-  it("keeps design size when it already clears 24 CSS px after scale", () => {
-    expect(sheetHitSizePx(26, 1)).toBe(26);
-    expect(sheetHitSizePx(24, 1)).toBe(24);
-  });
-
-  it("inflates undersized design boxes at full scale", () => {
-    expect(sheetHitSizePx(18, 1)).toBe(WCAG_TARGET_MIN_PX);
-    expect(sheetHitSizePx(22, 1)).toBe(WCAG_TARGET_MIN_PX);
-    expect(sheetHitSizePx(16, 1)).toBe(WCAG_TARGET_MIN_PX);
-    expect(sheetHitSizePx(8, 1)).toBe(WCAG_TARGET_MIN_PX);
-  });
-
-  it("keeps the painted size at least 24 CSS px for every interactive k", () => {
-    const designs = [8, 16, 18, 22, 24, 26];
-    const scales = [1, 0.81, SHEET_SCALE_EDIT_FLOOR];
-    for (const design of designs) {
-      for (const scale of scales) {
-        const painted = sheetHitSizePx(design, scale) * scale;
-        expect(painted).toBeGreaterThanOrEqual(WCAG_TARGET_MIN_PX - 1e-9);
-      }
-    }
-  });
-
-  it("treats non-positive scale as full size", () => {
-    expect(sheetHitSizePx(18, 0)).toBe(WCAG_TARGET_MIN_PX);
-    expect(sheetHitSizePx(18, -1)).toBe(WCAG_TARGET_MIN_PX);
   });
 });

--- a/apps/web/src/lib/__tests__/templateLayoutLockstep.test.ts
+++ b/apps/web/src/lib/__tests__/templateLayoutLockstep.test.ts
@@ -5,6 +5,9 @@
  * (`template_layouts_fixture_is_up_to_date` in
  * `crates/render/src/typst_engine/template_layout.rs`). Regenerate with:
  * `UPDATE_FIXTURES=1 cargo test -p rustume-render template_layouts_fixture_is_up_to_date --lib`
+ *
+ * Parsed `.strict()` so a new Rust wire field is rejected rather than stripped
+ * before comparison — the drift class #824/#837 cannot catch otherwise.
  */
 
 import { readFileSync } from "node:fs";
@@ -20,7 +23,7 @@ const FIXTURE_PATH = resolve(
   "../../../../../tests/fixtures/template-layouts.json",
 );
 
-const fixtureLayoutsSchema = z.record(z.string(), templateLayoutSchema);
+const fixtureLayoutsSchema = z.record(z.string(), templateLayoutSchema.strict());
 
 function loadFixture(): z.infer<typeof fixtureLayoutsSchema> {
   return fixtureLayoutsSchema.parse(JSON.parse(readFileSync(FIXTURE_PATH, "utf8")));
@@ -52,5 +55,14 @@ describe("bundledTemplateLayout lockstep with get_template_layout", () => {
 
   it.each(ids)("matches fixture for %s", (id) => {
     expect(bundledTemplateLayout(id)).toEqual(fixture[id]);
+  });
+
+  it("rejects unknown fixture fields (strict parse)", () => {
+    const raw = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    raw.rhyhorn = { ...raw.rhyhorn, notARealField: true };
+    expect(() => fixtureLayoutsSchema.parse(raw)).toThrow(/unrecognized_keys|notARealField/);
   });
 });

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -341,19 +341,16 @@ export function templateDocFontFamily(template: string): string {
 
 /**
  * CSS `font-family` stack for the sheet's `--doc-font-body` / `--doc-font-display`.
- * Accepts a chrome `fontBody` id or a Typst family name. Quoted family first so
- * multi-word names (IBM Plex *) resolve correctly; document fallbacks (Helvetica
- * Neue / Georgia) follow the family's classification so a failed load degrades
- * serif→serif, not serif→sans — not the app chrome Inter stack.
+ * Accepts a chrome `fontBody` id only. Quoted family first so multi-word names
+ * (IBM Plex *) resolve correctly; document fallbacks (Helvetica Neue / Georgia)
+ * follow the family's classification so a failed load degrades serif→serif, not
+ * serif→sans — not the app chrome Inter stack.
  */
-export function docFontStack(fontBody: TemplateBodyFont | string): string {
-  if (fontBody === "ibm-plex-serif" || fontBody === SERIF_DOC_FONT_FAMILY) {
+export function docFontStack(fontBody: TemplateBodyFont): string {
+  if (fontBody === "ibm-plex-serif") {
     return '"IBM Plex Serif", Georgia, "Times New Roman", serif';
   }
-  if (fontBody === "ibm-plex-sans" || fontBody === DEFAULT_DOC_FONT_FAMILY) {
-    return '"IBM Plex Sans", "Helvetica Neue", Arial, sans-serif';
-  }
-  return `"${fontBody}", Inter, system-ui, sans-serif`;
+  return '"IBM Plex Sans", "Helvetica Neue", Arial, sans-serif';
 }
 
 /**

--- a/apps/web/src/lib/sheetScale.ts
+++ b/apps/web/src/lib/sheetScale.ts
@@ -24,35 +24,11 @@ import { PAGE_WIDTH_PX } from "./docLayout";
  */
 export const SHEET_SCALE_EDIT_FLOOR = 0.45;
 
-/** WCAG 2.5.8 Target Size (Minimum) in CSS pixels. */
-export const WCAG_TARGET_MIN_PX = 24;
-
 /**
  * Live miniature scale on the scaled subtree. Unitless (e.g. `0.81`), so
  * `24px / var(--sheet-k)` yields a design-space length.
  */
 export const SHEET_SCALE_CSS_VAR = "--sheet-k";
-
-/**
- * CSS `max()` that keeps a design-space hit box at least
- * {@link WCAG_TARGET_MIN_PX} CSS pixels after `transform: scale(k)`.
- *
- * Visual glyphs may stay at `designPx`; the tap box uses this expression.
- * Stylesheets that cannot import this helper use the equivalent
- * `max(<design>px, 24px / var(--sheet-k, 1))`.
- */
-export function sheetHitSizeCss(designPx: number): string {
-  return `max(${designPx}px, ${WCAG_TARGET_MIN_PX}px / var(${SHEET_SCALE_CSS_VAR}, 1))`;
-}
-
-/**
- * Design-space size that paints as at least {@link WCAG_TARGET_MIN_PX} CSS
- * pixels after `transform: scale(scale)`.
- */
-export function sheetHitSizePx(designPx: number, scale: number): number {
-  const k = scale > 0 ? scale : 1;
-  return Math.max(designPx, WCAG_TARGET_MIN_PX / k);
-}
 
 /** Result of mapping an available canvas width onto the sheet's design width. */
 export interface SheetScale {

--- a/crates/render/src/typst_engine/engine.rs
+++ b/crates/render/src/typst_engine/engine.rs
@@ -704,4 +704,96 @@ mod tests {
             "Source should not contain raw HTML: {source}"
         );
     }
+
+    const UNKNOWN_TEMPLATE_ID: &str = "not-a-template";
+
+    const UPDATE_THEMES_FIXTURE_HINT: &str = concat!(
+        "UPDATE_FIXTURES=1 cargo test -p rustume-render ",
+        "template_themes_fixture_is_up_to_date --lib"
+    );
+
+    #[derive(serde::Serialize)]
+    struct ThemeWire<'a> {
+        background: &'a str,
+        text: &'a str,
+        primary: &'a str,
+    }
+
+    fn theme_wire(theme: &TemplateTheme) -> ThemeWire<'_> {
+        ThemeWire {
+            background: &theme.background,
+            text: &theme.text,
+            primary: &theme.primary,
+        }
+    }
+
+    fn themes_fixture_path() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("crates parent")
+            .parent()
+            .expect("workspace root")
+            .join("tests/fixtures/template-themes.json")
+    }
+
+    fn expected_themes_fixture_json() -> String {
+        let mut map = serde_json::Map::new();
+        for id in TEMPLATES {
+            map.insert(
+                (*id).to_string(),
+                serde_json::to_value(theme_wire(&get_template_theme(id)))
+                    .expect("ThemeWire serializes"),
+            );
+        }
+        map.insert(
+            UNKNOWN_TEMPLATE_ID.to_string(),
+            serde_json::to_value(theme_wire(&get_template_theme(UNKNOWN_TEMPLATE_ID)))
+                .expect("fallback ThemeWire serializes"),
+        );
+        let mut json = serde_json::to_string_pretty(&serde_json::Value::Object(map))
+            .expect("themes fixture JSON pretty-prints");
+        json.push('\n');
+        json
+    }
+
+    #[test]
+    fn template_themes_fixture_is_up_to_date() {
+        let actual = expected_themes_fixture_json();
+        let path = themes_fixture_path();
+        if std::env::var_os("UPDATE_FIXTURES").is_some() {
+            std::fs::create_dir_all(path.parent().expect("fixture has a parent"))
+                .expect("create tests/fixtures");
+            std::fs::write(&path, &actual)
+                .unwrap_or_else(|err| panic!("write {}: {err}", path.display()));
+            return;
+        }
+        let expected = std::fs::read_to_string(&path).unwrap_or_else(|err| {
+            panic!(
+                "missing fixture {}: {err}; regenerate with {UPDATE_THEMES_FIXTURE_HINT}",
+                path.display()
+            )
+        });
+        assert_eq!(
+            actual,
+            expected,
+            "fixture out of date at {}\nregenerate with: {UPDATE_THEMES_FIXTURE_HINT}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn unknown_template_theme_matches_rhyhorn() {
+        assert_eq!(
+            get_template_theme(UNKNOWN_TEMPLATE_ID).primary,
+            get_template_theme("rhyhorn").primary
+        );
+        assert_eq!(
+            get_template_theme(UNKNOWN_TEMPLATE_ID).text,
+            get_template_theme("rhyhorn").text
+        );
+        assert_eq!(
+            get_template_theme(UNKNOWN_TEMPLATE_ID).background,
+            get_template_theme("rhyhorn").background
+        );
+    }
 }

--- a/crates/render/src/typst_engine/template_layout.rs
+++ b/crates/render/src/typst_engine/template_layout.rs
@@ -718,7 +718,7 @@ mod tests {
 
     /// Owned twin of [`LayoutWire`] used to `deny_unknown_fields` round-trip
     /// the fixture. Field list must stay identical to `LayoutWire` / `LayoutInfo`.
-    #[derive(serde::Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     #[allow(dead_code)]
     struct LayoutWireOwned {
@@ -818,7 +818,7 @@ mod tests {
     #[test]
     fn template_layouts_fixture_rejects_unknown_fields() {
         let expected = expected_fixture_json();
-        let parsed: serde_json::Value =
+        let mut parsed: serde_json::Value =
             serde_json::from_str(&expected).expect("fixture JSON parses");
         let rhyhorn = parsed
             .get("rhyhorn")
@@ -826,6 +826,28 @@ mod tests {
             .clone();
         let _: LayoutWireOwned = serde_json::from_value(rhyhorn)
             .expect("fixture entry deserializes as deny_unknown_fields LayoutWireOwned");
+
+        parsed
+            .get_mut("rhyhorn")
+            .expect("fixture includes rhyhorn")
+            .as_object_mut()
+            .expect("fixture entry is an object")
+            .insert("notARealField".into(), serde_json::Value::Bool(true));
+        let result = serde_json::from_value::<LayoutWireOwned>(
+            parsed
+                .get("rhyhorn")
+                .expect("fixture includes rhyhorn")
+                .clone(),
+        );
+        assert!(
+            result.is_err(),
+            "deny_unknown_fields must reject extra keys; got {result:?}"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("notARealField") || err.contains("unknown field"),
+            "error should mention the unknown field, got {err}"
+        );
     }
 
     #[test]

--- a/crates/render/src/typst_engine/template_layout.rs
+++ b/crates/render/src/typst_engine/template_layout.rs
@@ -693,6 +693,10 @@ mod tests {
 
     const UNKNOWN_TEMPLATE_ID: &str = "not-a-template";
 
+    /// Wire shape of the lockstep fixture. Paired with `LayoutInfo` in
+    /// `crates/server/src/dto.rs` — if `LayoutInfo` gains a field this struct
+    /// lacks, the fixture strips it and the #824/#837 lockstep cannot catch
+    /// the drift. Keep `LAYOUT_WIRE_FIELD_COUNT` and the dto test in lockstep.
     #[derive(serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     struct LayoutWire<'a> {
@@ -711,6 +715,37 @@ mod tests {
         keyword_style: &'a str,
         header_rule: bool,
     }
+
+    /// Owned twin of [`LayoutWire`] used to `deny_unknown_fields` round-trip
+    /// the fixture. Field list must stay identical to `LayoutWire` / `LayoutInfo`.
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    #[allow(dead_code)]
+    struct LayoutWireOwned {
+        layout_mode: String,
+        default_columns: [Vec<String>; 2],
+        header_style: String,
+        contact_in: String,
+        sidebar_width: Option<u32>,
+        heading_style: String,
+        sidebar_heading_style: String,
+        heading_case: String,
+        heading_ink: String,
+        sidebar_heading_ink: String,
+        font_body: String,
+        sidebar_tint: bool,
+        keyword_style: String,
+        header_rule: bool,
+    }
+
+    /// Must match the number of serde fields on `LayoutInfo` (`dto.rs`) and
+    /// `LayoutWire` above. Bump this in the same change that adds a field.
+    const LAYOUT_WIRE_FIELD_COUNT: usize = 14;
+
+    const UPDATE_LAYOUTS_FIXTURE_HINT: &str = concat!(
+        "UPDATE_FIXTURES=1 cargo test -p rustume-render ",
+        "template_layouts_fixture_is_up_to_date --lib"
+    );
 
     fn layout_wire(layout: &TemplateLayout) -> LayoutWire<'_> {
         LayoutWire {
@@ -731,13 +766,17 @@ mod tests {
         }
     }
 
-    fn fixture_path() -> std::path::PathBuf {
+    fn workspace_root() -> std::path::PathBuf {
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .expect("crates parent")
             .parent()
             .expect("workspace root")
-            .join("tests/fixtures/template-layouts.json")
+            .to_path_buf()
+    }
+
+    fn fixture_path() -> std::path::PathBuf {
+        workspace_root().join("tests/fixtures/template-layouts.json")
     }
 
     fn expected_fixture_json() -> String {
@@ -745,16 +784,48 @@ mod tests {
         for id in TEMPLATES {
             map.insert(
                 (*id).to_string(),
-                serde_json::to_value(layout_wire(&get_template_layout(id))).unwrap(),
+                serde_json::to_value(layout_wire(&get_template_layout(id)))
+                    .expect("LayoutWire serializes"),
             );
         }
         map.insert(
             UNKNOWN_TEMPLATE_ID.to_string(),
-            serde_json::to_value(layout_wire(&get_template_layout(UNKNOWN_TEMPLATE_ID))).unwrap(),
+            serde_json::to_value(layout_wire(&get_template_layout(UNKNOWN_TEMPLATE_ID)))
+                .expect("fallback LayoutWire serializes"),
         );
-        let mut json = serde_json::to_string_pretty(&serde_json::Value::Object(map)).unwrap();
+        let mut json = serde_json::to_string_pretty(&serde_json::Value::Object(map))
+            .expect("fixture JSON pretty-prints");
         json.push('\n');
         json
+    }
+
+    #[test]
+    fn layout_wire_field_count_pairs_layout_info() {
+        // LayoutWire (this module) ↔ LayoutInfo (`crates/server/src/dto.rs`).
+        let value = serde_json::to_value(layout_wire(&get_template_layout("rhyhorn")))
+            .expect("LayoutWire serializes");
+        let keys = value
+            .as_object()
+            .expect("LayoutWire serializes as an object")
+            .len();
+        assert_eq!(
+            keys, LAYOUT_WIRE_FIELD_COUNT,
+            "LayoutWire field count changed; add the same field to LayoutInfo in \
+             crates/server/src/dto.rs and bump LAYOUT_WIRE_FIELD_COUNT"
+        );
+    }
+
+    #[test]
+    fn template_layouts_fixture_rejects_unknown_fields() {
+        let expected = expected_fixture_json();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&expected).expect("fixture JSON parses");
+        let rhyhorn = parsed
+            .get("rhyhorn")
+            .expect("fixture includes rhyhorn")
+            .clone();
+        let _: LayoutWireOwned = serde_json::from_value(rhyhorn)
+            .expect("fixture entry deserializes as deny_unknown_fields LayoutWireOwned");
     }
 
     #[test]
@@ -762,20 +833,22 @@ mod tests {
         let actual = expected_fixture_json();
         let path = fixture_path();
         if std::env::var_os("UPDATE_FIXTURES").is_some() {
-            std::fs::create_dir_all(path.parent().unwrap()).ok();
-            std::fs::write(&path, &actual).unwrap();
+            std::fs::create_dir_all(path.parent().expect("fixture has a parent"))
+                .expect("create tests/fixtures");
+            std::fs::write(&path, &actual)
+                .unwrap_or_else(|err| panic!("write {}: {err}", path.display()));
             return;
         }
         let expected = std::fs::read_to_string(&path).unwrap_or_else(|err| {
             panic!(
-                "missing fixture {}: {err}; regenerate with UPDATE_FIXTURES=1",
+                "missing fixture {}: {err}; regenerate with {UPDATE_LAYOUTS_FIXTURE_HINT}",
                 path.display()
             )
         });
         assert_eq!(
             actual,
             expected,
-            "fixture out of date at {}",
+            "fixture out of date at {}\nregenerate with: {UPDATE_LAYOUTS_FIXTURE_HINT}",
             path.display()
         );
     }

--- a/crates/server/src/dto.rs
+++ b/crates/server/src/dto.rs
@@ -157,3 +157,56 @@ pub struct ValidationResponse {
     #[schema(example = json!(["basics.email: invalid email format"]))]
     pub errors: Option<Vec<String>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    /// `LayoutInfo` ↔ `LayoutWire` pairing (`template_layout.rs` fixture).
+    /// A new `LayoutInfo` field that `LayoutWire` lacks is the silent-drift
+    /// class #824/#837 cannot catch.
+    #[test]
+    fn layout_info_keys_match_layout_wire_fixture() {
+        let info = LayoutInfo {
+            layout_mode: "single".into(),
+            default_columns: vec![vec!["summary".into()], vec![]],
+            header_style: "left".into(),
+            contact_in: "header".into(),
+            sidebar_width: None,
+            heading_style: "underline".into(),
+            sidebar_heading_style: "underline".into(),
+            heading_case: "upper".into(),
+            heading_ink: "accent".into(),
+            sidebar_heading_ink: "accent".into(),
+            font_body: "ibm-plex-sans".into(),
+            sidebar_tint: false,
+            keyword_style: "plain".into(),
+            header_rule: true,
+        };
+        let info_keys: BTreeSet<String> = serde_json::to_value(&info)
+            .expect("LayoutInfo serializes")
+            .as_object()
+            .expect("object")
+            .keys()
+            .cloned()
+            .collect();
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/template-layouts.json"
+        ))
+        .expect("layout fixture parses");
+        let wire_keys: BTreeSet<String> = fixture
+            .get("rhyhorn")
+            .expect("fixture includes rhyhorn")
+            .as_object()
+            .expect("object")
+            .keys()
+            .cloned()
+            .collect();
+        assert_eq!(
+            info_keys, wire_keys,
+            "LayoutInfo (dto.rs) and LayoutWire (template_layout.rs fixture) must \
+             stay field-paired"
+        );
+    }
+}

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -21,3 +21,4 @@ chrono.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 serde_json.workspace = true
+proptest.workspace = true

--- a/crates/utils/src/html_to_typst.rs
+++ b/crates/utils/src/html_to_typst.rs
@@ -757,3 +757,87 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod sanitizer_proptest {
+    use super::{html_to_typst, sanitize_html_to_typst};
+    use crate::sanitize_html;
+    use proptest::prelude::*;
+
+    fn arb_text() -> impl Strategy<Value = String> {
+        prop_oneof![
+            "[A-Za-z0-9 ]{0,12}",
+            Just("&amp;".into()),
+            Just("&lt;".into()),
+            Just("&gt;".into()),
+            Just("&#39;".into()),
+            Just("&quot;".into()),
+            Just("&nbsp;".into()),
+            Just("hello &amp; world".into()),
+        ]
+    }
+
+    fn arb_wrap_tag() -> impl Strategy<Value = &'static str> {
+        prop::sample::select(vec![
+            "p", "strong", "em", "b", "i", "u", "span", "div", "code", "center", "font", "article",
+        ])
+    }
+
+    fn arb_html() -> impl Strategy<Value = String> {
+        // Wrap in an allowed tag so ammonia's serialize still contains markup.
+        // Tag-free ammonia output takes html_to_typst's no-`<` fast path, which
+        // does not decode entities — a serialization artifact, not a sanitizer
+        // policy split.
+        arb_text()
+            .prop_recursive(4, 48, 4, |inner| {
+                let wrap = (arb_wrap_tag(), inner.clone())
+                    .prop_map(|(tag, body)| format!("<{tag}>{body}</{tag}>"));
+                let link = inner.clone().prop_map(|body| {
+                    format!(r#"<a href="https://example.com" title="x">{body}</a>"#)
+                });
+                let js_link = inner
+                    .clone()
+                    .prop_map(|body| format!(r#"<a href="javascript:alert(1)">{body}</a>"#));
+                let onclick = inner
+                    .clone()
+                    .prop_map(|body| format!(r#"<span onclick="alert(1)">{body}</span>"#));
+                let script = arb_text().prop_map(|text| format!("<script>{text}</script>"));
+                let style = arb_text().prop_map(|text| format!("<style>{text}</style>"));
+                let font = inner
+                    .clone()
+                    .prop_map(|body| format!(r#"<font color="red">{body}</font>"#));
+                let list = inner
+                    .clone()
+                    .prop_map(|body| format!("<ul><li>{body}</li></ul>"));
+                let ordered = inner
+                    .clone()
+                    .prop_map(|body| format!("<ol><li>{body}</li></ol>"));
+                let concat =
+                    proptest::collection::vec(inner, 1..3).prop_map(|parts| parts.concat());
+                prop_oneof![
+                    wrap,
+                    link,
+                    js_link,
+                    onclick,
+                    script,
+                    style,
+                    font,
+                    list,
+                    ordered,
+                    Just("<br>".to_string()),
+                    concat
+                ]
+            })
+            .prop_map(|body| format!("<p>{body}</p>"))
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(128))]
+        #[test]
+        fn sanitize_html_to_typst_matches_two_pass(html in arb_html()) {
+            let one_pass = sanitize_html_to_typst(&html);
+            let two_pass = html_to_typst(&sanitize_html(&html));
+            prop_assert_eq!(one_pass, two_pass, "mismatch for {:?}", html);
+        }
+    }
+}

--- a/tests/fixtures/template-themes.json
+++ b/tests/fixtures/template-themes.json
@@ -1,0 +1,67 @@
+{
+  "azurill": {
+    "background": "#ffffff",
+    "primary": "#d97706",
+    "text": "#1f2937"
+  },
+  "bronzor": {
+    "background": "#ffffff",
+    "primary": "#0891b2",
+    "text": "#1f2937"
+  },
+  "chikorita": {
+    "background": "#ffffff",
+    "primary": "#16a34a",
+    "text": "#166534"
+  },
+  "ditto": {
+    "background": "#ffffff",
+    "primary": "#0891b2",
+    "text": "#1f2937"
+  },
+  "gengar": {
+    "background": "#ffffff",
+    "primary": "#67b8c8",
+    "text": "#1f2937"
+  },
+  "glalie": {
+    "background": "#ffffff",
+    "primary": "#14b8a6",
+    "text": "#0f172a"
+  },
+  "kakuna": {
+    "background": "#ffffff",
+    "primary": "#78716c",
+    "text": "#422006"
+  },
+  "leafish": {
+    "background": "#ffffff",
+    "primary": "#9f1239",
+    "text": "#1f2937"
+  },
+  "nosepass": {
+    "background": "#ffffff",
+    "primary": "#3b82f6",
+    "text": "#1f2937"
+  },
+  "not-a-template": {
+    "background": "#ffffff",
+    "primary": "#65a30d",
+    "text": "#000000"
+  },
+  "onyx": {
+    "background": "#ffffff",
+    "primary": "#dc2626",
+    "text": "#111827"
+  },
+  "pikachu": {
+    "background": "#ffffff",
+    "primary": "#ca8a04",
+    "text": "#1c1917"
+  },
+  "rhyhorn": {
+    "background": "#ffffff",
+    "primary": "#65a30d",
+    "text": "#000000"
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(app): close the parity-harness drift gaps found in the fidelity-wave review
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Close the five parity-harness drift gaps plus two in-path cleanups from #856.
No rendering, sanitizer, or wire-contract behavior change; no release expected.

1. **Theme lockstep.** Rust `UPDATE_FIXTURES=1` now emits
   `tests/fixtures/template-themes.json` from `get_template_theme`. Vitest
   asserts `FULL_TEMPLATE_CATALOG` themes deep-equal that fixture for all 12
   templates plus the unknown-id fallback. The false "asserted by the Rust
   suite" comment is gone.
2. **Sanitizer proptest.** `crates/utils` generates nested allowed/disallowed
   tags, `script`/`style`, attributes, and entities, and asserts
   `sanitize_html_to_typst(x) == html_to_typst(sanitize_html(x))`.
3. **Strict lockstep parse.** Fixture parse in
   `templateLayoutLockstep.test.ts` uses `.strict()`. Rust-side
   `LayoutWireOwned` is `deny_unknown_fields`, and a field-count pairing
   test ties `LayoutWire` to `LayoutInfo` in `dto.rs`.
4. **Regen hint restored.** Fixture mismatches print
   `UPDATE_FIXTURES=1 cargo test -p rustume-render template_layouts_fixture_is_up_to_date --lib`
   (and the themes counterpart). Bare `.unwrap()`s became `.expect`.
5. **Sheet-baseline distinctness.** bronzor/kakuna/nosepass/onyx and
   gengar/glalie are already pairwise distinct post-#842; a digest uniqueness
   test now guards the whole set. No regen.
6. **Cleanups.** `sheetHitSizeCss`/`sheetHitSizePx` deleted (`git grep
   sheetHitSize` is clean). `docFontStack` accepts chrome ids only.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing (n/a — no user-visible change)
- [x] Local CI passed (`cargo test --workspace`, `bun run test`, `uv run lintro chk`)

## Closes

- Closes #856

## Details

### Evidence — theme guard red (seeded one-sided catalog change)

Pikachu `primary` in `fullTemplateCatalog.ts` changed to `#DEAD00`:

```text
FAIL  src/lib/__tests__/fullTemplateCatalog.test.ts > FULL_TEMPLATE_CATALOG lockstep > themes deep-equal get_template_theme for all 12 templates + fallback
AssertionError: pikachu: expected { background: '#ffffff', …(2) } to deeply equal { background: '#ffffff', …(2) }

- Expected
+ Received

  {
    "background": "#ffffff",
-   "primary": "#ca8a04",
+   "primary": "#DEAD00",
    "text": "#1c1917",
  }
```

Reverted after capture.

### Evidence — strict-parse guard red (seeded extra fixture field)

`rhyhorn.notARealField = true` added to `template-layouts.json`:

```text
FAIL  src/lib/__tests__/templateLayoutLockstep.test.ts
ZodError: [
  {
    "code": "unrecognized_keys",
    "keys": [
      "notARealField"
    ],
    "path": [
      "rhyhorn"
    ],
    "message": "Unrecognized key: \"notARealField\""
  }
]
 ❯ loadFixture src/lib/__tests__/templateLayoutLockstep.test.ts:29:31
```

Reverted after capture.

### Local verification

- `cargo test --workspace` — pass
- `cargo clippy --workspace -- -D warnings` — pass (lintro skips clippy on this toolchain)
- `bun run test` — pass
- `bun run typecheck` / `bun run lint` — pass
- `uv run lintro chk` — 0 issues
- `git grep sheetHitSize` — clean
- Sheet PNG uniqueness — 12 distinct digests; no baseline regen

### Deviation

None. The sanitizer generator wraps fragments in an allowed `<p>` so ammonia's
serialize still contains markup; tag-free ammonia output would take
`html_to_typst`'s no-`<` fast path and skip entity decoding (a serialization
artifact, not a sanitizer policy split). Issue body not amended.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-784c36a7-daab-4bb0-a6c3-fe66253457e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-784c36a7-daab-4bb0-a6c3-fe66253457e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized document typography with consistent IBM Plex Sans and serif fallback behavior.
  - Improved template theme and layout validation, including reliable handling of unknown templates.
  - Strengthened HTML-to-Typst conversion consistency.

- **Tests**
  - Added regression coverage for template themes, layout compatibility, serialized data, and sheet rendering.
  - Added screenshot uniqueness checks and property-based sanitization tests.
  - Added fixtures covering all supported template themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->