### PR TITLE
fix(ci): audit-mode egress for the release image verify job

### DIFF
--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -88,7 +88,12 @@ jobs:
         # composite in v0.50.0 (the action pre hook must install the agent).
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
-          egress-policy: block
+          # TEMPORARY (#882): audit instead of block. This job waits ~60 min
+          # for the cold tag Docker build, which outlives the block-mode
+          # VM-kill window (#868/#879) — every release's verify was killed
+          # mid-wait. Egress is still logged. Revert to block together with
+          # the #879 flip once StepSecurity ships a verified fix.
+          egress-policy: audit
           allowed-endpoints: >
             github.com:443
             api.github.com:443


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): audit-mode egress for the release image verify job`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Flips the `Verify Release Image` job in `publish-release-on-tag.yml` to `egress-policy: audit`, with the same TEMPORARY comment and revert condition as #880. The job waits ~60 minutes for the cold tag Docker build, which outlives the harden-runner block-mode VM-kill window (#868/#879): v0.67.4's and v0.67.5's publish runs both had this job killed mid-wait (v0.67.5: killed at 19m41s, then succeeded on a manual rerun once images existed). With this change, releases publish unattended.

Other jobs in the workflow stay on block — they complete in well under 14 minutes.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`)

## Closes

- Closes #882
- Relates to #868

## Details

One job's egress policy plus a comment block; companion to #880. Revert both together when StepSecurity ships a fix verified by a 30-minute block-mode spin surviving on ubuntu-24.04.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release verification workflow monitoring to audit outbound activity while release images are awaiting availability.
  * Added documentation noting that this is a temporary configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->