### PR TITLE
fix(ci): make the cross install step idempotent for binary-build reruns

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install cross (for cross-compilation)
         if: matrix.cross
-        run: cargo install cross --locked
+        run: bash scripts/ci/release/install-cross.sh
 
       - name: Build release binaries
         env:

--- a/scripts/ci/release/install-cross.sh
+++ b/scripts/ci/release/install-cross.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Install the `cross` cross-compilation tool if it is not already present.
+# Restored cargo caches can already contain the binary, and a plain
+# `cargo install` hard-fails on "binary `cross` already exists" (#885),
+# which broke publish-workflow reruns.
+set -euo pipefail
+
+if command -v cross >/dev/null 2>&1; then
+	echo "cross $(cross --version 2>/dev/null | head -1) already installed — skipping"
+	exit 0
+fi
+
+cargo install cross --locked

--- a/tests/bats/unit/release/test_install_cross.bats
+++ b/tests/bats/unit/release/test_install_cross.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/release/install-cross.sh idempotency (#885)
+
+bats_require_minimum_version 1.5.0
+
+load "../../helpers/common"
+
+SCRIPT="scripts/ci/release/install-cross.sh"
+
+setup() {
+	setup_temp_dir
+	STUB_BIN="${BATS_TEST_TMPDIR}/stubbin"
+	mkdir -p "${STUB_BIN}"
+	for tool in bash env head; do
+		if command -v "${tool}" >/dev/null 2>&1; then
+			ln -sf "$(command -v "${tool}")" "${STUB_BIN}/${tool}"
+		fi
+	done
+	CARGO_STUB_LOG="${BATS_TEST_TMPDIR}/cargo.log"
+	export CARGO_STUB_LOG
+}
+
+# Writes a cargo stub that records its invocations and always succeeds.
+_write_cargo_stub() {
+	cat >"${STUB_BIN}/cargo" <<-'EOF'
+		#!/usr/bin/env bash
+		echo "cargo $*" >>"${CARGO_STUB_LOG}"
+	EOF
+	chmod +x "${STUB_BIN}/cargo"
+}
+
+# Writes a cross stub so `command -v cross` succeeds.
+_write_cross_stub() {
+	cat >"${STUB_BIN}/cross" <<-'EOF'
+		#!/usr/bin/env bash
+		echo "cross 0.0.0-stub"
+	EOF
+	chmod +x "${STUB_BIN}/cross"
+}
+
+@test "skips cargo install when cross is already on PATH" {
+	_write_cargo_stub
+	_write_cross_stub
+	PATH="${STUB_BIN}" run -0 bash "${SCRIPT}"
+	[[ "${output}" == *"already installed"* ]]
+	[[ ! -s "${CARGO_STUB_LOG}" ]]
+}
+
+@test "installs cross via cargo when absent" {
+	_write_cargo_stub
+	PATH="${STUB_BIN}" run -0 bash "${SCRIPT}"
+	grep -q "install cross --locked" "${CARGO_STUB_LOG}"
+}
+
+@test "propagates cargo install failure" {
+	cat >"${STUB_BIN}/cargo" <<-'EOF'
+		#!/usr/bin/env bash
+		exit 101
+	EOF
+	chmod +x "${STUB_BIN}/cargo"
+	PATH="${STUB_BIN}" run ! bash "${SCRIPT}"
+}


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): make the cross install step idempotent for binary-build reruns`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`Install cross` in `build-binary.yml` moves to `scripts/ci/release/install-cross.sh`, which skips `cargo install` when `cross` is already on PATH. A restored cargo cache containing the binary made plain `cargo install cross --locked` hard-fail with `binary `cross` already exists in destination` (exit 101) — this killed the aarch64 leg of v0.67.5's publish rerun in 32 seconds (run 32102225525 attempt 2) and would affect any rerun after a cache save.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, `bats` 3/3)

## Closes

- Closes #885

## Details

Three BATS tests cover skip-when-present, install-when-absent, and failure propagation (with `bats_require_minimum_version 1.5.0` so `run !` asserts properly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release build setup by detecting existing installations of the required build tool and installing it only when needed.
  * Locked tool versions are now used consistently during release builds.
  * Installation errors are surfaced without being suppressed.

* **Tests**
  * Added automated coverage for existing-tool detection, installation behavior, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->