### PR TITLE
fix(ci): fail release publish when the image build fails

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -65,8 +65,11 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
   `create-github-release` composite). `📦 Create GitHub Release` is gated on
   `🔍 Verify Release Image`, which waits for the GHCR tags
   docker-build-publish.yml is contracted to publish, so a Release is never
-  created without its image (#597). The git tag is created earlier by
-  auto-tag-on-main.yml and is **not** covered by that gate
+  created without its image (#597). A failed image verify turns Create
+  GitHub Release red instead of skipped (#698). The git tag is created
+  earlier by auto-tag-on-main.yml and is **not** covered by that gate
+- **reconcile-releases.yml** — Daily / tag-push check that recent `v*` tags
+  still have a GitHub Release and a GHCR image (`scripts/ci/release/reconcile-releases.sh`)
 - **build-binary.yml** — Cross-platform release binaries (inline; Windows
   `actions/checkout` exception)
 
@@ -93,8 +96,8 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 - **boundary-guard.yml** — Ops boundary path and content guards (inline;
   `scripts/ci/boundary/`)
 - **test-boundary-shell.yml** / **test-docker-shell.yml** /
-  **test-maintenance-shell.yml** — BATS suites for `scripts/ci/` via
-  `reusable-test-shell`
+  **test-maintenance-shell.yml** / **test-release-shell.yml** — BATS suites
+  for `scripts/ci/` via `reusable-test-shell`
 - **ghcr-cleanup.yml** — GHCR prune (hybrid: `reusable-ghcr-cleanup` for untagged +
   inline tagged retention)
 - **renovate.yml** — Scheduled Renovate runs (direct `step-security/harden-runner` +

--- a/.github/workflows/publish-release-on-tag.yml
+++ b/.github/workflows/publish-release-on-tag.yml
@@ -69,9 +69,10 @@ jobs:
   # which is what keeps a GitHub Release from existing without its image.
   #
   # The wait budget covers the docker job's own timeout-minutes: 120 plus
-  # queueing. WATCH_WORKFLOW short-circuits the wait when that workflow has
-  # already concluded without success, so a dead runner fails in minutes
-  # rather than burning the full budget.
+  # queueing while that workflow is still running. WATCH_WORKFLOW
+  # short-circuits immediately on a failed/cancelled docker run, and once
+  # docker succeeds the remaining poll shrinks to POST_SUCCESS_TIMEOUT_SECONDS
+  # (GHCR lag only) so a missing tag cannot burn a runner for hours (#698).
   verify-image:
     name: 🔍 Verify Release Image
     needs: verify-tag
@@ -110,6 +111,7 @@ jobs:
           IMAGE_REF: ghcr.io/lgtm-hq/rustume
           EXPECT_PLATFORMS: linux/amd64,linux/arm64
           TIMEOUT_SECONDS: "8100"
+          POST_SUCCESS_TIMEOUT_SECONDS: "600"
           POLL_INTERVAL_SECONDS: "30"
           WATCH_WORKFLOW: docker-build-publish.yml
           REGISTRY_USERNAME: ${{ github.actor }}
@@ -120,12 +122,27 @@ jobs:
   release:
     name: 📦 Create GitHub Release
     needs: [verify-tag, build-binaries, verify-image]
+    # always() so a failed image verify turns this job red instead of skipped
+    # (#698). A skipped "Create GitHub Release" reads as "not applicable".
+    if: >-
+      always()
+      && needs.verify-tag.result == 'success'
+      && needs.build-binaries.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     timeout-minutes: 15
 
     steps:
+      - name: Fail when the release image is missing
+        if: needs.verify-image.result != 'success'
+        env:
+          VERIFY_RESULT: ${{ needs.verify-image.result }}
+        run: |
+          echo "::error::Create GitHub Release refused: Verify Release Image ${VERIFY_RESULT}."
+          echo "A missing image is a failed release, not a skip (#698)."
+          exit 1
+
       - name: Harden Runner
         # Direct step-security invocation: lgtm-ci removed its harden-runner
         # composite in v0.50.0 (the action pre hook must install the agent).

--- a/.github/workflows/reconcile-releases.yml
+++ b/.github/workflows/reconcile-releases.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Reconcile - GitHub Releases
+# Loud check that every recent v* tag still has a GitHub Release and a GHCR
+# image. Catches the silent-skip class of #698 after the fact.
+
+"on":
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch: {}
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions: {}
+
+concurrency:
+  group: reconcile-releases-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: 🔍 Reconcile Releases
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            ghcr.io:443
+
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
+        with:
+          fetch-depth: 0
+
+      - name: Reconcile tags against releases and images
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_REF: ghcr.io/lgtm-hq/rustume
+          MAX_TAGS: "50"
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/release/reconcile-releases.sh

--- a/.github/workflows/reconcile-releases.yml
+++ b/.github/workflows/reconcile-releases.yml
@@ -8,9 +8,9 @@ name: Reconcile - GitHub Releases
   schedule:
     - cron: "0 5 * * *"
   workflow_dispatch: {}
-  push:
-    tags:
-      - "v*.*.*"
+  # Tag push is deliberately omitted: reconcile is after-the-fact. Firing
+  # on `v*.*.*` races the publish workflows and fails while artifacts are
+  # still being written.
 
 permissions: {}
 

--- a/.github/workflows/test-release-shell.yml
+++ b/.github/workflows/test-release-shell.yml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+---
+name: Test - Release Shell Scripts
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/release/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-release-shell.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/ci/release/**'
+      - 'tests/bats/**'
+      - '.github/workflows/test-release-shell.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-release-shell-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  shell-tests:
+    permissions:
+      contents: read
+      pull-requests: write
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
+    with:
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
+      job-name: Release Shell Tests
+      test-path: tests/bats/unit/release
+      coverage: true
+      coverage-threshold: 0
+      upload-coverage: false
+      egress-policy: block
+      egress-preset: github-tooling
+      runner-image: ubuntu-24.04

--- a/.github/workflows/test-release-shell.yml
+++ b/.github/workflows/test-release-shell.yml
@@ -29,7 +29,7 @@ jobs:
   shell-tests:
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # publish-test-summary posts shell coverage on PRs
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-shell.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:

--- a/.github/workflows/test-release-shell.yml
+++ b/.github/workflows/test-release-shell.yml
@@ -9,12 +9,14 @@ name: Test - Release Shell Scripts
       - 'scripts/ci/release/**'
       - 'tests/bats/**'
       - '.github/workflows/test-release-shell.yml'
+      - '.github/workflows/reconcile-releases.yml'
   push:
     branches: [main]
     paths:
       - 'scripts/ci/release/**'
       - 'tests/bats/**'
       - '.github/workflows/test-release-shell.yml'
+      - '.github/workflows/reconcile-releases.yml'
 
 permissions:
   contents: read

--- a/scripts/ci/docker/verify-published-tags.sh
+++ b/scripts/ci/docker/verify-published-tags.sh
@@ -230,6 +230,29 @@ watched_build_succeeded() {
 	[[ "$conclusion" == "success" ]]
 }
 
+# Prints success | failed | pending | unknown. Lookup errors are unknown
+# (not a confirmed miss) so TIMEOUT_SECONDS cannot clip the GHCR budget.
+watched_build_status() {
+	local conclusion
+	if [[ -z "${WATCH_WORKFLOW:-}" || -z "${GITHUB_REPOSITORY:-}" ]]; then
+		printf 'unknown'
+		return 0
+	fi
+	if ! conclusion="$(watched_build_conclusion)"; then
+		printf 'unknown'
+		return 0
+	fi
+	if [[ -z "$conclusion" ]]; then
+		printf 'pending'
+		return 0
+	fi
+	if [[ "$conclusion" == "success" ]]; then
+		printf 'success'
+		return 0
+	fi
+	printf 'failed'
+}
+
 write_summary() {
 	[[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
 	printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"
@@ -289,12 +312,13 @@ while :; do
 	fi
 	missing=("${remaining[@]}")
 
-	if watched_build_failed; then
+	watch_status="$(watched_build_status)"
+	if [[ "$watch_status" == "failed" ]]; then
 		fail_fast="${WATCH_WORKFLOW} already concluded without success"
 		break
 	fi
 
-	if [[ -z "$success_deadline" ]] && watched_build_succeeded; then
+	if [[ "$watch_status" == "success" && -z "$success_deadline" ]]; then
 		success_deadline=$((SECONDS + POST_SUCCESS_TIMEOUT_SECONDS))
 		effective_timeout="$POST_SUCCESS_TIMEOUT_SECONDS"
 		printf 'Watched build succeeded; remaining poll budget %ss\n' \
@@ -307,8 +331,17 @@ while :; do
 	fi
 	# Once docker succeeds, only `success_deadline` bounds the wait —
 	# the original TIMEOUT_SECONDS must not clip the post-success budget.
+	# A transient status lookup at the timeout must not do that either:
+	# grant the GHCR window instead of failing the release (#698).
 	if [[ -z "$success_deadline" && "$elapsed" -ge "$TIMEOUT_SECONDS" ]]; then
-		break
+		if [[ -n "${WATCH_WORKFLOW:-}" && "$watch_status" == "unknown" ]]; then
+			success_deadline=$((SECONDS + POST_SUCCESS_TIMEOUT_SECONDS))
+			effective_timeout="$POST_SUCCESS_TIMEOUT_SECONDS"
+			printf 'Watch lookup inconclusive at timeout; granting %ss GHCR budget\n' \
+				"$POST_SUCCESS_TIMEOUT_SECONDS"
+		else
+			break
+		fi
 	fi
 
 	printf 'Waiting %ss for %s missing tag(s) (%ss/%ss elapsed)\n' \

--- a/scripts/ci/docker/verify-published-tags.sh
+++ b/scripts/ci/docker/verify-published-tags.sh
@@ -305,7 +305,9 @@ while :; do
 	if [[ -n "$success_deadline" && "$SECONDS" -ge "$success_deadline" ]]; then
 		break
 	fi
-	if [[ "$elapsed" -ge "$TIMEOUT_SECONDS" ]]; then
+	# Once docker succeeds, only `success_deadline` bounds the wait —
+	# the original TIMEOUT_SECONDS must not clip the post-success budget.
+	if [[ -z "$success_deadline" && "$elapsed" -ge "$TIMEOUT_SECONDS" ]]; then
 		break
 	fi
 

--- a/scripts/ci/docker/verify-published-tags.sh
+++ b/scripts/ci/docker/verify-published-tags.sh
@@ -31,8 +31,13 @@ set -euo pipefail
 #                            main                 -> main sha-<short>
 #   EXPECT_PLATFORMS       Comma/space separated os/arch list that every tag's
 #                          manifest must contain (default: none)
-#   TIMEOUT_SECONDS        Total time to keep polling for missing tags
-#                          (default 0 = single pass, fail immediately)
+#   TIMEOUT_SECONDS        Total time to keep polling for missing tags while
+#                          the watched build is still running (default 0 =
+#                          single pass, fail immediately)
+#   POST_SUCCESS_TIMEOUT_SECONDS
+#                          Remaining poll budget once WATCH_WORKFLOW has
+#                          succeeded (default 600). GHCR read-after-write
+#                          lag only — not another 2h wait (#698)
 #   POLL_INTERVAL_SECONDS  Delay between polls (default 20)
 #   REGISTRY_USERNAME      Basic-auth user for the registry token endpoint
 #   REGISTRY_PASSWORD      Basic-auth password/token (anonymous pull if unset)
@@ -40,7 +45,9 @@ set -euo pipefail
 #                          docker-build-publish.yml). While polling, if that
 #                          workflow's run for GITHUB_SHA has already concluded
 #                          without success, stop waiting and fail immediately.
-#                          Best effort: lookup errors keep polling.
+#                          After it succeeds, the poll budget shrinks to
+#                          POST_SUCCESS_TIMEOUT_SECONDS. Best effort: lookup
+#                          errors keep polling.
 #   GITHUB_REPOSITORY      owner/repo, required by WATCH_WORKFLOW
 #   GH_TOKEN               Token for the WATCH_WORKFLOW `gh api` lookup
 #   GITHUB_STEP_SUMMARY    When set, a short verdict is appended
@@ -56,7 +63,10 @@ Environment:
   IMAGE_REF              Image without tag (default ghcr.io/lgtm-hq/rustume)
   TAGS                   Explicit tag list (default: derived from the ref)
   EXPECT_PLATFORMS       Platforms every tag's manifest must contain
-  TIMEOUT_SECONDS        Poll budget for missing tags (default 0)
+  TIMEOUT_SECONDS        Poll budget while the watched build is running
+  POST_SUCCESS_TIMEOUT_SECONDS
+                         Remaining budget after a successful watched build
+                         (default 600)
   POLL_INTERVAL_SECONDS  Delay between polls (default 20)
   REGISTRY_USERNAME      Basic-auth user for the registry token endpoint
   REGISTRY_PASSWORD      Basic-auth password/token (anonymous when unset)
@@ -72,6 +82,7 @@ fi
 IMAGE_REF="${IMAGE_REF:-ghcr.io/lgtm-hq/rustume}"
 EXPECT_PLATFORMS="${EXPECT_PLATFORMS:-}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-0}"
+POST_SUCCESS_TIMEOUT_SECONDS="${POST_SUCCESS_TIMEOUT_SECONDS:-600}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-20}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-30}"
 
@@ -173,8 +184,8 @@ manifest_platforms() {
 	# not as a set -e abort that loses the attributable message.
 }
 
-# Best effort: has the watched build already concluded without success?
-watched_build_failed() {
+# Best effort: conclusion of the watched workflow run for this ref, or empty.
+watched_build_conclusion() {
 	[[ -n "${WATCH_WORKFLOW:-}" && -n "${GITHUB_REPOSITORY:-}" ]] || return 1
 	command -v gh >/dev/null 2>&1 || return 1
 
@@ -202,7 +213,21 @@ watched_build_failed() {
 		' 2>/dev/null
 	)" || return 1
 
+	printf '%s' "$conclusion"
+}
+
+# Best effort: has the watched build already concluded without success?
+watched_build_failed() {
+	local conclusion
+	conclusion="$(watched_build_conclusion)" || return 1
 	[[ -n "$conclusion" && "$conclusion" != "success" ]]
+}
+
+# Best effort: has the watched build already concluded successfully?
+watched_build_succeeded() {
+	local conclusion
+	conclusion="$(watched_build_conclusion)" || return 1
+	[[ "$conclusion" == "success" ]]
 }
 
 write_summary() {
@@ -239,6 +264,8 @@ printf 'Verifying %s tag(s) on %s: %s\n' \
 missing=("${expected_tags[@]}")
 started_at="$SECONDS"
 fail_fast=""
+success_deadline=""
+effective_timeout="$TIMEOUT_SECONDS"
 
 while :; do
 	token="$(fetch_token || true)"
@@ -267,13 +294,23 @@ while :; do
 		break
 	fi
 
+	if [[ -z "$success_deadline" ]] && watched_build_succeeded; then
+		success_deadline=$((SECONDS + POST_SUCCESS_TIMEOUT_SECONDS))
+		effective_timeout="$POST_SUCCESS_TIMEOUT_SECONDS"
+		printf 'Watched build succeeded; remaining poll budget %ss\n' \
+			"$POST_SUCCESS_TIMEOUT_SECONDS"
+	fi
+
 	elapsed=$((SECONDS - started_at))
+	if [[ -n "$success_deadline" && "$SECONDS" -ge "$success_deadline" ]]; then
+		break
+	fi
 	if [[ "$elapsed" -ge "$TIMEOUT_SECONDS" ]]; then
 		break
 	fi
 
 	printf 'Waiting %ss for %s missing tag(s) (%ss/%ss elapsed)\n' \
-		"$POLL_INTERVAL_SECONDS" "${#missing[@]}" "$elapsed" "$TIMEOUT_SECONDS"
+		"$POLL_INTERVAL_SECONDS" "${#missing[@]}" "$elapsed" "$effective_timeout"
 	sleep "$POLL_INTERVAL_SECONDS"
 done
 

--- a/scripts/ci/release/reconcile-releases.sh
+++ b/scripts/ci/release/reconcile-releases.sh
@@ -22,8 +22,11 @@ set -euo pipefail
 #                          listed from the local repo (`git tag`).
 #   MAX_TAGS               How many newest v*.*.* tags to check (default 50)
 #   MIN_TAG_AGE_SECONDS    Skip tags younger than this when listing from git
-#                          (default 7200). Avoids racing an in-flight publish
-#                          on the daily schedule. Explicit TAGS default to 0.
+#                          (default 7200). Age is the annotated-tag creator
+#                          date (`%(creatordate:unix)`), not the pointed-to
+#                          commit time — `auto-tag.sh` uses `git tag -a`, and
+#                          release commits are often older than the tag.
+#                          Explicit TAGS default to 0.
 #   REGISTRY_USERNAME      Basic-auth user for the registry token endpoint
 #   REGISTRY_PASSWORD      Basic-auth password/token (anonymous when unset)
 #   CURL_MAX_TIME          curl timeout (default 30)
@@ -97,6 +100,22 @@ list_version_tags() {
 	git tag -l 'v*.*.*' --sort=-v:refname | head -n "$MAX_TAGS"
 }
 
+# When the tag was created. Annotated tags (this repo's release tags) use
+# the tagger timestamp so a brand-new tag on an old commit still gets the
+# scheduled grace period. Lightweight tags fall back to the target commit.
+tag_created_unix() {
+	local git_tag="$1"
+	local created=""
+	created="$(
+		git for-each-ref --format='%(creatordate:unix)' "refs/tags/${git_tag}" \
+			2>/dev/null || true
+	)"
+	if [[ -z "$created" ]]; then
+		created="$(git log -1 --format=%ct "$git_tag" 2>/dev/null || true)"
+	fi
+	printf '%s' "$created"
+}
+
 expected_tags=()
 if [[ -n "${TAGS:-}" ]]; then
 	# shellcheck disable=SC2206 # deliberate word splitting of the tag list
@@ -118,7 +137,7 @@ if [[ "$MIN_TAG_AGE_SECONDS" -gt 0 ]]; then
 	now="$(date +%s)"
 	aged_tags=()
 	for git_tag in "${expected_tags[@]}"; do
-		created="$(git log -1 --format=%ct "$git_tag" 2>/dev/null || true)"
+		created="$(tag_created_unix "$git_tag")"
 		if [[ -n "$created" && $((now - created)) -lt "$MIN_TAG_AGE_SECONDS" ]]; then
 			printf '  skip young tag: %s (age %ss < %ss)\n' \
 				"$git_tag" "$((now - created))" "$MIN_TAG_AGE_SECONDS"

--- a/scripts/ci/release/reconcile-releases.sh
+++ b/scripts/ci/release/reconcile-releases.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+set -euo pipefail
+
+# reconcile-releases.sh
+#
+# For every recent v*.*.* tag, assert a matching GitHub Release and GHCR
+# image exist (#698). This is what would have caught v0.52.3 / v0.52.5:
+# the tag and binaries existed, the GitHub Release and image did not, and
+# nothing surfaced the gap.
+#
+# Usage:
+#   bash scripts/ci/release/reconcile-releases.sh
+#
+# Environment:
+#   GITHUB_REPOSITORY      owner/repo (required for `gh release view`)
+#   GH_TOKEN / GITHUB_TOKEN
+#                          Token for `gh`
+#   IMAGE_REF              Image without tag (default ghcr.io/lgtm-hq/rustume)
+#   TAGS                   Optional whitespace-separated git tags (vX.Y.Z).
+#                          When unset, the newest MAX_TAGS version tags are
+#                          listed from the local repo (`git tag`).
+#   MAX_TAGS               How many newest v*.*.* tags to check (default 50)
+#   REGISTRY_USERNAME      Basic-auth user for the registry token endpoint
+#   REGISTRY_PASSWORD      Basic-auth password/token (anonymous when unset)
+#   CURL_MAX_TIME          curl timeout (default 30)
+#   GITHUB_STEP_SUMMARY    When set, a short verdict is appended
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Reconcile v* git tags against GitHub Releases and GHCR images.
+
+Usage:
+  bash scripts/ci/release/reconcile-releases.sh
+
+Environment:
+  GITHUB_REPOSITORY      owner/repo (required)
+  IMAGE_REF              Image without tag (default ghcr.io/lgtm-hq/rustume)
+  TAGS                   Explicit vX.Y.Z tag list (default: newest git tags)
+  MAX_TAGS               Newest tags to check when TAGS is unset (default 50)
+  REGISTRY_USERNAME      Basic-auth user for the registry
+  REGISTRY_PASSWORD      Basic-auth password/token
+  GITHUB_STEP_SUMMARY    Appends a short verdict when set
+
+Exits non-zero when any checked tag is missing a GitHub Release or image.
+EOF
+	exit 0
+fi
+
+IMAGE_REF="${IMAGE_REF:-ghcr.io/lgtm-hq/rustume}"
+MAX_TAGS="${MAX_TAGS:-50}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-30}"
+
+MANIFEST_ACCEPT='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
+
+err() { printf '%s\n' "$*" >&2; }
+
+for required_command in curl jq git gh; do
+	if ! command -v "$required_command" >/dev/null 2>&1; then
+		err "Required command not found: ${required_command}"
+		exit 2
+	fi
+done
+
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+	err "GITHUB_REPOSITORY is required"
+	exit 2
+fi
+
+if [[ "$IMAGE_REF" != */* ]]; then
+	err "IMAGE_REF must be <registry>/<repository>, got: ${IMAGE_REF}"
+	exit 2
+fi
+REGISTRY="${IMAGE_REF%%/*}"
+REPOSITORY="${IMAGE_REF#*/}"
+
+write_summary() {
+	[[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+	printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"
+}
+
+list_version_tags() {
+	# Newest-first semver tags. Pre-releases (v1.2.3-rc.1) are included;
+	# they are still shipped artifacts that must not vanish silently.
+	git tag -l 'v*.*.*' --sort=-v:refname | head -n "$MAX_TAGS"
+}
+
+expected_tags=()
+if [[ -n "${TAGS:-}" ]]; then
+	# shellcheck disable=SC2206 # deliberate word splitting of the tag list
+	expected_tags=(${TAGS})
+else
+	while IFS= read -r derived_tag; do
+		if [[ -n "$derived_tag" ]]; then
+			expected_tags+=("$derived_tag")
+		fi
+	done < <(list_version_tags)
+fi
+
+if [[ ${#expected_tags[@]} -eq 0 ]]; then
+	err "No version tags to reconcile (set TAGS or fetch v*.*.* tags)"
+	exit 2
+fi
+
+fetch_token() {
+	local url="https://${REGISTRY}/token?service=${REGISTRY}"
+	url+="&scope=repository:${REPOSITORY}:pull"
+	local args=(-fsSL --max-time "$CURL_MAX_TIME")
+	if [[ -n "${REGISTRY_PASSWORD:-}" ]]; then
+		args+=(-u "${REGISTRY_USERNAME:-x}:${REGISTRY_PASSWORD}")
+	fi
+	curl "${args[@]}" "$url" 2>/dev/null |
+		jq -r '.token // .access_token // empty' 2>/dev/null
+}
+
+manifest_status() {
+	local tag="$1" token="$2" code=""
+	code="$(
+		curl -sS -o /dev/null -w '%{http_code}' --max-time "$CURL_MAX_TIME" \
+			-I -H "Authorization: Bearer ${token}" \
+			-H "Accept: ${MANIFEST_ACCEPT}" \
+			"https://${REGISTRY}/v2/${REPOSITORY}/manifests/${tag}" \
+			2>/dev/null || true
+	)"
+	printf '%s' "${code:-000}"
+}
+
+release_exists() {
+	local git_tag="$1"
+	gh release view "$git_tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1
+}
+
+token="$(fetch_token || true)"
+if [[ -z "$token" ]]; then
+	err "Could not obtain a ${REGISTRY} pull token"
+	exit 2
+fi
+
+printf 'Reconciling %s tag(s) on %s and %s\n' \
+	"${#expected_tags[@]}" "$GITHUB_REPOSITORY" "$IMAGE_REF"
+
+missing_releases=()
+missing_images=()
+
+for git_tag in "${expected_tags[@]}"; do
+	image_tag="${git_tag#v}"
+	if release_exists "$git_tag"; then
+		printf '  release present: %s\n' "$git_tag"
+	else
+		printf '  release MISSING: %s\n' "$git_tag"
+		missing_releases+=("$git_tag")
+	fi
+
+	status="$(manifest_status "$image_tag" "$token")"
+	if [[ "$status" == "200" ]]; then
+		printf '  image present:   %s:%s\n' "$IMAGE_REF" "$image_tag"
+	else
+		printf '  image MISSING:   %s:%s (HTTP %s)\n' \
+			"$IMAGE_REF" "$image_tag" "$status"
+		missing_images+=("${IMAGE_REF}:${image_tag}")
+	fi
+done
+
+if [[ ${#missing_releases[@]} -eq 0 && ${#missing_images[@]} -eq 0 ]]; then
+	printf 'All %s tag(s) have a GitHub Release and a GHCR image\n' \
+		"${#expected_tags[@]}"
+	write_summary "✅ Release reconciliation passed for ${#expected_tags[@]} tag(s)"
+	exit 0
+fi
+
+err "::error::Release reconciliation failed (#698)"
+if [[ ${#missing_releases[@]} -ne 0 ]]; then
+	err "Missing GitHub Release(s): ${missing_releases[*]}"
+fi
+if [[ ${#missing_images[@]} -ne 0 ]]; then
+	err "Missing GHCR image(s): ${missing_images[*]}"
+fi
+write_summary "❌ Release reconciliation failed: missing releases=${missing_releases[*]:-none} images=${missing_images[*]:-none}"
+exit 1

--- a/scripts/ci/release/reconcile-releases.sh
+++ b/scripts/ci/release/reconcile-releases.sh
@@ -21,6 +21,9 @@ set -euo pipefail
 #                          When unset, the newest MAX_TAGS version tags are
 #                          listed from the local repo (`git tag`).
 #   MAX_TAGS               How many newest v*.*.* tags to check (default 50)
+#   MIN_TAG_AGE_SECONDS    Skip tags younger than this when listing from git
+#                          (default 7200). Avoids racing an in-flight publish
+#                          on the daily schedule. Explicit TAGS default to 0.
 #   REGISTRY_USERNAME      Basic-auth user for the registry token endpoint
 #   REGISTRY_PASSWORD      Basic-auth password/token (anonymous when unset)
 #   CURL_MAX_TIME          curl timeout (default 30)
@@ -38,6 +41,7 @@ Environment:
   IMAGE_REF              Image without tag (default ghcr.io/lgtm-hq/rustume)
   TAGS                   Explicit vX.Y.Z tag list (default: newest git tags)
   MAX_TAGS               Newest tags to check when TAGS is unset (default 50)
+  MIN_TAG_AGE_SECONDS    Skip younger git tags (default 7200 when listing)
   REGISTRY_USERNAME      Basic-auth user for the registry
   REGISTRY_PASSWORD      Basic-auth password/token
   GITHUB_STEP_SUMMARY    Appends a short verdict when set
@@ -50,6 +54,14 @@ fi
 IMAGE_REF="${IMAGE_REF:-ghcr.io/lgtm-hq/rustume}"
 MAX_TAGS="${MAX_TAGS:-50}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-30}"
+# Explicit TAGS is a targeted check (tests / manual). The scheduled listing
+# path skips tags younger than two hours so 05:00 UTC cannot fail a tag
+# that is still publishing.
+if [[ -n "${TAGS:-}" ]]; then
+	MIN_TAG_AGE_SECONDS="${MIN_TAG_AGE_SECONDS:-0}"
+else
+	MIN_TAG_AGE_SECONDS="${MIN_TAG_AGE_SECONDS:-7200}"
+fi
 
 MANIFEST_ACCEPT='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
 
@@ -100,6 +112,27 @@ fi
 if [[ ${#expected_tags[@]} -eq 0 ]]; then
 	err "No version tags to reconcile (set TAGS or fetch v*.*.* tags)"
 	exit 2
+fi
+
+if [[ "$MIN_TAG_AGE_SECONDS" -gt 0 ]]; then
+	now="$(date +%s)"
+	aged_tags=()
+	for git_tag in "${expected_tags[@]}"; do
+		created="$(git log -1 --format=%ct "$git_tag" 2>/dev/null || true)"
+		if [[ -n "$created" && $((now - created)) -lt "$MIN_TAG_AGE_SECONDS" ]]; then
+			printf '  skip young tag: %s (age %ss < %ss)\n' \
+				"$git_tag" "$((now - created))" "$MIN_TAG_AGE_SECONDS"
+			continue
+		fi
+		aged_tags+=("$git_tag")
+	done
+	expected_tags=("${aged_tags[@]}")
+	if [[ ${#expected_tags[@]} -eq 0 ]]; then
+		printf 'No tags older than %ss; nothing to reconcile\n' \
+			"$MIN_TAG_AGE_SECONDS"
+		write_summary "✅ Release reconciliation skipped: no tags older than ${MIN_TAG_AGE_SECONDS}s"
+		exit 0
+	fi
 fi
 
 fetch_token() {

--- a/tests/bats/unit/docker/test_verify_published_tags.bats
+++ b/tests/bats/unit/docker/test_verify_published_tags.bats
@@ -363,6 +363,33 @@ if [[ $count -le 1 ]]; then printf "404"; else printf "200"; fi
 	assert_output --partial "All expected tags resolve"
 }
 
+@test "inconclusive watch lookup at timeout still grants the GHCR budget" {
+	# gh api fails (transient), TIMEOUT_SECONDS is already 0, and the tag
+	# appears on the next probe. The original timeout must not fail the
+	# release before POST_SUCCESS_TIMEOUT_SECONDS elapses.
+	local counter="${BATS_TEST_TMPDIR}/calls"
+	printf '0\n' >"${counter}"
+	mock_command_script "curl" '
+url="${@: -1}"
+if [[ "$url" == *"/token?"* ]]; then printf "{\"token\":\"tok\"}\n"; exit 0; fi
+count=$(cat "'"${counter}"'")
+count=$((count + 1))
+printf "%s\n" "$count" > "'"${counter}"'"
+if [[ $count -le 1 ]]; then printf "404"; else printf "200"; fi
+'
+	mock_command_script "gh" 'exit 1'
+	export TAGS=latest TIMEOUT_SECONDS=0 POLL_INTERVAL_SECONDS=0
+	export POST_SUCCESS_TIMEOUT_SECONDS=1
+	export WATCH_WORKFLOW=docker-build-publish.yml
+	export GITHUB_REPOSITORY=lgtm-hq/Rustume
+	export GITHUB_REF_NAME=v0.46.0 GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "Watch lookup inconclusive at timeout; granting 1s GHCR budget"
+	assert_output --partial "All expected tags resolve"
+}
+
 # =============================================================================
 # Input handling
 # =============================================================================

--- a/tests/bats/unit/docker/test_verify_published_tags.bats
+++ b/tests/bats/unit/docker/test_verify_published_tags.bats
@@ -336,6 +336,33 @@ if [[ $count -le 1 ]]; then printf "404"; else printf "200"; fi
 		fail "success must shrink the budget, not fail-fast as a failed build"
 }
 
+@test "post-success budget is not clipped by the original timeout" {
+	# TIMEOUT_SECONDS is already exhausted (0) when docker succeeds; the
+	# remaining wait must still be POST_SUCCESS_TIMEOUT_SECONDS so a tag
+	# that appears on the next probe is accepted.
+	local counter="${BATS_TEST_TMPDIR}/calls"
+	printf '0\n' >"${counter}"
+	mock_command_script "curl" '
+url="${@: -1}"
+if [[ "$url" == *"/token?"* ]]; then printf "{\"token\":\"tok\"}\n"; exit 0; fi
+count=$(cat "'"${counter}"'")
+count=$((count + 1))
+printf "%s\n" "$count" > "'"${counter}"'"
+if [[ $count -le 1 ]]; then printf "404"; else printf "200"; fi
+'
+	mock_command "gh" '{"workflow_runs":[{"run_number":1,"head_branch":"v0.46.0","status":"completed","conclusion":"success"}]}'
+	export TAGS=latest TIMEOUT_SECONDS=0 POLL_INTERVAL_SECONDS=0
+	export POST_SUCCESS_TIMEOUT_SECONDS=1
+	export WATCH_WORKFLOW=docker-build-publish.yml
+	export GITHUB_REPOSITORY=lgtm-hq/Rustume
+	export GITHUB_REF_NAME=v0.46.0 GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "Watched build succeeded; remaining poll budget 1s"
+	assert_output --partial "All expected tags resolve"
+}
+
 # =============================================================================
 # Input handling
 # =============================================================================

--- a/tests/bats/unit/docker/test_verify_published_tags.bats
+++ b/tests/bats/unit/docker/test_verify_published_tags.bats
@@ -18,6 +18,7 @@ setup() {
 	# Never wait for real time in unit tests.
 	mock_command_script "sleep" 'exit 0'
 	unset TAGS EXPECT_PLATFORMS TIMEOUT_SECONDS WATCH_WORKFLOW || true
+	unset POST_SUCCESS_TIMEOUT_SECONDS || true
 	unset REGISTRY_USERNAME REGISTRY_PASSWORD || true
 	export TIMEOUT_SECONDS=0
 	export POLL_INTERVAL_SECONDS=0
@@ -317,6 +318,22 @@ if [[ $count -le 1 ]]; then printf "404"; else printf "200"; fi
 	assert_failure
 	[[ "${output}" != *"Stopped waiting"* ]] ||
 		fail "a successful watched build must not short-circuit"
+}
+
+@test "a successful watched build shrinks the remaining poll budget" {
+	mock_registry ""
+	mock_command "gh" '{"workflow_runs":[{"run_number":1,"head_branch":"v0.46.0","status":"completed","conclusion":"success"}]}'
+	export TAGS=latest TIMEOUT_SECONDS=9000 POLL_INTERVAL_SECONDS=0
+	export POST_SUCCESS_TIMEOUT_SECONDS=0
+	export WATCH_WORKFLOW=docker-build-publish.yml
+	export GITHUB_REPOSITORY=lgtm-hq/Rustume
+	export GITHUB_REF_NAME=v0.46.0 GITHUB_SHA=abc1234567890
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_output --partial "Watched build succeeded; remaining poll budget 0s"
+	[[ "${output}" != *"Stopped waiting"* ]] ||
+		fail "success must shrink the budget, not fail-fast as a failed build"
 }
 
 # =============================================================================

--- a/tests/bats/unit/release/test_reconcile_releases.bats
+++ b/tests/bats/unit/release/test_reconcile_releases.bats
@@ -90,6 +90,12 @@ exit 1
 	assert_output --partial "Missing GHCR image"
 }
 
+@test "reconcile workflow does not fire on tag push" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reconcile-releases.yml"
+	run grep -n "tags:" "${workflow}"
+	assert_failure
+}
+
 @test "refuses to run without GITHUB_REPOSITORY" {
 	unset GITHUB_REPOSITORY
 	export TAGS=v0.1.0

--- a/tests/bats/unit/release/test_reconcile_releases.bats
+++ b/tests/bats/unit/release/test_reconcile_releases.bats
@@ -96,6 +96,32 @@ exit 1
 	assert_failure
 }
 
+@test "scheduled listing skips tags younger than MIN_TAG_AGE_SECONDS" {
+	mock_registry "0.1.0"
+	mock_releases "v0.1.0"
+	unset TAGS
+	export MIN_TAG_AGE_SECONDS=999999999
+	export MAX_TAGS=5
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "skip young tag:"
+	assert_output --partial "nothing to reconcile"
+}
+
+@test "explicit TAGS are not age-filtered by default" {
+	mock_registry "0.52.1"
+	mock_releases "v0.52.1"
+	export TAGS=v0.52.1
+	unset MIN_TAG_AGE_SECONDS
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "release present: v0.52.1"
+	[[ "${output}" != *"skip young tag"* ]] ||
+		fail "explicit TAGS must not apply the scheduled grace period"
+}
+
 @test "release shell workflow documents pull-requests write" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/test-release-shell.yml"
 	run grep -E 'pull-requests: write # publish-test-summary posts shell coverage on PRs' \

--- a/tests/bats/unit/release/test_reconcile_releases.bats
+++ b/tests/bats/unit/release/test_reconcile_releases.bats
@@ -126,6 +126,34 @@ seed_version_tag_repo() {
 	assert_output --partial "nothing to reconcile"
 }
 
+@test "scheduled listing uses tagger date not the pointed-to commit date" {
+	mock_registry "0.1.0"
+	mock_releases "v0.1.0"
+	unset TAGS
+	export MIN_TAG_AGE_SECONDS=7200
+	export MAX_TAGS=5
+
+	local repo="${BATS_TEST_TMPDIR}/tag-repo"
+	mkdir -p "${repo}"
+	git -C "${repo}" init -q
+	git -C "${repo}" config user.email "test@example.com"
+	git -C "${repo}" config user.name "test"
+	printf 'x\n' >"${repo}/file"
+	git -C "${repo}" add file
+	GIT_AUTHOR_DATE="2000-01-01T00:00:00Z" \
+		GIT_COMMITTER_DATE="2000-01-01T00:00:00Z" \
+		git -C "${repo}" -c commit.gpgsign=false commit -qm init
+	# Tag created now, pointing at a 26-year-old commit.
+	git -C "${repo}" -c commit.gpgsign=false tag -a v0.1.0 -m "Release v0.1.0"
+	export GIT_DIR="${repo}/.git"
+	export GIT_WORK_TREE="${repo}"
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "skip young tag:"
+	assert_output --partial "nothing to reconcile"
+}
+
 @test "explicit TAGS are not age-filtered by default" {
 	mock_registry "0.52.1"
 	mock_releases "v0.52.1"

--- a/tests/bats/unit/release/test_reconcile_releases.bats
+++ b/tests/bats/unit/release/test_reconcile_releases.bats
@@ -14,7 +14,7 @@ setup() {
 	export SCRIPT
 	export GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/step_summary"
 	: >"${GITHUB_STEP_SUMMARY}"
-	unset TAGS MAX_TAGS || true
+	unset TAGS MAX_TAGS MIN_TAG_AGE_SECONDS GIT_DIR GIT_WORK_TREE || true
 	export GITHUB_REPOSITORY=lgtm-hq/Rustume
 	export IMAGE_REF=ghcr.io/lgtm-hq/rustume
 }
@@ -96,12 +96,29 @@ exit 1
 	assert_failure
 }
 
+seed_version_tag_repo() {
+	# CI PR checkouts are often tagless; the listing path must not depend on
+	# whatever tags happen to exist in the runner clone.
+	local repo="${BATS_TEST_TMPDIR}/tag-repo"
+	mkdir -p "${repo}"
+	git -C "${repo}" init -q
+	git -C "${repo}" config user.email "test@example.com"
+	git -C "${repo}" config user.name "test"
+	printf 'x\n' >"${repo}/file"
+	git -C "${repo}" add file
+	git -C "${repo}" -c commit.gpgsign=false commit -qm init
+	git -C "${repo}" tag v0.1.0
+	export GIT_DIR="${repo}/.git"
+	export GIT_WORK_TREE="${repo}"
+}
+
 @test "scheduled listing skips tags younger than MIN_TAG_AGE_SECONDS" {
 	mock_registry "0.1.0"
 	mock_releases "v0.1.0"
 	unset TAGS
 	export MIN_TAG_AGE_SECONDS=999999999
 	export MAX_TAGS=5
+	seed_version_tag_repo
 
 	run bash "${SCRIPT}"
 	assert_success

--- a/tests/bats/unit/release/test_reconcile_releases.bats
+++ b/tests/bats/unit/release/test_reconcile_releases.bats
@@ -96,6 +96,13 @@ exit 1
 	assert_failure
 }
 
+@test "release shell workflow documents pull-requests write" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/test-release-shell.yml"
+	run grep -E 'pull-requests: write # publish-test-summary posts shell coverage on PRs' \
+		"${workflow}"
+	assert_success
+}
+
 @test "refuses to run without GITHUB_REPOSITORY" {
 	unset GITHUB_REPOSITORY
 	export TAGS=v0.1.0

--- a/tests/bats/unit/release/test_reconcile_releases.bats
+++ b/tests/bats/unit/release/test_reconcile_releases.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: AGPL-3.0-only
+# Purpose: Tests for scripts/ci/release/reconcile-releases.sh (#698)
+
+bats_require_minimum_version 1.5.0
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/release/reconcile-releases.sh"
+
+setup() {
+	setup_temp_dir
+	export SCRIPT
+	export GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/step_summary"
+	: >"${GITHUB_STEP_SUMMARY}"
+	unset TAGS MAX_TAGS || true
+	export GITHUB_REPOSITORY=lgtm-hq/Rustume
+	export IMAGE_REF=ghcr.io/lgtm-hq/rustume
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+mock_registry() {
+	local present="$1"
+	local present_file="${BATS_TEST_TMPDIR}/present"
+	printf '%s\n' "${present}" >"${present_file}"
+	mock_command_script "curl" '
+present_file="'"${present_file}"'"
+url="${@: -1}"
+if [[ "$url" == *"/token?"* ]]; then printf "{\"token\":\"tok\"}\n"; exit 0; fi
+tag="${url##*/manifests/}"
+if grep -qxF "$tag" "$present_file"; then printf "200"; else printf "404"; fi
+'
+}
+
+mock_releases() {
+	local present="$1"
+	local present_file="${BATS_TEST_TMPDIR}/releases"
+	printf '%s\n' "${present}" >"${present_file}"
+	mock_command_script "gh" '
+present_file="'"${present_file}"'"
+tag=""
+for arg in "$@"; do
+	if [[ "$arg" == v* ]]; then tag="$arg"; fi
+done
+if grep -qxF "$tag" "$present_file"; then exit 0; fi
+exit 1
+'
+}
+
+@test "--help exits zero and documents the contract" {
+	run bash "${SCRIPT}" --help
+	assert_success
+	assert_output --partial "Reconcile v* git tags"
+}
+
+@test "passes when every tag has a release and an image" {
+	mock_registry "0.52.1"
+	mock_releases "v0.52.1"
+	export TAGS=v0.52.1
+
+	run bash "${SCRIPT}"
+	assert_success
+	assert_output --partial "release present: v0.52.1"
+	assert_output --partial "image present:"
+}
+
+@test "fails when the GitHub Release is missing" {
+	mock_registry "0.52.5"
+	mock_releases ""
+	export TAGS=v0.52.5
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_output --partial "release MISSING: v0.52.5"
+	assert_output --partial "Missing GitHub Release"
+}
+
+@test "fails when the GHCR image is missing" {
+	mock_registry ""
+	mock_releases "v0.52.3"
+	export TAGS=v0.52.3
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_output --partial "image MISSING:"
+	assert_output --partial "Missing GHCR image"
+}
+
+@test "refuses to run without GITHUB_REPOSITORY" {
+	unset GITHUB_REPOSITORY
+	export TAGS=v0.1.0
+
+	run bash "${SCRIPT}"
+	assert_failure
+	assert_output --partial "GITHUB_REPOSITORY is required"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): fail release publish when the image build fails
  ```

- Type:
  - [x] fix / perf (patch)
  - [ ] feat (minor)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Release publish no longer reports success when the image build failed. The verify-published-tags path fails the job if the watched build conclusion is `failure` (or an unexpected terminal state), instead of treating a missing published tag as a skip.

Follow-ups:

- Reconcile-releases does not fire on tag push (schedule + dispatch only).
- `TIMEOUT_SECONDS` only applies before `success_deadline`.
- Transient `gh api` miss at timeout grants a short post-success window.
- Scheduled listing skips tags younger than 7200s; explicit `TAGS` default age to 0.
- The age-filter bats test seeds its own `v0.1.0` repo so CI PR checkouts (often tagless) still exercise `skip young tag`.
- Tag age uses the annotated-tag creator date (`%(creatordate:unix)`), not the pointed-to commit time, so a new `git tag -a` on an older release commit still gets the grace period.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`bats tests/bats/unit/release/test_reconcile_releases.bats`, `uv run --group lint lintro chk`)

## Related Issues

Closes #698

## Details

`auto-tag.sh` creates annotated tags. Measuring `git log %ct` treated those tags as already old whenever the release commit predated the two-hour window.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddab4cfb-3004-4f13-a16c-02d931c4801c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddab4cfb-3004-4f13-a16c-02d931c4801c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated reconciliation to detect missing GitHub Releases or container images for recent version tags.
  - Added release-script testing for pull requests and relevant changes.
  - Release creation now requires successful tag verification and binary builds.

- **Bug Fixes**
  - Improved release image verification with workflow-aware polling and faster completion after successful builds.

- **Tests**
  - Added coverage for release reconciliation, missing artifacts, validation errors, and successful image verification.

- **Documentation**
  - Clarified release gating and consolidated the maintenance workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->











<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes release publication fail visibly when image verification fails and adds scheduled reconciliation for missing release artifacts.
- Separates the watched-build timeout from the post-success GHCR propagation budget.
- Removes tag-push reconciliation and applies a two-hour grace period to scheduled tag checks.
- Adds release-shell workflows and BATS coverage for timeout, reconciliation, and tag-age behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/docker/verify-published-tags.sh | Adds explicit watched-build states and a bounded post-success propagation deadline without leaving the previously reported timeout truncation paths. |
| scripts/ci/release/reconcile-releases.sh | Adds scheduled checks for missing GitHub Releases and GHCR images, including age filtering based on annotated-tag creation time. |
| .github/workflows/publish-release-on-tag.yml | Makes image-verification failure produce an explicit failed release job while retaining binary and tag prerequisites. |
| .github/workflows/reconcile-releases.yml | Runs reconciliation only on schedule or manual dispatch, avoiding the previously reported tag-publication race. |
| tests/bats/unit/docker/test_verify_published_tags.bats | Covers successful-build budget shrinking and the previously reported timeout and transient-lookup edge cases. |
| tests/bats/unit/release/test_reconcile_releases.bats | Covers missing artifacts, scheduled age filtering, annotated-tag timestamps, and explicit-tag behavior. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Tag as Version tag
  participant Docker as Docker workflow
  participant Verify as Image verification
  participant GHCR
  participant Release as GitHub Release job
  Tag->>Docker: Trigger image build
  Tag->>Verify: Start verification
  Verify->>Docker: Poll workflow conclusion
  Docker-->>Verify: success
  Verify->>GHCR: Poll image tags during propagation budget
  alt Required tags resolve
    GHCR-->>Verify: manifests present
    Verify-->>Release: verification succeeds
    Release->>Release: create GitHub Release
  else Build fails or tags remain missing
    Verify-->>Release: verification fails
    Release->>Release: fail visibly
  end
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(ci): age scheduled reconcile tags by..."](https://github.com/lgtm-hq/rustume/commit/dff96c5e94ceb64a2b89a3cefb4435115c6b5e1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55719528)</sub>

<!-- /greptile_comment -->