### PR TITLE
fix(docker): export cooked deps and drop the amd64 footprint diet

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -117,6 +117,9 @@ Pass `runner-image: ubuntu-24.04` on reusables that expose the input (lgtm-ci #3
 Action-only wrappers (`reusable-codeql`, `reusable-dependency-review`, etc.) and
 multi-arch Docker (`runner-map`) follow the exceptions in
 [lgtm-ci workflow-contract](https://github.com/lgtm-hq/lgtm-ci/blob/main/docs/workflow-contract.md#runner-pinning-exceptions).
+The Docker amd64 leg is pinned to `blacksmith-8vcpu-ubuntu-2404` because
+GitHub-hosted `ubuntu-24.04` amd64 VMs are reclaimed at ~19m45s (#868);
+arm64 stays on `ubuntu-24.04-arm`.
 
 ## Version pin inventory
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -117,9 +117,6 @@ Pass `runner-image: ubuntu-24.04` on reusables that expose the input (lgtm-ci #3
 Action-only wrappers (`reusable-codeql`, `reusable-dependency-review`, etc.) and
 multi-arch Docker (`runner-map`) follow the exceptions in
 [lgtm-ci workflow-contract](https://github.com/lgtm-hq/lgtm-ci/blob/main/docs/workflow-contract.md#runner-pinning-exceptions).
-The Docker amd64 leg is pinned to `blacksmith-8vcpu-ubuntu-2404` because
-GitHub-hosted `ubuntu-24.04` amd64 VMs are reclaimed at ~19m45s (#868);
-arm64 stays on `ubuntu-24.04-arm`.
 
 ## Version pin inventory
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, coverage, release automation,
 and publishing. Most workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`9cfddc566c014117e9fcce6e93ef78580c09c7a3` (**v0.63.6** release commit; not the annotated
+`396e1e28f14d371761558178e75be9c56cc994cf` (**v0.63.6** release commit; not the annotated
 tag object SHA). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
@@ -105,9 +105,9 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 Use the **release commit SHA**, not the annotated tag object SHA:
 
 ```yaml
-uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
 with:
-  tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6 release commit
+  tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6 release commit
 ```
 
 Sparse `lgtm-hq` tooling checkouts may use `actions/checkout` when `ref:` is quoted and

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, coverage, release automation,
 and publishing. Most workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`23c79b65490a3307fb08cdefafa22db12f75b9b2` (**v0.63.1** release commit; not the annotated
+`9cfddc566c014117e9fcce6e93ef78580c09c7a3` (**v0.63.6** release commit; not the annotated
 tag object SHA). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
@@ -105,9 +105,9 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 Use the **release commit SHA**, not the annotated tag object SHA:
 
 ```yaml
-uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
 with:
-  tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1 release commit
+  tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6 release commit
 ```
 
 Sparse `lgtm-hq` tooling checkouts may use `actions/checkout` when `ref:` is quoted and

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -137,8 +137,8 @@ Renovate config lives in `renovate.json`; the shared preset is
 | `.github/workflows/README.md` | `## Pin format` example | Illustrative lgtm-ci pin | **Manual — no manager**; `pin-sync-guard.yml` does not read Markdown |
 | `docker/Dockerfile` | `FROM <image>@sha256:<digest>` | `rust`, `gcr.io/distroless/static` | Renovate `dockerfile` (digest updates automerged) |
 | `docker/Dockerfile` | `ARG BUN_VERSION=` | bun release tarball | Renovate custom manager (`oven-sh/bun`, `github-releases`) |
-| `docker/Dockerfile` | `ARG BINSTALL_VERSION=` plus per-arch `BINSTALL_SHA256` | cargo-binstall release tarballs | **Manual — version and both SHA-256 values move together** |
-| `docker/Dockerfile` | `cargo install cargo-chef@<version>` | cargo-chef | Renovate custom manager (`cargo-chef`, `crate`) |
+| `scripts/ci/docker/install-cargo-binstall.sh` | `DEFAULT_BINSTALL_VERSION` plus per-arch checksums | cargo-binstall release tarballs used by Docker chef and web-builder | **Manual — version and both SHA-256 values move together** |
+| `docker/Dockerfile` | `ARG CARGO_CHEF_VERSION=` | cargo-chef prebuilt via cargo-binstall | Renovate custom manager (`cargo-chef`, `crate`) |
 | `scripts/ci/testing/web/install-wasm-pack.sh` | `DEFAULT_WASM_PACK_VERSION` plus per-arch checksums | wasm-pack release tarballs used by CI and Docker | **Manual — canonical version/checksum source** |
 | `docker/Dockerfile` | `wasm-bindgen-cli@${WASM_BINDGEN_VERSION}` | Derived from `Cargo.lock` at build time | n/a — no literal pin to update |
 | `docker-compose.yml` | `image: postgres:<tag>@sha256:<digest>` | Local dev Postgres | Renovate `docker-compose` |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, coverage, release automation,
 and publishing. Most workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`240daf3ed1f7475b3f322502035b15994be210a8` (**v0.59.16** release commit; not the annotated
+`23c79b65490a3307fb08cdefafa22db12f75b9b2` (**v0.63.1** release commit; not the annotated
 tag object SHA). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
@@ -105,9 +105,9 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 Use the **release commit SHA**, not the annotated tag object SHA:
 
 ```yaml
-uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
 with:
-  tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16 release commit
+  tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1 release commit
 ```
 
 Sparse `lgtm-hq` tooling checkouts may use `actions/checkout` when `ref:` is quoted and
@@ -137,7 +137,9 @@ Renovate config lives in `renovate.json`; the shared preset is
 | `.github/workflows/README.md` | `## Pin format` example | Illustrative lgtm-ci pin | **Manual — no manager**; `pin-sync-guard.yml` does not read Markdown |
 | `docker/Dockerfile` | `FROM <image>@sha256:<digest>` | `rust`, `gcr.io/distroless/static` | Renovate `dockerfile` (digest updates automerged) |
 | `docker/Dockerfile` | `ARG BUN_VERSION=` | bun release tarball | Renovate custom manager (`oven-sh/bun`, `github-releases`) |
+| `docker/Dockerfile` | `ARG BINSTALL_VERSION=` plus per-arch `BINSTALL_SHA256` | cargo-binstall release tarballs | **Manual — version and both SHA-256 values move together** |
 | `docker/Dockerfile` | `cargo install cargo-chef@<version>` | cargo-chef | Renovate custom manager (`cargo-chef`, `crate`) |
+| `scripts/ci/testing/web/install-wasm-pack.sh` | `DEFAULT_WASM_PACK_VERSION` plus per-arch checksums | wasm-pack release tarballs used by CI and Docker | **Manual — canonical version/checksum source** |
 | `docker/Dockerfile` | `wasm-bindgen-cli@${WASM_BINDGEN_VERSION}` | Derived from `Cargo.lock` at build time | n/a — no literal pin to update |
 | `docker-compose.yml` | `image: postgres:<tag>@sha256:<digest>` | Local dev Postgres | Renovate `docker-compose` |
 | `docker-compose.yml` | `image: ghcr.io/lgtm-hq/rustume:latest` | This repo's own image | n/a — deliberately floating |

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -40,12 +40,12 @@ jobs:
       (github.event.workflow_run.head_branch == 'main' ||
       startsWith(github.event.workflow_run.head_branch, 'v'))
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       actions: write # rerun failed jobs and read failed-job logs
       contents: read # read repository context for the tooling checkout
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       # run id/attempt are numbers in the event payload; format() passes them
       # as the strings the reusable workflow inputs expect.
       run-id: ${{ format('{0}', github.event.workflow_run.id) }}

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -42,8 +42,8 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
-      actions: write
-      contents: read
+      actions: write # rerun failed jobs and read failed-job logs
+      contents: read # read repository context for the tooling checkout
     with:
       tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       # run id/attempt are numbers in the event payload; format() passes them

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -40,12 +40,12 @@ jobs:
       (github.event.workflow_run.head_branch == 'main' ||
       startsWith(github.event.workflow_run.head_branch, 'v'))
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       actions: write
       contents: read
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       # run id/attempt are numbers in the event payload; format() passes them
       # as the strings the reusable workflow inputs expect.
       run-id: ${{ format('{0}', github.event.workflow_run.id) }}

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -40,12 +40,12 @@ jobs:
       (github.event.workflow_run.head_branch == 'main' ||
       startsWith(github.event.workflow_run.head_branch, 'v'))
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       actions: write # rerun failed jobs and read failed-job logs
       contents: read # read repository context for the tooling checkout
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       # run id/attempt are numbers in the event payload; format() passes them
       # as the strings the reusable workflow inputs expect.
       run-id: ${{ format('{0}', github.event.workflow_run.id) }}

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -18,9 +18,9 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "🏷️ Create Release Tag"
       version-source: cargo
       create-release: false

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -18,9 +18,9 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "🏷️ Create Release Tag"
       version-source: cargo
       create-release: false

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -18,9 +18,9 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "🏷️ Create Release Tag"
       version-source: cargo
       create-release: false

--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
         with:
           persist-credentials: false
 

--- a/.github/workflows/boundary-guard.yml
+++ b/.github/workflows/boundary-guard.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           persist-credentials: false
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -68,7 +68,7 @@ jobs:
         # setup-rust cargo-binstall fix for Windows Git Bash
         # (MINGW64_NT-* was "Unsupported OS", skipping release artifacts).
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -68,7 +68,7 @@ jobs:
         # setup-rust cargo-binstall fix for Windows Git Bash
         # (MINGW64_NT-* was "Unsupported OS", skipping release artifacts).
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout
         if: runner.os != 'Windows'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
 
       - name: Checkout (Windows)
         if: runner.os == 'Windows'
@@ -68,7 +68,7 @@ jobs:
         # setup-rust cargo-binstall fix for Windows Git Bash
         # (MINGW64_NT-* was "Unsupported OS", skipping release artifacts).
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-rust@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -48,12 +48,12 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read # checkout repository sources for lintro analysis
       packages: read # pull the pinned lintro image from GHCR
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "🛠️ Lintro Code Quality"
       lintro-tool-options: clippy:timeout=300
       timeout-minutes: 30
@@ -71,14 +71,14 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read # read quality job outputs and artifacts
       pull-requests: write # post or update the quality summary comment
     with:
       exit-code: >-
         ${{ needs.quality.outputs.exit-code != '' && needs.quality.outputs.exit-code || '1' }}
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "🛠️ Lintro Code Quality PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -48,12 +48,12 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read # checkout repository sources for lintro analysis
       packages: read # pull the pinned lintro image from GHCR
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "🛠️ Lintro Code Quality"
       lintro-tool-options: clippy:timeout=300
       timeout-minutes: 30
@@ -71,14 +71,14 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read # read quality job outputs and artifacts
       pull-requests: write # post or update the quality summary comment
     with:
       exit-code: >-
         ${{ needs.quality.outputs.exit-code != '' && needs.quality.outputs.exit-code || '1' }}
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "🛠️ Lintro Code Quality PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -48,12 +48,12 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read # checkout repository sources for lintro analysis
       packages: read # pull the pinned lintro image from GHCR
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "🛠️ Lintro Code Quality"
       lintro-tool-options: clippy:timeout=300
       timeout-minutes: 30
@@ -71,14 +71,14 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read # read quality job outputs and artifacts
       pull-requests: write # post or update the quality summary comment
     with:
       exit-code: >-
         ${{ needs.quality.outputs.exit-code != '' && needs.quality.outputs.exit-code || '1' }}
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "🛠️ Lintro Code Quality PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,9 +39,9 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "🔬 CodeQL Analysis"
       languages: actions,rust
       language-build-modes: '{"rust":"none","actions":"none"}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,9 +39,9 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "🔬 CodeQL Analysis"
       languages: actions,rust
       language-build-modes: '{"rust":"none","actions":"none"}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,9 +39,9 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "🔬 CodeQL Analysis"
       languages: actions,rust
       language-build-modes: '{"rust":"none","actions":"none"}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,12 +47,12 @@ jobs:
   # instrumented, as a superset of the old dedicated job's filter.
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "🦀 Rust Coverage"
       coverage: true
       setup-script: scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -65,12 +65,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,12 +47,12 @@ jobs:
   # instrumented, as a superset of the old dedicated job's filter.
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "🦀 Rust Coverage"
       coverage: true
       setup-script: scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -65,12 +65,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,12 +47,12 @@ jobs:
   # instrumented, as a superset of the old dedicated job's filter.
   rust-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "🦀 Rust Coverage"
       coverage: true
       setup-script: scripts/ci/testing/rust/setup-postgres-test-db.sh
@@ -65,12 +65,12 @@ jobs:
 
   web-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "🌐 Web Coverage"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,11 +15,11 @@ concurrency:
 jobs:
   review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       job-name: "🔍 Dependency Review"
       fail-on-severity: high
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       # github-tooling preset + api.deps.dev: dependency-review-action

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,11 +15,11 @@ concurrency:
 jobs:
   review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       job-name: "🔍 Dependency Review"
       fail-on-severity: high
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       egress-policy: block
       egress-preset: github-tooling
       # github-tooling preset + api.deps.dev: dependency-review-action

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,11 +15,11 @@ concurrency:
 jobs:
   review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       job-name: "🔍 Dependency Review"
       fail-on-severity: high
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       # github-tooling preset + api.deps.dev: dependency-review-action

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
       actions: write
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       # Explicit space-separated (folded scalar) allowlists: the reusable
       # workflow's newline block-scalar defaults are mis-parsed by the
@@ -74,7 +74,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
       actions: write
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       # Explicit space-separated (folded scalar) allowlists: the reusable
       # workflow's newline block-scalar defaults are mis-parsed by the
@@ -74,7 +74,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,7 +35,7 @@ jobs:
       actions: write
     # Pin commit SHA (not annotated tag object SHA) for reusable workflow resolution.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       # Explicit space-separated (folded scalar) allowlists: the reusable
       # workflow's newline block-scalar defaults are mis-parsed by the
@@ -74,7 +74,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -153,7 +153,8 @@ jobs:
       # build stages run through the host egress proxy under harden-runner) +
       # rust hosts (rustup target add wasm32 pulls from static.rust-lang.org;
       # cargo install cargo-chef fetches the crates index / .crate files;
-      # cargo-binstall fetches wasm tooling from GitHub release assets) +
+      # pinned wasm-pack/cargo-binstall assets and wasm-bindgen-cli come from
+      # GitHub releases) +
       # registry.npmjs.org (bun install in the web-builder stage downloads
       # packages from the npm registry on cache-cold builds).
       allowed-endpoints-mode: replace
@@ -228,7 +229,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
 
       - name: Verify published tags resolve
         env:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -119,10 +119,17 @@ jobs:
         || startsWith(github.ref, 'refs/tags/v')) }}
       validate-on-pr: ${{ github.event_name == 'pull_request' }}
       platforms: linux/amd64,linux/arm64
-      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
-      # The amd64 hosted image carries large SDK/toolcache trees that this
-      # Docker-only job does not use. Reclaim them before BuildKit starts and
-      # sample memory/disk usage so any remaining runner loss is attributable.
+      # GitHub-hosted ubuntu-24.04 amd64 VMs are reclaimed at ~19m45s
+      # regardless of cargo parallelism (#868). No Dockerfile diet can beat
+      # that timer. Route amd64 onto the org Blacksmith pool (already
+      # enabled for public repos); arm64 stays on GitHub-hosted
+      # ubuntu-24.04-arm, which is not affected.
+      # yamllint disable-line rule:line-length
+      runner-map: '{"linux/amd64":"blacksmith-8vcpu-ubuntu-2404","linux/arm64":"ubuntu-24.04-arm"}'
+      # Reclaim unused SDK/toolcache before BuildKit starts. Sample
+      # memory/disk so a later runner loss is attributable (lgtm-ci #856
+      # still needs the monitor to tee to stdout — file-only dumps die
+      # with the VM).
       free-disk-space: true
       resource-monitor: true
       smoke-test-script: scripts/ci/docker/smoke-test.sh

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -100,7 +100,7 @@ jobs:
       && needs.classify.outputs.pipeline != 'false'
       && needs.classify.outputs.bump-only != 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: write
@@ -108,7 +108,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-
@@ -229,7 +229,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
 
       - name: Verify published tags resolve
         env:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -119,17 +119,10 @@ jobs:
         || startsWith(github.ref, 'refs/tags/v')) }}
       validate-on-pr: ${{ github.event_name == 'pull_request' }}
       platforms: linux/amd64,linux/arm64
-      # GitHub-hosted ubuntu-24.04 amd64 VMs are reclaimed at ~19m45s
-      # regardless of cargo parallelism (#868). No Dockerfile diet can beat
-      # that timer. Route amd64 onto the org Blacksmith pool (already
-      # enabled for public repos); arm64 stays on GitHub-hosted
-      # ubuntu-24.04-arm, which is not affected.
-      # yamllint disable-line rule:line-length
-      runner-map: '{"linux/amd64":"blacksmith-8vcpu-ubuntu-2404","linux/arm64":"ubuntu-24.04-arm"}'
-      # Reclaim unused SDK/toolcache before BuildKit starts. Sample
-      # memory/disk so a later runner loss is attributable (lgtm-ci #856
-      # still needs the monitor to tee to stdout — file-only dumps die
-      # with the VM).
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      # The amd64 hosted image carries large SDK/toolcache trees that this
+      # Docker-only job does not use. Reclaim them before BuildKit starts and
+      # sample memory/disk usage so any remaining runner loss is attributable.
       free-disk-space: true
       resource-monitor: true
       smoke-test-script: scripts/ci/docker/smoke-test.sh

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -152,9 +152,9 @@ jobs:
       # dl-cdn.alpinelinux.org (apk package installs in docker/Dockerfile
       # build stages run through the host egress proxy under harden-runner) +
       # rust hosts (rustup target add wasm32 pulls from static.rust-lang.org;
-      # cargo install cargo-chef fetches the crates index / .crate files;
-      # pinned wasm-pack/cargo-binstall assets and wasm-bindgen-cli come from
-      # GitHub releases) +
+      # cargo chef cook fetches the crates index / .crate files;
+      # pinned cargo-binstall, cargo-chef, wasm-pack, and wasm-bindgen-cli
+      # assets come from GitHub releases) +
       # registry.npmjs.org (bun install in the web-builder stage downloads
       # packages from the npm registry on cache-cold builds).
       allowed-endpoints-mode: replace

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -100,7 +100,7 @@ jobs:
       && needs.classify.outputs.pipeline != 'false'
       && needs.classify.outputs.bump-only != 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
       packages: write
@@ -108,7 +108,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-
@@ -120,6 +120,11 @@ jobs:
       validate-on-pr: ${{ github.event_name == 'pull_request' }}
       platforms: linux/amd64,linux/arm64
       runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      # The amd64 hosted image carries large SDK/toolcache trees that this
+      # Docker-only job does not use. Reclaim them before BuildKit starts and
+      # sample memory/disk usage so any remaining runner loss is attributable.
+      free-disk-space: true
+      resource-monitor: true
       smoke-test-script: scripts/ci/docker/smoke-test.sh
       # Stamps the running build's commit into `GET /version` (#584) so a deploy
       # can be verified against the `sha-<commit>` tag rustume-ops pins in
@@ -147,8 +152,8 @@ jobs:
       # dl-cdn.alpinelinux.org (apk package installs in docker/Dockerfile
       # build stages run through the host egress proxy under harden-runner) +
       # rust hosts (rustup target add wasm32 pulls from static.rust-lang.org;
-      # cargo install cargo-chef/wasm-pack/wasm-bindgen-cli fetch the crates
-      # index and .crate files from index.crates.io / static.crates.io) +
+      # cargo install cargo-chef fetches the crates index / .crate files;
+      # cargo-binstall fetches wasm tooling from GitHub release assets) +
       # registry.npmjs.org (bun install in the web-builder stage downloads
       # packages from the npm registry on cache-cold builds).
       allowed-endpoints-mode: replace

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -100,7 +100,7 @@ jobs:
       && needs.classify.outputs.pipeline != 'false'
       && needs.classify.outputs.bump-only != 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read
       packages: write
@@ -108,7 +108,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       file: docker/Dockerfile
       image-name: lgtm-hq/rustume
       version: >-
@@ -229,7 +229,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
 
       - name: Verify published tags resolve
         env:

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -40,7 +40,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
       packages: write
@@ -48,7 +48,7 @@ jobs:
       package-name: rustume
       min-age-days: ${{ inputs.min_age_days || 7 }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       egress-policy: audit
       runner-image: ubuntu-24.04
     secrets:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -40,7 +40,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: write
@@ -48,7 +48,7 @@ jobs:
       package-name: rustume
       min-age-days: ${{ inputs.min_age_days || 7 }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: audit
       runner-image: ubuntu-24.04
     secrets:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           persist-credentials: false
 

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -40,7 +40,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read
       packages: write
@@ -48,7 +48,7 @@ jobs:
       package-name: rustume
       min-age-days: ${{ inputs.min_age_days || 7 }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       egress-policy: audit
       runner-image: ubuntu-24.04
     secrets:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
         with:
           persist-credentials: false
 

--- a/.github/workflows/pin-sync-guard.yml
+++ b/.github/workflows/pin-sync-guard.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           persist-credentials: false
 

--- a/.github/workflows/pin-sync-guard.yml
+++ b/.github/workflows/pin-sync-guard.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
         with:
           persist-credentials: false
 

--- a/.github/workflows/pin-sync-guard.yml
+++ b/.github/workflows/pin-sync-guard.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -13,11 +13,11 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       job-name: "👤 Auto Assign PR Author"
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -13,11 +13,11 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       job-name: "👤 Auto Assign PR Author"
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -13,11 +13,11 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       job-name: "👤 Auto Assign PR Author"
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       runner-image: ubuntu-24.04

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,12 +12,12 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       job-name: "🏷️ Auto Label PR"
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,12 +12,12 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       job-name: "🏷️ Auto Label PR"
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,12 +12,12 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       job-name: "🏷️ Auto Label PR"
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
 
       - name: Wait for the release image to be published
         env:
@@ -137,7 +137,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -157,7 +157,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
 
       - name: Wait for the release image to be published
         env:
@@ -137,7 +137,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -157,7 +157,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
 
       - name: Wait for the release image to be published
         env:
@@ -137,7 +137,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
 
       - name: Download all artifacts
         # yamllint disable-line rule:line-length
@@ -157,7 +157,7 @@ jobs:
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/create-github-release@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
         with:
           tag: ${{ github.ref_name }}
           generate-notes: "true"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       job-name: "🛡️ Scorecard Analysis"
       # v0.54.0 hard-cut the no-op tooling-ref / egress-preset /

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       job-name: "🛡️ Scorecard Analysis"
       # v0.54.0 hard-cut the no-op tooling-ref / egress-preset /

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       job-name: "🛡️ Scorecard Analysis"
       # v0.54.0 hard-cut the no-op tooling-ref / egress-preset /

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -27,12 +27,12 @@ concurrency:
 jobs:
   security-audit:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read
       packages: read # pull the pinned lintro audit image from GHCR
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "Scan dependencies"
       runner-image: ubuntu-24.04
       # yamllint disable-line rule:line-length
@@ -71,7 +71,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+          ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
           sparse-checkout: |
             scripts/ci/
           sparse-checkout-cone-mode: true
@@ -89,12 +89,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs: security-audit
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish the audit summary on this PR
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "💬 Post PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -27,12 +27,12 @@ concurrency:
 jobs:
   security-audit:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: read # pull the pinned lintro audit image from GHCR
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "Scan dependencies"
       runner-image: ubuntu-24.04
       # yamllint disable-line rule:line-length
@@ -71,7 +71,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+          ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
           sparse-checkout: |
             scripts/ci/
           sparse-checkout-cone-mode: true
@@ -89,12 +89,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs: security-audit
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish the audit summary on this PR
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "💬 Post PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -30,7 +30,7 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
-      packages: read
+      packages: read # pull the pinned lintro audit image from GHCR
     with:
       tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "Scan dependencies"
@@ -92,7 +92,7 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # publish the audit summary on this PR
     with:
       tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "💬 Post PR Comment"

--- a/.github/workflows/security-dependency-review.yml
+++ b/.github/workflows/security-dependency-review.yml
@@ -27,12 +27,12 @@ concurrency:
 jobs:
   security-audit:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
       packages: read
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "Scan dependencies"
       runner-image: ubuntu-24.04
       # yamllint disable-line rule:line-length
@@ -71,7 +71,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+          ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
           sparse-checkout: |
             scripts/ci/
           sparse-checkout-cone-mode: true
@@ -89,12 +89,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs: security-audit
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
       pull-requests: write
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "💬 Post PR Comment"
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       job-name: "📝 Validate PR Title"
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       comment-marker: "<!-- semantic-pr-title -->"

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       job-name: "📝 Validate PR Title"
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       egress-policy: block
       egress-preset: github-tooling
       comment-marker: "<!-- semantic-pr-title -->"

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       job-name: "📝 Validate PR Title"
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       comment-marker: "<!-- semantic-pr-title -->"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -50,12 +50,12 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       ecosystems: rust
       auto-merge: true
       max-bump: minor
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       # Harden-runner pre reads workflow inputs only (not resolved presets)

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -50,12 +50,12 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       ecosystems: rust
       auto-merge: true
       max-bump: minor
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       # Harden-runner pre reads workflow inputs only (not resolved presets)

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -50,12 +50,12 @@ jobs:
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       ecosystems: rust
       auto-merge: true
       max-bump: minor
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       egress-policy: block
       egress-preset: github-tooling
       # Harden-runner pre reads workflow inputs only (not resolved presets)

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           persist-credentials: false
 
@@ -59,12 +59,12 @@ jobs:
 
   site-quality:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       pull-requests: write # required: reusable declares this on internal publish job
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: Build and check documentation site
       test-job-name: Test documentation site
       node-version: '22'

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
         with:
           persist-credentials: false
 
@@ -59,12 +59,12 @@ jobs:
 
   site-quality:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read
       pull-requests: write # required: reusable declares this on internal publish job
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: Build and check documentation site
       test-job-name: Test documentation site
       node-version: '22'

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
         with:
           persist-credentials: false
 
@@ -59,12 +59,12 @@ jobs:
 
   site-quality:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
       pull-requests: write # required: reusable declares this on internal publish job
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: Build and check documentation site
       test-job-name: Test documentation site
       node-version: '22'

--- a/.github/workflows/test-boundary-shell.yml
+++ b/.github/workflows/test-boundary-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: Boundary Shell Tests
       test-path: tests/bats/unit/boundary
       coverage: true

--- a/.github/workflows/test-boundary-shell.yml
+++ b/.github/workflows/test-boundary-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: Boundary Shell Tests
       test-path: tests/bats/unit/boundary
       coverage: true

--- a/.github/workflows/test-boundary-shell.yml
+++ b/.github/workflows/test-boundary-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: Boundary Shell Tests
       test-path: tests/bats/unit/boundary
       coverage: true

--- a/.github/workflows/test-docker-shell.yml
+++ b/.github/workflows/test-docker-shell.yml
@@ -7,12 +7,14 @@ name: Test - Docker Shell Scripts
     branches: [main]
     paths:
       - 'scripts/ci/docker/**'
+      - 'scripts/ci/testing/web/install-wasm-pack.sh'
       - 'tests/bats/**'
       - '.github/workflows/test-docker-shell.yml'
   push:
     branches: [main]
     paths:
       - 'scripts/ci/docker/**'
+      - 'scripts/ci/testing/web/install-wasm-pack.sh'
       - 'tests/bats/**'
       - '.github/workflows/test-docker-shell.yml'
 

--- a/.github/workflows/test-docker-shell.yml
+++ b/.github/workflows/test-docker-shell.yml
@@ -31,9 +31,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: Docker Shell Tests
       test-path: tests/bats/unit/docker
       coverage: true

--- a/.github/workflows/test-docker-shell.yml
+++ b/.github/workflows/test-docker-shell.yml
@@ -31,9 +31,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: Docker Shell Tests
       test-path: tests/bats/unit/docker
       coverage: true

--- a/.github/workflows/test-docker-shell.yml
+++ b/.github/workflows/test-docker-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: Docker Shell Tests
       test-path: tests/bats/unit/docker
       coverage: true

--- a/.github/workflows/test-e2e-site.yml
+++ b/.github/workflows/test-e2e-site.yml
@@ -53,12 +53,12 @@ concurrency:
 jobs:
   site-e2e:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "♿ Site E2E"
       node-version: "22"
       working-directory: apps/site

--- a/.github/workflows/test-e2e-site.yml
+++ b/.github/workflows/test-e2e-site.yml
@@ -53,12 +53,12 @@ concurrency:
 jobs:
   site-e2e:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "♿ Site E2E"
       node-version: "22"
       working-directory: apps/site

--- a/.github/workflows/test-e2e-site.yml
+++ b/.github/workflows/test-e2e-site.yml
@@ -53,12 +53,12 @@ concurrency:
 jobs:
   site-e2e:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "♿ Site E2E"
       node-version: "22"
       working-directory: apps/site

--- a/.github/workflows/test-e2e-web.yml
+++ b/.github/workflows/test-e2e-web.yml
@@ -58,12 +58,12 @@ concurrency:
 jobs:
   web-e2e:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: "🎭 Web E2E"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/test-e2e-web.yml
+++ b/.github/workflows/test-e2e-web.yml
@@ -58,12 +58,12 @@ concurrency:
 jobs:
   web-e2e:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: "🎭 Web E2E"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/test-e2e-web.yml
+++ b/.github/workflows/test-e2e-web.yml
@@ -58,12 +58,12 @@ concurrency:
 jobs:
   web-e2e:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-e2e-playwright.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       pull-requests: write # publish-test-summary on PRs
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: "🎭 Web E2E"
       node-version: "22"
       working-directory: apps/web

--- a/.github/workflows/test-maintenance-shell.yml
+++ b/.github/workflows/test-maintenance-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       job-name: Maintenance Shell Tests
       test-path: tests/bats/unit/maintenance
       coverage: true

--- a/.github/workflows/test-maintenance-shell.yml
+++ b/.github/workflows/test-maintenance-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: Maintenance Shell Tests
       test-path: tests/bats/unit/maintenance
       coverage: true

--- a/.github/workflows/test-maintenance-shell.yml
+++ b/.github/workflows/test-maintenance-shell.yml
@@ -29,9 +29,9 @@ jobs:
       contents: read
       pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       job-name: Maintenance Shell Tests
       test-path: tests/bats/unit/maintenance
       coverage: true

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -39,10 +39,10 @@ jobs:
     # ruleset check name stays rust-build / 🔨 Build Check — an extra nesting
     # hop would prefix build / and break required-status matching.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       job-name: "🔨 Build Check"
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       draft-pr-skip: true
       egress-policy: block
       egress-preset: quality

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -39,10 +39,10 @@ jobs:
     # ruleset check name stays rust-build / 🔨 Build Check — an extra nesting
     # hop would prefix build / and break required-status matching.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       job-name: "🔨 Build Check"
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       draft-pr-skip: true
       egress-policy: block
       egress-preset: quality

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -39,10 +39,10 @@ jobs:
     # ruleset check name stays rust-build / 🔨 Build Check — an extra nesting
     # hop would prefix build / and break required-status matching.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust-build.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       job-name: "🔨 Build Check"
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       draft-pr-skip: true
       egress-policy: block
       egress-preset: quality

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       job-name: '📌 Validate Action Pinning'
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3'  # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf'  # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       fail-on-error: true

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       job-name: '📌 Validate Action Pinning'
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2'  # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3'  # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       fail-on-error: true

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       job-name: '📌 Validate Action Pinning'
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8'  # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2'  # v0.63.1
       egress-policy: block
       egress-preset: github-tooling
       fail-on-error: true

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -19,10 +19,10 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
     with:
       job-name: "🔍 Check Vulnerability Suppressions"
-      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
+      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -19,10 +19,10 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@240daf3ed1f7475b3f322502035b15994be210a8 # v0.59.16
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@23c79b65490a3307fb08cdefafa22db12f75b9b2 # v0.63.1
     with:
       job-name: "🔍 Check Vulnerability Suppressions"
-      tooling-ref: '240daf3ed1f7475b3f322502035b15994be210a8' # v0.59.16
+      tooling-ref: '23c79b65490a3307fb08cdefafa22db12f75b9b2' # v0.63.1
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -19,10 +19,10 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@9cfddc566c014117e9fcce6e93ef78580c09c7a3 # v0.63.6
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       job-name: "🔍 Check Vulnerability Suppressions"
-      tooling-ref: '9cfddc566c014117e9fcce6e93ef78580c09c7a3' # v0.63.6
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,17 @@ ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}
 
 WORKDIR /app
 # musl-dev + make: required for tikv-jemalloc-sys to compile jemalloc from C source
-# Map TARGETARCH → Rust triple and persist for downstream stages
-RUN apk add --no-cache musl-dev make curl && \
-    cargo install cargo-chef@0.1.77 --locked && \
+# Map TARGETARCH → Rust triple and persist for downstream stages.
+# cargo-chef is a checksum-verified prebuilt (via cargo-binstall), not a
+# from-source compile — compiling it would recreate the rustc peak #868
+# is trying to leave.
+ARG CARGO_CHEF_VERSION=0.1.77
+COPY scripts/ci/docker/install-cargo-binstall.sh /tmp/install-cargo-binstall.sh
+RUN apk add --no-cache musl-dev make curl bash && \
+    bash /tmp/install-cargo-binstall.sh && \
+    cargo binstall --no-confirm --locked --disable-strategies compile \
+      "cargo-chef@${CARGO_CHEF_VERSION}" && \
+    rm /tmp/install-cargo-binstall.sh && \
     case "${TARGETARCH}" in \
       amd64) echo "x86_64-unknown-linux-musl" > /tmp/rust_target ;; \
       arm64) echo "aarch64-unknown-linux-musl" > /tmp/rust_target ;; \
@@ -66,19 +74,16 @@ ARG TARGETARCH
 # provide broad glyph-coverage fallbacks for user-configured families.
 RUN apk add --no-cache font-liberation font-dejavu
 
-# Cook dependencies — this layer is cached as long as recipe.json is unchanged.
-# Cache mounts persist compiled artifacts and crate sources across builds,
-# speeding up cold rebuilds when recipe.json changes (dep bumps, toolchain upgrades).
-#
-# NOTE: the /app/target cache mount is LOAD-BEARING across the cook and build
-# RUNs below — cook writes compiled deps there, build reads them. Cache mounts
-# are ephemeral (not captured in layers), so BOTH RUNs must mount the same id
-# (rustume-target-<arch>). Removing the mount on cook breaks the hand-off and
-# forces build to recompile all deps from scratch even on warm cache.
-# Cache ids are scoped per-arch so concurrent amd64/arm64 builds don't collide.
+# Cook dependencies into the layer filesystem. recipe.json is the cache key.
+# Do NOT mount /app/target: BuildKit cache mounts are not exported by
+# cache-to type=gha / type=registry (the only backends lgtm-ci uses). A
+# mount would make the cook layer look cached on the next runner while
+# leaving /app/target empty, so cargo build would recompile the whole
+# tree and the #868 warm-path payoff would never happen. The same-stage
+# layer carries target/ from cook to build — that is the cargo-chef
+# contract. Registry mounts stay: crate tarballs are cheap vs rustc.
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TARGETARCH} \
-    --mount=type=cache,target=/app/target,id=rustume-target-${TARGETARCH} \
     RUST_TARGET="$(cat /tmp/rust_target)" && \
     cargo chef cook --release --target "${RUST_TARGET}" \
       --recipe-path recipe.json -p rustume-server
@@ -89,7 +94,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TA
 # not know, so local `docker build` needs no build args.
 ARG GIT_COMMIT=""
 
-# Copy workspace source and build (reuses cooked deps via shared target cache mount)
+# Copy workspace source and build (reuses cooked deps from the previous layer)
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY bindings ./bindings
@@ -99,7 +104,6 @@ COPY bindings ./bindings
 # BUILD_TIME is stamped here rather than passed in: it is the time this layer
 # actually compiled the binary, which stays truthful on a cache hit.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=rustume-registry-${TARGETARCH} \
-    --mount=type=cache,target=/app/target,id=rustume-target-${TARGETARCH} \
     RUST_TARGET="$(cat /tmp/rust_target)" && \
     GIT_COMMIT="$(printf '%.7s' "${GIT_COMMIT}")" && \
     BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)" && \
@@ -118,7 +122,6 @@ FROM rust:1.97-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088
 # Re-declare — ARGs do not cross FROM boundaries
 ARG TARGETARCH
 ARG BUN_VERSION=1.3.14
-ARG BINSTALL_VERSION=1.21.1
 # Same cap as chef. This stage no longer compiles wasm tooling from
 # source (cargo-binstall below); the cap still covers rustup/cargo
 # work and any future cargo install in this stage.
@@ -130,6 +133,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 COPY Cargo.lock /tmp/Cargo.lock
 COPY scripts/ci/testing/web/install-wasm-pack.sh /tmp/install-wasm-pack.sh
+COPY scripts/ci/docker/install-cargo-binstall.sh /tmp/install-cargo-binstall.sh
 
 # Install wasm-pack through the repo's canonical checksum-pinned installer,
 # then install a checksum-verified cargo-binstall release for the lockfile-
@@ -141,32 +145,17 @@ RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
     update-ca-certificates && \
     rustup target add wasm32-unknown-unknown && \
     bash /tmp/install-wasm-pack.sh && \
+    bash /tmp/install-cargo-binstall.sh && \
     case "${TARGETARCH}" in \
-      amd64) \
-        BINSTALL_TARGET=x86_64-unknown-linux-musl; \
-        BINSTALL_SHA256=630c8f8803a686aa6779497f0f0fb51d49822fb5fc3c514d8ced33b34e338e6e; \
-        BUN_ARCH=x64-musl \
-        ;; \
-      arm64) \
-        BINSTALL_TARGET=aarch64-unknown-linux-musl; \
-        BINSTALL_SHA256=1dc2979f3c83aade9a1b4344589d14fafa63459b759222528d11419f5cca9cc2; \
-        BUN_ARCH=aarch64-musl \
-        ;; \
+      amd64) BUN_ARCH=x64-musl ;; \
+      arm64) BUN_ARCH=aarch64-musl ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2 && exit 1 ;; \
     esac && \
-    BINSTALL_ARCHIVE="cargo-binstall-${BINSTALL_TARGET}.tgz" && \
-    curl -fsSL \
-      "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/${BINSTALL_ARCHIVE}" \
-      -o "/tmp/${BINSTALL_ARCHIVE}" && \
-    echo "${BINSTALL_SHA256}  /tmp/${BINSTALL_ARCHIVE}" | sha256sum -c - && \
-    mkdir /tmp/cargo-binstall && \
-    tar -xzf "/tmp/${BINSTALL_ARCHIVE}" -C /tmp/cargo-binstall && \
-    install -m 755 /tmp/cargo-binstall/cargo-binstall /usr/local/bin/cargo-binstall && \
     WASM_BINDGEN_VERSION=$(grep 'name = "wasm-bindgen"' /tmp/Cargo.lock -A 1 | grep version | head -1 | cut -d '"' -f 2) && \
     cargo binstall --no-confirm --locked --disable-strategies compile \
       "wasm-bindgen-cli@${WASM_BINDGEN_VERSION}" && \
-    rm -rf /tmp/cargo-binstall "/tmp/${BINSTALL_ARCHIVE}" \
-      /tmp/install-wasm-pack.sh /tmp/Cargo.lock && \
+    rm -rf /tmp/install-cargo-binstall.sh /tmp/install-wasm-pack.sh \
+      /tmp/Cargo.lock && \
     BUN_ZIP="bun-linux-${BUN_ARCH}.zip" && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${BUN_ZIP}" -o "/tmp/${BUN_ZIP}" && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" -o /tmp/SHASUMS256.txt && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,11 +13,13 @@ ARG TARGETARCH
 
 # Cap rustc parallelism. GitHub-hosted runners are 4 vCPU / 16 GB; cargo's
 # default ncpu job count drives peak rustc memory past the VM ceiling and
-# the runner is killed ~20 min into a cold `cargo chef cook` (#868). A
-# slower build that survives beats a fast one that is killed. Overridable
-# via `--build-arg CARGO_BUILD_JOBS=N`. Inherited by planner/builder
+# the runner is killed ~20 min into a cold `cargo chef cook` (#868).
+# jobs=2 still died mid-cook on PR #869 (web-builder already finished;
+# the last ~15 min were cook-only). jobs=1 is the right setting for a
+# 16 GB box compiling typst release. Overridable via
+# `--build-arg CARGO_BUILD_JOBS=N`. Inherited by planner/builder
 # (both FROM chef).
-ARG CARGO_BUILD_JOBS=2
+ARG CARGO_BUILD_JOBS=1
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 
 WORKDIR /app
@@ -112,10 +114,10 @@ FROM rust:1.97-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088
 # Re-declare — ARGs do not cross FROM boundaries
 ARG TARGETARCH
 ARG BUN_VERSION=1.3.14
-# Same cap as chef: this stage used to compile wasm-pack and
-# wasm-bindgen-cli from source concurrently with the cook, which is
-# what pushed the 4 vCPU / 16 GB runner over the kill threshold (#868).
-ARG CARGO_BUILD_JOBS=2
+# Same cap as chef. This stage no longer compiles wasm tooling from
+# source (cargo-binstall below); the cap still covers rustup/cargo
+# work and any future cargo install in this stage.
+ARG CARGO_BUILD_JOBS=1
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 
 WORKDIR /app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,12 +15,16 @@ ARG TARGETARCH
 # default ncpu job count drives peak rustc memory past the VM ceiling and
 # the runner is killed ~20 min into a cold `cargo chef cook` (#868).
 # jobs=2 still died mid-cook on PR #869 (web-builder already finished;
-# the last ~15 min were cook-only). jobs=1 is the right setting for a
-# 16 GB box compiling typst release. Overridable via
-# `--build-arg CARGO_BUILD_JOBS=N`. Inherited by planner/builder
-# (both FROM chef).
+# the last ~15 min were cook-only). jobs=1 alone was still killed at ~20 min
+# on PR #869 — with one job rustc collapses the release profile to a single
+# codegen unit, which multiplies per-process memory for typst-scale crates.
+# codegen-units=16 splits each crate into smaller units so single-job rustc
+# peaks fit 16 GB. Both overridable via build args. Inherited by
+# planner/builder (both FROM chef).
 ARG CARGO_BUILD_JOBS=1
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
+ARG CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16
+ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}
 
 WORKDIR /app
 # musl-dev + make: required for tikv-jemalloc-sys to compile jemalloc from C source

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,17 +128,21 @@ COPY Cargo.lock /tmp/Cargo.lock
 # binstall from source would recreate the rustc peak this stage is meant
 # to avoid). Both linux/amd64 and linux/arm64 publish musl artifacts
 # (wasm-pack v0.15+, wasm-bindgen-cli since 0.2.104; lock is 0.2.127),
-# so binstall is used on both arches. wasm-bindgen CLI version is grepped
-# from Cargo.lock so it matches the crate the WASM bindings compile against.
+# so binstall is used on both arches. --disable-strategies compile fails
+# the RUN if a musl prebuilt disappears instead of compiling from source
+# and recreating the rustc peak. wasm-bindgen CLI version is grepped from
+# Cargo.lock so it matches the crate the WASM bindings compile against.
 RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
     update-ca-certificates && \
     rustup target add wasm32-unknown-unknown && \
     curl -L --proto '=https' --tlsv1.2 -sSf \
       https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
       | bash && \
-    cargo binstall --no-confirm --locked wasm-pack && \
+    cargo binstall --no-confirm --locked --disable-strategies compile \
+      wasm-pack && \
     WASM_BINDGEN_VERSION=$(grep 'name = "wasm-bindgen"' /tmp/Cargo.lock -A 1 | grep version | head -1 | cut -d '"' -f 2) && \
-    cargo binstall --no-confirm --locked "wasm-bindgen-cli@${WASM_BINDGEN_VERSION}" && \
+    cargo binstall --no-confirm --locked --disable-strategies compile \
+      "wasm-bindgen-cli@${WASM_BINDGEN_VERSION}" && \
     rm /tmp/Cargo.lock && \
     case "${TARGETARCH}" in \
       amd64) BUN_ARCH=x64-musl ;; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,6 +114,7 @@ FROM rust:1.97-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088
 # Re-declare — ARGs do not cross FROM boundaries
 ARG TARGETARCH
 ARG BUN_VERSION=1.3.14
+ARG BINSTALL_VERSION=1.21.1
 # Same cap as chef. This stage no longer compiles wasm tooling from
 # source (cargo-binstall below); the cap still covers rustup/cargo
 # work and any future cargo install in this stage.
@@ -124,33 +125,44 @@ WORKDIR /app
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 COPY Cargo.lock /tmp/Cargo.lock
+COPY scripts/ci/testing/web/install-wasm-pack.sh /tmp/install-wasm-pack.sh
 
-# Install wasm-pack / wasm-bindgen-cli as prebuilt binaries via cargo-binstall
-# (official installer, not `cargo install cargo-binstall` — compiling
-# binstall from source would recreate the rustc peak this stage is meant
-# to avoid). Both linux/amd64 and linux/arm64 publish musl artifacts
-# (wasm-pack v0.15+, wasm-bindgen-cli since 0.2.104; lock is 0.2.127),
-# so binstall is used on both arches. --disable-strategies compile fails
-# the RUN if a musl prebuilt disappears instead of compiling from source
-# and recreating the rustc peak. wasm-bindgen CLI version is grepped from
-# Cargo.lock so it matches the crate the WASM bindings compile against.
+# Install wasm-pack through the repo's canonical checksum-pinned installer,
+# then install a checksum-verified cargo-binstall release for the lockfile-
+# pinned wasm-bindgen-cli binary. Compiling either tool from source would
+# recreate the rustc peak this stage is meant to avoid. Both architectures
+# publish musl artifacts; --disable-strategies compile fails closed if the
+# wasm-bindgen prebuilt disappears.
 RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
     update-ca-certificates && \
     rustup target add wasm32-unknown-unknown && \
-    curl -L --proto '=https' --tlsv1.2 -sSf \
-      https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
-      | bash && \
-    cargo binstall --no-confirm --locked --disable-strategies compile \
-      wasm-pack && \
+    bash /tmp/install-wasm-pack.sh && \
+    case "${TARGETARCH}" in \
+      amd64) \
+        BINSTALL_TARGET=x86_64-unknown-linux-musl; \
+        BINSTALL_SHA256=630c8f8803a686aa6779497f0f0fb51d49822fb5fc3c514d8ced33b34e338e6e; \
+        BUN_ARCH=x64-musl \
+        ;; \
+      arm64) \
+        BINSTALL_TARGET=aarch64-unknown-linux-musl; \
+        BINSTALL_SHA256=1dc2979f3c83aade9a1b4344589d14fafa63459b759222528d11419f5cca9cc2; \
+        BUN_ARCH=aarch64-musl \
+        ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2 && exit 1 ;; \
+    esac && \
+    BINSTALL_ARCHIVE="cargo-binstall-${BINSTALL_TARGET}.tgz" && \
+    curl -fsSL \
+      "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/${BINSTALL_ARCHIVE}" \
+      -o "/tmp/${BINSTALL_ARCHIVE}" && \
+    echo "${BINSTALL_SHA256}  /tmp/${BINSTALL_ARCHIVE}" | sha256sum -c - && \
+    mkdir /tmp/cargo-binstall && \
+    tar -xzf "/tmp/${BINSTALL_ARCHIVE}" -C /tmp/cargo-binstall && \
+    install -m 755 /tmp/cargo-binstall/cargo-binstall /usr/local/bin/cargo-binstall && \
     WASM_BINDGEN_VERSION=$(grep 'name = "wasm-bindgen"' /tmp/Cargo.lock -A 1 | grep version | head -1 | cut -d '"' -f 2) && \
     cargo binstall --no-confirm --locked --disable-strategies compile \
       "wasm-bindgen-cli@${WASM_BINDGEN_VERSION}" && \
-    rm /tmp/Cargo.lock && \
-    case "${TARGETARCH}" in \
-      amd64) BUN_ARCH=x64-musl ;; \
-      arm64) BUN_ARCH=aarch64-musl ;; \
-      *) echo "unsupported TARGETARCH for bun: ${TARGETARCH}" >&2 && exit 1 ;; \
-    esac && \
+    rm -rf /tmp/cargo-binstall "/tmp/${BINSTALL_ARCHIVE}" \
+      /tmp/install-wasm-pack.sh /tmp/Cargo.lock && \
     BUN_ZIP="bun-linux-${BUN_ARCH}.zip" && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${BUN_ZIP}" -o "/tmp/${BUN_ZIP}" && \
     curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" -o /tmp/SHASUMS256.txt && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,15 @@ FROM rust:1.97-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088
 # BuildKit auto-populates TARGETARCH per --platform (amd64 | arm64)
 ARG TARGETARCH
 
+# Cap rustc parallelism. GitHub-hosted runners are 4 vCPU / 16 GB; cargo's
+# default ncpu job count drives peak rustc memory past the VM ceiling and
+# the runner is killed ~20 min into a cold `cargo chef cook` (#868). A
+# slower build that survives beats a fast one that is killed. Overridable
+# via `--build-arg CARGO_BUILD_JOBS=N`. Inherited by planner/builder
+# (both FROM chef).
+ARG CARGO_BUILD_JOBS=2
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
+
 WORKDIR /app
 # musl-dev + make: required for tikv-jemalloc-sys to compile jemalloc from C source
 # Map TARGETARCH → Rust triple and persist for downstream stages
@@ -103,18 +112,33 @@ FROM rust:1.97-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088
 # Re-declare — ARGs do not cross FROM boundaries
 ARG TARGETARCH
 ARG BUN_VERSION=1.3.14
+# Same cap as chef: this stage used to compile wasm-pack and
+# wasm-bindgen-cli from source concurrently with the cook, which is
+# what pushed the 4 vCPU / 16 GB runner over the kill threshold (#868).
+ARG CARGO_BUILD_JOBS=2
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 
 WORKDIR /app
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 COPY Cargo.lock /tmp/Cargo.lock
 
+# Install wasm-pack / wasm-bindgen-cli as prebuilt binaries via cargo-binstall
+# (official installer, not `cargo install cargo-binstall` — compiling
+# binstall from source would recreate the rustc peak this stage is meant
+# to avoid). Both linux/amd64 and linux/arm64 publish musl artifacts
+# (wasm-pack v0.15+, wasm-bindgen-cli since 0.2.104; lock is 0.2.127),
+# so binstall is used on both arches. wasm-bindgen CLI version is grepped
+# from Cargo.lock so it matches the crate the WASM bindings compile against.
 RUN apk add --no-cache musl-dev bash unzip ca-certificates curl && \
     update-ca-certificates && \
     rustup target add wasm32-unknown-unknown && \
-    cargo install wasm-pack --locked && \
+    curl -L --proto '=https' --tlsv1.2 -sSf \
+      https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
+      | bash && \
+    cargo binstall --no-confirm --locked wasm-pack && \
     WASM_BINDGEN_VERSION=$(grep 'name = "wasm-bindgen"' /tmp/Cargo.lock -A 1 | grep version | head -1 | cut -d '"' -f 2) && \
-    cargo install "wasm-bindgen-cli@${WASM_BINDGEN_VERSION}" --locked && \
+    cargo binstall --no-confirm --locked "wasm-bindgen-cli@${WASM_BINDGEN_VERSION}" && \
     rm /tmp/Cargo.lock && \
     case "${TARGETARCH}" in \
       amd64) BUN_ARCH=x64-musl ;; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,27 +11,14 @@ FROM rust:1.97-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088
 # BuildKit auto-populates TARGETARCH per --platform (amd64 | arm64)
 ARG TARGETARCH
 
-# Cap rustc parallelism. GitHub-hosted runners are 4 vCPU / 16 GB; cargo's
-# default ncpu job count drives peak rustc memory past the VM ceiling and
-# the runner is killed ~20 min into a cold `cargo chef cook` (#868).
-# jobs=2 still died mid-cook on PR #869 (web-builder already finished;
-# the last ~15 min were cook-only). jobs=1 alone was still killed at ~20 min
-# on PR #869 — with one job rustc collapses the release profile to a single
-# codegen unit, which multiplies per-process memory for typst-scale crates.
-# codegen-units=16 splits each crate into smaller units so single-job rustc
-# peaks fit 16 GB. Both overridable via build args. Inherited by
-# planner/builder (both FROM chef).
-ARG CARGO_BUILD_JOBS=1
-ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
-ARG CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16
-ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}
-
 WORKDIR /app
 # musl-dev + make: required for tikv-jemalloc-sys to compile jemalloc from C source
 # Map TARGETARCH → Rust triple and persist for downstream stages.
 # cargo-chef is a checksum-verified prebuilt (via cargo-binstall), not a
-# from-source compile — compiling it would recreate the rustc peak #868
-# is trying to leave.
+# from-source compile. Do not cap CARGO_BUILD_JOBS here: jobs=1 and jobs=2
+# still died at ~20 min on linux/amd64 (same band as default ncpu), and
+# jobs=1 stretched linux/arm64 from ~15 min to 47 min. A jobs cap, if
+# ever restored, must be TARGETARCH=amd64 only.
 ARG CARGO_CHEF_VERSION=0.1.77
 COPY scripts/ci/docker/install-cargo-binstall.sh /tmp/install-cargo-binstall.sh
 RUN apk add --no-cache musl-dev make curl bash && \
@@ -122,11 +109,6 @@ FROM rust:1.97-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088
 # Re-declare — ARGs do not cross FROM boundaries
 ARG TARGETARCH
 ARG BUN_VERSION=1.3.14
-# Same cap as chef. This stage no longer compiles wasm tooling from
-# source (cargo-binstall below); the cap still covers rustup/cargo
-# work and any future cargo install in this stage.
-ARG CARGO_BUILD_JOBS=1
-ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 
 WORKDIR /app
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/^docker/Dockerfile$/"],
       "matchStrings": [
-        "cargo install cargo-chef@(?<currentValue>\\S+) --locked"
+        "ARG CARGO_CHEF_VERSION=(?<currentValue>\\S+)"
       ],
       "depNameTemplate": "cargo-chef",
       "datasourceTemplate": "crate"

--- a/scripts/ci/docker/install-cargo-binstall.sh
+++ b/scripts/ci/docker/install-cargo-binstall.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Install a pinned cargo-binstall release binary (Linux musl) for Docker/CI.
+# Verifies the archive against a pinned SHA-256 before installing.
+set -euo pipefail
+
+DEFAULT_BINSTALL_VERSION="1.21.1"
+BINSTALL_VERSION="${BINSTALL_VERSION:-${DEFAULT_BINSTALL_VERSION}}"
+
+# The bundled checksums only cover the default version — a version override
+# must bring its own checksum or the verification failure would be opaque.
+if [[ "${BINSTALL_VERSION}" != "${DEFAULT_BINSTALL_VERSION}" && -z "${BINSTALL_SHA256:-}" ]]; then
+	echo "install-cargo-binstall.sh: BINSTALL_VERSION=${BINSTALL_VERSION} overrides the default" \
+		"(${DEFAULT_BINSTALL_VERSION}) — set BINSTALL_SHA256 for that release too" >&2
+	exit 1
+fi
+
+# Docker BuildKit sets TARGETARCH (amd64|arm64); local/CI callers use uname.
+arch="${TARGETARCH:-$(uname -m)}"
+case "${arch}" in
+amd64 | x86_64)
+	target_triple="x86_64-unknown-linux-musl"
+	default_sha256="630c8f8803a686aa6779497f0f0fb51d49822fb5fc3c514d8ced33b34e338e6e"
+	;;
+arm64 | aarch64)
+	target_triple="aarch64-unknown-linux-musl"
+	default_sha256="1dc2979f3c83aade9a1b4344589d14fafa63459b759222528d11419f5cca9cc2"
+	;;
+*)
+	echo "install-cargo-binstall.sh: unsupported architecture '${arch}'" >&2
+	exit 1
+	;;
+esac
+BINSTALL_SHA256="${BINSTALL_SHA256:-${default_sha256}}"
+install_dir="${CARGO_HOME:-${HOME}/.cargo}/bin"
+
+if command -v cargo-binstall >/dev/null 2>&1; then
+	installed_version="$(cargo-binstall --version | awk '{print $2}')"
+	if [[ "${installed_version}" == "${BINSTALL_VERSION}" ]]; then
+		echo "cargo-binstall ${installed_version} already installed — matches pin"
+		exit 0
+	fi
+	echo "cargo-binstall ${installed_version} found but pin is ${BINSTALL_VERSION} — reinstalling"
+fi
+
+archive="cargo-binstall-${target_triple}.tgz"
+url="https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/${archive}"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+echo "Downloading ${url}"
+curl --fail --silent --show-error --location --output "${tmp_dir}/${archive}" "${url}"
+
+echo "${BINSTALL_SHA256}  ${tmp_dir}/${archive}" | sha256sum -c -
+
+tar -xzf "${tmp_dir}/${archive}" -C "${tmp_dir}"
+mkdir -p "${install_dir}"
+install -m 0755 "${tmp_dir}/cargo-binstall" "${install_dir}/cargo-binstall"
+
+echo "Installed $("${install_dir}/cargo-binstall" --version)"

--- a/scripts/ci/testing/web/install-wasm-pack.sh
+++ b/scripts/ci/testing/web/install-wasm-pack.sh
@@ -53,7 +53,7 @@ trap 'rm -rf "${tmp_dir}"' EXIT
 echo "Downloading ${url}"
 curl --fail --silent --show-error --location --output "${tmp_dir}/${archive}" "${url}"
 
-echo "${WASM_PACK_SHA256}  ${tmp_dir}/${archive}" | sha256sum --check --quiet
+echo "${WASM_PACK_SHA256}  ${tmp_dir}/${archive}" | sha256sum -c -
 
 tar -xzf "${tmp_dir}/${archive}" -C "${tmp_dir}"
 mkdir -p "${install_dir}"
@@ -61,4 +61,4 @@ install -m 0755 \
 	"${tmp_dir}/wasm-pack-v${WASM_PACK_VERSION}-${target_triple}/wasm-pack" \
 	"${install_dir}/wasm-pack"
 
-echo "Installed $(wasm-pack --version)"
+echo "Installed $("${install_dir}/wasm-pack" --version)"

--- a/scripts/ci/testing/web/install-wasm-pack.sh
+++ b/scripts/ci/testing/web/install-wasm-pack.sh
@@ -31,6 +31,7 @@ aarch64 | arm64)
 	;;
 esac
 WASM_PACK_SHA256="${WASM_PACK_SHA256:-${default_sha256}}"
+install_dir="${CARGO_HOME:-${HOME}/.cargo}/bin"
 
 # Only trust a preinstalled binary when it matches the pinned version;
 # anything else is replaced by the checksum-verified release below.
@@ -55,8 +56,9 @@ curl --fail --silent --show-error --location --output "${tmp_dir}/${archive}" "$
 echo "${WASM_PACK_SHA256}  ${tmp_dir}/${archive}" | sha256sum --check --quiet
 
 tar -xzf "${tmp_dir}/${archive}" -C "${tmp_dir}"
+mkdir -p "${install_dir}"
 install -m 0755 \
 	"${tmp_dir}/wasm-pack-v${WASM_PACK_VERSION}-${target_triple}/wasm-pack" \
-	"${HOME}/.cargo/bin/wasm-pack"
+	"${install_dir}/wasm-pack"
 
 echo "Installed $(wasm-pack --version)"

--- a/tests/bats/unit/docker/test_install_cargo_binstall.bats
+++ b/tests/bats/unit/docker/test_install_cargo_binstall.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/docker/install-cargo-binstall.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/docker/install-cargo-binstall.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export CARGO_HOME="${BATS_TEST_TMPDIR}/cargo"
+	export HOME="${BATS_TEST_TMPDIR}/home"
+	export SHA_ARGS_FILE="${BATS_TEST_TMPDIR}/sha-args"
+	unset TARGETARCH BINSTALL_VERSION BINSTALL_SHA256 || true
+
+	mock_command "uname" "x86_64"
+	mock_command "cargo-binstall" "cargo-binstall 0.0.0"
+	mock_command_script "curl" '
+while (($#)); do
+	if [[ "$1" == "--output" ]]; then
+		shift
+		mkdir -p "$(dirname "$1")"
+		: >"$1"
+		exit 0
+	fi
+	shift
+done
+exit 2
+'
+	mock_command_script "tar" '
+destination=""
+while (($#)); do
+	case "$1" in
+	-C)
+		destination="$2"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+cat >"${destination}/cargo-binstall" <<'"'"'SCRIPT'"'"'
+#!/usr/bin/env bash
+printf "cargo-binstall 1.21.1\n"
+SCRIPT
+chmod +x "${destination}/cargo-binstall"
+'
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "Docker-style TARGETARCH invocation verifies the archive portably" {
+	mock_command_script "sha256sum" '
+printf "%s\n" "$*" >"${SHA_ARGS_FILE}"
+cat >/dev/null
+exit 0
+'
+
+	run env CARGO_HOME="${CARGO_HOME}" HOME="${HOME}" TARGETARCH=amd64 \
+		bash "${SCRIPT}"
+
+	assert_success
+	assert_output --partial "Installed cargo-binstall 1.21.1"
+	[[ -x "${CARGO_HOME}/bin/cargo-binstall" ]]
+	run cat "${SHA_ARGS_FILE}"
+	assert_output "-c -"
+}
+
+@test "checksum mismatch fails before extracting or installing" {
+	export TAR_CALLED_FILE="${BATS_TEST_TMPDIR}/tar-called"
+	mock_command_script "sha256sum" '
+cat >/dev/null
+exit 1
+'
+	mock_command_script "tar" '
+: >"${TAR_CALLED_FILE}"
+exit 99
+'
+
+	run env CARGO_HOME="${CARGO_HOME}" HOME="${HOME}" TARGETARCH=arm64 \
+		TAR_CALLED_FILE="${TAR_CALLED_FILE}" bash "${SCRIPT}"
+
+	assert_failure
+	[[ ! -e "${TAR_CALLED_FILE}" ]]
+	[[ ! -e "${CARGO_HOME}/bin/cargo-binstall" ]]
+}
+
+@test "version override without checksum fails closed" {
+	run env CARGO_HOME="${CARGO_HOME}" HOME="${HOME}" \
+		BINSTALL_VERSION=9.9.9 bash "${SCRIPT}"
+
+	assert_failure
+	assert_output --partial "set BINSTALL_SHA256"
+}

--- a/tests/bats/unit/docker/test_install_wasm_pack.bats
+++ b/tests/bats/unit/docker/test_install_wasm_pack.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/testing/web/install-wasm-pack.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/testing/web/install-wasm-pack.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export CARGO_HOME="${BATS_TEST_TMPDIR}/cargo"
+	export HOME="${BATS_TEST_TMPDIR}/home"
+	export SHA_ARGS_FILE="${BATS_TEST_TMPDIR}/sha-args"
+
+	mock_command "uname" "x86_64"
+	mock_command "wasm-pack" "wasm-pack 0.0.0"
+	mock_command_script "curl" '
+while (($#)); do
+	if [[ "$1" == "--output" ]]; then
+		shift
+		mkdir -p "$(dirname "$1")"
+		: >"$1"
+		exit 0
+	fi
+	shift
+done
+exit 2
+'
+	mock_command_script "tar" '
+archive=""
+destination=""
+while (($#)); do
+	case "$1" in
+	-xzf)
+		archive="$2"
+		shift 2
+		;;
+	-C)
+		destination="$2"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+directory="$(basename "${archive}" .tar.gz)"
+mkdir -p "${destination}/${directory}"
+cat >"${destination}/${directory}/wasm-pack" <<'"'"'SCRIPT'"'"'
+#!/usr/bin/env bash
+printf "wasm-pack 0.15.0\n"
+SCRIPT
+chmod +x "${destination}/${directory}/wasm-pack"
+'
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "Docker-style invocation creates CARGO_HOME bin and verifies the archive portably" {
+	mock_command_script "sha256sum" '
+printf "%s\n" "$*" >"${SHA_ARGS_FILE}"
+cat >/dev/null
+exit 0
+'
+
+	run env CARGO_HOME="${CARGO_HOME}" HOME="${HOME}" bash "${SCRIPT}"
+
+	assert_success
+	assert_output --partial "Installed wasm-pack 0.15.0"
+	[[ -x "${CARGO_HOME}/bin/wasm-pack" ]]
+	run cat "${SHA_ARGS_FILE}"
+	assert_output "-c -"
+}
+
+@test "checksum mismatch fails before extracting or installing" {
+	mock_command_script "sha256sum" '
+cat >/dev/null
+exit 1
+'
+	mock_command "tar" "" 99
+
+	run env CARGO_HOME="${CARGO_HOME}" HOME="${HOME}" bash "${SCRIPT}"
+
+	assert_failure
+	[[ ! -e "${CARGO_HOME}/bin/wasm-pack" ]]
+}

--- a/tests/bats/unit/docker/test_install_wasm_pack.bats
+++ b/tests/bats/unit/docker/test_install_wasm_pack.bats
@@ -13,6 +13,7 @@ setup() {
 	export CARGO_HOME="${BATS_TEST_TMPDIR}/cargo"
 	export HOME="${BATS_TEST_TMPDIR}/home"
 	export SHA_ARGS_FILE="${BATS_TEST_TMPDIR}/sha-args"
+	unset WASM_PACK_VERSION WASM_PACK_SHA256 || true
 
 	mock_command "uname" "x86_64"
 	mock_command "wasm-pack" "wasm-pack 0.0.0"

--- a/tests/bats/unit/docker/test_install_wasm_pack.bats
+++ b/tests/bats/unit/docker/test_install_wasm_pack.bats
@@ -78,14 +78,20 @@ exit 0
 }
 
 @test "checksum mismatch fails before extracting or installing" {
+	export TAR_CALLED_FILE="${BATS_TEST_TMPDIR}/tar-called"
 	mock_command_script "sha256sum" '
 cat >/dev/null
 exit 1
 '
-	mock_command "tar" "" 99
+	mock_command_script "tar" '
+: >"${TAR_CALLED_FILE}"
+exit 99
+'
 
-	run env CARGO_HOME="${CARGO_HOME}" HOME="${HOME}" bash "${SCRIPT}"
+	run env CARGO_HOME="${CARGO_HOME}" HOME="${HOME}" \
+		TAR_CALLED_FILE="${TAR_CALLED_FILE}" bash "${SCRIPT}"
 
 	assert_failure
+	[[ ! -e "${TAR_CALLED_FILE}" ]]
 	[[ ! -e "${CARGO_HOME}/bin/wasm-pack" ]]
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(docker): export cooked deps and drop the amd64 footprint diet
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type or a body containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Controlled experiment (run 31930491600 and six siblings): GitHub-hosted
`ubuntu-24.04` amd64 VMs are reclaimed at ~19m45s regardless of cargo
parallelism. That is a pool lifetime timer, not OOM or disk. A Dockerfile
diet cannot beat it, and this PR does **not** move amd64 onto a paid runner.

This PR keeps the merge-worthy cache/tooling work on GitHub-hosted runners:

- Write cooked `/app/target` into the image layer (no target cache mount) so
  `cache-to` type=gha / type=registry actually carries compiled deps.
- Install cargo-chef, wasm-pack, and lockfile-matched wasm-bindgen-cli as
  checksum-verified prebuilts; compilation fallback is disabled.
- Pin all lgtm-ci workflow/tooling references to released v0.63.1.
- Enable Docker runner free-disk-space cleanup and resource monitoring.
- Add BATS coverage for the Alpine-compatible installer paths and checksum
  failures.
- Do **not** cap `CARGO_BUILD_JOBS` or set `CARGO_PROFILE_RELEASE_CODEGEN_UNITS`
  — the first is not the kill, and 16 is already the cargo default.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated where workflow/tool pins changed
- [x] Local code-quality checks completed (0 lint findings; see note below)

## Closes

- Closes #868

## Details

- cargo-binstall 1.21.1 and wasm-pack 0.15.0 release archives are SHA-256
  verified for amd64 and arm64. wasm-bindgen-cli stays derived from Cargo.lock.
  cargo-chef is pinned via `ARG CARGO_CHEF_VERSION` (Renovate crate manager).
- `free-disk-space` and `resource-monitor` come from lgtm-ci v0.63.1 (#854).
- Validation completed locally: lintro reported 0 findings; hadolint, yamllint,
  shellcheck, and shfmt passed; Docker BATS tests passed. The local pip-audit
  process still exits with the pre-existing uv CPython 3.13 venv SIGABRT;
  CI is the audit gate.
- Acceptance: do not merge while the GitHub-hosted amd64 Docker leg still dies
  on the ~20-minute metronome. Remaining free levers are a warm-cache seed
  (one successful amd64 export), an ubuntu-22.04 pool experiment, xx-style
  cross-compile on the arm64 runner, or a GitHub support case.
- After merge, verify `ghcr.io/lgtm-hq/rustume:cache-linux-amd64` refreshes and
  a later cook layer is `CACHED` with a short `cargo build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved container build efficiency by reusing compiled dependency artifacts.
  * Added verified prebuilt installation for key Rust and WebAssembly build tools.
  * Added architecture checks and clearer failures for unsupported platforms.

* **CI & Release**
  * Updated automated build, test, security, and release workflows to the latest tooling version.
  * Added runner disk cleanup and resource monitoring for more reliable builds.

* **Tests**
  * Added coverage for tool installation success and checksum-failure scenarios.

* **Documentation**
  * Updated tool versions, checksums, and workflow references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->