### PR TITLE
fix(ci): pin Trivy DB to ghcr.io so Vulnerability Scan stops 404ing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -51,7 +51,10 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
   rustume-ops repo — this repo ends at the GHCR publish). A trailing
   `🔍 Verify Published Tags` job asserts the contracted tags actually resolve
   (`scripts/ci/docker/verify-published-tags.sh`), so a skipped manifest merge
-  fails the run instead of passing as "mostly green with skips" (#597)
+  fails the run instead of passing as "mostly green with skips" (#597).
+  Post-merge Vulnerability Scan is a local Trivy job with
+  `TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db` (#851); reusable
+  Trivy stays PR-only.
 
 ## Release
 

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -52,3 +52,11 @@ jobs:
       run-attempt: ${{ format('{0}', github.event.workflow_run.run_attempt) }}
       egress-policy: block
       egress-preset: github-minimal
+      # Trivy GCR-mirror 404s are infra, not CVEs (#851). The durable pin is
+      # the local scan job; this signature recovers leftover reusable scans
+      # (PR validate still uses lgtm-ci Trivy).
+      signatures: |
+        failed to download vulnerability DB
+        mirror.gcr.io/aquasec/trivy-db
+        failed to fetch the layer: GET https://mirror.gcr.io/artifacts-downloads
+

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -59,4 +59,3 @@ jobs:
         failed to download vulnerability DB
         mirror.gcr.io/aquasec/trivy-db
         failed to fetch the layer: GET https://mirror.gcr.io/artifacts-downloads
-

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -311,9 +311,8 @@ jobs:
           exit-code: "1"
 
       - name: Upload Trivy scan results
-        if: always()
+        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: trivy-results.sarif
           category: trivy-ghcr-db
-

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -135,7 +135,10 @@ jobs:
       # Cold amd64 builds (no registry cache hit) exceed the 60-minute
       # default: the workspace cargo build alone runs ~50 minutes (#439).
       timeout-minutes: 120
-      scan: true
+      # PR-only: the reusable post-merge Trivy job downloads its DB from
+      # mirror.gcr.io and 404s (#851). Main/tag scans run in the local
+      # `vulnerability-scan` job with TRIVY_DB_REPOSITORY pinned to ghcr.
+      scan: ${{ github.event_name == 'pull_request' }}
       scan-exit-code: "1"
       cosign-sign: true
       cache-registry-ref: ghcr.io/lgtm-hq/rustume:cache
@@ -148,7 +151,8 @@ jobs:
       # Full list = reusable-docker default + gcr.io (distroless base image
       # in docker/Dockerfile) + sigstore hosts (cosign-sign on push runs) +
       # trivy hosts (installer downloads from get.trivy.dev; vulnerability DB
-      # is pulled from ghcr.io with mirror.gcr.io / public.ecr.aws fallbacks) +
+      # is pinned to ghcr.io/aquasecurity/trivy-db in the local scan job —
+      # mirror.gcr.io 404s, see #851) +
       # dl-cdn.alpinelinux.org (apk package installs in docker/Dockerfile
       # build stages run through the host egress proxy under harden-runner) +
       # rust hosts (rustup target add wasm32 pulls from static.rust-lang.org;
@@ -249,3 +253,67 @@ jobs:
           REGISTRY_USERNAME: ${{ github.actor }}
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci/docker/verify-published-tags.sh
+
+  # Local replacement for the reusable-docker post-merge Trivy job (#851).
+  # aquasecurity/trivy-action defaults through mirror.gcr.io, which 404s and
+  # fails Vulnerability Scan after the image has already published. Pin the
+  # DB to ghcr.io/aquasecurity so scans do not depend on that cache.
+  vulnerability-scan:
+    name: 🛡️ Vulnerability Scan
+    needs: [classify, docker]
+    if: >-
+      always()
+      && github.event_name != 'pull_request'
+      && (github.ref == 'refs/heads/main'
+      || startsWith(github.ref, 'refs/tags/v'))
+      && needs.classify.outputs.pipeline != 'false'
+      && needs.classify.outputs.bump-only != 'true'
+      && needs.docker.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            get.trivy.dev:443
+
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db
+        with:
+          image-ref: ghcr.io/lgtm-hq/rustume@${{ needs.docker.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+
+      - name: Upload Trivy scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-ghcr-db
+

--- a/tests/bats/unit/docker/test_trivy_db_pin.bats
+++ b/tests/bats/unit/docker/test_trivy_db_pin.bats
@@ -22,6 +22,11 @@ RERUN="${PROJECT_ROOT}/.github/workflows/auto-rerun-on-infra-failure.yml"
 	assert_success
 }
 
+@test "Trivy SARIF upload is skipped when the scanner produced no file" {
+	run grep -F "hashFiles('trivy-results.sarif')" "${WORKFLOW}"
+	assert_success
+}
+
 @test "Auto Rerun knows the Trivy GCR-mirror 404 signature" {
 	run grep -F "mirror.gcr.io/aquasec/trivy-db" "${RERUN}"
 	assert_success

--- a/tests/bats/unit/docker/test_trivy_db_pin.bats
+++ b/tests/bats/unit/docker/test_trivy_db_pin.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Guard the #851 Trivy DB pin so scans do not use mirror.gcr.io.
+
+bats_require_minimum_version 1.5.0
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/docker-build-publish.yml"
+RERUN="${PROJECT_ROOT}/.github/workflows/auto-rerun-on-infra-failure.yml"
+
+@test "post-merge Vulnerability Scan pins Trivy DB to ghcr.io" {
+	run grep -F "TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db" "${WORKFLOW}"
+	assert_success
+	run grep -F "TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db" \
+		"${WORKFLOW}"
+	assert_success
+}
+
+@test "reusable Trivy is PR-only so the GCR-mirror job does not run on main" {
+	run grep -F "scan: \${{ github.event_name == 'pull_request' }}" "${WORKFLOW}"
+	assert_success
+}
+
+@test "Auto Rerun knows the Trivy GCR-mirror 404 signature" {
+	run grep -F "mirror.gcr.io/aquasec/trivy-db" "${RERUN}"
+	assert_success
+	run grep -F "failed to download vulnerability DB" "${RERUN}"
+	assert_success
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): pin Trivy DB to ghcr.io so Vulnerability Scan stops 404ing
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Reusable lgtm-ci Trivy (GCR mirror) is PR-only. Post-merge Vulnerability Scan uses `aquasecurity/trivy-action` with `TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db`. Auto Rerun treats leftover GCR-mirror 404s as infra.

Follow-up: drop trailing YAML blank lines (Lintro yamllint). Skip SARIF upload when Trivy did not write `trivy-results.sarif`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`bats tests/bats/unit/docker/test_trivy_db_pin.bats`, `uv run lintro chk`)

## Related Issues

Closes #851

## Details

`ghcr.io/lgtm-hq/lgtm-ci` reusable-docker has no `TRIVY_DB_REPOSITORY` input, so the durable pin is the local job.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddab4cfb-3004-4f13-a16c-02d931c4801c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddab4cfb-3004-4f13-a16c-02d931c4801c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the reusable post-merge Trivy scan with a local scan pinned to GHCR while retaining reusable scanning for pull requests.
- Pins both Trivy vulnerability databases to GHCR.
- Guards SARIF upload when the scanner produces no output.
- Adds automatic-rerun signatures for the GCR mirror failure.
- Documents and statically tests the new workflow behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/docker-build-publish.yml | Adds the pinned post-merge Trivy job and correctly guards SARIF upload against absent output. |
| .github/workflows/auto-rerun-on-infra-failure.yml | Adds signatures for rerunning scans affected by the known GCR mirror failure. |
| tests/bats/unit/docker/test_trivy_db_pin.bats | Adds static guards for database pins, PR-only reusable scanning, conditional SARIF upload, and rerun signatures. |
| .github/workflows/README.md | Documents the split between reusable pull-request scanning and the local post-merge scan. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): drop extra YAML blank lines and..."](https://github.com/lgtm-hq/rustume/commit/b9e5ac19d0e09a4b69bede967d904ac7668e3c76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55719539)</sub>

<!-- /greptile_comment -->