### PR TITLE
fix(ci): switch docker build jobs to audit-mode egress until block mode is fixed

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -157,6 +157,13 @@ jobs:
       # assets come from GitHub releases) +
       # registry.npmjs.org (bun install in the web-builder stage downloads
       # packages from the npm registry on cache-cold builds).
+      # TEMPORARY (#879): audit instead of block. Harden-runner's block-mode
+      # agent kills ubuntu-24.04 amd64 VMs ~14-65 min into the job (proven by
+      # the 4-arm wall probe in #879; history in #868), and tag builds are
+      # always cold (no-cache above), so releases cannot survive block mode.
+      # Egress is still logged. Revert to block once StepSecurity ships a fix
+      # verified by a 30-minute block-mode spin surviving on ubuntu-24.04.
+      egress-policy: audit
       allowed-endpoints-mode: replace
       allowed-endpoints: >
         github.com:443


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): switch docker build jobs to audit-mode egress until block mode is fixed`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Passes `egress-policy: audit` to `reusable-docker.yml` for the two Docker build jobs, as a labeled TEMPORARY measure. Harden-runner's block-mode agent kills `ubuntu-24.04` amd64 runner VMs ~14–65 minutes into the job — proven by the 4-arm wall probe (bare spin, idle sleep, and audit-mode spin all survived 30 minutes; block-mode spin was killed at 15m45s with the production shutdown signature; run 32061823816). Tag builds run `no-cache` by design, so release images always need a ~60-minute cold build; v0.67.4's tag run was killed six consecutive times and v0.67.1–v0.67.4 are all withheld.

Audit mode keeps egress fully logged on these jobs; block enforcement is unchanged everywhere else. The in-file comment states the revert condition: restore `block` once StepSecurity ships a fix verified by a 30-minute block-mode spin surviving on `ubuntu-24.04`.

This PR is release-typed so the resulting tag run carries the audit-mode workflow and can publish, superseding the withheld releases.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`)

## Closes

- Closes #879
- Relates to #868

## Details

One-input change plus a comment block. No test changes: the acceptance test is the next release's tag-triggered Docker run completing its cold amd64 build under audit mode. Warm PR/main legs (~7 min, seeded by #869) were already passing under block; this addresses the always-cold paths (tag builds, dep-bump PRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build security monitoring to audit network activity while retaining the configured endpoint allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->