### PR TITLE
fix(web): declare per-template margin support and disable the inert control

### DIFF
--- a/apps/web/src/api/schemas.ts
+++ b/apps/web/src/api/schemas.ts
@@ -108,6 +108,13 @@ export const templateLayoutSchema = z.object({
     .optional()
     .catch(undefined)
     .transform((v) => v ?? true),
+  // Missing on older self-hosted servers: assume the template uses margins
+  // rather than hiding a working control (#859 / #842 skew).
+  supportsMargins: z
+    .boolean()
+    .optional()
+    .catch(undefined)
+    .transform((v) => v ?? true),
 });
 
 export const templateInfoSchema = z.object({

--- a/apps/web/src/components/doc-editor/PageDialog.tsx
+++ b/apps/web/src/components/doc-editor/PageDialog.tsx
@@ -1,0 +1,116 @@
+/**
+ * Page settings for the document editor's top bar.
+ *
+ * A modal matching ThemeDialog: one document-settings surface for the page
+ * inset. Full-bleed templates ignore `metadata.page.margin` in Typst (#859),
+ * so the control disables with an explanation rather than pretending to work.
+ * Every write routes through `docEdits` (decision 4).
+ */
+
+import { Show, type JSX } from "solid-js";
+import { Modal } from "../ui";
+import { updatePageMargin } from "./docEdits";
+import type { TemplateLayout } from "../../lib/docLayout";
+import type { ResumeData } from "../../wasm/types";
+
+export interface PageDialogProps {
+  resume: ResumeData;
+  templateLayout: TemplateLayout;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const MARGIN_INPUT_ID = "page-margin";
+const MARGIN_REASON_ID = "page-margin-full-bleed-reason";
+const MARGIN_HINT_ID = "page-margin-hint";
+
+const FULL_BLEED_REASON = "This template is full-bleed and does not use page margins";
+
+export function PageDialog(props: PageDialogProps): JSX.Element {
+  return (
+    <Modal
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      title="Page"
+      description="Page settings for the rendered document — the PDF uses them too."
+      size="md"
+    >
+      <div class="flex flex-col gap-6" data-testid="page-dialog">
+        <PageMarginField
+          margin={props.resume.metadata.page.margin}
+          enabled={props.templateLayout.supportsMargins}
+        />
+      </div>
+    </Modal>
+  );
+}
+
+function PageMarginField(props: { margin: number; enabled: boolean }): JSX.Element {
+  const describedBy = (): string => (props.enabled ? MARGIN_HINT_ID : MARGIN_REASON_ID);
+
+  function commit(raw: string): void {
+    if (!props.enabled) return;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return;
+    updatePageMargin(parsed);
+  }
+
+  return (
+    <section aria-label="Page margins">
+      <h3 class="mb-2 font-mono text-xs uppercase tracking-wider text-stone">Margins</h3>
+      <div class="flex flex-col gap-1.5">
+        <label
+          for={MARGIN_INPUT_ID}
+          class="block font-mono text-xs uppercase tracking-wider text-stone"
+        >
+          Page margin
+        </label>
+        <div class="flex items-center gap-2">
+          {/*
+            `aria-disabled` rather than native `disabled`: a disabled control
+            leaves the accessibility tree, so the reason would never be read.
+            Keep it focusable and block writes in the handler (#859 / #352).
+          */}
+          <input
+            id={MARGIN_INPUT_ID}
+            type="number"
+            min={0}
+            max={200}
+            step={1}
+            value={props.margin}
+            inputMode="numeric"
+            aria-disabled={!props.enabled || undefined}
+            aria-describedby={describedBy()}
+            readOnly={!props.enabled}
+            data-testid="page-margin-input"
+            class="focus-ring w-24 rounded-lg border border-border bg-surface px-2 py-1.5
+              font-mono text-sm text-ink
+              aria-disabled:cursor-not-allowed"
+            onInput={(event) => {
+              if (!props.enabled) {
+                event.currentTarget.value = String(props.margin);
+                return;
+              }
+              commit(event.currentTarget.value);
+            }}
+          />
+          <span class="font-mono text-xs text-stone" aria-hidden="true">
+            pt
+          </span>
+        </div>
+        <Show
+          when={props.enabled}
+          fallback={
+            <p id={MARGIN_REASON_ID} class="text-sm text-stone">
+              {FULL_BLEED_REASON}
+            </p>
+          }
+        >
+          <p id={MARGIN_HINT_ID} class="text-sm text-stone">
+            Inset around the page, in typographic points.
+          </p>
+        </Show>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/doc-editor/PageDialog.tsx
+++ b/apps/web/src/components/doc-editor/PageDialog.tsx
@@ -50,7 +50,11 @@ function PageMarginField(props: { margin: number; enabled: boolean }): JSX.Eleme
 
   function commit(raw: string): void {
     if (!props.enabled) return;
-    const parsed = Number(raw);
+    const trimmed = raw.trim();
+    // Empty is an in-progress edit (`Number("") === 0` would persist a
+    // zero margin and mark the resume dirty while the user is still typing).
+    if (trimmed === "") return;
+    const parsed = Number(trimmed);
     if (!Number.isFinite(parsed)) return;
     updatePageMargin(parsed);
   }

--- a/apps/web/src/components/doc-editor/__tests__/pageDialog.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/pageDialog.test.tsx
@@ -71,4 +71,18 @@ describe("page dialog margin control", () => {
       margin: 32,
     });
   });
+
+  it("does not persist zero while the enabled margin field is cleared", () => {
+    const dialog = openDialog("rhyhorn");
+    const input = within(dialog).getByRole("spinbutton", { name: "Page margin" });
+
+    fireEvent.input(input, { target: { value: "" } });
+    expect(store.updateMetadata).not.toHaveBeenCalled();
+
+    fireEvent.input(input, { target: { value: "24" } });
+    expect(store.updateMetadata).toHaveBeenCalledExactlyOnceWith("page", {
+      ...resume.metadata.page,
+      margin: 24,
+    });
+  });
 });

--- a/apps/web/src/components/doc-editor/__tests__/pageDialog.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/pageDialog.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Page settings (#859): the top-bar Page dialog exposes a margin control
+ * that disables — with an accessible reason — when the active template is
+ * full-bleed and ignores `page.margin`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@solidjs/testing-library";
+import { loadDocEditorFixture } from "../../../test/docEditorFixture";
+import { bundledTemplateLayout } from "../../../lib/docLayout";
+import { PageDialog } from "../PageDialog";
+import type { ResumeData } from "../../../wasm/types";
+
+const store = vi.hoisted(() => ({
+  store: { resume: null as unknown },
+  updateMetadata: vi.fn(),
+}));
+
+vi.mock("../../../stores/resume", () => ({ resumeStore: store }));
+
+const FULL_BLEED_REASON = "This template is full-bleed and does not use page margins";
+
+describe("page dialog margin control", () => {
+  let resume: ResumeData;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resume = loadDocEditorFixture();
+    resume.metadata.page.margin = 18;
+    store.store.resume = resume;
+  });
+
+  function openDialog(templateId: string) {
+    render(() => (
+      <PageDialog
+        resume={resume}
+        templateLayout={bundledTemplateLayout(templateId)}
+        open
+        onOpenChange={vi.fn()}
+      />
+    ));
+    return screen.getByTestId("page-dialog");
+  }
+
+  it("disables the margin control with an explanation on pikachu (full-bleed)", () => {
+    const dialog = openDialog("pikachu");
+    const input = within(dialog).getByRole("spinbutton", { name: "Page margin" });
+
+    expect(input).toHaveAttribute("aria-disabled", "true");
+    expect(within(dialog).getByText(FULL_BLEED_REASON)).toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-describedby", "page-margin-full-bleed-reason");
+    expect(document.getElementById("page-margin-full-bleed-reason")).toHaveTextContent(
+      FULL_BLEED_REASON,
+    );
+
+    fireEvent.input(input, { target: { value: "32" } });
+    expect(store.updateMetadata).not.toHaveBeenCalled();
+  });
+
+  it("enables the margin control on rhyhorn (margin-honoring)", () => {
+    const dialog = openDialog("rhyhorn");
+    const input = within(dialog).getByRole("spinbutton", { name: "Page margin" });
+
+    expect(input).not.toHaveAttribute("aria-disabled");
+    expect(within(dialog).queryByText(FULL_BLEED_REASON)).not.toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-describedby", "page-margin-hint");
+
+    fireEvent.input(input, { target: { value: "32" } });
+    expect(store.updateMetadata).toHaveBeenCalledExactlyOnceWith("page", {
+      ...resume.metadata.page,
+      margin: 32,
+    });
+  });
+});

--- a/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/panels.test.tsx
@@ -50,6 +50,7 @@ const TEMPLATES: TemplateInfo[] = [
       sidebarTint: true,
       keywordStyle: "chips",
       headerRule: false,
+      supportsMargins: true,
     },
   },
   {

--- a/apps/web/src/components/doc-editor/docEdits.ts
+++ b/apps/web/src/components/doc-editor/docEdits.ts
@@ -214,3 +214,24 @@ export function updateSidebarRatio(ratio: number): void {
     sidebarRatio: clampSidebarRatio(ratio),
   });
 }
+
+/** Inclusive range for `metadata.page.margin`, in typographic points. */
+const MIN_PAGE_MARGIN_PT = 0;
+const MAX_PAGE_MARGIN_PT = 200;
+
+/**
+ * Persist the page inset as `metadata.page.margin`. Full-bleed templates
+ * ignore this on the PDF (#859); the editor disables the control rather
+ * than writing a value the sheet cannot use. Clamped to 0–200 pt; one
+ * committed change is one store action and one undo entry.
+ */
+export function updatePageMargin(margin: number): void {
+  const resume = resumeStore.store.resume;
+  if (!resume) return;
+  const next = Math.min(MAX_PAGE_MARGIN_PT, Math.max(MIN_PAGE_MARGIN_PT, Math.round(margin)));
+  if (next === resume.metadata.page.margin) return;
+  resumeStore.updateMetadata("page", {
+    ...resume.metadata.page,
+    margin: next,
+  });
+}

--- a/apps/web/src/components/doc-editor/index.ts
+++ b/apps/web/src/components/doc-editor/index.ts
@@ -11,5 +11,6 @@ export { PhotoDialog, type PhotoDialogProps } from "./PhotoDialog";
 export { TemplatesDrawer, type TemplatesDrawerProps } from "./TemplatesDrawer";
 export { SectionsPanel, type SectionsPanelProps } from "./SectionsPanel";
 export { ThemeDialog, type ThemeDialogProps } from "./ThemeDialog";
+export { PageDialog, type PageDialogProps } from "./PageDialog";
 export { MarkdownView } from "./MarkdownView";
 export { SheetModeContext, useSheetEditable, type SheetMode } from "./sheetMode";

--- a/apps/web/src/lib/__tests__/templateChrome.test.ts
+++ b/apps/web/src/lib/__tests__/templateChrome.test.ts
@@ -46,6 +46,28 @@ describe("template chrome metadata", () => {
     expect(bundledTemplateLayout("chikorita").sidebarTint).toBe(true);
   });
 
+  it("declares no margin support only on full-bleed templates", () => {
+    const fullBleed = new Set(["pikachu", "ditto", "gengar", "glalie"]);
+    const ids = [
+      "rhyhorn",
+      "onyx",
+      "nosepass",
+      "bronzor",
+      "kakuna",
+      "azurill",
+      "chikorita",
+      "ditto",
+      "gengar",
+      "glalie",
+      "pikachu",
+      "leafish",
+    ];
+    for (const id of ids) {
+      expect(bundledTemplateLayout(id).supportsMargins).toBe(!fullBleed.has(id));
+    }
+    expect(bundledTemplateLayout("not-a-template").supportsMargins).toBe(true);
+  });
+
   it("covers every gallery template with chrome fields", () => {
     const ids = [
       "rhyhorn",

--- a/apps/web/src/lib/__tests__/templateLayoutLockstep.test.ts
+++ b/apps/web/src/lib/__tests__/templateLayoutLockstep.test.ts
@@ -57,6 +57,17 @@ describe("bundledTemplateLayout lockstep with get_template_layout", () => {
     expect(bundledTemplateLayout(id)).toEqual(fixture[id]);
   });
 
+  it("defaults missing supportsMargins to true (skew with older servers)", () => {
+    const parsed = templateLayoutSchema.parse({
+      layoutMode: "single",
+      defaultColumns: [["summary"], []],
+      headerStyle: "left",
+      contactIn: "header",
+      sidebarWidth: null,
+    });
+    expect(parsed.supportsMargins).toBe(true);
+  });
+
   it("rejects unknown fixture fields (strict parse)", () => {
     const raw = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as Record<
       string,

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -165,6 +165,11 @@ export interface TemplateLayout {
   keywordStyle: TemplateKeywordStyle;
   /** Whether an accent rule sits under the identity header. */
   headerRule: boolean;
+  /**
+   * Whether the template honours `metadata.page.margin` on the page box.
+   * Full-bleed templates (`margin: 0pt` in Typst) are `false` — see #859.
+   */
+  supportsMargins: boolean;
 }
 
 /**
@@ -185,6 +190,7 @@ const FALLBACK_CHROME = {
   sidebarTint: false,
   keywordStyle: "plain" as TemplateKeywordStyle,
   headerRule: true,
+  supportsMargins: true,
 };
 
 export const FALLBACK_TEMPLATE_LAYOUT: TemplateLayout = {
@@ -289,6 +295,7 @@ function bundledSingle(headerStyle: TemplateHeaderStyle, chrome: BundledChrome):
     headerStyle,
     contactIn: "header",
     sidebarWidth: null,
+    supportsMargins: true,
     ...chrome,
   };
 }
@@ -309,8 +316,14 @@ function bundledTwoColumn(
     headerStyle,
     contactIn,
     sidebarWidth,
+    supportsMargins: true,
     ...chrome,
   };
+}
+
+/** Full-bleed templates set Typst `margin: 0pt` and ignore `page.margin` (#859). */
+function fullBleed(layout: TemplateLayout): TemplateLayout {
+  return { ...layout, supportsMargins: false };
 }
 
 /**
@@ -397,49 +410,51 @@ export function bundledTemplateLayout(template: string): TemplateLayout {
         chromeUnderlineChips(true, true),
       );
     case "ditto":
-      return bundledTwoColumn(
-        "sidebar-left",
-        "banner",
-        "banner",
-        160,
-        chromeUnderlineChips(false, true),
+      return fullBleed(
+        bundledTwoColumn("sidebar-left", "banner", "banner", 160, chromeUnderlineChips(false, true)),
       );
     case "gengar":
-      return bundledTwoColumn("sidebar-left", "sidebar", "sidebar", 170, {
-        headingStyle: "underline",
-        sidebarHeadingStyle: "underline",
-        headingCase: "upper",
-        headingInk: "text",
-        sidebarHeadingInk: "accent",
-        fontBody: "ibm-plex-sans",
-        sidebarTint: true,
-        keywordStyle: "chips",
-        headerRule: false,
-      });
+      return fullBleed(
+        bundledTwoColumn("sidebar-left", "sidebar", "sidebar", 170, {
+          headingStyle: "underline",
+          sidebarHeadingStyle: "underline",
+          headingCase: "upper",
+          headingInk: "text",
+          sidebarHeadingInk: "accent",
+          fontBody: "ibm-plex-sans",
+          sidebarTint: true,
+          keywordStyle: "chips",
+          headerRule: false,
+        }),
+      );
     case "glalie":
-      return bundledTwoColumn("sidebar-left", "sidebar", "sidebar", 170, {
-        headingStyle: "underline",
-        sidebarHeadingStyle: "underline",
-        headingCase: "as-written",
-        headingInk: "accent",
-        sidebarHeadingInk: "accent",
-        fontBody: "ibm-plex-sans",
-        sidebarTint: true,
-        keywordStyle: "plain",
-        headerRule: false,
-      });
+      return fullBleed(
+        bundledTwoColumn("sidebar-left", "sidebar", "sidebar", 170, {
+          headingStyle: "underline",
+          sidebarHeadingStyle: "underline",
+          headingCase: "as-written",
+          headingInk: "accent",
+          sidebarHeadingInk: "accent",
+          fontBody: "ibm-plex-sans",
+          sidebarTint: true,
+          keywordStyle: "plain",
+          headerRule: false,
+        }),
+      );
     case "pikachu":
-      return bundledTwoColumn("sidebar-left", "left", "sidebar", 180, {
-        headingStyle: "band",
-        sidebarHeadingStyle: "plain",
-        headingCase: "upper",
-        headingInk: "accent",
-        sidebarHeadingInk: "accent",
-        fontBody: "ibm-plex-sans",
-        sidebarTint: true,
-        keywordStyle: "plain",
-        headerRule: false,
-      });
+      return fullBleed(
+        bundledTwoColumn("sidebar-left", "left", "sidebar", 180, {
+          headingStyle: "band",
+          sidebarHeadingStyle: "plain",
+          headingCase: "upper",
+          headingInk: "accent",
+          sidebarHeadingInk: "accent",
+          fontBody: "ibm-plex-sans",
+          sidebarTint: true,
+          keywordStyle: "plain",
+          headerRule: false,
+        }),
+      );
     case "leafish":
       return {
         layoutMode: "header-split",
@@ -450,6 +465,7 @@ export function bundledTemplateLayout(template: string): TemplateLayout {
         headerStyle: "banner",
         contactIn: "banner",
         sidebarWidth: null,
+        supportsMargins: true,
         ...chromeUnderlineChips(false, false),
       };
     default:

--- a/apps/web/src/lib/docLayout.ts
+++ b/apps/web/src/lib/docLayout.ts
@@ -411,7 +411,13 @@ export function bundledTemplateLayout(template: string): TemplateLayout {
       );
     case "ditto":
       return fullBleed(
-        bundledTwoColumn("sidebar-left", "banner", "banner", 160, chromeUnderlineChips(false, true)),
+        bundledTwoColumn(
+          "sidebar-left",
+          "banner",
+          "banner",
+          160,
+          chromeUnderlineChips(false, true),
+        ),
       );
     case "gengar":
       return fullBleed(

--- a/apps/web/src/pages/DocEditor.tsx
+++ b/apps/web/src/pages/DocEditor.tsx
@@ -25,7 +25,13 @@ import {
 } from "solid-js";
 import { useNavigate, useParams } from "@solidjs/router";
 import { Button, Spinner, toast } from "../components/ui";
-import { DocSheet, SectionsPanel, TemplatesDrawer, ThemeDialog } from "../components/doc-editor";
+import {
+  DocSheet,
+  PageDialog,
+  SectionsPanel,
+  TemplatesDrawer,
+  ThemeDialog,
+} from "../components/doc-editor";
 import type { SheetMode } from "../components/doc-editor/sheetMode";
 import { CustomCssInjector } from "../components/templates/CustomCssInjector";
 import { useHotkeys, type Shortcut } from "../hooks/useHotkeys";
@@ -163,6 +169,9 @@ export default function DocEditor() {
 
   // Theme selection lives in the top bar (spec §1.2, owner addition).
   const [isThemeOpen, setIsThemeOpen] = createSignal(false);
+  // Page settings (margin) sit next to Theme — document settings, not a form
+  // builder control (#859 / #735).
+  const [isPageOpen, setIsPageOpen] = createSignal(false);
 
   // Edit or Done, per document. A brand-new empty resume opens ready to type;
   // an existing one opens as the clean rendered document. Below the sheet's
@@ -318,6 +327,34 @@ export default function DocEditor() {
             </svg>
             Theme
           </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="doc-editor-page-button"
+            onClick={() => setIsPageOpen(true)}
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M7 3h8l4 4v14a2 2 0 01-2 2H7a2 2 0 01-2-2V5a2 2 0 012-2z"
+              />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M15 3v4h4M8 12h8M8 16h8"
+              />
+            </svg>
+            Page
+          </Button>
           <Button variant="ghost" size="sm" onClick={() => openModal("versionHistory")}>
             <svg
               class="w-4 h-4"
@@ -450,6 +487,12 @@ export default function DocEditor() {
                   onOpenChange={setIsSectionsOpen}
                 />
                 <ThemeDialog resume={resume()} open={isThemeOpen()} onOpenChange={setIsThemeOpen} />
+                <PageDialog
+                  resume={resume()}
+                  templateLayout={templateLayout()}
+                  open={isPageOpen()}
+                  onOpenChange={setIsPageOpen}
+                />
               </>
             )}
           </Show>

--- a/apps/web/src/pages/__tests__/DocEditor.test.tsx
+++ b/apps/web/src/pages/__tests__/DocEditor.test.tsx
@@ -352,6 +352,16 @@ describe("DocEditor sheet", () => {
     expect(screen.getByTestId("theme-dialog")).toBeInTheDocument();
   });
 
+  it("opens page settings from the top bar", async () => {
+    await renderSheet();
+
+    const topBar = screen.getByTestId("doc-editor-topbar");
+    fireEvent.click(within(topBar).getByRole("button", { name: "Page" }));
+
+    expect(await screen.findByRole("dialog", { name: /Page/ })).toBeInTheDocument();
+    expect(screen.getByTestId("page-dialog")).toBeInTheDocument();
+  });
+
   it("has no axe violations in Edit mode", async () => {
     const { container } = await renderSheet();
 

--- a/apps/web/src/test/docEditorFixture.ts
+++ b/apps/web/src/test/docEditorFixture.ts
@@ -262,6 +262,7 @@ export const SINGLE_TEMPLATE: TemplateLayout = {
   sidebarTint: false,
   keywordStyle: "plain",
   headerRule: true,
+  supportsMargins: true,
 };
 
 /** Mirrors `pikachu`: fixed 180pt sidebar painted on the left. */
@@ -294,6 +295,7 @@ export const SIDEBAR_TEMPLATE: TemplateLayout = {
   sidebarTint: true,
   keywordStyle: "plain",
   headerRule: false,
+  supportsMargins: false,
 };
 
 /** Mirrors a proportional two-column template with no fixed sidebar width. */

--- a/crates/render/src/typst_engine/template_layout.rs
+++ b/crates/render/src/typst_engine/template_layout.rs
@@ -244,6 +244,12 @@ pub struct TemplateLayout {
     /// sidebar is a fixed width. `None` when the split is proportional
     /// (`fr` units) or when the template has no sidebar at all.
     pub sidebar_width: Option<u32>,
+    /// Whether the template honours `metadata.page.margin` on the page box.
+    ///
+    /// Full-bleed templates set Typst `margin: 0pt` so the sidebar paint meets
+    /// the paper edge; they ignore the stored margin. `false` only for those
+    /// sources — see #859.
+    pub supports_margins: bool,
     /// Per-template presentation chrome (headings, fonts, accent usage).
     pub chrome: TemplateChrome,
 }
@@ -339,6 +345,7 @@ fn single(header_style: HeaderStyle, chrome: TemplateChrome) -> TemplateLayout {
         header_style,
         contact_in: ContactIn::Header,
         sidebar_width: None,
+        supports_margins: true,
         chrome,
     }
 }
@@ -357,7 +364,17 @@ fn two_column(
         header_style,
         contact_in,
         sidebar_width,
+        supports_margins: true,
         chrome,
+    }
+}
+
+/// Full-bleed templates set Typst `set page(margin: 0pt)` and ignore
+/// `metadata.page.margin` on the page box (#859).
+fn full_bleed(layout: TemplateLayout) -> TemplateLayout {
+    TemplateLayout {
+        supports_margins: false,
+        ..layout
     }
 }
 
@@ -410,14 +427,14 @@ pub fn get_template_layout(template: &str) -> TemplateLayout {
             // Tinted: chikorita.typ wraps the right column in a light-bg box.
             chrome_underline_chips(true, true),
         ),
-        "ditto" => two_column(
+        "ditto" => full_bleed(two_column(
             LayoutMode::SidebarLeft,
             HeaderStyle::Banner,
             ContactIn::Banner,
             Some(160),
             chrome_underline_chips(false, true),
-        ),
-        "gengar" => two_column(
+        )),
+        "gengar" => full_bleed(two_column(
             LayoutMode::SidebarLeft,
             HeaderStyle::Sidebar,
             ContactIn::Sidebar,
@@ -433,8 +450,8 @@ pub fn get_template_layout(template: &str) -> TemplateLayout {
                 keyword_style: KeywordStyle::Chips,
                 header_rule: false,
             },
-        ),
-        "glalie" => two_column(
+        )),
+        "glalie" => full_bleed(two_column(
             LayoutMode::SidebarLeft,
             HeaderStyle::Sidebar,
             ContactIn::Sidebar,
@@ -450,8 +467,8 @@ pub fn get_template_layout(template: &str) -> TemplateLayout {
                 keyword_style: KeywordStyle::Plain,
                 header_rule: false,
             },
-        ),
-        "pikachu" => two_column(
+        )),
+        "pikachu" => full_bleed(two_column(
             LayoutMode::SidebarLeft,
             HeaderStyle::Left,
             ContactIn::Sidebar,
@@ -467,7 +484,7 @@ pub fn get_template_layout(template: &str) -> TemplateLayout {
                 keyword_style: KeywordStyle::Plain,
                 header_rule: false,
             },
-        ),
+        )),
         "leafish" => TemplateLayout {
             layout_mode: LayoutMode::HeaderSplit,
             default_columns: [
@@ -477,6 +494,7 @@ pub fn get_template_layout(template: &str) -> TemplateLayout {
             header_style: HeaderStyle::Banner,
             contact_in: ContactIn::Banner,
             sidebar_width: None,
+            supports_margins: true,
             chrome: chrome_underline_chips(false, false),
         },
         _ => single(HeaderStyle::Left, chrome_underline_plain(true)),
@@ -691,6 +709,26 @@ mod tests {
         assert!(get_template_layout("chikorita").chrome.sidebar_tint);
     }
 
+    /// Templates whose Typst `set page(margin: …)` is `0pt` (full-bleed).
+    /// Verified against the sources; do not expand from the audit tag list.
+    const FULL_BLEED_TEMPLATES: &[&str] = &["ditto", "gengar", "glalie", "pikachu"];
+
+    #[test]
+    fn full_bleed_templates_declare_no_margin_support() {
+        for template in TEMPLATES {
+            let layout = get_template_layout(template);
+            let expected = !FULL_BLEED_TEMPLATES.contains(template);
+            assert_eq!(
+                layout.supports_margins, expected,
+                "{template} supports_margins"
+            );
+        }
+        assert!(
+            get_template_layout(UNKNOWN_TEMPLATE_ID).supports_margins,
+            "unknown ids fall back to rhyhorn, which honours page margins"
+        );
+    }
+
     const UNKNOWN_TEMPLATE_ID: &str = "not-a-template";
 
     /// Wire shape of the lockstep fixture. Paired with `LayoutInfo` in
@@ -714,6 +752,7 @@ mod tests {
         sidebar_tint: bool,
         keyword_style: &'a str,
         header_rule: bool,
+        supports_margins: bool,
     }
 
     /// Owned twin of [`LayoutWire`] used to `deny_unknown_fields` round-trip
@@ -736,11 +775,12 @@ mod tests {
         sidebar_tint: bool,
         keyword_style: String,
         header_rule: bool,
+        supports_margins: bool,
     }
 
     /// Must match the number of serde fields on `LayoutInfo` (`dto.rs`) and
     /// `LayoutWire` above. Bump this in the same change that adds a field.
-    const LAYOUT_WIRE_FIELD_COUNT: usize = 14;
+    const LAYOUT_WIRE_FIELD_COUNT: usize = 15;
 
     const UPDATE_LAYOUTS_FIXTURE_HINT: &str = concat!(
         "UPDATE_FIXTURES=1 cargo test -p rustume-render ",
@@ -763,6 +803,7 @@ mod tests {
             sidebar_tint: layout.chrome.sidebar_tint,
             keyword_style: layout.chrome.keyword_style.as_str(),
             header_rule: layout.chrome.header_rule,
+            supports_margins: layout.supports_margins,
         }
     }
 

--- a/crates/server/src/dto.rs
+++ b/crates/server/src/dto.rs
@@ -130,6 +130,9 @@ pub struct LayoutInfo {
     pub keyword_style: String,
     /// Whether an accent rule sits under the identity header
     pub header_rule: bool,
+    /// Whether the template honours `page.margin` on the page box.
+    /// Full-bleed templates set Typst `margin: 0pt` and ignore the stored value.
+    pub supports_margins: bool,
 }
 
 /// Theme colors for a template
@@ -183,6 +186,7 @@ mod tests {
             sidebar_tint: false,
             keyword_style: "plain".into(),
             header_rule: true,
+            supports_margins: true,
         };
         let info_keys: BTreeSet<String> = serde_json::to_value(&info)
             .expect("LayoutInfo serializes")

--- a/crates/server/src/routes/templates.rs
+++ b/crates/server/src/routes/templates.rs
@@ -149,6 +149,7 @@ pub async fn list_templates() -> Json<Vec<TemplateInfo>> {
                     sidebar_tint: layout.chrome.sidebar_tint,
                     keyword_style: layout.chrome.keyword_style.as_str().to_string(),
                     header_rule: layout.chrome.header_rule,
+                    supports_margins: layout.supports_margins,
                 },
             }
         })

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -87,6 +87,7 @@ These recur on almost every template; each template page repeats only the ones t
 | Avatar without photo | — | Closed by #857: photo-less default is **collapsed**; initials disc is `showInitials` opt-in. Hidden photos collapse. No pikachu exception. |
 | Mono dates: sheet uses `--doc-font-mono` for education dates; Typst uses muted body face | owner-decision-needed | Mono is a sheet editing affordance; decide whether PDF should match. |
 | `metadata.typography.font.size` / `lineHeight`: engine emits a top-level `#set text`, then nearly every template re-locks size and leading | fix-in-typst | Tracked by #701 — lift shared resolution into `_common.typ`. |
+| `page.margin` on full-bleed templates (pikachu, ditto, gengar, glalie) | decided (#859) | Owner: PDFs keep ignoring it. Template metadata declares `supportsMargins: false`; the editor disables the margin control with an accessible explanation. |
 
 ## Related code
 

--- a/docs/templates/ditto.md
+++ b/docs/templates/ditto.md
@@ -65,7 +65,7 @@ bodies above.
 | Sheet banner tint/boxing approximates banner but not ditto's solid accent fill + white type | fix-in-sheet |
 | Body 9pt denser leading not mirrored on sheet | fix-in-sheet |
 | Experience lead field was company-first in Typst | fixed (#858) |
-| `page.margin` inert (full-bleed) | owner-decision-needed (surface in UI) |
+| `page.margin` inert (full-bleed) | decided (#859) |
 | Typography metadata ignored | fix-in-typst (#701) |
 
 ### Audit evidence

--- a/docs/templates/gengar.md
+++ b/docs/templates/gengar.md
@@ -68,7 +68,7 @@ bodies above.
 | Level boxes vs sheet dots | fix-in-sheet |
 | No PDF initials fallback while sheet edit mode shows initials | fixed (#857): Done/PDF collapse; edit keeps a placeholder; initials are `showInitials` opt-in |
 | Experience lead field was company-first in Typst | fixed (#858) |
-| `page.margin` does not inset the page box (full-bleed); `content-width()` still uses it for ratio math | owner-decision-needed / fix-in-sheet (UI only) |
+| `page.margin` does not inset the page box (full-bleed); `content-width()` still uses it for ratio math | decided (#859) |
 | Typography metadata ignored | fix-in-typst (#701) |
 
 ### Audit evidence

--- a/docs/templates/glalie.md
+++ b/docs/templates/glalie.md
@@ -64,7 +64,7 @@ bodies above.
 | Sheet uppercases section titles; Typst keeps title-case | fix-in-sheet |
 | Justify-on in Typst vs sheet left-aligned body | owner-decision-needed |
 | Experience lead field was company-first in Typst | fixed (#858) |
-| `page.margin` does not inset the page box (full-bleed); `content-width()` still uses it for ratio math | owner-decision-needed (surface in UI) |
+| `page.margin` does not inset the page box (full-bleed); `content-width()` still uses it for ratio math | decided (#859) |
 
 ### Audit evidence
 

--- a/docs/templates/pikachu.md
+++ b/docs/templates/pikachu.md
@@ -70,7 +70,7 @@ bodies above.
 | Sheet profile prefers username; Typst uses `network` | fix-in-sheet |
 | Photo-less avatar: PDF/Done-mode collapse; edit keeps a placeholder; initials are `showInitials` opt-in | fixed (#857) |
 | Education on sheet uses degree-first row layout even when education sits in the sidebar | fix-in-sheet |
-| `page.margin` inert — document as intentional; surface in editor | owner-decision-needed / fix-in-sheet (UI only) |
+| `page.margin` inert — document as intentional; editor disables the control | decided (#859) |
 | Typography honouring incomplete across templates | fix-in-typst (#701) |
 
 ### Audit evidence

--- a/tests/fixtures/template-layouts.json
+++ b/tests/fixtures/template-layouts.json
@@ -35,7 +35,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": false,
-    "sidebarWidth": null
+    "sidebarWidth": null,
+    "supportsMargins": true
   },
   "bronzor": {
     "contactIn": "header",
@@ -69,7 +70,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": false,
-    "sidebarWidth": null
+    "sidebarWidth": null,
+    "supportsMargins": true
   },
   "chikorita": {
     "contactIn": "header",
@@ -107,7 +109,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": true,
-    "sidebarWidth": null
+    "sidebarWidth": null,
+    "supportsMargins": true
   },
   "ditto": {
     "contactIn": "banner",
@@ -145,7 +148,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": true,
-    "sidebarWidth": 160
+    "sidebarWidth": 160,
+    "supportsMargins": false
   },
   "gengar": {
     "contactIn": "sidebar",
@@ -183,7 +187,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": true,
-    "sidebarWidth": 170
+    "sidebarWidth": 170,
+    "supportsMargins": false
   },
   "glalie": {
     "contactIn": "sidebar",
@@ -221,7 +226,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": true,
-    "sidebarWidth": 170
+    "sidebarWidth": 170,
+    "supportsMargins": false
   },
   "kakuna": {
     "contactIn": "header",
@@ -255,7 +261,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": false,
-    "sidebarWidth": null
+    "sidebarWidth": null,
+    "supportsMargins": true
   },
   "leafish": {
     "contactIn": "banner",
@@ -293,7 +300,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": false,
-    "sidebarWidth": null
+    "sidebarWidth": null,
+    "supportsMargins": true
   },
   "nosepass": {
     "contactIn": "header",
@@ -327,7 +335,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "rule",
     "sidebarTint": false,
-    "sidebarWidth": null
+    "sidebarWidth": null,
+    "supportsMargins": true
   },
   "not-a-template": {
     "contactIn": "header",
@@ -361,7 +370,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": false,
-    "sidebarWidth": null
+    "sidebarWidth": null,
+    "supportsMargins": true
   },
   "onyx": {
     "contactIn": "header",
@@ -395,7 +405,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": false,
-    "sidebarWidth": null
+    "sidebarWidth": null,
+    "supportsMargins": true
   },
   "pikachu": {
     "contactIn": "sidebar",
@@ -433,7 +444,8 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "plain",
     "sidebarTint": true,
-    "sidebarWidth": 180
+    "sidebarWidth": 180,
+    "supportsMargins": false
   },
   "rhyhorn": {
     "contactIn": "header",
@@ -467,6 +479,7 @@
     "sidebarHeadingInk": "accent",
     "sidebarHeadingStyle": "underline",
     "sidebarTint": false,
-    "sidebarWidth": null
+    "sidebarWidth": null,
+    "supportsMargins": true
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(web): declare per-template margin support and disable the inert control
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Template layout metadata now declares `supportsMargins`. The document editor gained a Page dialog (form builder was retired, so the control had to be added). On full-bleed templates the margin input stays focusable, uses `aria-disabled` + `aria-describedby`, and explains: "This template is full-bleed and does not use page margins".

Verified against Typst sources — full-bleed (`margin: 0pt`) is **pikachu, ditto, gengar, glalie**. The issue body's azurill/rhyhorn/onyx list does not match current templates. No PDF output change.

Follow-up for Greptile: clearing the enabled margin field no longer persists `0` (`Number("")`) while the user is still typing.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`bun run test:coverage` on `pageDialog.test.tsx`, `bun run lint`, `bun run typecheck`, `uv run lintro chk`)

## Related Issues

Closes #859
Related #826

## Details

Lockstep: `cargo test -p rustume-server layout_info_keys_match_layout_wire_fixture --lib` goes red if `supportsMargins` is removed from one side of the fixture. Audit rows marked decided.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddab4cfb-3004-4f13-a16c-02d931c4801c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddab4cfb-3004-4f13-a16c-02d931c4801c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds per-template margin capability metadata across the renderer, server contract, and web client, then introduces a Page dialog whose margin control is read-only with an accessible explanation for full-bleed templates.
- Adds `supportsMargins` to Rust and TypeScript template-layout models and lockstep fixtures.
- Marks ditto, gengar, glalie, and pikachu as full-bleed.
- Adds bounded page-margin editing and tests the enabled, disabled, and empty-input states.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until the outstanding template-metadata fallback is made template-aware so full-bleed templates cannot expose an inert margin control.

When template metadata is unavailable, missing, or still loading, `DocEditor` selects the generic layout with margin support enabled rather than the active template's bundled layout; users of ditto, gengar, glalie, or pikachu can therefore persist a margin that the rendered PDF ignores.

**Files Needing Attention:** apps/web/src/pages/DocEditor.tsx, apps/web/src/lib/docLayout.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/doc-editor/PageDialog.tsx | Adds the accessible Page settings dialog and safely ignores empty, invalid, or disabled margin edits. |
| apps/web/src/components/doc-editor/docEdits.ts | Adds centralized page-margin persistence with integer rounding, bounds enforcement, and no-op suppression. |
| apps/web/src/lib/docLayout.ts | Extends bundled template metadata with margin support and marks the four full-bleed templates accordingly. |
| apps/web/src/pages/DocEditor.tsx | Adds the Page top-bar action and connects the dialog to the resolved template layout. |
| crates/render/src/typst_engine/template_layout.rs | Declares authoritative per-template margin capability and updates lockstep fixture coverage. |
| crates/server/src/dto.rs | Extends the template-layout wire contract with `supportsMargins`. |
| crates/server/src/routes/templates.rs | Exposes renderer-provided margin capability through the templates endpoint. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Typst[Typst template layout] --> Render[Render metadata]
  Render --> Server[GET /api/templates]
  Server --> Web[Web template layout]
  Web --> Dialog[Page dialog]
  Dialog -->|supportsMargins true| Editable[Editable margin input]
  Dialog -->|supportsMargins false| ReadOnly[Read-only input with explanation]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(web): ignore empty page-margin input"](https://github.com/lgtm-hq/rustume/commit/f75a1f243b472dea23bc292875b435bd5412d9a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55719533)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/rustume/-/docs/web-app.md)
- Knowledge Base — [Render: Typst-Based PDF Rendering](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/rustume/-/docs/render.md)
- Knowledge Base — [HTTP request flow through the Rustume server](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/rustume/-/docs/server-http.md)
</details>


<!-- /greptile_comment -->