### PR TITLE
fix(web): match Done mode to PDF on glalie justify and education dates

### DIFF
--- a/apps/web/src/components/doc-editor/DocSection.tsx
+++ b/apps/web/src/components/doc-editor/DocSection.tsx
@@ -7,7 +7,8 @@
  *
  * - `experience`: position over a company · date meta row, a location row with
  *   a pin glyph, then the rich summary, tag chips and extra fields.
- * - `education`: degree over `institution · area`, a mono date, summary.
+ * - `education`: degree over `institution · area`, a date (mono in Edit,
+ *   muted body face in Done — #860), summary.
  * - `profiles` / `languages` / `skills`: compact rows — brand or name plus
  *   proficiency dots; the whole row is the edit affordance (spec §1.9).
  * - `interests`: a plain list, managed through the add-block and dialog.
@@ -492,7 +493,10 @@ export function DocSection(props: DocSectionProps): JSX.Element {
           <div class="doc-sheet__edu-school">{school()}</div>
         </Show>
         <Show when={hasText(item.date)}>
-          <div class="doc-sheet__edu-date">
+          <div
+            class="doc-sheet__edu-date"
+            classList={{ "doc-sheet__edu-date--body": !isEditable() }}
+          >
             <Slot field={bind(item.date, "Date", "date")} />
           </div>
         </Show>

--- a/apps/web/src/components/doc-editor/DocSheet.tsx
+++ b/apps/web/src/components/doc-editor/DocSheet.tsx
@@ -1001,8 +1001,14 @@ export function DocSheet(props: DocSheetProps): JSX.Element {
                   "doc-sheet--done": !isEditable(),
                   "doc-sheet--sidebar-tint": chrome().sidebarTint,
                   "doc-sheet--header-rule": chrome().headerRule,
+                  /* glalie Typst `set par(justify: true)` — scoped class so
+                     tests can pin it without a chrome-field fork (#860). */
+                  "doc-sheet--justify-body": props.resume.metadata.template === "glalie",
                 }}
                 data-testid="doc-sheet"
+                /* `data-sheet-mode` + `doc-sheet--done`/`--editing` let CSS
+                   scope Done-mode PDF fidelity (education date face) without
+                   a JS branch in every field (#860). */
                 data-sheet-mode={mode()}
                 data-heading-style={chrome().headingStyle}
                 data-sidebar-heading-style={chrome().sidebarHeadingStyle}

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -233,6 +233,60 @@ describe("document sheet structural chrome", () => {
     });
   });
 
+  describe("Done-mode PDF fidelity (#860)", () => {
+    function eduDate(sheet: HTMLElement): HTMLElement {
+      const date = sheet.querySelector<HTMLElement>(".doc-sheet__edu-date");
+      expect(date, "expected an education date").not.toBeNull();
+      return date!;
+    }
+
+    it("justifies glalie body text in Done mode", () => {
+      resume.metadata.template = "glalie";
+      renderSheet({ template: bundledTemplateLayout("glalie"), mode: "done" });
+
+      const sheet = screen.getByTestId("doc-sheet");
+      expect(sheet.className).toContain("doc-sheet--tpl-glalie");
+      expect(sheet.classList.contains("doc-sheet--justify-body")).toBe(true);
+      expect(sheet).toHaveAttribute("data-sheet-mode", "done");
+      expect(sheet.querySelector(".doc-sheet__summary")).not.toBeNull();
+    });
+
+    it("leaves other templates' Done-mode body start-aligned", () => {
+      for (const id of ["onyx", "gengar", "rhyhorn"] as const) {
+        resume.metadata.template = id;
+        const { unmount } = renderSheet({
+          template: bundledTemplateLayout(id),
+          mode: "done",
+        });
+        const sheets = screen.getAllByTestId("doc-sheet");
+        const sheet = sheets[sheets.length - 1];
+        expect(sheet.className).toContain(`doc-sheet--tpl-${id}`);
+        expect(sheet.classList.contains("doc-sheet--justify-body")).toBe(false);
+        unmount();
+      }
+    });
+
+    it("uses the muted body face for education dates in Done mode", () => {
+      resume.metadata.template = "glalie";
+      renderSheet({ template: bundledTemplateLayout("glalie"), mode: "done" });
+
+      const sheet = screen.getByTestId("doc-sheet");
+      const date = eduDate(sheet);
+      expect(date.classList.contains("doc-sheet__edu-date--body")).toBe(true);
+    });
+
+    it("keeps education dates mono in edit mode", () => {
+      resume.metadata.template = "glalie";
+      renderSheet({ template: bundledTemplateLayout("glalie"), mode: "edit" });
+
+      const sheet = screen.getByTestId("doc-sheet");
+      expect(sheet).toHaveAttribute("data-sheet-mode", "edit");
+      const date = eduDate(sheet);
+      expect(date.classList.contains("doc-sheet__edu-date--body")).toBe(false);
+      expect(date.className).toContain("doc-sheet__edu-date");
+    });
+  });
+
   describe("section cards", () => {
     it("hides a fixed section through toggleSectionVisibility, and says so", async () => {
       renderSheet();

--- a/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
+++ b/apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx
@@ -249,6 +249,7 @@ describe("document sheet structural chrome", () => {
       expect(sheet.classList.contains("doc-sheet--justify-body")).toBe(true);
       expect(sheet).toHaveAttribute("data-sheet-mode", "done");
       expect(sheet.querySelector(".doc-sheet__summary")).not.toBeNull();
+      expect(sheet.querySelector(".doc-sheet__lang-desc")).not.toBeNull();
     });
 
     it("leaves other templates' Done-mode body start-aligned", () => {

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -1307,6 +1307,8 @@ button.doc-sheet__avatar-btn:focus-visible {
 
 .doc-sheet__edu-date {
   display: block;
+  /* Edit mode: mono is a sanctioned editing affordance (#860). Done mode
+     drops it below so the date matches the PDF's muted body face. */
   font-family: var(--doc-font-mono);
   font-size: 0.64rem;
   color: var(--doc-sheet-muted);
@@ -1589,11 +1591,33 @@ button.doc-sheet__avatar-btn:focus-visible {
  *
  * The rendered document: no card affordances on hover. The editing controls
  * themselves are not mounted in this mode (see `sheetMode`); this only
- * silences the pure-CSS hover cues.
+ * silences the pure-CSS hover cues. Mode-scoped fidelity rules (#860) live
+ * here so Edit can keep its affordances while Done matches the PDF.
  */
 .doc-sheet--done .doc-sheet__entry-row:hover {
   background: transparent;
   border-color: transparent;
+}
+
+/* Education dates: PDF uses the muted body face; Edit keeps mono (#860).
+   `.doc-sheet__edu-date--body` is the Done-mode hook; the `--done` ancestor
+   rule covers the same state if a date is rendered without the hook class. */
+.doc-sheet--done .doc-sheet__edu-date,
+.doc-sheet__edu-date--body {
+  font-family: var(--doc-font-body);
+}
+
+/* glalie Typst `set par(justify: true)` — body prose on the sheet, both
+   modes (justification does not fight the dialog editors). Other templates
+   stay start-aligned. `--tpl-glalie` and `--justify-body` are equivalent;
+   the latter is the testable hook set on the sheet root. */
+.doc-sheet--tpl-glalie .doc-sheet__summary,
+.doc-sheet--tpl-glalie .doc-sheet__entry-sum,
+.doc-sheet--tpl-glalie .doc-sheet__entry-desc,
+.doc-sheet--justify-body .doc-sheet__summary,
+.doc-sheet--justify-body .doc-sheet__entry-sum,
+.doc-sheet--justify-body .doc-sheet__entry-desc {
+  text-align: justify;
 }
 
 /* ── Insert-page-break pill control (#796) ─────────────────────────────── */

--- a/apps/web/src/components/doc-editor/docSheet.css
+++ b/apps/web/src/components/doc-editor/docSheet.css
@@ -1614,9 +1614,11 @@ button.doc-sheet__avatar-btn:focus-visible {
 .doc-sheet--tpl-glalie .doc-sheet__summary,
 .doc-sheet--tpl-glalie .doc-sheet__entry-sum,
 .doc-sheet--tpl-glalie .doc-sheet__entry-desc,
+.doc-sheet--tpl-glalie .doc-sheet__lang-desc,
 .doc-sheet--justify-body .doc-sheet__summary,
 .doc-sheet--justify-body .doc-sheet__entry-sum,
-.doc-sheet--justify-body .doc-sheet__entry-desc {
+.doc-sheet--justify-body .doc-sheet__entry-desc,
+.doc-sheet--justify-body .doc-sheet__lang-desc {
   text-align: justify;
 }
 

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -730,6 +730,12 @@ describe("templateDocFontFamily / docFontStack", () => {
       resolve(__dirname, "../../components/doc-editor/docSheet.css"),
       "utf8",
     );
+    expect(css).toMatch(
+      /\.doc-sheet--justify-body[\s\S]*\.doc-sheet__lang-desc[\s\S]*text-align:\s*justify/,
+    );
+    expect(css).toMatch(
+      /\.doc-sheet--tpl-glalie[\s\S]*\.doc-sheet__lang-desc[\s\S]*text-align:\s*justify/,
+    );
     expect(css).toMatch(/\.doc-sheet--justify-body[\s\S]*text-align:\s*justify/);
     expect(css).toMatch(/\.doc-sheet--tpl-glalie[\s\S]*text-align:\s*justify/);
     expect(css).toMatch(/\.doc-sheet__edu-date--body[\s\S]*font-family:\s*var\(--doc-font-body\)/);

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -725,6 +725,17 @@ describe("templateDocFontFamily / docFontStack", () => {
     expect(css).not.toMatch(/var\(--font-mono\)/);
   });
 
+  it("justifies glalie body and drops mono education dates in Done mode (#860)", () => {
+    const css = readFileSync(
+      resolve(__dirname, "../../components/doc-editor/docSheet.css"),
+      "utf8",
+    );
+    expect(css).toMatch(/\.doc-sheet--justify-body[\s\S]*text-align:\s*justify/);
+    expect(css).toMatch(/\.doc-sheet--tpl-glalie[\s\S]*text-align:\s*justify/);
+    expect(css).toMatch(/\.doc-sheet__edu-date--body[\s\S]*font-family:\s*var\(--doc-font-body\)/);
+    expect(css).toMatch(/\.doc-sheet__edu-date\s*\{[\s\S]*font-family:\s*var\(--doc-font-mono\)/);
+  });
+
   it("every @font-face url in docFonts.css exists under public/fonts", () => {
     const css = readFileSync(
       resolve(__dirname, "../../components/doc-editor/docFonts.css"),

--- a/apps/web/src/lib/__tests__/docLayout.test.ts
+++ b/apps/web/src/lib/__tests__/docLayout.test.ts
@@ -731,15 +731,15 @@ describe("templateDocFontFamily / docFontStack", () => {
       "utf8",
     );
     expect(css).toMatch(
-      /\.doc-sheet--justify-body[\s\S]*\.doc-sheet__lang-desc[\s\S]*text-align:\s*justify/,
+      /\.doc-sheet--justify-body[^}]*\.doc-sheet__lang-desc[^}]*text-align:\s*justify/,
     );
     expect(css).toMatch(
-      /\.doc-sheet--tpl-glalie[\s\S]*\.doc-sheet__lang-desc[\s\S]*text-align:\s*justify/,
+      /\.doc-sheet--tpl-glalie[^}]*\.doc-sheet__lang-desc[^}]*text-align:\s*justify/,
     );
-    expect(css).toMatch(/\.doc-sheet--justify-body[\s\S]*text-align:\s*justify/);
-    expect(css).toMatch(/\.doc-sheet--tpl-glalie[\s\S]*text-align:\s*justify/);
-    expect(css).toMatch(/\.doc-sheet__edu-date--body[\s\S]*font-family:\s*var\(--doc-font-body\)/);
-    expect(css).toMatch(/\.doc-sheet__edu-date\s*\{[\s\S]*font-family:\s*var\(--doc-font-mono\)/);
+    expect(css).toMatch(/\.doc-sheet--justify-body[^}]*text-align:\s*justify/);
+    expect(css).toMatch(/\.doc-sheet--tpl-glalie[^}]*text-align:\s*justify/);
+    expect(css).toMatch(/\.doc-sheet__edu-date--body[^}]*font-family:\s*var\(--doc-font-body\)/);
+    expect(css).toMatch(/\.doc-sheet__edu-date\s*\{[^}]*font-family:\s*var\(--doc-font-mono\)/);
   });
 
   it("every @font-face url in docFonts.css exists under public/fonts", () => {

--- a/docs/design/item-presentation.md
+++ b/docs/design/item-presentation.md
@@ -60,9 +60,14 @@ Composition is **degree-first**. Never join `studyType` and `area` with `" in "`
 | Date | `date` | Separate (header column, badge, or own row) — never folded into the degree line |
 | Optional | `score`, `summary`, keywords, custom fields | After the lines above |
 
+| Surface | Date face |
+| --- | --- |
+| PDF / Done-mode sheet | Muted **body** face — Typst has no mono, and Done follows the PDF (#860) |
+| Edit-mode sheet | `--doc-font-mono` — sanctioned editing affordance, same class of edit↔done divergence as the avatar placeholder (#857) |
+
 Helpers: Typst `education-degree` / `education-school`; sheet `educationDegree` /
 `educationSchool`. The legacy `format-degree` helper (which joined with `" in "`) is
-removed; new call sites must use the helpers above.
+removed; new call sites must use the helpers above. Sheet class: `.doc-sheet__edu-date`.
 
 ---
 
@@ -117,6 +122,8 @@ Company URLs stay on the company text. Volunteer (`organization` / `position`) i
 2. Avatar call sites use `render-avatar` / `avatar-above` / `avatar-beside` and collapse when the
    contract says so.
 3. Education uses `education-degree` + `education-school` (never `"… in …"`).
-4. Every keyword-bearing section prints keywords.
-5. Levels go through `clamp-level` / `should-render-level` / `render-level`.
-6. Experience leads with `position`, then company and dates.
+4. Education dates use the muted body face on PDF and Done-mode sheet; Edit may
+   keep `--doc-font-mono` as the documented affordance (#860).
+5. Every keyword-bearing section prints keywords.
+6. Levels go through `clamp-level` / `should-render-level` / `render-level`.
+7. Experience leads with `position`, then company and dates.

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -86,7 +86,7 @@ These recur on almost every template; each template page repeats only the ones t
 | Level glyphs: sheet always draws five dots; Typst `template-default` is bars / squares / dots / text bullets per template, and `metadata.levelDisplay` can override | fix-in-sheet | Sheet should follow `levelDisplay`, with `template-default` matching the template native glyph. |
 | Skill / interest keywords: sheet uses soft tag chips for skills (and experience/education extras); Typst mixes comma lists, middots, chips, and `— keywords` | fix-in-sheet | Match the Typst treatment named in each template spec. |
 | Avatar without photo | — | Closed by #857: photo-less default is **collapsed**; initials disc is `showInitials` opt-in. Hidden photos collapse. No pikachu exception. |
-| Mono dates: sheet uses `--doc-font-mono` for education dates; Typst uses muted body face | — | Closed by #860: Done mode uses the muted body face (PDF). Edit mode keeps mono as a sanctioned editing affordance. Documented in [`item-presentation.md`](../design/item-presentation.md). |
+| Education dates: PDF and Done mode use the muted body face; Edit mode uses `--doc-font-mono` | — | Closed by #860. Documented in [`item-presentation.md`](../design/item-presentation.md). |
 | `metadata.typography.font.size` / `lineHeight`: engine emits a top-level `#set text`, then nearly every template re-locks size and leading | fix-in-typst | Tracked by #701 — lift shared resolution into `_common.typ`. |
 
 ## Related code

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -55,8 +55,9 @@ leading (~0.65em) and most lock **IBM Plex Sans**. Issue #701 should:
   template paints a full-bleed sidebar that ignores `page.margin`.
 
 Display sizes (name ~18–28pt, section titles ~8–11pt) stay template-authored.
-There is no separate mono face in Typst; the sheet's `--doc-font-mono` dates are a
-sheet-only convention until an owner decision says otherwise.
+There is no separate mono face in Typst. Education dates use the muted body face
+on the PDF and in Done mode; Edit mode keeps `--doc-font-mono` as a sanctioned
+editing affordance (#860).
 
 ## Divergence tags
 
@@ -85,7 +86,7 @@ These recur on almost every template; each template page repeats only the ones t
 | Level glyphs: sheet always draws five dots; Typst `template-default` is bars / squares / dots / text bullets per template, and `metadata.levelDisplay` can override | fix-in-sheet | Sheet should follow `levelDisplay`, with `template-default` matching the template native glyph. |
 | Skill / interest keywords: sheet uses soft tag chips for skills (and experience/education extras); Typst mixes comma lists, middots, chips, and `— keywords` | fix-in-sheet | Match the Typst treatment named in each template spec. |
 | Avatar without photo | — | Closed by #857: photo-less default is **collapsed**; initials disc is `showInitials` opt-in. Hidden photos collapse. No pikachu exception. |
-| Mono dates: sheet uses `--doc-font-mono` for education dates; Typst uses muted body face | owner-decision-needed | Mono is a sheet editing affordance; decide whether PDF should match. |
+| Mono dates: sheet uses `--doc-font-mono` for education dates; Typst uses muted body face | — | Closed by #860: Done mode uses the muted body face (PDF). Edit mode keeps mono as a sanctioned editing affordance. Documented in [`item-presentation.md`](../design/item-presentation.md). |
 | `metadata.typography.font.size` / `lineHeight`: engine emits a top-level `#set text`, then nearly every template re-locks size and leading | fix-in-typst | Tracked by #701 — lift shared resolution into `_common.typ`. |
 
 ## Related code

--- a/docs/templates/glalie.md
+++ b/docs/templates/glalie.md
@@ -62,7 +62,7 @@ bodies above.
 | --- | --- |
 | Sheet locks IBM Plex Serif; PDF honors `metadata.typography.font.family` (schema default Serif) | owner-decision-needed |
 | Sheet uppercases section titles; Typst keeps title-case | fix-in-sheet |
-| Justify-on in Typst vs sheet left-aligned body | owner-decision-needed |
+| Justify-on in Typst vs sheet left-aligned body | fixed (#860): sheet body (`summary` / entry sum / desc) is justified, both modes |
 | Experience lead field was company-first in Typst | fixed (#858) |
 | `page.margin` does not inset the page box (full-bleed); `content-width()` still uses it for ratio math | owner-decision-needed (surface in UI) |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(web): match Done mode to PDF on glalie justify and education dates
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Done mode now matches the PDF on two fidelity points from #826 owner rulings 5–6:

1. glalie body prose is justified (glalie-scoped CSS; other templates stay start-aligned), including skill/language `.doc-sheet__lang-desc` (Typst `set par(justify: true)` covers that prose)
2. Education dates use the muted body face in Done mode; Edit mode keeps mono as a sanctioned editing affordance

CodeRabbit follow-up:

- CSS contract tests now match each declaration only inside its own rule (`[^}]*`), so a later `text-align: justify` cannot satisfy the glalie/justify-body assertions
- The templates README divergence row now leads with the resolved faces (PDF/Done muted body; Edit mono) instead of the old "sheet uses mono" wording

No PDF/Typst or font-family changes (#701).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`bun run test:coverage` on sectionCards + docLayout, `bun run lint`, `uv run --group lint lintro chk` on the touched files)

## Related Issues

Closes #860
Related #826

## Details

Contract docs: `docs/design/item-presentation.md`, `docs/templates/glalie.md`, `docs/templates/README.md`. Sheet visual e2e stayed within existing baselines; PDF baselines unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddab4cfb-3004-4f13-a16c-02d931c4801c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddab4cfb-3004-4f13-a16c-02d931c4801c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved document and PDF typography for education dates, using muted body styling in completed views while preserving the monospace editing style.
  * Added justified body text support for Glalie templates, including summaries, entries, and descriptions.
  * Improved alignment and presentation consistency across document templates.

* **Documentation**
  * Updated template and design guidance to reflect the finalized typography and text-alignment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns the web document sheet more closely with Glalie PDF typography while preserving Edit-mode affordances.
- Justifies Glalie body prose, including skill and language descriptions.
- Uses the muted body face for education dates in Done mode while retaining monospace in Edit mode.
- Updates focused tests and presentation-contract documentation.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/doc-editor/DocSection.tsx | Adds the Done-mode education-date body-face hook without changing field behavior. |
| apps/web/src/components/doc-editor/DocSheet.tsx | Adds template- and mode-scoped root hooks for Glalie justification and Done-mode styling. |
| apps/web/src/components/doc-editor/docSheet.css | Fully addresses the prior Glalie description-alignment finding and scopes education-date typography by mode. |
| apps/web/src/components/doc-editor/__tests__/sectionCards.test.tsx | Covers Glalie scoping, description presence, and education-date mode classes. |
| apps/web/src/lib/__tests__/docLayout.test.ts | Pins the relevant CSS selectors and document font variables. |
| docs/design/item-presentation.md | Documents the education-date face contract across PDF, Done, and Edit surfaces. |
| docs/templates/README.md | Updates the shared template typography guidance. |
| docs/templates/glalie.md | Documents Glalie body-justification and education-date parity expectations. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(templates): qualify education-date ..."](https://github.com/lgtm-hq/rustume/commit/1cb7528c4a57fe1ffd36e4f1e4df082f4b3a526b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55719530)</sub>

<!-- /greptile_comment -->